### PR TITLE
feat(cloud-sdk): audit-verify --pdf/--otlp/--siem-* cross-checks

### DIFF
--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -186,7 +186,9 @@ def cross_check_otlp(otlp_path: Path, expected_bundle_sha256: str) -> str | None
         return f"otlp: could not read: {e}"
     if not isinstance(doc, dict):
         return "otlp: file is not a JSON object"
-    audit = doc.get("_jamjet_audit", {})
+    audit = doc.get("_jamjet_audit")
+    if not isinstance(audit, dict):
+        return "otlp: _jamjet_audit field missing or not an object"
     actual = audit.get("bundle_sha256")
     if actual != expected_bundle_sha256:
         return (f"otlp: _jamjet_audit.bundle_sha256 = {actual!r} "
@@ -199,7 +201,7 @@ def cross_check_siem_jsonl(siem_path: Path, expected_bundle_sha256: str, *, splu
     try:
         raw = siem_path.read_text()
     except OSError as e:
-        return f"could not read {flavor}: {e}"
+        return f"{flavor}: could not read: {e}"
     field_name = "jj_audit_bundle_sha256"
     seen = 0
     for i, line in enumerate(ln for ln in raw.splitlines() if ln.strip()):
@@ -207,14 +209,19 @@ def cross_check_siem_jsonl(siem_path: Path, expected_bundle_sha256: str, *, splu
         try:
             rec = json.loads(line)
         except json.JSONDecodeError as e:
-            return f"{flavor} line {i} not valid JSON: {e}"
+            return f"{flavor}: line {i} not valid JSON: {e}"
+        if not isinstance(rec, dict):
+            return f"{flavor}: line {i} is not a JSON object"
         if splunk:
-            actual = rec.get("fields", {}).get(field_name)
+            fields = rec.get("fields")
+            if not isinstance(fields, dict):
+                return f"{flavor}: line {i} missing or non-object fields container"
+            actual = fields.get(field_name)
         else:
             actual = rec.get(field_name)
         if actual != expected_bundle_sha256:
-            return (f"{flavor} line {i} {field_name} = {actual!r} "
+            return (f"{flavor}: line {i} {field_name} = {actual!r} "
                     f"does not match canonical bundle digest {expected_bundle_sha256!r}")
     if seen == 0:
-        return f"{flavor} file contains no records — possible tampering"
+        return f"{flavor}: file contains no records — possible tampering"
     return None

--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -9,6 +9,8 @@ import base64
 import binascii
 import hashlib
 import json
+import re
+import zlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -152,25 +154,19 @@ def verify_from_files(
     return result
 
 
-import re
-
-
 def cross_check_pdf(pdf_path: Path, expected_bundle_sha256: str) -> str | None:
-    """If `pdf_path` is given, extract the embedded bundle_sha256 from the
-    PDF cover page (which prints it as text) and assert equality.
-    Returns None if OK, or a failure-reason string."""
+    """Best-effort PDF cross-check. Heuristic: scans raw bytes for the
+    expected digest hex; on miss, also tries decompressing FlateDecode
+    streams. Not a full PDF parser — false negatives are possible if
+    typst-pdf's stream framing diverges from the regex used here."""
     try:
         raw = pdf_path.read_bytes()
     except OSError as e:
-        return f"could not read pdf: {e}"
+        return f"pdf: could not read: {e}"
     if not raw.startswith(b"%PDF-"):
-        return f"{pdf_path} does not look like a PDF (missing %PDF- magic)"
-    # The sha256 (64 hex chars) appears in a content stream. typst-pdf
-    # may compress streams; decompress to find it.
+        return f"pdf: {pdf_path.name} does not look like a PDF (missing %PDF- magic)"
     if expected_bundle_sha256.encode() in raw:
         return None
-    # Try zlib-decompressing each /FlateDecode object naively.
-    import zlib
     for chunk in re.findall(rb"stream\r?\n(.*?)\r?\nendstream", raw, re.DOTALL):
         try:
             decompressed = zlib.decompress(chunk)
@@ -178,8 +174,8 @@ def cross_check_pdf(pdf_path: Path, expected_bundle_sha256: str) -> str | None:
             continue
         if expected_bundle_sha256.encode() in decompressed:
             return None
-    return (f"pdf metadata sha256 not found in {pdf_path.name} "
-            f"(expected {expected_bundle_sha256[:16]}…); "
+    return (f"pdf: metadata sha256 not found in {pdf_path.name} "
+            f"(expected {expected_bundle_sha256[:16]}...); "
             f"pdf may have been re-rendered or tampered")
 
 
@@ -187,33 +183,38 @@ def cross_check_otlp(otlp_path: Path, expected_bundle_sha256: str) -> str | None
     try:
         doc = json.loads(otlp_path.read_text())
     except (OSError, json.JSONDecodeError) as e:
-        return f"could not read otlp: {e}"
+        return f"otlp: could not read: {e}"
     if not isinstance(doc, dict):
-        return "otlp file is not a JSON object"
+        return "otlp: file is not a JSON object"
     audit = doc.get("_jamjet_audit", {})
     actual = audit.get("bundle_sha256")
     if actual != expected_bundle_sha256:
-        return (f"otlp _jamjet_audit.bundle_sha256 = {actual!r} "
+        return (f"otlp: _jamjet_audit.bundle_sha256 = {actual!r} "
                 f"does not match canonical bundle digest {expected_bundle_sha256!r}")
     return None
 
 
 def cross_check_siem_jsonl(siem_path: Path, expected_bundle_sha256: str, *, splunk: bool) -> str | None:
+    flavor = "siem_splunk" if splunk else "siem_datadog"
     try:
         raw = siem_path.read_text()
     except OSError as e:
-        return f"could not read siem jsonl: {e}"
+        return f"could not read {flavor}: {e}"
     field_name = "jj_audit_bundle_sha256"
-    for i, line in enumerate(l for l in raw.splitlines() if l.strip()):
+    seen = 0
+    for i, line in enumerate(ln for ln in raw.splitlines() if ln.strip()):
+        seen += 1
         try:
             rec = json.loads(line)
         except json.JSONDecodeError as e:
-            return f"siem line {i} not valid JSON: {e}"
+            return f"{flavor} line {i} not valid JSON: {e}"
         if splunk:
             actual = rec.get("fields", {}).get(field_name)
         else:
             actual = rec.get(field_name)
         if actual != expected_bundle_sha256:
-            return (f"siem line {i} {field_name} = {actual!r} "
+            return (f"{flavor} line {i} {field_name} = {actual!r} "
                     f"does not match canonical bundle digest {expected_bundle_sha256!r}")
+    if seen == 0:
+        return f"{flavor} file contains no records — possible tampering"
     return None

--- a/sdk/python/jamjet/cloud/audit_verify.py
+++ b/sdk/python/jamjet/cloud/audit_verify.py
@@ -54,6 +54,10 @@ def verify_from_files(
     metadata_path: Path,
     *,
     api_url: str = "https://api.jamjet.dev",
+    pdf_path: Path | None = None,
+    otlp_path: Path | None = None,
+    siem_splunk_path: Path | None = None,
+    siem_datadog_path: Path | None = None,
 ) -> VerifyResult:
     """Read a package + its POST-response metadata, fetch the published
     public key, and verify.
@@ -125,4 +129,91 @@ def verify_from_files(
         return VerifyResult(False, digest_hex, f"invalid base64 encoding: {e}")
     result = verify_package(bundle, sig, pk_bytes)
     result.key_id = key_id
+
+    if not result.ok:
+        return result
+
+    expected_digest = digest_hex
+    for path, kind, fn in (
+        (pdf_path, "pdf",
+         lambda p: cross_check_pdf(p, expected_digest)),
+        (otlp_path, "otlp",
+         lambda p: cross_check_otlp(p, expected_digest)),
+        (siem_splunk_path, "siem_splunk",
+         lambda p: cross_check_siem_jsonl(p, expected_digest, splunk=True)),
+        (siem_datadog_path, "siem_datadog",
+         lambda p: cross_check_siem_jsonl(p, expected_digest, splunk=False)),
+    ):
+        if path is not None:
+            err = fn(path)
+            if err is not None:
+                return VerifyResult(False, expected_digest, err, key_id)
+
     return result
+
+
+import re
+
+
+def cross_check_pdf(pdf_path: Path, expected_bundle_sha256: str) -> str | None:
+    """If `pdf_path` is given, extract the embedded bundle_sha256 from the
+    PDF cover page (which prints it as text) and assert equality.
+    Returns None if OK, or a failure-reason string."""
+    try:
+        raw = pdf_path.read_bytes()
+    except OSError as e:
+        return f"could not read pdf: {e}"
+    if not raw.startswith(b"%PDF-"):
+        return f"{pdf_path} does not look like a PDF (missing %PDF- magic)"
+    # The sha256 (64 hex chars) appears in a content stream. typst-pdf
+    # may compress streams; decompress to find it.
+    if expected_bundle_sha256.encode() in raw:
+        return None
+    # Try zlib-decompressing each /FlateDecode object naively.
+    import zlib
+    for chunk in re.findall(rb"stream\r?\n(.*?)\r?\nendstream", raw, re.DOTALL):
+        try:
+            decompressed = zlib.decompress(chunk)
+        except zlib.error:
+            continue
+        if expected_bundle_sha256.encode() in decompressed:
+            return None
+    return (f"pdf metadata sha256 not found in {pdf_path.name} "
+            f"(expected {expected_bundle_sha256[:16]}…); "
+            f"pdf may have been re-rendered or tampered")
+
+
+def cross_check_otlp(otlp_path: Path, expected_bundle_sha256: str) -> str | None:
+    try:
+        doc = json.loads(otlp_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        return f"could not read otlp: {e}"
+    if not isinstance(doc, dict):
+        return "otlp file is not a JSON object"
+    audit = doc.get("_jamjet_audit", {})
+    actual = audit.get("bundle_sha256")
+    if actual != expected_bundle_sha256:
+        return (f"otlp _jamjet_audit.bundle_sha256 = {actual!r} "
+                f"does not match canonical bundle digest {expected_bundle_sha256!r}")
+    return None
+
+
+def cross_check_siem_jsonl(siem_path: Path, expected_bundle_sha256: str, *, splunk: bool) -> str | None:
+    try:
+        raw = siem_path.read_text()
+    except OSError as e:
+        return f"could not read siem jsonl: {e}"
+    field_name = "jj_audit_bundle_sha256"
+    for i, line in enumerate(l for l in raw.splitlines() if l.strip()):
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError as e:
+            return f"siem line {i} not valid JSON: {e}"
+        if splunk:
+            actual = rec.get("fields", {}).get(field_name)
+        else:
+            actual = rec.get(field_name)
+        if actual != expected_bundle_sha256:
+            return (f"siem line {i} {field_name} = {actual!r} "
+                    f"does not match canonical bundle digest {expected_bundle_sha256!r}")
+    return None

--- a/sdk/python/jamjet/cloud/cli.py
+++ b/sdk/python/jamjet/cloud/cli.py
@@ -230,10 +230,26 @@ def audit_verify(
                                    help="Path to the metadata JSON saved from POST /v1/audit/export."),
     api_url: str = typer.Option(_DEFAULT_API_URL, "--api-url",
                                 help="Cloud base URL (override for self-hosted or local dev)."),
+    pdf: Path | None = typer.Option(None, "--pdf", exists=True, dir_okay=False, readable=True,
+                                    help="Optional PDF report — cross-check that its embedded bundle_sha256 matches."),
+    otlp: Path | None = typer.Option(None, "--otlp", exists=True, dir_okay=False, readable=True,
+                                     help="Optional OTLP JSON file — cross-check _jamjet_audit.bundle_sha256."),
+    siem_splunk: Path | None = typer.Option(None, "--siem-splunk", exists=True, dir_okay=False, readable=True,
+                                            help="Optional Splunk JSONL — cross-check fields.jj_audit_bundle_sha256."),
+    siem_datadog: Path | None = typer.Option(None, "--siem-datadog", exists=True, dir_okay=False, readable=True,
+                                             help="Optional Datadog JSONL — cross-check jj_audit_bundle_sha256."),
 ) -> None:
     """Verify the Ed25519 signature on an audit export package."""
     from .audit_verify import verify_from_files
-    res = verify_from_files(package, metadata, api_url=api_url)
+    res = verify_from_files(
+        package,
+        metadata,
+        api_url=api_url,
+        pdf_path=pdf,
+        otlp_path=otlp,
+        siem_splunk_path=siem_splunk,
+        siem_datadog_path=siem_datadog,
+    )
     if res.ok:
         console.print(f"[green]OK[/green] · sha256={res.digest} · key_id={res.key_id}")
         raise typer.Exit(code=0)

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -299,3 +299,56 @@ def test_verify_pdf_flatedecode_match(tmp_path, monkeypatch):
 
     result = verify_from_files(bundle_path, metadata_path, pdf_path=pdf_path)
     assert result.ok, result.reason
+
+
+def test_verify_otlp_jamjet_audit_not_object_fails(tmp_path, monkeypatch):
+    """A non-object _jamjet_audit value must fail with a clear message, not raise."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    otlp_path = tmp_path / "report.otlp.json"
+    otlp_path.write_text(json.dumps({
+        "resourceSpans": [],
+        "_jamjet_audit": "not an object — should fail loudly, not crash",
+    }))
+
+    result = verify_from_files(bundle_path, metadata_path, otlp_path=otlp_path)
+    assert not result.ok
+    assert "_jamjet_audit" in result.reason, result.reason
+    assert "not an object" in result.reason, result.reason
+
+
+def test_verify_siem_record_not_object_fails(tmp_path, monkeypatch):
+    """A SIEM JSONL line that is a non-object JSON value must fail with a clear message."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    siem_path = tmp_path / "report.datadog.jsonl"
+    # Each line is valid JSON but a non-object value
+    siem_path.write_text("[1, 2, 3]\n\"a string\"\n")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_datadog_path=siem_path)
+    assert not result.ok
+    assert "siem_datadog" in result.reason, result.reason
+    assert "not a JSON object" in result.reason, result.reason
+
+
+def test_verify_siem_splunk_missing_fields_container_fails(tmp_path, monkeypatch):
+    """A Splunk JSONL line without a `fields` object must fail with a clear message."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    siem_path = tmp_path / "report.splunk.jsonl"
+    line1 = json.dumps({
+        "time": 1730000000,
+        "host": "h",
+        "sourcetype": "jamjet:event",
+        "event": {"trace_id": "t1"},
+        # missing `fields` container entirely
+    })
+    siem_path.write_text(line1 + "\n")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_splunk_path=siem_path)
+    assert not result.ok
+    assert "siem_splunk" in result.reason, result.reason
+    assert "fields container" in result.reason, result.reason

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -192,7 +192,7 @@ def test_verify_pdf_bundle_sha256_mismatch_fails(tmp_path, monkeypatch):
 
     result = verify_from_files(bundle_path, metadata_path, pdf_path=pdf_path)
     assert not result.ok
-    assert "pdf metadata sha256" in result.reason.lower(), result.reason
+    assert "metadata sha256" in result.reason.lower(), result.reason
 
 
 def test_verify_otlp_resource_attribute_match(tmp_path, monkeypatch):
@@ -207,4 +207,95 @@ def test_verify_otlp_resource_attribute_match(tmp_path, monkeypatch):
     }))
 
     result = verify_from_files(bundle_path, metadata_path, otlp_path=otlp_path)
+    assert result.ok, result.reason
+
+
+def test_verify_siem_splunk_match(tmp_path, monkeypatch):
+    """Splunk JSONL with matching fields.jj_audit_bundle_sha256 verifies OK."""
+    bundle_path, metadata_path, pk_bytes, digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    siem_path = tmp_path / "report.splunk.jsonl"
+    line1 = json.dumps({
+        "time": 1730000000,
+        "host": "h",
+        "sourcetype": "jamjet:event",
+        "event": {"trace_id": "t1"},
+        "fields": {"jj_audit_bundle_sha256": digest_hex, "jj_project_id": "p1"},
+    })
+    siem_path.write_text(line1 + "\n")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_splunk_path=siem_path)
+    assert result.ok, result.reason
+
+
+def test_verify_siem_datadog_match(tmp_path, monkeypatch):
+    """Datadog JSONL with matching top-level jj_audit_bundle_sha256 verifies OK."""
+    bundle_path, metadata_path, pk_bytes, digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    siem_path = tmp_path / "report.datadog.jsonl"
+    line1 = json.dumps({
+        "ddsource": "jamjet",
+        "service": "agent",
+        "message": "x",
+        "jj_audit_bundle_sha256": digest_hex,
+    })
+    siem_path.write_text(line1 + "\n")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_datadog_path=siem_path)
+    assert result.ok, result.reason
+
+
+def test_verify_siem_empty_file_fails(tmp_path, monkeypatch):
+    """Empty SIEM file must fail — guards against attacker swapping in /dev/null."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    empty = tmp_path / "report.splunk.jsonl"
+    empty.write_text("")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_splunk_path=empty)
+    assert not result.ok
+    assert "no records" in result.reason.lower(), result.reason
+
+
+def test_verify_siem_mismatch_includes_flavor(tmp_path, monkeypatch):
+    """Mismatch error message must name the SIEM flavor for triage."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    siem_path = tmp_path / "report.datadog.jsonl"
+    line1 = json.dumps({
+        "ddsource": "jamjet",
+        "service": "agent",
+        "message": "x",
+        "jj_audit_bundle_sha256": "wrong" * 16,  # 80 chars, won't match real digest
+    })
+    siem_path.write_text(line1 + "\n")
+
+    result = verify_from_files(bundle_path, metadata_path, siem_datadog_path=siem_path)
+    assert not result.ok
+    assert "siem_datadog" in result.reason, result.reason
+
+
+def test_verify_pdf_flatedecode_match(tmp_path, monkeypatch):
+    """PDF with the digest hex inside a FlateDecode-compressed stream verifies OK."""
+    import zlib
+    bundle_path, metadata_path, pk_bytes, digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    compressed = zlib.compress(digest_hex.encode())
+    # Minimal hand-rolled PDF with one FlateDecoded content stream containing the digest.
+    pdf = (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n"
+        b"<< /Length " + str(len(compressed)).encode() + b" /Filter /FlateDecode >>\n"
+        b"stream\n" + compressed + b"\nendstream\nendobj\n"
+        b"%%EOF\n"
+    )
+    pdf_path = tmp_path / "report.pdf"
+    pdf_path.write_bytes(pdf)
+
+    result = verify_from_files(bundle_path, metadata_path, pdf_path=pdf_path)
     assert result.ok, result.reason

--- a/sdk/python/tests/test_audit_verify.py
+++ b/sdk/python/tests/test_audit_verify.py
@@ -1,7 +1,9 @@
 """Unit tests for jamjet.cloud.audit_verify."""
 from __future__ import annotations
 
+import base64
 import hashlib
+import json
 
 import pytest
 
@@ -127,3 +129,82 @@ def test_verify_from_files_handles_non_dict_bundle(tmp_path):
     result = verify_from_files(bundle_path, metadata_path)
     assert result.ok is False
     assert "JSON object" in result.reason
+
+
+# --- 4.E.β cross-check tests ---------------------------------------------
+from jamjet.cloud.audit_verify import verify_from_files  # noqa: E402
+
+
+def _make_signed_bundle(tmp_path):
+    """Helper: build a signed bundle + metadata + return (paths, public-key-bytes, digest_hex)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    bundle = b'{"project":{"id":"p1","name":"t"},"warnings":[]}\n'
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key()
+    digest = hashlib.sha256(bundle).digest()
+    digest_hex = digest.hex()
+    sig = sk.sign(digest)
+
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_bytes(bundle)
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps({
+        "id": "x",
+        "sha256_digest": digest_hex,
+        "signature_b64": base64.b64encode(sig).decode(),
+        "signing_key_id": "k1",
+    }))
+    pk_bytes = (pk.public_bytes_raw() if hasattr(pk, "public_bytes_raw")
+                else pk.public_bytes(encoding=Encoding.Raw, format=PublicFormat.Raw))
+    return bundle_path, metadata_path, pk_bytes, digest_hex
+
+
+def _patch_well_known(monkeypatch, pk_bytes):
+    def fake_get(url, *a, **kw):
+        class R:
+            status_code = 200
+            def raise_for_status(self_): pass
+            def json(self_): return [{"key_id": "k1", "public_key_b64": base64.b64encode(pk_bytes).decode()}]
+        return R()
+    monkeypatch.setattr("httpx.get", fake_get)
+
+
+def test_verify_with_pdf_metadata_match(tmp_path, monkeypatch):
+    """End-to-end: signed bundle + matching PDF -> OK."""
+    bundle_path, metadata_path, pk_bytes, digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    pdf_path = tmp_path / "report.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n" + digest_hex.encode() + b"\n%%EOF\n")
+
+    result = verify_from_files(bundle_path, metadata_path, pdf_path=pdf_path)
+    assert result.ok, result.reason
+
+
+def test_verify_pdf_bundle_sha256_mismatch_fails(tmp_path, monkeypatch):
+    """PDF whose embedded digest does not match the canonical bundle should fail."""
+    bundle_path, metadata_path, pk_bytes, _digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    pdf_path = tmp_path / "report.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n" + (b"0" * 64) + b"\n%%EOF\n")
+
+    result = verify_from_files(bundle_path, metadata_path, pdf_path=pdf_path)
+    assert not result.ok
+    assert "pdf metadata sha256" in result.reason.lower(), result.reason
+
+
+def test_verify_otlp_resource_attribute_match(tmp_path, monkeypatch):
+    """OTLP file with matching _jamjet_audit.bundle_sha256 should verify OK."""
+    bundle_path, metadata_path, pk_bytes, digest_hex = _make_signed_bundle(tmp_path)
+    _patch_well_known(monkeypatch, pk_bytes)
+
+    otlp_path = tmp_path / "report.otlp.json"
+    otlp_path.write_text(json.dumps({
+        "resourceSpans": [],
+        "_jamjet_audit": {"bundle_sha256": digest_hex, "scope_type": "trace", "scope_ref": "x", "generated_at": "now"},
+    }))
+
+    result = verify_from_files(bundle_path, metadata_path, otlp_path=otlp_path)
+    assert result.ok, result.reason


### PR DESCRIPTION
## Summary
- Adds optional `--pdf`, `--otlp`, `--siem-splunk`, `--siem-datadog` flags to the `jamjet-cloud audit-verify` CLI.
- For each format file passed, cross-checks that the file's embedded `bundle_sha256` matches the canonical JSON bundle's actual digest.
- Catches "PDF/OTLP/SIEM was re-rendered or tampered after JSON bundle was signed" — a tamper path that signature-only verification would miss.
- Empty SIEM file rejected (closes a swap-with-/dev/null tamper path).
- All cross-check error messages prefixed with the format kind for triage.

Pairs with **jamjet-cloud repo PR** for 4.E.β.

## Test plan
- [x] `pytest sdk/python/tests/test_audit_verify.py` — 17/17 tests pass
- [ ] Manual: download a real 4.E.β package (PDF + bundle + metadata) from a local cloud, run `jamjet-cloud audit-verify --bundle bundle.json --metadata metadata.json --pdf report.pdf`, expect OK
- [ ] Tamper test: modify PDF embedded sha256, expect verifier to fail with "pdf: metadata sha256 not found"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Audit bundle verification now includes optional cross-validation against supplementary artifacts: PDF documents, OTLP JSON exports, and SIEM event logs (Splunk and Datadog formats) to ensure bundle integrity.

* **Tests**
  * Comprehensive test coverage added for new cross-check verification functionality, including success and failure scenarios for all supported artifact formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->