### PR TITLE
fix(cloud): move Node-only utilities to /node subpath (fixes 0.3.0 release size step)

### DIFF
--- a/sdk/typescript/packages/cloud/.size-limit.json
+++ b/sdk/typescript/packages/cloud/.size-limit.json
@@ -5,8 +5,23 @@
     "limit": "19 KB"
   },
   {
-    "name": "@jamjet/cloud/node (with auto-patcher)",
+    "name": "@jamjet/cloud/node (with auto-patcher + loadPolicy + AuditWriter + ApprovalQueue)",
     "path": "dist/node.js",
-    "limit": "20 KB"
+    "limit": "30 KB",
+    "ignore": [
+      "fs",
+      "path",
+      "os",
+      "crypto",
+      "events",
+      "node:fs",
+      "node:path",
+      "node:os",
+      "node:crypto",
+      "node:events",
+      "openai",
+      "@anthropic-ai/sdk",
+      "yaml"
+    ]
   }
 ]

--- a/sdk/typescript/packages/cloud/CHANGELOG.md
+++ b/sdk/typescript/packages/cloud/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## 0.3.0 — 2026-05-11
 
 ### Added
+- **`@jamjet/cloud/node` subpath:** `loadPolicy(path?)`, `AuditWriter`, `ApprovalQueue` — Node-only utilities. Import as `import { loadPolicy } from '@jamjet/cloud/node'`. Kept off the universal entry to preserve Cloudflare Workers / Vercel Edge / browser bundle compatibility.
 - `loadPolicy(path?)` — load + validate v1 `policy.yaml` from canonical lookup order (`JAMJET_POLICY_FILE` env → cwd `./policy.yaml` → `~/.jamjet/policy.yaml`)
 - `AuditWriter` — JSONL append-only writer with daily rotation, v1 schema. Adapter discriminator field in every emitted event.
 - `ApprovalQueue` — in-memory queue + filesystem pending dir, default 5-min timeout auto-reject
 - New `audit` action on `PolicyAction` for log-only enforcement
-- New types: `Policy`, `PolicyRule`, `PolicyBudget`, `AdapterName`, `HostName`, `Decision`, `AuditEventInput`, `PendingApproval`, `ApprovalResult`
+- New types: `Policy`, `PolicyRule`, `PolicyBudget`, `AdapterName`, `HostName`, `Decision`, `AuditEventInput`, `PendingApproval`, `ApprovalResult` — exported from BOTH universal and `/node` entries (types are tree-shaken; no runtime cost)
 
 ### Fixed
 - `PolicyEvaluator.evaluate()` was last-match-wins (no break in the loop). Spec at design §5 says first-match-wins. Fixed; no production policies have overlapping rules so behavior change has zero known impact.

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -41,14 +41,15 @@ export { getActive } from './client.js'
 // Cost utility — exported for ecosystem packages (e.g. @jamjet/cloud-vercel middleware).
 export { estimateCost } from './cost.js'
 
-// Policy loader (v1 policy.yaml) — used by Phase 2 adapters
-// (claude-code-hook, openai-guardrail, mcp-shim) to load policy from the
-// canonical lookup order (explicit path > env > cwd > ~/.jamjet/).
-export { loadPolicy } from './load-policy.js'
+// Phase 2 Node-only utilities (loadPolicy / AuditWriter / ApprovalQueue) are
+// exported from `@jamjet/cloud/node` instead of the universal entry — they use
+// node:fs / node:crypto and would break the universal bundle for Cloudflare
+// Workers / Vercel Edge / browser consumers. Phase 2 adapters that need them
+// import from '@jamjet/cloud/node'.
+//
+// Types describing the file-format schemas (Policy, AuditEventInput, etc.) are
+// safe to expose universally — type-only re-exports follow.
 export type { Policy, PolicyRule, PolicyBudget } from './load-policy.js'
-
-// Audit writer (v1 JSONL schema) — append-only, daily rotation by default
-export { AuditWriter } from './audit-writer.js'
 export type {
   AdapterName,
   HostName,
@@ -56,9 +57,6 @@ export type {
   AuditEventInput,
   AuditWriterOptions,
 } from './audit-writer.js'
-
-// Approval queue — in-memory + filesystem pending dir, 5-min default timeout
-export { ApprovalQueue } from './approval-queue.js'
 export type {
   PendingApproval,
   ApprovalResult,

--- a/sdk/typescript/packages/cloud/src/node.ts
+++ b/sdk/typescript/packages/cloud/src/node.ts
@@ -30,3 +30,10 @@ async function tryPatchAnthropic(): Promise<void> {
 export { wrap } from './wrap.js'
 export { VERSION } from './index.js'
 export type { InitOptions } from './config.js'
+
+// Phase 2 Node-only utilities — live here (not in the universal entry) because
+// they use node:fs / node:crypto and would break Cloudflare Workers / Vercel
+// Edge / browser bundles if exposed from '@jamjet/cloud'.
+export { loadPolicy } from './load-policy.js'
+export { AuditWriter } from './audit-writer.js'
+export { ApprovalQueue } from './approval-queue.js'


### PR DESCRIPTION
## Problem

`ts-sdk-v0.3.0` release workflow failed at the `size` step. The new `loadPolicy` / `AuditWriter` / `ApprovalQueue` use `node:fs` / `node:crypto` but were exported from the **universal** `@jamjet/cloud` entry — which:

1. Breaks size-limit's esbuild bundle (defaults to browser platform; can't resolve `node:*`)
2. Would break Cloudflare Workers / Vercel Edge / browser consumers if anyone tried to use the universal entry there

`@jamjet/cloud@0.3.0` is **not** yet on npm (publish never ran).

## Fix

- Move the three runtime exports from `src/index.ts` to `src/node.ts`. New import path: `import { loadPolicy } from '@jamjet/cloud/node'`.
- Type-only exports (`Policy`, `AuditEventInput`, etc.) stay on the universal entry — types are tree-shaken at runtime.
- Update `.size-limit.json` for the Node entry: `ignore` Node built-ins + optional peer deps (`openai`, `@anthropic-ai/sdk`, `yaml`), raise limit to 30 KB.

## Sizes (after fix)

- Universal: **18.27 kB** (under 19 kB limit) — clean, no Node built-ins
- Node: **19.06 kB** (well under 30 kB limit)

## Tests

188/188 still passing. Build + typecheck clean.

## After merge

Delete the existing `ts-sdk-v0.3.0` tag (it points at the broken commit) and re-tag main HEAD. The release workflow then publishes `@jamjet/cloud@0.3.0` successfully.