### PR TITLE
fix(cloud): tighten Span.kind to EventKind Literal + runtime validation

### DIFF
--- a/sdk/python/jamjet/cloud/models.py
+++ b/sdk/python/jamjet/cloud/models.py
@@ -3,7 +3,25 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal, get_args
+
+# Mirrors the events_kind_check constraint on the cloud side (migration 0008).
+# Sending any other value used to surface as a 500 from the DB; the server
+# now returns 400, and this Literal lets static type checkers catch the same
+# class of bug at write time. ALLOWED_KINDS is the runtime counterpart for
+# `__post_init__` validation and for users who compose `kind` from a variable.
+EventKind = Literal[
+    "llm_call",
+    "tool_call",
+    "policy_decision",
+    "approval",
+    "budget_check",
+    "error",
+    "custom",
+    "mcp_tool_call",
+    "agent_call",
+]
+ALLOWED_KINDS: tuple[str, ...] = get_args(EventKind)
 
 
 @dataclass
@@ -12,7 +30,7 @@ class Span:
 
     trace_id: str
     span_id: str
-    kind: str
+    kind: EventKind
     name: str
     parent_span_id: str | None = None
     sequence: int = 0
@@ -45,6 +63,13 @@ class Span:
     end_user_email: str | None = None
     tags: tuple[str, ...] = ()
     _start_time: float = field(default_factory=time.monotonic, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.kind not in ALLOWED_KINDS:
+            raise ValueError(
+                f"Invalid event kind {self.kind!r}. Must be one of: "
+                f"{', '.join(ALLOWED_KINDS)}"
+            )
 
     def finish(self, status: str = "ok", duration_ms: float | None = None) -> None:
         """Mark span as finished with a status and computed duration."""

--- a/sdk/python/jamjet/cloud/trace.py
+++ b/sdk/python/jamjet/cloud/trace.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 
 from .agent import get_current_agent
 from .events import emit
-from .models import Span
+from .models import EventKind, Span
 from .propagation import get_originating
 from .user_context import get_process_context, get_user_context
 
@@ -24,7 +24,7 @@ class TraceContext:
         self._seq: int = 0
         self._lock = threading.Lock()
 
-    def new_span(self, kind: str, name: str) -> Span:
+    def new_span(self, kind: EventKind, name: str) -> Span:
         """Create a new Span belonging to this trace, tagged with the current
         agent and (when applicable) cross-trace lineage from the upstream caller."""
         with self._lock:

--- a/sdk/python/tests/test_cloud_models.py
+++ b/sdk/python/tests/test_cloud_models.py
@@ -1,0 +1,40 @@
+"""Issue jamjet-cloud#14 (server side) → mirror on the SDK side.
+
+Constructing a Span with a kind outside the cloud's events_kind_check
+constraint must raise ValueError immediately, not at flush time. The
+server's allowed set lives in ALLOWED_KINDS (single source of truth via
+typing.get_args(EventKind)).
+"""
+from __future__ import annotations
+
+from typing import get_args
+
+import pytest
+
+from jamjet.cloud.models import ALLOWED_KINDS, EventKind, Span
+
+
+def _span(kind: str) -> Span:
+    return Span(trace_id="tr_x", span_id="sp_x", kind=kind, name="probe")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("ok_kind", list(get_args(EventKind)))
+def test_long_form_kinds_construct_cleanly(ok_kind: str) -> None:
+    s = _span(ok_kind)
+    assert s.kind == ok_kind
+
+
+@pytest.mark.parametrize("bad_kind", ["llm", "tool", "agent", "step", ""])
+def test_short_form_kinds_raise_value_error_with_allowed_list(bad_kind: str) -> None:
+    with pytest.raises(ValueError) as exc:
+        _span(bad_kind)
+    msg = str(exc.value)
+    assert "Invalid event kind" in msg
+    assert "llm_call" in msg, f"expected allowed list in error, got {msg!r}"
+
+
+def test_allowed_kinds_matches_event_kind_literal() -> None:
+    """ALLOWED_KINDS and EventKind must stay in sync — one is the runtime
+    counterpart of the other. The cloud server-side constraint is the
+    upstream source; this test catches local drift."""
+    assert tuple(ALLOWED_KINDS) == get_args(EventKind)


### PR DESCRIPTION
SDK-side companion to **jamjet-labs/jamjet-cloud#17** (server-side validation that closes jamjet-cloud#14).

## Summary
- `Span.kind` was typed `str` with no docstring listing valid values. Users guessed `"llm"`, `"tool"`, `"agent"`, `"step"` and got opaque server errors. Now:
  - `EventKind` Literal alias mirrors the cloud's `events_kind_check` constraint (long forms only).
  - `Span.__post_init__` raises `ValueError` with the allowed list when an unknown kind sneaks past the type checker (e.g. dynamic `str`).
  - `TraceContext.new_span(kind: EventKind, …)` carries the type through the public API so static type checkers catch typos at write time.
- `ALLOWED_KINDS` is `get_args(EventKind)` — single source of truth, no risk of the runtime list and the type alias drifting apart (test asserts this).

## What this does NOT change
- The wire format and HTTP path are unchanged. The cloud API is the authoritative validator (see PR #17 on jamjet-cloud).
- No bump to PyPI version yet — pairs with the cloud-side merge before release.

## Test plan
- [x] `pytest sdk/python/tests/test_cloud_models.py -v` — 15 passed (9 long-form, 5 short-form rejects, 1 drift detector)
- [x] `pytest sdk/python/tests/test_cloud_replay.py sdk/python/tests/test_redaction.py` — 27 passed (no regressions)
- [ ] Pair with jamjet-cloud PR #17 before merging — server should be returning 400s on legacy short-form payloads first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Span creation now validates event kinds against allowed values, raising clear error messages that list valid options when invalid kinds are provided.

* **Improvements**
  * Enhanced type safety for the trace API, providing better IDE autocompletion, faster validation, and catching invalid event kinds earlier in development.

* **Tests**
  * Added comprehensive validation tests for event kind constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamjet-labs/jamjet/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->