### PR TITLE
release(python-sdk): jamjet 0.8.2 — v1 audit schema retrofit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## 0.8.2 — 2026-05-11
+
+### Added
+- `jamjet demo` audit events now emit the v1 portable schema: `adapter: "python-sdk"`, `host: "python"`, `schema_version: 1`, `policy_version: "1"`, `rule_kind`. Plus `args`, `server`, and the `ts` field (replaces `timestamp`).
+- Audit events from `jamjet` now share the same JSONL shape as `@jamjet/claude-code-hook`, `@jamjet/mcp-shim`, and `@jamjet/cloud` — `cat ~/.jamjet/audit/<YYYY-MM-DD>/*.jsonl` gives a unified view across every JamJet adapter.
+
+### Changed
+- Internal `DemoAuditEvent.timestamp` field renamed to `ts`. The `timestamp` key is preserved on serialized output as an alias for backward compatibility with anything reading jamjet 0.8.1 audit JSON.
+
+### Notes
+- Foundation for Phase 2's "one policy, one audit trail" claim. Other JamJet adapters (claude-code-hook, mcp-shim, openai-guardrail) live in [`jamjet-labs/jamjet-policy`](https://github.com/jamjet-labs/jamjet-policy).
+
+---
+
 ## [0.8.1] — 2026-05-11
 
 ### Added

