### PR TITLE
Phase 1 (TS): @jamjet/cloud 0.2.2 — safety demos + README hero

### DIFF
--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -28,8 +28,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck
+      # Build before typecheck so @jamjet/cloud-vercel can resolve
+      # @jamjet/cloud's emitted .d.ts (workspace dep typecheck order).
       - run: pnpm build
+      - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm size
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -2,13 +2,26 @@
 
 Monorepo for JamJet's TypeScript SDK packages.
 
-| Package | Status |
-|---|---|
-| `@jamjet/cloud` | In development (Plan 1) |
-| `@jamjet/cloud-vercel` | Planned (Plan 3) |
-| `@jamjet/cli` | Planned (Plan 4) |
+| Package | npm | Status |
+|---|---|---|
+| `@jamjet/cloud` | [0.2.2](https://www.npmjs.com/package/@jamjet/cloud) | Plan 1 + 2 + safety-demo wedge |
+| `@jamjet/cloud-vercel` | [0.1.0](https://www.npmjs.com/package/@jamjet/cloud-vercel) | Plan 3 — Vercel AI SDK adapter |
 
 Internal design specs live in `docs/superpowers/` (not committed). Public docs are at [jamjet.dev](https://jamjet.dev).
+
+## Examples
+
+Four zero-setup safety demos under `examples/`:
+
+- `01-block-unsafe-tool` — block a destructive tool call before execution
+- `02-human-approval` — pause for human approval on a risky action
+- `03-budget-cap` — stop a runaway agent loop at a hard dollar cap
+- `04-mcp-tool-policy` — evaluate policy against an MCP-shaped envelope (Gateway preview)
+
+```bash
+pnpm install
+pnpm --filter @jamjet/example-01-block-unsafe-tool start
+```
 
 ## Dev setup
 

--- a/sdk/typescript/examples/01-block-unsafe-tool/README.md
+++ b/sdk/typescript/examples/01-block-unsafe-tool/README.md
@@ -1,0 +1,32 @@
+# 01 — Block an unsafe tool call
+
+Show JamJet's policy enforcement blocking a destructive tool call before execution.
+
+## Run
+
+```bash
+pnpm install
+pnpm start
+```
+
+## Expected output
+
+```
+Tool: database.delete_all_customers
+Policy: block '*delete*'
+Decision: BLOCKED
+Executed: false
+The model is mocked. The enforcement path is real.
+```
+
+## What this proves
+
+The agent (mocked) plans `database.delete_all_customers`. The runtime policy
+matches `*delete*` and blocks the call. Nothing executes. No API key, no
+network — this exercises the enforcement path directly.
+
+## Same enforcement, different surfaces
+
+The same `PolicyEvaluator` runs inside `@jamjet/cloud` auto-instrumentation —
+when `init()` is configured, every OpenAI / Anthropic call in your process is
+filtered by this policy.

--- a/sdk/typescript/examples/01-block-unsafe-tool/README.md
+++ b/sdk/typescript/examples/01-block-unsafe-tool/README.md
@@ -11,7 +11,7 @@ pnpm start
 
 ## Expected output
 
-```
+```text
 Tool: database.delete_all_customers
 Policy: block '*delete*'
 Decision: BLOCKED

--- a/sdk/typescript/examples/01-block-unsafe-tool/index.ts
+++ b/sdk/typescript/examples/01-block-unsafe-tool/index.ts
@@ -1,0 +1,22 @@
+// Block an unsafe tool call before execution. No API key required.
+//
+// Uses the @jamjet/cloud PolicyEvaluator primitive directly — no network,
+// no init(), no Cloud account. Mirrors examples/01-block-unsafe-tool (Python).
+
+import { PolicyEvaluator } from '@jamjet/cloud'
+
+function main(): void {
+  const evaluator = new PolicyEvaluator()
+  evaluator.add('block', '*delete*')
+
+  const tool = 'database.delete_all_customers'
+  const decision = evaluator.evaluate(tool)
+
+  console.log(`Tool: ${tool}`)
+  console.log(`Policy: block '*delete*'`)
+  console.log(`Decision: ${decision.blocked ? 'BLOCKED' : 'ALLOWED'}`)
+  console.log(`Executed: ${decision.blocked ? 'false' : 'true'}`)
+  console.log('The model is mocked. The enforcement path is real.')
+}
+
+main()

--- a/sdk/typescript/examples/01-block-unsafe-tool/package.json
+++ b/sdk/typescript/examples/01-block-unsafe-tool/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jamjet/example-01-block-unsafe-tool",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@jamjet/cloud": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/typescript/examples/01-block-unsafe-tool/tsconfig.json
+++ b/sdk/typescript/examples/01-block-unsafe-tool/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/sdk/typescript/examples/02-human-approval/README.md
+++ b/sdk/typescript/examples/02-human-approval/README.md
@@ -11,7 +11,7 @@ pnpm start
 
 ## Expected output
 
-```
+```text
 Tool: payments.refund
 Policy: payments.* requires approval
 Decision: WAITING_FOR_APPROVAL

--- a/sdk/typescript/examples/02-human-approval/README.md
+++ b/sdk/typescript/examples/02-human-approval/README.md
@@ -1,0 +1,29 @@
+# 02 — Human approval for risky actions
+
+Show JamJet pausing a tool call until a human approves.
+
+## Run
+
+```bash
+pnpm install
+pnpm start
+```
+
+## Expected output
+
+```
+Tool: payments.refund
+Policy: payments.* requires approval
+Decision: WAITING_FOR_APPROVAL
+Approve via your control plane, then resume.
+The model is mocked. The enforcement path is real.
+```
+
+## What this proves
+
+The agent (mocked) plans `payments.refund`. The runtime policy matches
+`payments.*` with `require_approval` and pauses. No API key, no network.
+
+In a live `init()`-backed app the policy evaluator runs in-process; the
+companion `requireApproval()` helper then polls JamJet Cloud until a human
+approves or rejects via the dashboard.

--- a/sdk/typescript/examples/02-human-approval/index.ts
+++ b/sdk/typescript/examples/02-human-approval/index.ts
@@ -1,0 +1,26 @@
+// Pause for human approval on a risky action. No API key required.
+//
+// Uses the @jamjet/cloud PolicyEvaluator primitive directly — no network,
+// no init(), no Cloud account. Mirrors examples/02-human-approval (Python).
+
+import { PolicyEvaluator } from '@jamjet/cloud'
+
+function main(): void {
+  const evaluator = new PolicyEvaluator()
+  evaluator.add('require_approval', 'payments.*')
+
+  const tool = 'payments.refund'
+  const decision = evaluator.evaluate(tool)
+
+  console.log(`Tool: ${tool}`)
+  console.log('Policy: payments.* requires approval')
+  if (decision.policyKind === 'require_approval') {
+    console.log('Decision: WAITING_FOR_APPROVAL')
+    console.log('Approve via your control plane, then resume.')
+  } else {
+    console.log('Decision: ALLOWED')
+  }
+  console.log('The model is mocked. The enforcement path is real.')
+}
+
+main()

--- a/sdk/typescript/examples/02-human-approval/package.json
+++ b/sdk/typescript/examples/02-human-approval/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jamjet/example-02-human-approval",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@jamjet/cloud": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/typescript/examples/02-human-approval/tsconfig.json
+++ b/sdk/typescript/examples/02-human-approval/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/sdk/typescript/examples/03-budget-cap/README.md
+++ b/sdk/typescript/examples/03-budget-cap/README.md
@@ -11,7 +11,7 @@ pnpm start
 
 ## Expected output
 
-```
+```text
 Step 1: search.web $0.02  ALLOWED
 Step 2: search.web $0.02  ALLOWED
 Step 3: search.web $0.02  BUDGET_EXCEEDED

--- a/sdk/typescript/examples/03-budget-cap/README.md
+++ b/sdk/typescript/examples/03-budget-cap/README.md
@@ -1,0 +1,32 @@
+# 03 — Budget cap
+
+Show JamJet stopping a runaway agent loop at a hard dollar cap.
+
+## Run
+
+```bash
+pnpm install
+pnpm start
+```
+
+## Expected output
+
+```
+Step 1: search.web $0.02  ALLOWED
+Step 2: search.web $0.02  ALLOWED
+Step 3: search.web $0.02  BUDGET_EXCEEDED
+Spent: $0.04 of $0.05 cap
+Decision: BUDGET_EXCEEDED
+The model is mocked. The enforcement path is real.
+```
+
+## What this proves
+
+A three-step `search.web` loop runs against a `BudgetManager` capped at $0.05.
+The third call would push spend over the cap, so it throws
+`JamjetBudgetExceeded` before the cost is recorded. No API key, no network —
+this exercises the budget enforcement path directly.
+
+In a live `init()`-backed app the same `BudgetManager` is wired to the
+auto-patcher; every OpenAI / Anthropic call's cost is recorded automatically
+and the budget short-circuits before the model is hit.

--- a/sdk/typescript/examples/03-budget-cap/index.ts
+++ b/sdk/typescript/examples/03-budget-cap/index.ts
@@ -1,0 +1,43 @@
+// Stop a runaway agent loop at a $0.05 budget cap. No API key required.
+//
+// Uses the @jamjet/cloud BudgetManager primitive directly — no network,
+// no init(), no Cloud account. Mirrors examples/03-budget-cap (Python).
+
+import { BudgetManager, JamjetBudgetExceeded } from '@jamjet/cloud'
+
+const CAP_USD = 0.05
+const STEPS: Array<[string, number]> = [
+  ['search.web', 0.02],
+  ['search.web', 0.02],
+  ['search.web', 0.02],
+]
+
+function main(): void {
+  const budget = new BudgetManager(CAP_USD)
+  let blocked: number | null = null
+
+  for (let i = 0; i < STEPS.length; i++) {
+    const step = STEPS[i]
+    if (!step) continue
+    const [tool, cost] = step
+    const stepNo = i + 1
+    try {
+      budget.checkOrThrow({ estimatedCost: cost })
+      budget.record(cost)
+      console.log(`Step ${stepNo}: ${tool} $${cost.toFixed(2)}  ALLOWED`)
+    } catch (err) {
+      if (err instanceof JamjetBudgetExceeded) {
+        blocked = stepNo
+        console.log(`Step ${stepNo}: ${tool} $${cost.toFixed(2)}  BUDGET_EXCEEDED`)
+        break
+      }
+      throw err
+    }
+  }
+
+  console.log(`Spent: $${budget.spent.toFixed(2)} of $${CAP_USD.toFixed(2)} cap`)
+  console.log(blocked !== null ? 'Decision: BUDGET_EXCEEDED' : 'Decision: WITHIN_BUDGET')
+  console.log('The model is mocked. The enforcement path is real.')
+}
+
+main()

--- a/sdk/typescript/examples/03-budget-cap/package.json
+++ b/sdk/typescript/examples/03-budget-cap/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jamjet/example-03-budget-cap",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@jamjet/cloud": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/typescript/examples/03-budget-cap/tsconfig.json
+++ b/sdk/typescript/examples/03-budget-cap/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/sdk/typescript/examples/04-mcp-tool-policy/README.md
+++ b/sdk/typescript/examples/04-mcp-tool-policy/README.md
@@ -16,7 +16,7 @@ pnpm start
 
 ## Expected output
 
-```
+```text
 Server: postgres-mcp
 Tool: postgres/database.delete_all_customers
 Policy: block '*delete*'

--- a/sdk/typescript/examples/04-mcp-tool-policy/README.md
+++ b/sdk/typescript/examples/04-mcp-tool-policy/README.md
@@ -1,0 +1,27 @@
+# 04 — MCP-shaped tool policy (preview)
+
+Show JamJet evaluating policy against an MCP-shaped tool request. This is a
+**preview** of the upcoming JamJet Gateway, which will run as an MCP proxy
+between Claude Desktop / Cursor / any MCP client and the real MCP servers.
+
+Today the demo evaluates the policy synchronously. The Gateway will run as a
+standalone process and apply the same policy across networked MCP traffic.
+
+## Run
+
+```bash
+pnpm install
+pnpm start
+```
+
+## Expected output
+
+```
+Server: postgres-mcp
+Tool: postgres/database.delete_all_customers
+Policy: block '*delete*'
+Decision: BLOCKED
+This demo uses an MCP-shaped request envelope to show policy evaluation.
+It is not yet an MCP proxy. Full MCP proxy support is planned for JamJet Gateway.
+The model is mocked. The enforcement path is real.
+```

--- a/sdk/typescript/examples/04-mcp-tool-policy/index.ts
+++ b/sdk/typescript/examples/04-mcp-tool-policy/index.ts
@@ -1,0 +1,35 @@
+// Evaluate a policy against an MCP-shaped request envelope. Preview of
+// JamJet Gateway. No API key required.
+//
+// Uses the @jamjet/cloud PolicyEvaluator primitive directly — no network,
+// no init(), no Cloud account. Mirrors examples/04-mcp-tool-policy (Python).
+
+import { PolicyEvaluator } from '@jamjet/cloud'
+
+interface McpEnvelope {
+  server: string
+  tool: string
+  arguments: Record<string, unknown>
+}
+
+function main(): void {
+  const evaluator = new PolicyEvaluator()
+  evaluator.add('block', '*delete*')
+
+  const envelope: McpEnvelope = {
+    server: 'postgres-mcp',
+    tool: 'postgres/database.delete_all_customers',
+    arguments: { confirm: true },
+  }
+  const decision = evaluator.evaluate(envelope.tool)
+
+  console.log(`Server: ${envelope.server}`)
+  console.log(`Tool: ${envelope.tool}`)
+  console.log(`Policy: block '*delete*'`)
+  console.log(`Decision: ${decision.blocked ? 'BLOCKED' : 'ALLOWED'}`)
+  console.log('This demo uses an MCP-shaped request envelope to show policy evaluation.')
+  console.log('It is not yet an MCP proxy. Full MCP proxy support is planned for JamJet Gateway.')
+  console.log('The model is mocked. The enforcement path is real.')
+}
+
+main()

--- a/sdk/typescript/examples/04-mcp-tool-policy/package.json
+++ b/sdk/typescript/examples/04-mcp-tool-policy/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@jamjet/example-04-mcp-tool-policy",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@jamjet/cloud": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/typescript/examples/04-mcp-tool-policy/tsconfig.json
+++ b/sdk/typescript/examples/04-mcp-tool-policy/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}

--- a/sdk/typescript/packages/cloud/README.md
+++ b/sdk/typescript/packages/cloud/README.md
@@ -26,7 +26,7 @@ pnpm --filter @jamjet/example-01-block-unsafe-tool start
 
 Output:
 
-```
+```text
 Tool: database.delete_all_customers
 Policy: block '*delete*'
 Decision: BLOCKED

--- a/sdk/typescript/packages/cloud/README.md
+++ b/sdk/typescript/packages/cloud/README.md
@@ -2,7 +2,41 @@
 
 [![npm version](https://img.shields.io/npm/v/@jamjet/cloud.svg)](https://www.npmjs.com/package/@jamjet/cloud)
 
-Drop-in governance for TypeScript AI applications. Two-line install gets you spans, cost tracking, and PII redaction in [JamJet Cloud](https://app.jamjet.dev).
+**The open-source safety layer for AI agents — TypeScript edition.**
+
+- **Block** unsafe tool calls at runtime
+- **Pause** for human approval on risky actions
+- **Cap** cost per agent, per run, per project
+- **Audit** every decision the agent made
+- **Replay or resume** a crashed run
+
+Keep your AI framework (Vercel AI SDK, OpenAI SDK, Anthropic SDK, LangChain.js).
+Add `@jamjet/cloud` where tool calls need control.
+
+## See it in 60 seconds
+
+Clone the repo and run the four safety demos — no API keys, no network calls:
+
+```bash
+git clone https://github.com/jamjet-labs/jamjet.git
+cd jamjet/sdk/typescript
+pnpm install
+pnpm --filter @jamjet/example-01-block-unsafe-tool start
+```
+
+Output:
+
+```
+Tool: database.delete_all_customers
+Policy: block '*delete*'
+Decision: BLOCKED
+Executed: false
+The model is mocked. The enforcement path is real.
+```
+
+The other three demos live in `examples/02-human-approval`, `examples/03-budget-cap`,
+and `examples/04-mcp-tool-policy`. Each exercises a different enforcement path
+with the same zero-setup contract.
 
 ## Install
 
@@ -57,6 +91,39 @@ import { init, wrap } from '@jamjet/cloud'
 await init({ apiKey: process.env.JAMJET_API_KEY!, project: 'my-app' })
 const openai = wrap(new OpenAI())
 ```
+
+## Add a policy
+
+```ts
+import { init, policy, budget } from '@jamjet/cloud'
+
+await init({ apiKey: process.env.JAMJET_API_KEY!, project: 'my-app' })
+
+policy('block', 'database.*delete*')
+policy('require_approval', 'payments.*')
+budget(5.00) // hard cap in USD
+```
+
+`policy()` and `budget()` apply to every wrapped LLM client in the process.
+Blocked tools are stripped before the model sees them; budget exhaustion throws
+`JamjetBudgetExceeded` before the next call goes out.
+
+## Standalone primitives (no Cloud account)
+
+The same evaluator that powers the auto-patcher is also exposed directly —
+useful for tests, gateways, or any code that wants policy enforcement without
+spinning up a `Client`:
+
+```ts
+import { PolicyEvaluator, BudgetManager } from '@jamjet/cloud'
+
+const evaluator = new PolicyEvaluator()
+evaluator.add('block', '*delete*')
+const decision = evaluator.evaluate('database.delete_all_customers')
+// decision.blocked === true
+```
+
+This is the path the four `examples/0*` demos take.
 
 ## Testing
 

--- a/sdk/typescript/packages/cloud/package.json
+++ b/sdk/typescript/packages/cloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jamjet/cloud",
-  "version": "0.2.1",
-  "description": "JamJet Cloud SDK — drop-in governance for TypeScript AI apps",
+  "version": "0.2.2",
+  "description": "JamJet — open-source safety layer for AI agents (TypeScript). Block unsafe tool calls, require approval, enforce budgets, audit, replay.",
   "license": "Apache-2.0",
   "type": "module",
   "files": ["dist", "README.md"],
@@ -59,7 +59,19 @@
     "access": "public",
     "provenance": true
   },
-  "keywords": ["jamjet", "ai", "agents", "governance", "observability", "openai", "anthropic"],
+  "keywords": [
+    "jamjet",
+    "ai",
+    "agents",
+    "agent-safety",
+    "governance",
+    "observability",
+    "openai",
+    "anthropic",
+    "mcp",
+    "human-in-the-loop",
+    "audit-log"
+  ],
   "homepage": "https://jamjet.dev",
   "repository": {
     "type": "git",

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.2.0'
+export const VERSION = '0.2.2'
 
 export { init } from './init.js'
 export { wrap } from './wrap.js'
@@ -24,6 +24,8 @@ export {
 export type { RequireApprovalOptions } from './governance.js'
 export type { AgentRef, UserContext } from './context.js'
 export type { PolicyAction, PolicyDecision } from './policy.js'
+export { PolicyEvaluator } from './policy.js'
+export { BudgetManager } from './budget.js'
 export {
   JamjetBudgetExceeded,
   JamjetPolicyBlocked,

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -12,6 +12,58 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
 
+  examples/01-block-unsafe-tool:
+    dependencies:
+      '@jamjet/cloud':
+        specifier: workspace:*
+        version: link:../../packages/cloud
+    devDependencies:
+      tsx:
+        specifier: ^4.16.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+  examples/02-human-approval:
+    dependencies:
+      '@jamjet/cloud':
+        specifier: workspace:*
+        version: link:../../packages/cloud
+    devDependencies:
+      tsx:
+        specifier: ^4.16.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+  examples/03-budget-cap:
+    dependencies:
+      '@jamjet/cloud':
+        specifier: workspace:*
+        version: link:../../packages/cloud
+    devDependencies:
+      tsx:
+        specifier: ^4.16.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+  examples/04-mcp-tool-policy:
+    dependencies:
+      '@jamjet/cloud':
+        specifier: workspace:*
+        version: link:../../packages/cloud
+    devDependencies:
+      tsx:
+        specifier: ^4.16.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
   examples/smoke-test:
     dependencies:
       '@ai-sdk/openai':


### PR DESCRIPTION
## Summary

Phase 1 parity for the TypeScript SDK. Ships `@jamjet/cloud@0.2.2` with four zero-setup safety demos mirroring the Python `jamjet 0.8.1` release, plus a README hero rewrite leading with the safety wedge instead of observability framing.

This is the TS half of the Phase 1 launch — same wedge, different language ergonomics.

## What ships

### Four safety demos (`sdk/typescript/examples/0{1,2,3,4}-*/`)

| Example | Story |
|---|---|
| `01-block-unsafe-tool` | Mock agent → `database.delete_all_customers` → `BLOCKED` via `PolicyEvaluator` |
| `02-human-approval` | Mock agent → `payments.refund` → `WAITING_FOR_APPROVAL` (illustrative; resume flow documented) |
| `03-budget-cap` | 3-step mock loop → `BUDGET_EXCEEDED` at `$0.05` cap via `BudgetManager` |
| `04-mcp-tool-policy` | MCP-shaped envelope → `BLOCKED` → footer foreshadows JamJet Gateway |

Each example: standalone `index.ts`, `package.json` with `"start": "tsx index.ts"`, mirrored `README.md` + expected-output documented. **Zero setup** — no API keys, no network calls. Every demo prints **"The model is mocked. The enforcement path is real."**

### Zero-setup primitives exposed at root

The agent ran into the fact that TS `policy()` / `budget()` / `init()` require a live Cloud client and would force API-key setup for the demos. To avoid that and match the Python pattern (`from jamjet.cloud.policy import PolicyEvaluator`), two classes were promoted from internal to public root exports:

```ts
export { PolicyEvaluator } from './policy.js'
export { BudgetManager } from './budget.js'
```

**Semver note:** additive change under a patch bump (allowed by semver), but it widens what consumers can pin against. If you'd rather lock these to `0.3.0` minor bump for safety, the version is the only thing to change.

### `@jamjet/cloud` package metadata

- `version`: `0.2.1` → `0.2.2`
- `description`: rewritten to lead with safety wedge — *"JamJet — open-source safety layer for AI agents (TypeScript). Block unsafe tool calls, require approval, enforce budgets, audit, replay."*
- `keywords`: added `agent-safety`, `mcp`, `human-in-the-loop`, `audit-log`

### README hero rewrite (`sdk/typescript/packages/cloud/README.md`)

Was: *"Drop-in governance for TypeScript AI applications. Two-line install gets you spans, cost tracking, and PII redaction in JamJet Cloud."* (observability framing)

Now: 5-bullet safety wedge (block / approve / cap / audit / replay) + 60-second demo block + new "Standalone primitives (no Cloud account)" section. Existing Next.js / Express / Vercel AI SDK quickstart sections preserved below the fold.

### Top-level `sdk/typescript/README.md` package table updated

Now reflects published state with npm version badges instead of "in development" status.

## Tests

- `@jamjet/cloud`: **142/142 passing** (20 test files), build clean, typecheck clean
- `@jamjet/cloud-vercel`: **22/22 passing**, no regressions

Each example was verified end-to-end via `node --import tsx index.ts` and produces output character-equivalent to the Python `expected-output.txt`.

## Test plan

- [ ] `pnpm install && pnpm -r build && pnpm -r test` from `sdk/typescript/` — all green
- [ ] `cd sdk/typescript/examples/01-block-unsafe-tool && pnpm install && pnpm start` — exit 0 with honesty line
- [ ] Repeat for 02, 03, 04
- [ ] `pnpm typecheck` clean across workspace
- [ ] Visual check README renders correctly on github.com
- [ ] Spot-check the new `PolicyEvaluator` / `BudgetManager` exports in the built `dist/index.d.ts` for type accuracy

## Out of scope (deferred)

- **`pnpm publish @jamjet/cloud@0.2.2`** — held until merge + your gate
- **JamJet Gateway** — separate Phase 2 spec
- **`@jamjet/cloud-vercel` rewrite** — adapter package stays as-is for this PR

## Related

Mirrors the Python PR #48 (`jamjet 0.8.1`) which shipped the same wedge for Python. Same wedge, two languages, same launch window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new TypeScript safety demo examples: blocking unsafe tool calls, requiring human approval, enforcing budget caps, and evaluating MCP requests against policies.
  * Expanded SDK exports with additional standalone primitives for direct policy evaluation and budget management without requiring a cloud account.

* **Documentation**
  * Enhanced SDK README with improved product positioning and comprehensive documentation of policy/budget usage patterns and standalone implementation options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamjet-labs/jamjet/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->