### PR TITLE
ci(coderabbit): enable ruff, hadolint, actionlint, gitleaks, yamllint

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,5 +12,15 @@ reviews:
   tools:
     clippy:
       enabled: true
+    ruff:
+      enabled: true
+    hadolint:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    yamllint:
+      enabled: true
 chat:
   auto_reply: true


### PR DESCRIPTION
## Summary

Expand CodeRabbit's review tools beyond `clippy` to cover the rest of this polyglot repo:

- `ruff` — Python (sdk/python)
- `hadolint` — Dockerfiles (root + runtime/engram-server)
- `actionlint` — GitHub Actions workflows
- `gitleaks` — secret scanning
- `yamllint` — repo YAML configs

`chill` profile and existing path filters preserved. Activates automatically on the next PR.
