### PR TITLE
fix(ci): ts-sdk-release tags prereleases as next + bump to 0.4.0-alpha.1

### DIFF
--- a/.github/workflows/ts-sdk-release.yml
+++ b/.github/workflows/ts-sdk-release.yml
@@ -47,5 +47,16 @@ jobs:
       - name: Publish to npm with provenance (trusted publisher OIDC)
         # Use npx to fetch a fresh npm >= 11.5.1 (trusted-publisher OIDC support)
         # without overwriting the system npm bundled with Node 22 (which is too old).
+        # Prerelease versions (containing a hyphen, e.g. 0.4.0-alpha.0) are
+        # tagged "next" so they don't clobber the stable "latest" tag used
+        # by `npm install @jamjet/cloud`.
         working-directory: sdk/typescript/packages/cloud
-        run: npx -y npm@latest publish --access=public --provenance
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            TAG="next"
+          else
+            TAG="latest"
+          fi
+          echo "Publishing $VERSION with --tag=$TAG"
+          npx -y npm@latest publish --access=public --provenance --tag="$TAG"

--- a/sdk/typescript/packages/cloud/CHANGELOG.md
+++ b/sdk/typescript/packages/cloud/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.4.0-alpha.0 — 2026-05-17 (unreleased)
+## 0.4.0-alpha.1 — 2026-05-18 (unreleased)
+
+### Fixed
+- CI release workflow now passes `--tag=next` for prerelease versions so they do not clobber the stable `latest` dist-tag. The `0.4.0-alpha.0` tag was created but never published; this `.1` bump pairs with the workflow fix.
+
+## 0.4.0-alpha.0 — 2026-05-17 (unreleased — workflow needed --tag fix; never reached npm)
 
 ### Added
 - **Cost-waste detection signal:** every Anthropic-patched span now emits an optional `prompt_prefix_hash` (SHA-256 over the normalized first 80% of the input prompt, truncated to 16 hex chars). The Cloud groups spans by this hash to detect repeated uncached prefixes — the foundation of the Phase 8.1 cost-leak detector.

--- a/sdk/typescript/packages/cloud/package.json
+++ b/sdk/typescript/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jamjet/cloud",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0-alpha.1",
   "description": "JamJet engine — policy evaluation, budget enforcement, audit writing, approval queue. The shared brain across all JamJet adapters.",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.4.0-alpha.0'
+export const VERSION = '0.4.0-alpha.1'
 
 export { init } from './init.js'
 export { wrap } from './wrap.js'


### PR DESCRIPTION
Fixes the ts-sdk-release workflow so it can publish prerelease versions. npm refused to publish 0.4.0-alpha.0 because no --tag was passed (would clobber the latest dist-tag). Workflow now detects hyphenated versions and routes them to --tag=next. Bumped to 0.4.0-alpha.1 since the previous tag attempted-publish failed.

Files:
- .github/workflows/ts-sdk-release.yml - hyphen detection + tag routing
- package.json + index.ts - version bump to 0.4.0-alpha.1
- CHANGELOG.md - notes the fix

After merge: git tag ts-sdk-v0.4.0-alpha.1 && git push origin ts-sdk-v0.4.0-alpha.1 -> workflow re-runs, this time with --tag=next.

See run 26009940221 for the original failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release publishing process to properly distinguish between prerelease and stable releases using distribution tags, preventing unintended overwriting of stable versions.
  * Package version updated to 0.4.0-alpha.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamjet-labs/jamjet/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->