### PR TITLE
perf(engram): batch-embed facts in import + extract paths

### DIFF
--- a/runtime/engram/src/memory.rs
+++ b/runtime/engram/src/memory.rs
@@ -385,6 +385,13 @@ impl Memory {
         // Batch-embed all fact texts in one provider call.
         let texts: Vec<&str> = facts.iter().map(|f| f.text.as_str()).collect();
         let embeddings = self.embedding.embed(&texts).await?;
+        if embeddings.len() != texts.len() {
+            return Err(MemoryError::Embedding(format!(
+                "provider returned {} embeddings for {} texts (cardinality mismatch)",
+                embeddings.len(),
+                texts.len(),
+            )));
+        }
 
         let mut imported: u64 = 0;
         for (mut fact, embedding) in facts.into_iter().zip(embeddings) {
@@ -481,6 +488,13 @@ impl Memory {
         } else {
             self.embedding.embed(&fact_texts).await?
         };
+        if batch_embeddings.len() != fact_texts.len() {
+            return Err(MemoryError::Embedding(format!(
+                "provider returned {} embeddings for {} texts (cardinality mismatch)",
+                batch_embeddings.len(),
+                fact_texts.len(),
+            )));
+        }
 
         for (extracted, embedding) in extraction.facts.into_iter().zip(batch_embeddings) {
             let mut fact = Fact::new(&extracted.text, scope.clone());

--- a/runtime/engram/src/memory.rs
+++ b/runtime/engram/src/memory.rs
@@ -379,13 +379,15 @@ impl Memory {
     ///
     /// Returns the number of facts successfully imported (skips duplicates by id).
     pub async fn import(&self, facts: Vec<Fact>) -> Result<u64, MemoryError> {
+        if facts.is_empty() {
+            return Ok(0);
+        }
+        // Batch-embed all fact texts in one provider call.
+        let texts: Vec<&str> = facts.iter().map(|f| f.text.as_str()).collect();
+        let embeddings = self.embedding.embed(&texts).await?;
+
         let mut imported: u64 = 0;
-        for mut fact in facts {
-            // Re-embed the fact text.
-            let mut embeddings = self.embedding.embed(&[fact.text.as_str()]).await?;
-            let embedding = embeddings.pop().ok_or_else(|| {
-                MemoryError::Embedding("provider returned empty embeddings".to_string())
-            })?;
+        for (mut fact, embedding) in facts.into_iter().zip(embeddings) {
             fact.embedding = embedding.clone();
 
             let fact_id = fact.id;
@@ -470,13 +472,17 @@ impl Memory {
 
         let mut fact_ids = Vec::new();
 
-        for extracted in extraction.facts {
-            // Create and embed the fact
-            let mut embeddings = self.embedding.embed(&[extracted.text.as_str()]).await?;
-            let embedding = embeddings
-                .pop()
-                .ok_or_else(|| MemoryError::Embedding("empty embedding".to_string()))?;
+        // Batch-embed all extracted facts in one provider call instead of N individual
+        // calls. This cuts N HTTP round trips to ollama down to 1, which is the main
+        // throughput bottleneck when ingesting large conversation batches.
+        let fact_texts: Vec<&str> = extraction.facts.iter().map(|f| f.text.as_str()).collect();
+        let batch_embeddings = if fact_texts.is_empty() {
+            vec![]
+        } else {
+            self.embedding.embed(&fact_texts).await?
+        };
 
+        for (extracted, embedding) in extraction.facts.into_iter().zip(batch_embeddings) {
             let mut fact = Fact::new(&extracted.text, scope.clone());
             fact.confidence = Some(extracted.confidence as f32);
             fact.category = extracted.category;


### PR DESCRIPTION
## Summary

Two-commit perf + correctness change to `runtime/engram/src/memory.rs`:

1. **Batch-embed facts in `import` and `extract` paths.** Previously each fact triggered its own `embedding.embed(&[text])` call — N HTTP round trips to ollama per import. Replaced with one batched call per path. Main throughput bottleneck when ingesting large conversation batches.

2. **Cardinality guard on the batched embeddings.** CodeRabbit flagged that `zip(embeddings)` silently truncates if the provider returns fewer/more vectors than texts; facts could drop without surfacing an error. Added explicit length check in both paths returning `MemoryError::Embedding` with a clear message.

This was originally bundled into `feat/audit-verify-beta` (PR #41) by accident — the SDK verifier branch was cut from local main before main was pushed. Splitting it out so the SDK PR's diff narrows to just the verifier work.

## Test plan
- [x] `cargo build -p jamjet-engram` — clean
- [x] `cargo test --lib -p jamjet-engram` — 66/66 passing
- [ ] Live: import a non-trivial conversation and observe the single batched embedding call (vs N) in ollama logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for text embeddings, with better detection of mismatched embedding counts.

* **Performance**
  * Optimized embedding operations through batch processing for faster execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->