### PR TITLE
release(python-sdk): jamjet 0.8.3 — openai_guardrail integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## 0.8.3 — 2026-05-11
+
+### Added
+- `jamjet.integrations.openai_guardrail` — JamJet policy as an OpenAI Agents SDK tool guardrail. Same `policy.yaml`, same v1 audit JSONL as `@jamjet/claude-code-hook` / `@jamjet/mcp-shim` / `@jamjet/openai-guardrail` (TS).
+- New exceptions: `JamjetPolicyBlocked`, `JamjetApprovalRequired`.
+
+### Notes
+- Approval flow surfaces as `JamjetApprovalRequired` exception in v0.1. Full approval flow with `jamjet approve <run-id>` integrates with the OpenAI Agents SDK approval API in v0.2.
+
+---
+
 ## 0.8.2 — 2026-05-11
 
 ### Added

--- a/sdk/python/jamjet/integrations/__init__.py
+++ b/sdk/python/jamjet/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""JamJet integrations with third-party AI frameworks."""

--- a/sdk/python/jamjet/integrations/openai_guardrail/__init__.py
+++ b/sdk/python/jamjet/integrations/openai_guardrail/__init__.py
@@ -1,0 +1,9 @@
+"""JamJet policy as an OpenAI Agents SDK tool guardrail."""
+
+from jamjet.integrations.openai_guardrail.guardrail import (
+    JamjetApprovalRequired,
+    JamjetPolicyBlocked,
+    jamjet_guardrail,
+)
+
+__all__ = ["JamjetApprovalRequired", "JamjetPolicyBlocked", "jamjet_guardrail"]

--- a/sdk/python/jamjet/integrations/openai_guardrail/guardrail.py
+++ b/sdk/python/jamjet/integrations/openai_guardrail/guardrail.py
@@ -1,0 +1,176 @@
+"""JamJet policy guardrail for the OpenAI Agents SDK.
+
+Usage::
+
+    from openai_agents import tool
+    from jamjet.integrations.openai_guardrail import jamjet_guardrail
+
+    refund = tool(
+        name="payments.refund",
+        input_guardrails=[jamjet_guardrail(policy="~/.jamjet/policy.yaml")],
+        execute=refund_customer,
+    )
+
+Loads policy from the canonical lookup order: explicit path > ``JAMJET_POLICY_FILE``
+env > cwd ``./policy.yaml`` > ``~/.jamjet/policy.yaml``. Emits audit events conformant
+with the v1 portable schema to ``~/.jamjet/audit/<YYYY-MM-DD>/openai-guardrail.jsonl``.
+
+Note: we define a small ``_AuditEvent`` dataclass parallel to
+``jamjet.cli._demo_audit.DemoAuditEvent`` rather than reusing the latter because
+``DemoAuditEvent`` carries a ``demo`` field that is meaningless outside the
+``jamjet demo`` flow. Both serialise to the same v1 schema shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from jamjet.cloud.policy import PolicyEvaluator
+
+
+class JamjetPolicyBlocked(RuntimeError):
+    """Raised when JamJet policy blocks a tool call."""
+
+    def __init__(self, tool: str, rule: str | None) -> None:
+        super().__init__(f"JamJet policy: BLOCKED (tool: {tool}, rule: {rule or 'unknown'})")
+        self.tool = tool
+        self.rule = rule
+
+
+class JamjetApprovalRequired(RuntimeError):
+    """Raised when JamJet policy requires approval for a tool call.
+
+    v0.1 surfaces as an exception; v0.2 will integrate with the OpenAI Agents SDK
+    approval API + JamJet's ApprovalQueue.
+    """
+
+    def __init__(self, tool: str, rule: str | None) -> None:
+        super().__init__(
+            f"JamJet policy: WAITING_FOR_APPROVAL (tool: {tool}, rule: {rule or 'unknown'})"
+        )
+        self.tool = tool
+        self.rule = rule
+
+
+@dataclass
+class _AuditEvent:
+    run_id: str
+    decision: str
+    tool: str
+    args: dict[str, Any]
+    rule: str | None
+    rule_kind: Literal["allow", "block", "require_approval", "audit"] | None
+    executed: bool
+    adapter: str = "openai-guardrail"
+    host: str = "openai-agents-sdk"
+    server: str | None = None
+    trace_id: str | None = None
+    decision_id: str | None = None
+    policy_version: str = "1"
+    schema_version: int = 1
+    ts: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+def _resolve_policy_path(explicit: str | None) -> Path:
+    if explicit:
+        return Path(os.path.expanduser(explicit))
+    env_path = os.environ.get("JAMJET_POLICY_FILE")
+    if env_path:
+        return Path(os.path.expanduser(env_path))
+    cwd_candidate = Path.cwd() / "policy.yaml"
+    if cwd_candidate.exists():
+        return cwd_candidate
+    home_candidate = Path.home() / ".jamjet" / "policy.yaml"
+    if home_candidate.exists():
+        return home_candidate
+    raise FileNotFoundError(
+        "No policy file found. Set JAMJET_POLICY_FILE, or place policy.yaml in cwd or ~/.jamjet/"
+    )
+
+
+def _load_policy_into_evaluator(path: Path) -> PolicyEvaluator:
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict) or raw.get("version") != 1:
+        version = raw.get("version") if isinstance(raw, dict) else "n/a"
+        raise ValueError(f"unsupported policy version: {version}")
+    rules = raw.get("rules") or []
+    ev = PolicyEvaluator()
+    for i, rule in enumerate(rules):
+        if not isinstance(rule, dict) or "match" not in rule or "action" not in rule:
+            raise ValueError(f"rule[{i}] missing match/action")
+        action = rule["action"]
+        if action not in {"allow", "block", "require_approval", "audit"}:
+            raise ValueError(f"rule[{i}]: unknown action: {action}")
+        ev.add(action, rule["match"])
+    return ev
+
+
+def _write_audit(event: _AuditEvent, audit_destination: str | None) -> None:
+    base = (
+        Path(os.path.expanduser(audit_destination))
+        if audit_destination
+        else Path.home() / ".jamjet" / "audit"
+    )
+    day_dir = base / event.ts[:10]
+    day_dir.mkdir(parents=True, exist_ok=True)
+    path = day_dir / "openai-guardrail.jsonl"
+    payload = asdict(event)
+    # Backward-compat alias for jamjet 0.8.1 consumers that read `timestamp`.
+    payload["timestamp"] = payload["ts"]
+    existing = path.read_text() if path.exists() else ""
+    path.write_text(existing + json.dumps(payload, sort_keys=True) + "\n")
+
+
+def jamjet_guardrail(
+    *, policy: str | None = None, audit_destination: str | None = None
+) -> Callable[[dict[str, Any]], None]:
+    """Build a JamJet guardrail callable for the OpenAI Agents SDK.
+
+    Returns a callable taking ``{"toolName": str, "toolArgs": dict}`` and either
+    raising (BLOCKED / WAITING_FOR_APPROVAL) or returning None (ALLOWED / AUDIT).
+    """
+    evaluator = _load_policy_into_evaluator(_resolve_policy_path(policy))
+
+    def guardrail(input: dict[str, Any]) -> None:
+        tool_name = str(input.get("toolName", ""))
+        tool_args = input.get("toolArgs") or {}
+        d = evaluator.evaluate(tool_name)
+
+        rule_kind: Literal["allow", "block", "require_approval", "audit"] | None
+        if d.blocked:
+            decision, rule_kind, executed = "BLOCKED", "block", False
+        elif d.policy_kind == "require_approval":
+            decision, rule_kind, executed = "WAITING_FOR_APPROVAL", "require_approval", False
+        elif d.policy_kind == "audit":
+            decision, rule_kind, executed = "AUDIT", "audit", True
+        else:
+            decision = "ALLOWED"
+            rule_kind = "allow" if d.pattern else None
+            executed = True
+
+        event = _AuditEvent(
+            run_id=f"run_{secrets.token_hex(6)}",
+            decision=decision,
+            tool=tool_name,
+            args=dict(tool_args) if isinstance(tool_args, dict) else {},
+            rule=d.pattern,
+            rule_kind=rule_kind,
+            executed=executed,
+        )
+        _write_audit(event, audit_destination)
+
+        if decision == "BLOCKED":
+            raise JamjetPolicyBlocked(tool_name, d.pattern)
+        if decision == "WAITING_FOR_APPROVAL":
+            raise JamjetApprovalRequired(tool_name, d.pattern)
+
+    return guardrail

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.8.2"
+version = "0.8.3"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/tests/integrations/test_openai_guardrail.py
+++ b/sdk/python/tests/integrations/test_openai_guardrail.py
@@ -1,0 +1,68 @@
+"""Tests for jamjet.integrations.openai_guardrail."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from jamjet.integrations.openai_guardrail import (
+    JamjetApprovalRequired,
+    JamjetPolicyBlocked,
+    jamjet_guardrail,
+)
+
+
+def _write_policy(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "policy.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_block_destructive_tool(tmp_path: Path) -> None:
+    policy = _write_policy(tmp_path, 'version: 1\nrules:\n  - { match: "*delete*", action: block }\n')
+    audit_dir = tmp_path / "audit"
+    guard = jamjet_guardrail(policy=str(policy), audit_destination=str(audit_dir))
+    with pytest.raises(JamjetPolicyBlocked, match=r"\*delete\*"):
+        guard({"toolName": "database.delete_all", "toolArgs": {}})
+
+
+def test_require_approval(tmp_path: Path) -> None:
+    policy = _write_policy(
+        tmp_path, 'version: 1\nrules:\n  - { match: "payments.*", action: require_approval }\n'
+    )
+    audit_dir = tmp_path / "audit"
+    guard = jamjet_guardrail(policy=str(policy), audit_destination=str(audit_dir))
+    with pytest.raises(JamjetApprovalRequired):
+        guard({"toolName": "payments.refund", "toolArgs": {"amount": 100}})
+
+
+def test_allow_passes_through(tmp_path: Path) -> None:
+    policy = _write_policy(tmp_path, 'version: 1\nrules:\n  - { match: "*delete*", action: block }\n')
+    audit_dir = tmp_path / "audit"
+    guard = jamjet_guardrail(policy=str(policy), audit_destination=str(audit_dir))
+    guard({"toolName": "database.read_orders", "toolArgs": {}})  # no exception
+
+
+def test_audit_event_written_v1_schema(tmp_path: Path) -> None:
+    policy = _write_policy(tmp_path, 'version: 1\nrules:\n  - { match: "*delete*", action: block }\n')
+    audit_dir = tmp_path / "audit"
+    guard = jamjet_guardrail(policy=str(policy), audit_destination=str(audit_dir))
+    try:
+        guard({"toolName": "database.delete_all", "toolArgs": {"reason": "cleanup"}})
+    except JamjetPolicyBlocked:
+        pass
+    today = datetime.now(UTC).isoformat()[:10]
+    path = audit_dir / today / "openai-guardrail.jsonl"
+    assert path.exists()
+    lines = [line for line in path.read_text().splitlines() if line]
+    event = json.loads(lines[-1])
+    assert event["adapter"] == "openai-guardrail"
+    assert event["host"] == "openai-agents-sdk"
+    assert event["schema_version"] == 1
+    assert event["decision"] == "BLOCKED"
+    assert event["rule"] == "*delete*"
+    assert event["rule_kind"] == "block"
+    assert event["executed"] is False


### PR DESCRIPTION
## Summary

`jamjet 0.8.3` — adds `jamjet.integrations.openai_guardrail` as a Python sister to the just-shipped `@jamjet/openai-guardrail` npm package. Same `policy.yaml`, same v1 audit JSONL, OpenAI Agents SDK-compatible callable shape.

## Usage

```python
from openai_agents import tool
from jamjet.integrations.openai_guardrail import jamjet_guardrail

refund = tool(
    name="payments.refund",
    input_guardrails=[jamjet_guardrail(policy="~/.jamjet/policy.yaml")],
    execute=refund_customer,
)
```

## Tests

4 new tests in `tests/integrations/test_openai_guardrail.py`. All green.

## Out of scope

- npm `@jamjet/openai-guardrail` TS package (ships from jamjet-policy repo, parallel work)
- Full approval-flow integration with OpenAI Agents SDK approval API (v0.2)
