### PR TITLE
feat(audit-verify): 4.E.α — SDK verifier + jamjet-cloud audit-verify CLI

### DIFF
--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -1,0 +1,103 @@
+"""Verify jamjet-cloud audit export packages.
+
+Used both as a library (``verify_package(...)``) and via the
+``jamjet-cloud audit-verify`` CLI subcommand.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+
+@dataclass
+class VerifyResult:
+    ok: bool
+    digest: str
+    reason: str = ""
+    key_id: str | None = None
+
+
+def verify_package(bundle: bytes, signature: bytes, public_key_bytes: bytes) -> VerifyResult:
+    """Verify a bundle's Ed25519 signature against a 32-byte raw public key.
+
+    The signed payload is ``sha256(bundle)``; this function recomputes the
+    digest and validates the signature against it. Mismatches in length,
+    key, or signature integrity all surface as ``ok=False``.
+    """
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    digest_bytes = hashlib.sha256(bundle).digest()
+    digest_hex = digest_bytes.hex()
+    if len(signature) != 64:
+        return VerifyResult(False, digest_hex, "signature wrong length (expected 64 bytes)")
+    if len(public_key_bytes) != 32:
+        return VerifyResult(False, digest_hex, "public key wrong length (expected 32 bytes)")
+    try:
+        pk = Ed25519PublicKey.from_public_bytes(public_key_bytes)
+        pk.verify(signature, digest_bytes)
+        return VerifyResult(True, digest_hex)
+    except InvalidSignature:
+        return VerifyResult(False, digest_hex, "signature did not match the public key")
+    except Exception as e:  # pragma: no cover — defensive
+        return VerifyResult(False, digest_hex, f"verify error: {e}")
+
+
+def verify_from_files(
+    package_path: Path,
+    metadata_path: Path,
+    *,
+    api_url: str = "https://api.jamjet.dev",
+) -> VerifyResult:
+    """Read a package + its POST-response metadata, fetch the published
+    public key, and verify.
+
+    metadata_path JSON shape (from `POST /v1/audit/export`):
+        {
+          "id": "...",
+          "sha256_digest": "...",
+          "signature_b64": "...",
+          "signing_key_id": "...",
+          "expires_at": "...",
+          "download_urls": {...}
+        }
+    """
+    bundle = package_path.read_bytes()
+    digest_hex = hashlib.sha256(bundle).hexdigest()
+
+    try:
+        meta = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return VerifyResult(False, digest_hex, f"could not read metadata: {e}")
+
+    sig_b64 = meta.get("signature_b64")
+    key_id = meta.get("signing_key_id")
+    if not sig_b64 or not key_id:
+        return VerifyResult(False, digest_hex, "metadata missing signature_b64 or signing_key_id")
+
+    if meta.get("sha256_digest") and meta["sha256_digest"] != digest_hex:
+        return VerifyResult(False, digest_hex,
+                            f"bundle digest {digest_hex} does not match metadata.sha256_digest {meta['sha256_digest']}")
+
+    project_id = json.loads(bundle).get("project", {}).get("id")
+    if not project_id:
+        return VerifyResult(False, digest_hex, "bundle missing project.id")
+
+    keys = httpx.get(
+        f"{api_url}/.well-known/jamjet-audit-key.json",
+        params={"project_id": project_id},
+        timeout=10,
+    ).json()
+    matching = [k for k in keys if k["key_id"] == key_id]
+    if not matching:
+        return VerifyResult(False, digest_hex, f"key_id {key_id} not in published keys")
+    pk_bytes = base64.b64decode(matching[0]["public_key_b64"])
+    sig = base64.b64decode(sig_b64)
+    result = verify_package(bundle, sig, pk_bytes)
+    result.key_id = key_id
+    return result

--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -6,6 +6,7 @@ Used both as a library (``verify_package(...)``) and via the
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import json
 from dataclasses import dataclass
@@ -67,7 +68,10 @@ def verify_from_files(
           "download_urls": {...}
         }
     """
-    bundle = package_path.read_bytes()
+    try:
+        bundle = package_path.read_bytes()
+    except OSError as e:
+        return VerifyResult(False, "", f"could not read package: {e}")
     digest_hex = hashlib.sha256(bundle).hexdigest()
 
     try:
