### PR TITLE
chore: broaden Claude/skill artifact ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,10 @@ strategy/
 docs/superpowers/
 paper/
 
-# Local AI/editor agent config
-.claude/*.local.*
-.claude/settings.local.json
+# Local AI/editor agent config — never commit Claude/skill artifacts
+.claude/
+.superpowers/
+.playwright-mcp/
 .cursor/
 .copilot/
 


### PR DESCRIPTION
## Summary

Mirrors the rule established in `jamjet-cloud` PR #9 so Claude/skill-generated files can't slip into this repo either.

**Before:**
- `.claude/*.local.*` and `.claude/settings.local.json` — narrow patterns that only ignore local-suffixed files; most things under `.claude/` (skills, settings.json, hooks) would still track if accidentally `git add`ed.

**After:**
- `.claude/` — full directory.
- `.superpowers/` — superpowers cache/state directory (already untracked but unprotected).
- `.playwright-mcp/` — Playwright MCP runtime state (already untracked but unprotected).

`docs/superpowers/`, `.cursor/`, `.copilot/`, `CLAUDE.md`, `strategy/`, `paper/` were already ignored.

No tracked files removed — `git ls-files` confirms nothing matching these patterns is currently in the repo.

## Test plan
- [ ] CI green (no behaviour changes; pure ignore-rule update)
