### PR TITLE
feat(redaction): 4.B PII redaction — SDK side (jamjet.cloud.redact + auto-mode)

### DIFF
--- a/sdk/python/jamjet/cloud/__init__.py
+++ b/sdk/python/jamjet/cloud/__init__.py
@@ -86,9 +86,8 @@ def configure(
     # Process-wide context (environment, release_version) for every span.
     set_process_context(environment=environment, release_version=release_version)
 
-    if redact:
-        from .redaction import configure as _redact_cfg
-        _redact_cfg(enabled=True, pii_types=redact_types)
+    from .redaction import configure as _redact_cfg
+    _redact_cfg(enabled=redact, pii_types=redact_types)
 
     if auto_patch:
         patch_all()

--- a/sdk/python/jamjet/cloud/__init__.py
+++ b/sdk/python/jamjet/cloud/__init__.py
@@ -13,6 +13,7 @@ from .events import init_queue
 from .patcher import patch_all, unpatch_all
 from .policy import get_evaluator
 from .propagation import extract_headers, inject_headers
+from .redaction import redact
 from .trace import trace
 from .user_context import set_process_context, set_user_context, user_context
 
@@ -26,6 +27,7 @@ __all__ = [
     "inject_headers",
     "patch_all",
     "policy",
+    "redact",
     "require_approval",
     "set_user_context",
     "trace",
@@ -45,6 +47,8 @@ def configure(
     flush_interval: float = 5.0,
     flush_size: int = 50,
     api_url: str = "https://api.jamjet.dev",
+    redact: bool = False,
+    redact_types: list[str] | None = None,
 ) -> None:
     """Initialize the JamJet Cloud SDK.
 
@@ -81,6 +85,10 @@ def configure(
 
     # Process-wide context (environment, release_version) for every span.
     set_process_context(environment=environment, release_version=release_version)
+
+    if redact:
+        from .redaction import configure as _redact_cfg
+        _redact_cfg(enabled=True, pii_types=redact_types)
 
     if auto_patch:
         patch_all()

--- a/sdk/python/jamjet/cloud/events.py
+++ b/sdk/python/jamjet/cloud/events.py
@@ -117,9 +117,10 @@ def _scrub_event(event: dict[str, Any], redact_dict: Any) -> dict[str, Any]:
     result = dict(event)
     if result.get("payload") is not None:
         result["payload"] = redact_dict(result["payload"])
-    if result.get("end_user_email"):
+    email = result.get("end_user_email")
+    if isinstance(email, str) and email:
         from .redaction import redact as _redact
-        result["end_user_email"] = _redact(result["end_user_email"])
+        result["end_user_email"] = _redact(email)
     return result
 
 

--- a/sdk/python/jamjet/cloud/events.py
+++ b/sdk/python/jamjet/cloud/events.py
@@ -70,6 +70,10 @@ class EventQueue:
 
     def _send(self, batch: list[dict[str, Any]]) -> None:
         """POST a batch of events to the ingest endpoint."""
+        from .redaction import _config as _r_cfg, _redact_dict
+        if _r_cfg.get("enabled"):
+            batch = [_scrub_event(event, _redact_dict) for event in batch]
+
         cfg = get_config()
         if not cfg.api_key or not cfg.enabled:
             return
@@ -107,6 +111,16 @@ class EventQueue:
         """Number of events waiting to be flushed."""
         with self._lock:
             return len(self._queue)
+
+
+def _scrub_event(event: dict[str, Any], redact_dict: Any) -> dict[str, Any]:
+    result = dict(event)
+    if result.get("payload") is not None:
+        result["payload"] = redact_dict(result["payload"])
+    if result.get("end_user_email"):
+        from .redaction import redact as _redact
+        result["end_user_email"] = _redact(result["end_user_email"])
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/jamjet/cloud/redaction.py
+++ b/sdk/python/jamjet/cloud/redaction.py
@@ -6,6 +6,7 @@ Falls back to compiled regex patterns otherwise.
 from __future__ import annotations
 
 import re
+import threading
 from typing import Any
 
 try:
@@ -20,6 +21,8 @@ except ImportError:
     _presidio_available = False
     _analyzer = None
     _anonymizer = None
+
+_presidio_lock = threading.Lock()
 
 
 _REGEX_PATTERNS: dict[str, re.Pattern[str]] = {
@@ -48,10 +51,19 @@ _config: dict[str, Any] = {
 
 
 def _setup_presidio() -> None:
-    global _analyzer, _anonymizer
-    if _presidio_available and _analyzer is None:
-        _analyzer = AnalyzerEngine()
-        _anonymizer = AnonymizerEngine()
+    global _analyzer, _anonymizer, _presidio_available
+    if not _presidio_available or _analyzer is not None:
+        return
+    with _presidio_lock:
+        if not _presidio_available or _analyzer is not None:
+            return
+        try:
+            _analyzer = AnalyzerEngine()
+            _anonymizer = AnonymizerEngine()
+        except Exception:
+            _presidio_available = False
+            _analyzer = None
+            _anonymizer = None
 
 
 def _make_replacement(pii_type: str) -> str:
@@ -86,8 +98,12 @@ def _redact_presidio(text: str, pii_types: list[str]) -> str:
 
 
 def redact(text: str, *, pii_types: list[str] | None = None) -> str:
-    """Redact PII from text. Uses Presidio if available, else regex."""
-    types = pii_types or _config["pii_types"]
+    """Redact PII from text. Uses Presidio if available, else regex.
+
+    Pass ``pii_types=[]`` to disable redaction for this call (returns text
+    unchanged). Pass ``pii_types=None`` (default) to use the configured set.
+    """
+    types = _config["pii_types"] if pii_types is None else pii_types
     if _presidio_available:
         return _redact_presidio(text, types)
     return _redact_regex(text, types)
@@ -110,9 +126,12 @@ def configure(
     pii_types: list[str] | None = None,
     replacement_format: str | None = None,
 ) -> None:
-    """Configure auto-mode. Called by jamjet.configure(redact=True)."""
+    """Configure auto-mode. Called by jamjet.configure(redact=True).
+
+    Each call resets ``pii_types`` and ``replacement_format`` to either the
+    explicit value or the module defaults — earlier customization does not
+    bleed into later calls.
+    """
     _config["enabled"] = enabled
-    if pii_types is not None:
-        _config["pii_types"] = pii_types
-    if replacement_format is not None:
-        _config["replacement_format"] = replacement_format
+    _config["pii_types"] = list(DEFAULT_PII_TYPES) if pii_types is None else list(pii_types)
+    _config["replacement_format"] = "[{type}]" if replacement_format is None else replacement_format

--- a/sdk/python/jamjet/cloud/redaction.py
+++ b/sdk/python/jamjet/cloud/redaction.py
@@ -1,0 +1,118 @@
+"""PII redaction for JamJet Cloud SDK.
+
+Uses Presidio (presidio-analyzer + spacy en_core_web_lg) when installed.
+Falls back to compiled regex patterns otherwise.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+try:
+    from presidio_analyzer import AnalyzerEngine
+    from presidio_anonymizer import AnonymizerEngine
+    from presidio_anonymizer.entities import OperatorConfig
+
+    _presidio_available = True
+    _analyzer: Any = None
+    _anonymizer: Any = None
+except ImportError:
+    _presidio_available = False
+    _analyzer = None
+    _anonymizer = None
+
+
+_REGEX_PATTERNS: dict[str, re.Pattern[str]] = {
+    "EMAIL_ADDRESS": re.compile(
+        r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"
+    ),
+    "CREDIT_CARD": re.compile(r"\b(?:\d[\s\-]?){13,15}\d\b"),
+    "US_SSN": re.compile(r"\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b"),
+    "PHONE_NUMBER": re.compile(
+        r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"
+    ),
+    "IP_ADDRESS": re.compile(
+        r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b"
+    ),
+    "IBAN_CODE": re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b"),
+}
+
+DEFAULT_PII_TYPES = list(_REGEX_PATTERNS.keys())
+
+
+_config: dict[str, Any] = {
+    "enabled": False,
+    "pii_types": DEFAULT_PII_TYPES,
+    "replacement_format": "[{type}]",
+}
+
+
+def _setup_presidio() -> None:
+    global _analyzer, _anonymizer
+    if _presidio_available and _analyzer is None:
+        _analyzer = AnalyzerEngine()
+        _anonymizer = AnonymizerEngine()
+
+
+def _make_replacement(pii_type: str) -> str:
+    return _config["replacement_format"].replace("{type}", pii_type)
+
+
+def _redact_regex(text: str, pii_types: list[str]) -> str:
+    result = text
+    for pii_type in pii_types:
+        pattern = _REGEX_PATTERNS.get(pii_type)
+        if pattern:
+            result = pattern.sub(_make_replacement(pii_type), result)
+    return result
+
+
+def _redact_presidio(text: str, pii_types: list[str]) -> str:
+    _setup_presidio()
+    if _analyzer is None or _anonymizer is None:
+        return _redact_regex(text, pii_types)
+    results = _analyzer.analyze(text=text, entities=pii_types, language="en")
+    if not results:
+        return text
+    operators = {
+        r.entity_type: OperatorConfig(
+            "replace", {"new_value": _make_replacement(r.entity_type)}
+        )
+        for r in results
+    }
+    return _anonymizer.anonymize(
+        text=text, analyzer_results=results, operators=operators
+    ).text
+
+
+def redact(text: str, *, pii_types: list[str] | None = None) -> str:
+    """Redact PII from text. Uses Presidio if available, else regex."""
+    types = pii_types or _config["pii_types"]
+    if _presidio_available:
+        return _redact_presidio(text, types)
+    return _redact_regex(text, types)
+
+
+def _redact_dict(obj: Any) -> Any:
+    """Recursively redact PII from all string values in a dict/list."""
+    if isinstance(obj, str):
+        return redact(obj)
+    if isinstance(obj, dict):
+        return {k: _redact_dict(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact_dict(item) for item in obj]
+    return obj
+
+
+def configure(
+    *,
+    enabled: bool = True,
+    pii_types: list[str] | None = None,
+    replacement_format: str | None = None,
+) -> None:
+    """Configure auto-mode. Called by jamjet.configure(redact=True)."""
+    _config["enabled"] = enabled
+    if pii_types is not None:
+        _config["pii_types"] = pii_types
+    if replacement_format is not None:
+        _config["replacement_format"] = replacement_format

--- a/sdk/python/tests/test_redaction.py
+++ b/sdk/python/tests/test_redaction.py
@@ -1,0 +1,99 @@
+"""Unit tests for jamjet.cloud.redaction."""
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+
+
+def test_redact_email():
+    from jamjet.cloud import redaction
+    result = redaction.redact("contact me at user@example.com please")
+    assert "user@example.com" not in result
+    assert "[EMAIL_ADDRESS]" in result
+
+
+def test_redact_phone():
+    from jamjet.cloud import redaction
+    result = redaction.redact("call me at 415-555-1234 anytime")
+    assert "415-555-1234" not in result
+
+
+def test_redact_clean_string():
+    from jamjet.cloud import redaction
+    result = redaction.redact("nothing sensitive here")
+    assert result == "nothing sensitive here"
+
+
+def test_redact_no_presidio_fallback(monkeypatch):
+    """When Presidio is unavailable, regex fallback fires."""
+    from jamjet.cloud import redaction as r
+    monkeypatch.setattr(r, "_presidio_available", False)
+    result = r.redact("email is a@b.com")
+    assert "a@b.com" not in result
+    assert "[EMAIL_ADDRESS]" in result
+
+
+def test_redact_dict_nested():
+    from jamjet.cloud.redaction import _redact_dict
+    obj = {"messages": [{"role": "user", "content": "my email is x@y.com"}]}
+    out = _redact_dict(obj)
+    assert "x@y.com" not in out["messages"][0]["content"]
+    assert "[EMAIL_ADDRESS]" in out["messages"][0]["content"]
+
+
+def test_custom_pii_types():
+    from jamjet.cloud import redaction
+    result = redaction.redact(
+        "email a@b.com phone 415-555-1234",
+        pii_types=["EMAIL_ADDRESS"],
+    )
+    assert "[EMAIL_ADDRESS]" in result
+    assert "415-555-1234" in result
+
+
+def test_replacement_format_static():
+    from jamjet.cloud import redaction as r
+    original_fmt = r._config["replacement_format"]
+    r._config["replacement_format"] = "[REDACTED]"
+    try:
+        result = r.redact("email a@b.com")
+        assert "[REDACTED]" in result
+        assert "[EMAIL_ADDRESS]" not in result
+    finally:
+        r._config["replacement_format"] = original_fmt
+
+
+def test_auto_mode_scrubs_payload():
+    """Auto-mode redacts email in event payload before POST."""
+    from jamjet.cloud import redaction as r
+
+    r.configure(enabled=True)
+
+    captured: list[dict] = []
+
+    def fake_send(self, batch):
+        captured.extend(batch)
+
+    with mock.patch(
+        "jamjet.cloud.events.EventQueue._send",
+        new=fake_send,
+    ):
+        from jamjet.cloud.events import EventQueue
+        q = EventQueue(flush_size=1)
+        q.push({
+            "trace_id": "t1",
+            "span_id": "s1",
+            "sequence": 0,
+            "kind": "llm",
+            "timestamp": "2026-04-28T00:00:00Z",
+            "payload": {"content": "email me at secret@example.com"},
+        })
+        q._flush()
+
+    assert captured, "No events captured"
+    content = captured[0]["payload"]["content"]
+    assert "secret@example.com" not in content
+    assert "[EMAIL_ADDRESS]" in content
+
+    r._config["enabled"] = False  # reset

--- a/sdk/python/tests/test_redaction.py
+++ b/sdk/python/tests/test_redaction.py
@@ -64,6 +64,45 @@ def test_replacement_format_static():
         r._config["replacement_format"] = original_fmt
 
 
+def test_pii_types_empty_list_disables_for_call():
+    """pii_types=[] means 'disable all detectors for this call' (not 'use defaults')."""
+    from jamjet.cloud import redaction
+    text = "email a@b.com phone 415-555-1234"
+    assert redaction.redact(text, pii_types=[]) == text
+
+
+def test_configure_resets_to_defaults():
+    """A second configure() call without pii_types resets to module defaults."""
+    from jamjet.cloud import redaction as r
+    r.configure(enabled=True, pii_types=["EMAIL_ADDRESS"])
+    assert r._config["pii_types"] == ["EMAIL_ADDRESS"]
+    r.configure(enabled=True)
+    assert r._config["pii_types"] == r.DEFAULT_PII_TYPES
+    assert r._config["replacement_format"] == "[{type}]"
+    r._config["enabled"] = False  # reset
+
+
+def test_scrub_event_handles_non_string_email():
+    """Non-string end_user_email is left unchanged (no crash)."""
+    from jamjet.cloud.events import _scrub_event
+    from jamjet.cloud.redaction import _redact_dict
+    out = _scrub_event(
+        {"payload": {"x": "y"}, "end_user_email": 12345},
+        _redact_dict,
+    )
+    assert out["end_user_email"] == 12345
+
+
+def test_configure_redact_false_disables_in_top_level():
+    """jamjet.configure(redact=False) actually turns off auto-mode."""
+    import jamjet.cloud as jj
+    from jamjet.cloud import redaction as r
+    r.configure(enabled=True)
+    assert r._config["enabled"] is True
+    jj.configure(api_key="test", redact=False, auto_patch=False)
+    assert r._config["enabled"] is False
+
+
 def test_auto_mode_scrubs_payload():
     """Auto-mode redacts email in event payload before POST hits the network."""
     from jamjet.cloud import redaction as r

--- a/sdk/python/tests/test_redaction.py
+++ b/sdk/python/tests/test_redaction.py
@@ -65,35 +65,43 @@ def test_replacement_format_static():
 
 
 def test_auto_mode_scrubs_payload():
-    """Auto-mode redacts email in event payload before POST."""
+    """Auto-mode redacts email in event payload before POST hits the network."""
     from jamjet.cloud import redaction as r
+    from jamjet.cloud.config import set_config
+    from jamjet.cloud.events import EventQueue
 
+    set_config(api_key="test-key", project="test", api_url="http://x", enabled=True)
     r.configure(enabled=True)
 
-    captured: list[dict] = []
+    captured_payloads: list[dict] = []
 
-    def fake_send(self, batch):
-        captured.extend(batch)
+    class FakeResp:
+        status_code = 200
 
-    with mock.patch(
-        "jamjet.cloud.events.EventQueue._send",
-        new=fake_send,
-    ):
-        from jamjet.cloud.events import EventQueue
-        q = EventQueue(flush_size=1)
-        q.push({
-            "trace_id": "t1",
-            "span_id": "s1",
-            "sequence": 0,
-            "kind": "llm",
-            "timestamp": "2026-04-28T00:00:00Z",
-            "payload": {"content": "email me at secret@example.com"},
-        })
-        q._flush()
+        def raise_for_status(self):
+            pass
 
-    assert captured, "No events captured"
-    content = captured[0]["payload"]["content"]
-    assert "secret@example.com" not in content
-    assert "[EMAIL_ADDRESS]" in content
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured_payloads.append(json)
+        return FakeResp()
 
-    r._config["enabled"] = False  # reset
+    try:
+        with mock.patch("jamjet.cloud.events.httpx.post", side_effect=fake_post):
+            q = EventQueue()
+            q.push({
+                "trace_id": "t1",
+                "span_id": "s1",
+                "sequence": 0,
+                "kind": "llm",
+                "timestamp": "2026-04-28T00:00:00Z",
+                "payload": {"content": "email me at secret@example.com"},
+            })
+            q._flush()
+
+        assert captured_payloads, "No HTTP POST captured"
+        events = captured_payloads[0]["events"]
+        content = events[0]["payload"]["content"]
+        assert "secret@example.com" not in content
+        assert "[EMAIL_ADDRESS]" in content
+    finally:
+        r._config["enabled"] = False


### PR DESCRIPTION
## Summary

SDK companion to [jamjet-cloud#5](https://github.com/jamjet-labs/jamjet-cloud/pull/5). Adds client-side PII redaction so payloads are scrubbed **before they leave the process** — the server-side engine is a backstop, this is the primary defense.

- **`jamjet.cloud.redaction`** module — Presidio (optional) with regex fallback. 6 entity types matching the Rust server engine for consistency: EMAIL_ADDRESS, CREDIT_CARD, US_SSN, PHONE_NUMBER, IP_ADDRESS, IBAN_CODE.
- **`redact(text, pii_types=...)`** public API + recursive `_redact_dict` for JSON payloads.
- **Auto-mode** — `jamjet.configure(redact=True, redact_types=[...])` enables in-process scrubbing in `EventQueue._send()`. Both `payload` and `end_user_email` fields are scrubbed pre-POST.
- **Exported** as `jamjet.cloud.redact` for explicit one-shot use.

Related: [Master plan 4.B](https://github.com/jamjet-labs/jamjet-business/blob/main/MASTER-PLAN.md).

## Test plan

- [x] `pytest tests/test_redaction.py` — **8/8 pass** (regex engine, presidio fallback, custom types, replacement format, recursive dict redaction, auto-mode pre-POST hook)
- [x] `pytest tests/` (full SDK suite) — **387/387 pass**, no regressions
- [ ] Manually verify `jamjet.configure(redact=True)` end-to-end against a Team-tier project once cloud PR #5 is merged

## Plan deviation

The plan's auto-mode test patched `EventQueue._send` directly, which would have bypassed the very redaction it tested. Rewrote the test to patch `httpx.post` instead, exercising the real `_send` path including the new redaction hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PII redaction capability for event payloads, supporting email, credit card, SSN, phone numbers, IP addresses, and IBAN.
  * New `redact()` function to redact personally identifiable information from text.
  * Enhanced `configure()` function with `redact` and `redact_types` parameters to enable and customize automatic event redaction.

* **Tests**
  * Added comprehensive test coverage for redaction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->