@@ -86,8 +90,10 @@ def verify_from_files(
 
     try:
         bundle_json = json.loads(bundle)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         return VerifyResult(False, digest_hex, f"bundle is not valid JSON: {e}")
+    if not isinstance(bundle_json, dict):
+        return VerifyResult(False, digest_hex, "bundle must be a JSON object")
     project_id = bundle_json.get("project", {}).get("id")
     if not project_id:
         return VerifyResult(False, digest_hex, "bundle missing project.id")
@@ -106,11 +112,17 @@ def verify_from_files(
         return VerifyResult(False, digest_hex, f"could not fetch public key: {e}")
     except json.JSONDecodeError as e:
         return VerifyResult(False, digest_hex, f"well-known response not JSON: {e}")
-    matching = [k for k in keys if k["key_id"] == key_id]
+    matching = [k for k in keys if isinstance(k, dict) and k.get("key_id") == key_id]
     if not matching:
         return VerifyResult(False, digest_hex, f"key_id {key_id} not in published keys")
-    pk_bytes = base64.b64decode(matching[0]["public_key_b64"])
-    sig = base64.b64decode(sig_b64)
+    public_key_b64 = matching[0].get("public_key_b64")
+    if not public_key_b64:
+        return VerifyResult(False, digest_hex, f"key_id {key_id} missing public_key_b64")
+    try:
+        pk_bytes = base64.b64decode(public_key_b64, validate=True)
+        sig = base64.b64decode(sig_b64, validate=True)
+    except (binascii.Error, ValueError, TypeError) as e:
+        return VerifyResult(False, digest_hex, f"invalid base64 encoding: {e}")
     result = verify_package(bundle, sig, pk_bytes)
     result.key_id = key_id
     return result

--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -84,15 +84,28 @@ def verify_from_files(
         return VerifyResult(False, digest_hex,
                             f"bundle digest {digest_hex} does not match metadata.sha256_digest {meta['sha256_digest']}")
 
-    project_id = json.loads(bundle).get("project", {}).get("id")
+    try:
+        bundle_json = json.loads(bundle)
+    except json.JSONDecodeError as e:
+        return VerifyResult(False, digest_hex, f"bundle is not valid JSON: {e}")
+    project_id = bundle_json.get("project", {}).get("id")
     if not project_id:
         return VerifyResult(False, digest_hex, "bundle missing project.id")
 
-    keys = httpx.get(
-        f"{api_url}/.well-known/jamjet-audit-key.json",
-        params={"project_id": project_id},
-        timeout=10,
-    ).json()
+    try:
+        keys_resp = httpx.get(
+            f"{api_url}/.well-known/jamjet-audit-key.json",
+            params={"project_id": project_id},
+            timeout=10,
+        )
+        keys_resp.raise_for_status()
+        keys = keys_resp.json()
+        if not isinstance(keys, list):
+            return VerifyResult(False, digest_hex, f"well-known endpoint returned unexpected shape: {type(keys).__name__}")
+    except httpx.HTTPError as e:
+        return VerifyResult(False, digest_hex, f"could not fetch public key: {e}")
+    except json.JSONDecodeError as e:
+        return VerifyResult(False, digest_hex, f"well-known response not JSON: {e}")
     matching = [k for k in keys if k["key_id"] == key_id]
     if not matching:
         return VerifyResult(False, digest_hex, f"key_id {key_id} not in published keys")

--- a/sdk/python/jamjet/cloud/cli.py
+++ b/sdk/python/jamjet/cloud/cli.py
@@ -222,5 +222,24 @@ def _sanitize(s: str) -> str:
     return "".join(c if c.isalnum() or c in "-_" else "_" for c in s)
 
 
+@app.command("audit-verify")
+def audit_verify(
+    package: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True,
+                                   help="Path to the .json audit package."),
+    metadata: Path = typer.Option(..., "--metadata", "-m", exists=True, dir_okay=False, readable=True,
+                                   help="Path to the metadata JSON saved from POST /v1/audit/export."),
+    api_url: str = typer.Option(_DEFAULT_API_URL, "--api-url",
+                                help="Cloud base URL (override for self-hosted or local dev)."),
+) -> None:
+    """Verify the Ed25519 signature on an audit export package."""
+    from .audit_verify import verify_from_files
+    res = verify_from_files(package, metadata, api_url=api_url)
+    if res.ok:
+        console.print(f"[green]OK[/green] · sha256={res.digest} · key_id={res.key_id}")
+        raise typer.Exit(code=0)
+    console.print(f"[red]FAIL[/red] · {res.reason} · sha256={res.digest}")
+    raise typer.Exit(code=2)
+
+
 def main() -> None:
     app()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "rich>=13.0",
     "anyio>=4.0",
     "pyyaml>=6.0",
+    "cryptography>=42",
 ]
 
 [project.urls]

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -56,3 +56,28 @@ def test_verify_rejects_short_signature():
     result = verify_package(b"x", b"\x00" * 10, pk_bytes)
     assert result.ok is False
     assert "signature" in result.reason.lower()
+
+
+def test_verify_from_files_handles_invalid_json_bundle(tmp_path):
+    """Bundle that isn't JSON returns ok=False, doesn't raise."""
+    from jamjet.cloud.audit_verify import verify_from_files
+    bundle_path = tmp_path / "bad.json"
+    bundle_path.write_bytes(b"not valid json{{")
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text('{"signature_b64":"x","signing_key_id":"y"}')
+    result = verify_from_files(bundle_path, metadata_path)
+    assert result.ok is False
+    assert "not valid JSON" in result.reason
+
+
+def test_verify_from_files_handles_unreachable_well_known(tmp_path):
+    """Failed HTTP call to well-known endpoint returns ok=False, doesn't raise."""
+    from jamjet.cloud.audit_verify import verify_from_files
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_bytes(b'{"project":{"id":"abc"}}')
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text('{"signature_b64":"AAAA","signing_key_id":"y"}')
+    # Use an unroutable URL so httpx fails to connect.
+    result = verify_from_files(bundle_path, metadata_path, api_url="http://127.0.0.1:1")
+    assert result.ok is False
+    assert "could not fetch public key" in result.reason or "fetch" in result.reason.lower()

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -81,3 +81,49 @@ def test_verify_from_files_handles_unreachable_well_known(tmp_path):
     result = verify_from_files(bundle_path, metadata_path, api_url="http://127.0.0.1:1")
     assert result.ok is False
     assert "could not fetch public key" in result.reason or "fetch" in result.reason.lower()
+
+
+def test_verify_from_files_handles_missing_package_file(tmp_path):
+    """Nonexistent package path returns ok=False, doesn't raise."""
+    from jamjet.cloud.audit_verify import verify_from_files
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text('{"signature_b64":"x","signing_key_id":"y"}')
+    result = verify_from_files(tmp_path / "no-such-file.json", metadata_path)
+    assert result.ok is False
+    assert "could not read package" in result.reason
+
+
+def test_verify_from_files_handles_invalid_base64_signature(tmp_path, monkeypatch):
+    """Invalid base64 in metadata signature returns ok=False, doesn't raise."""
+    import jamjet.cloud.audit_verify as av
+
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_bytes(b'{"project":{"id":"abc"}}')
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text('{"signature_b64":"!!!not-valid!!!","signing_key_id":"y"}')
+
+    # Stub the well-known fetch so we get past the network step.
+    import httpx
+    def fake_get(url, params=None, timeout=None):
+        class R:
+            status_code = 200
+            def raise_for_status(self): pass
+            def json(self): return [{"key_id": "y", "public_key_b64": "AAAA"}]
+        return R()
+    monkeypatch.setattr(av.httpx, "get", fake_get)
+
+    result = av.verify_from_files(bundle_path, metadata_path)
+    assert result.ok is False
+    assert "base64" in result.reason.lower() or "invalid" in result.reason.lower()
+
+
+def test_verify_from_files_handles_non_dict_bundle(tmp_path):
+    """Bundle that's a JSON array (not object) returns ok=False, doesn't raise."""
+    from jamjet.cloud.audit_verify import verify_from_files
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_bytes(b'["not", "an", "object"]')
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text('{"signature_b64":"AAAA","signing_key_id":"y"}')
+    result = verify_from_files(bundle_path, metadata_path)
+    assert result.ok is False
+    assert "JSON object" in result.reason

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -1,0 +1,58 @@
+"""Unit tests for jamjet.cloud.audit_verify."""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+cryptography = pytest.importorskip("cryptography")
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def _sign_fixture(bundle: bytes) -> tuple[bytes, bytes]:
+    """Returns (public_key_bytes, signature_bytes)."""
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key()
+    digest = hashlib.sha256(bundle).digest()
+    sig = sk.sign(digest)
+    pk_bytes = pk.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return pk_bytes, sig
+
+
+def test_verify_ok_round_trip():
+    from jamjet.cloud.audit_verify import verify_package
+    bundle = b'{"schema_version":"1.0","payload":"x"}\n'
+    pk_bytes, sig = _sign_fixture(bundle)
+    result = verify_package(bundle, sig, pk_bytes)
+    assert result.ok is True
+    assert result.digest == hashlib.sha256(bundle).hexdigest()
+
+
+def test_verify_fails_on_tampered_bundle():
+    from jamjet.cloud.audit_verify import verify_package
+    bundle = b'{"schema_version":"1.0","payload":"x"}\n'
+    pk_bytes, sig = _sign_fixture(bundle)
+    tampered = bundle.replace(b'"x"', b'"y"')
+    result = verify_package(tampered, sig, pk_bytes)
+    assert result.ok is False
+
+
+def test_verify_fails_on_wrong_key():
+    from jamjet.cloud.audit_verify import verify_package
+    bundle = b'{}\n'
+    _, sig = _sign_fixture(bundle)
+    other_pk_bytes, _ = _sign_fixture(b"other")
+    result = verify_package(bundle, sig, other_pk_bytes)
+    assert result.ok is False
+
+
+def test_verify_rejects_short_signature():
+    from jamjet.cloud.audit_verify import verify_package
+    pk_bytes, _ = _sign_fixture(b"x")
+    result = verify_package(b"x", b"\x00" * 10, pk_bytes)
+    assert result.ok is False
+    assert "signature" in result.reason.lower()


### PR DESCRIPTION
## Summary

SDK companion to [jamjet-cloud#7](https://github.com/jamjet-labs/jamjet-cloud/pull/7) — Phase **4.E.α audit-verify CLI + library**.

External auditors get a signed bundle via `/dashboard/audit/export`, save the POST response as `metadata.json`, download the bundle as `bundle.json`, then run:

```
jamjet-cloud audit-verify bundle.json --metadata metadata.json
```

The CLI fetches the project's published Ed25519 public key from `https://api.jamjet.dev/.well-known/jamjet-audit-key.json`, base64-decodes the signature from metadata, and verifies `Ed25519.verify(sig, sha256(bundle))`. Zero credentials needed.

- **`jamjet.cloud.audit_verify`** module — `verify_package(bundle, signature, public_key_bytes) -> VerifyResult` (library use) + `verify_from_files(package_path, metadata_path, *, api_url) -> VerifyResult` (one-shot from disk)
- **Defensive everywhere** — invalid JSON bundle, unreachable well-known endpoint, malformed responses, wrong key length, tampered bundle: all surface as `ok=False` with a reason, never raise
- **`jamjet-cloud audit-verify`** typer subcommand — exits 0 on OK with green sha256+key_id confirmation, exits 2 on FAIL with red reason
- **`cryptography>=42`** dep added (only loaded lazily inside `verify_package`)
- **6 unit tests:** round-trip ok, tampered bundle, wrong key, short signature, invalid JSON bundle, unreachable well-known

## Test plan

- [x] `pytest tests/test_audit_verify.py` — 6/6 pass
- [x] Full SDK suite — 393/395 pass (2 pre-existing `test_cli_json_output` failures, unrelated)
- [x] CLI smoke-test via `typer.testing.CliRunner` — `--help` exits 0
- [x] End-to-end against the local cloud-side API: signature verifies against published key
- [ ] Manually run against prod after [jamjet-cloud#7](https://github.com/jamjet-labs/jamjet-cloud/pull/7) deploys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `jamjet-cloud audit-verify` command to verify the integrity and authenticity of audit export bundles
  * Verification validates bundles against published cryptographic signatures and provides detailed feedback on failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->