### PR TITLE
ci: namespace release tag triggers per artifact

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "crates-v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -22,9 +22,9 @@ jobs:
         with:
           images: jamjetdev/jamjet
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=match,pattern=crates-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=crates-v(\d+\.\d+),group=1
+            type=match,pattern=crates-v(\d+),group=1
             type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,7 +1,7 @@
 name: Publish Crates
 
 # Publishes all workspace crates to crates.io in dependency order.
-# Triggered by version tags (same as release-wheels.yml) or manual dispatch.
+# Triggered by crates-v*.*.* tags (paired with docker-publish.yml) or manual dispatch.
 #
 # Handles crates.io rate limits (429) with retry + backoff.
 # Skips crates that are already published (e.g., on re-run after partial failure).
@@ -13,7 +13,7 @@ name: Publish Crates
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "crates-v*.*.*"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Builds and publishes the jamjet Python wheel and platform-specific
-# jamjet-server binaries on version tags (v*.*.*) or manual dispatch.
+# jamjet-server binaries on python-sdk-v*.*.* tags or manual dispatch.
 #
 # Distribution model:
 #   - jamjet wheel  →  pure Python, published to PyPI via Trusted Publishing
@@ -13,7 +13,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "python-sdk-v*.*.*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- All three release workflows fired on `v*.*.*` — one tag push triggered crates publish + PyPI wheel + Docker image at once. Past releases only worked because crates no-op'd duplicates and Docker happily tagged whatever version was pushed.
- Split the triggers so each artifact has its own namespace:
  - `release-wheels.yml` → `python-sdk-v*.*.*`
  - `release-crates.yml` → `crates-v*.*.*`
  - `docker-publish.yml` → `crates-v*.*.*` (Docker image ships the Rust runtime — they release together)
- Docker image metadata switches from `type=semver` to `type=match,pattern=crates-v(...)` so the `crates-v` prefix gets stripped from the published image tag (e.g. tag `crates-v0.5.1` → image `jamjetdev/jamjet:0.5.1`).

## Test plan
- [ ] YAML parses (GH validates on push)
- [ ] Verify next Python release uses `python-sdk-v0.8.5` and fires only `release-wheels.yml`
- [ ] Verify next runtime release uses `crates-v0.5.1` and fires only crates + docker
- [ ] `_download_server_binary()` in the Python CLI still resolves the latest release via the GH API — no hardcoded tag format expected

## Notes
- Past tags (`v0.8.3`, etc.) are preserved as historical anchors — they just don't fire anything anymore.
- The four `cli-v*` / `ts-sdk-v*` / `ts-sdk-vercel-v*` / `openai-guardrail-v*` etc. workflows were already correctly namespaced and unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use explicit tag naming conventions for different package types (Crates, Python SDK, Docker), improving release pipeline organization and preventing unintended triggering of multiple release workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamjet-labs/jamjet/pull/62)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->