--- a/sdk/python/jamjet/cli/_demo_audit.py
+++ b/sdk/python/jamjet/cli/_demo_audit.py
@@ -1,4 +1,9 @@
-"""Audit event for jamjet demo commands. Writes to .jamjet-demo/runs/<id>.json."""
+"""Audit event for jamjet demo commands. Writes to .jamjet-demo/runs/<id>.json.
+
+Emits the v1 portable audit schema (adapter/host/ts/schema_version/...) so
+output from `jamjet demo` matches @jamjet/claude-code-hook, @jamjet/mcp-shim,
+and @jamjet/cloud. See jamjet-policy/conformance/audit-event-shape.json.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +11,10 @@ import json
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+
+RuleKind = Literal["allow", "block", "require_approval", "audit"]
 
 
 @dataclass
@@ -19,11 +27,22 @@ class DemoAuditEvent:
     executed: bool = False
     trace_id: str | None = None
     decision_id: str | None = None
+    rule_kind: RuleKind | None = None
+    args: dict[str, Any] = field(default_factory=dict)
     extra: dict[str, Any] = field(default_factory=dict)
-    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    ts: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    # v1 audit-schema discriminators
+    adapter: str = "python-sdk"
+    host: str = "python"
+    server: str | None = None
+    policy_version: str = "1"
+    schema_version: int = 1
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        d = asdict(self)
+        # Backward-compat alias for jamjet 0.8.1 consumers that read `timestamp`.
+        d["timestamp"] = d["ts"]
+        return d
 
 
 def write_audit_event(event: DemoAuditEvent, base_dir: Path | None = None) -> Path:

--- a/sdk/python/jamjet/cli/demo.py
+++ b/sdk/python/jamjet/cli/demo.py
@@ -45,9 +45,11 @@ def unsafe_tool_call(
         decision="BLOCKED" if decision.blocked else "ALLOWED",
         tool=plan.tool,
         rule=decision.pattern,
+        rule_kind="block" if decision.blocked else ("allow" if decision.pattern else None),
         executed=False if decision.blocked else True,
         trace_id="jj_7f21c9",
         decision_id="dec_91ab2",
+        args=dict(plan.arguments),
     )
     audit_path = write_audit_event(event)
 
@@ -127,7 +129,9 @@ def approval(
         decision="WAITING_FOR_APPROVAL",
         tool=plan.tool,
         rule="payments.* requires approval",
+        rule_kind="require_approval",
         executed=False,
+        args=dict(plan.arguments),
         extra={"arguments": plan.arguments},
     )
     audit_path = write_audit_event(event)
@@ -181,7 +185,9 @@ def budget_cap(
         decision="BUDGET_EXCEEDED" if blocked_at else "ALLOWED",
         tool=plans[blocked_at - 1].tool if blocked_at else "—",
         rule=f"budget cap ${cap_usd:.2f}",
+        rule_kind=None,  # budget is a separate concern, not a rule action
         executed=False if blocked_at else True,
+        args=dict(plans[blocked_at - 1].arguments) if blocked_at else {},
         extra={"spent_usd": round(spent, 2), "cap_usd": cap_usd, "log": log},
     )
     audit_path = write_audit_event(event)
@@ -228,7 +234,10 @@ def mcp_tool_policy(
         decision="BLOCKED" if decision.blocked else "ALLOWED",
         tool=plan.tool,
         rule=decision.pattern,
+        rule_kind="block" if decision.blocked else ("allow" if decision.pattern else None),
         executed=False if decision.blocked else True,
+        server="postgres-mcp",
+        args=dict(plan.arguments),
         extra={
             "server": "postgres-mcp",
             "envelope": {"server": "postgres-mcp", "tool": plan.tool, "arguments": plan.arguments},

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.8.1"
+version = "0.8.2"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/tests/test_audit_v1_schema.py
+++ b/sdk/python/tests/test_audit_v1_schema.py
@@ -1,0 +1,60 @@
+"""Verifies the Python SDK demo audit output conforms to the v1 audit schema."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from jamjet.cli.main import app
+
+runner = CliRunner()
+
+# Subset of the v1 schema required keys (see jamjet-policy/conformance/audit-event-shape.json).
+V1_REQUIRED = {"ts", "run_id", "adapter", "host", "tool", "decision", "executed", "schema_version"}
+
+
+def _run_demo_json(cmd: str, tmp_path: Path, monkeypatch) -> dict:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["demo", cmd, "--json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+def test_unsafe_tool_call_emits_v1_required_fields(tmp_path, monkeypatch) -> None:
+    payload = _run_demo_json("unsafe-tool-call", tmp_path, monkeypatch)
+    missing = V1_REQUIRED - set(payload.keys())
+    assert not missing, f"missing v1 required fields: {missing}"
+    assert payload["adapter"] == "python-sdk"
+    assert payload["host"] == "python"
+    assert payload["schema_version"] == 1
+    assert payload["policy_version"] == "1"
+    assert payload["decision"] == "BLOCKED"
+    assert payload["rule_kind"] == "block"
+
+
+def test_approval_emits_v1_schema(tmp_path, monkeypatch) -> None:
+    payload = _run_demo_json("approval", tmp_path, monkeypatch)
+    assert {"ts", "adapter", "host", "schema_version"} <= set(payload.keys())
+    assert payload["adapter"] == "python-sdk"
+    assert payload["decision"] == "WAITING_FOR_APPROVAL"
+    assert payload["rule_kind"] == "require_approval"
+
+
+def test_budget_cap_emits_v1_schema(tmp_path, monkeypatch) -> None:
+    payload = _run_demo_json("budget-cap", tmp_path, monkeypatch)
+    assert {"ts", "adapter", "host", "schema_version"} <= set(payload.keys())
+    assert payload["decision"] == "BUDGET_EXCEEDED"
+
+
+def test_mcp_tool_policy_emits_v1_schema(tmp_path, monkeypatch) -> None:
+    payload = _run_demo_json("mcp-tool-policy", tmp_path, monkeypatch)
+    assert {"ts", "adapter", "host", "schema_version"} <= set(payload.keys())
+    assert payload["adapter"] == "python-sdk"
+    assert payload["decision"] == "BLOCKED"
+
+
+def test_backward_compat_keeps_timestamp_alias(tmp_path, monkeypatch) -> None:
+    """The pre-v1 `timestamp` field is preserved as an alias for `ts` so existing
+    consumers (e.g. ad-hoc scripts written against jamjet 0.8.1) keep working."""
+    payload = _run_demo_json("unsafe-tool-call", tmp_path, monkeypatch)
+    assert payload.get("timestamp") == payload["ts"]


### PR DESCRIPTION
## Summary

`jamjet 0.8.2` — retrofit Python SDK demo audit output to emit the v1 portable audit schema. Foundation for Phase 2's "one policy, one audit trail" claim across hooks, guardrails, MCP shim, Python/TS SDKs.

## What changed

- Audit events now emit `ts` (instead of `timestamp`), plus `adapter`, `host`, `server`, `schema_version`, `policy_version`, `rule_kind`, `args`
- `timestamp` is preserved as an alias for backward compat with 0.8.1 consumers
- All four `jamjet demo` commands updated to pass the new fields

## Tests

- New `tests/test_audit_v1_schema.py` — 5 tests asserting v1 required fields + alias
- Pre-existing `tests/test_cli_demo.py` updated where assertions needed to track new shape; all green

## Test plan

- [ ] `pytest tests/test_audit_v1_schema.py tests/test_cli_demo.py` clean
- [ ] `jamjet demo unsafe-tool-call --json | python3 -m json.tool` shows `adapter`, `host`, `ts`, `schema_version`
- [ ] Compare against `cat ~/.jamjet/audit/<today>/claude-code-hook.jsonl` and `mcp-shim.jsonl` — same field set

## Out of scope

- npm `@jamjet/cloud` retrofit (Wave 2 Task 2.11 — already conformant; verified separately)
- Wave 3 (`@jamjet/openai-guardrail` + `@jamjet/cli` + cumulative launch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Audit events now emit standardized v1 schema format for consistent logging across all adapters
  * Enriched audit records with additional metadata fields for improved tracking and policy visibility
  * Backward compatibility maintained for existing audit log consumers

* **Tests**
  * Added comprehensive validation tests for v1 schema compliance across multiple scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamjet-labs/jamjet/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->