### PR TITLE
Add durable + governed loan-underwriter example (Java)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,3 +10,7 @@ Numbered examples in this directory:
 
 Each example is self-contained. The fifth example includes its own virtual
 environment setup script and runs without a model API key.
+
+## Java
+
+- `loan-underwriter-agent/` - A durable, auditable loan-underwriting agent on the JVM, built on Spring Boot, the JamJet Java runtime, and AgentBoundary action receipts. It survives a `kill -9` mid-run and resumes from disk checkpoints without repeating work, gates disbursement on a human officer approval, and produces a verifiable signed receipt bundle. Runs without a model API key. Requires JDK 21. See `loan-underwriter-agent/README.md` and `loan-underwriter-agent/scripts/demo.sh` for the crash demo.

--- a/examples/loan-underwriter-agent/.gitignore
+++ b/examples/loan-underwriter-agent/.gitignore
@@ -1,0 +1,10 @@
+target/
+.idea/
+*.iml
+.claude/
+.DS_Store
+*.log
+.env
+*.env
+application-local.yml
+application-local.yaml

--- a/examples/loan-underwriter-agent/README.md
+++ b/examples/loan-underwriter-agent/README.md
@@ -1,0 +1,102 @@
+# loan-underwriter-agent
+
+A durable, auditable loan-underwriting agent on the JVM. Built on Spring Boot, the JamJet Java runtime, and AgentBoundary action receipts. Where Spring AI and LangChain4j stop (at stateless request/response), this demo picks up: every underwriting run checkpoints its steps to disk, survives a hard process kill, resumes without repeating work, requires a human officer approval before disbursement, and produces a verifiable signed receipt bundle that proves exactly what the agent did and who approved it.
+
+## Prerequisites
+
+- JDK 21 (the `dev.jamjet:*:0.3.1` artifacts are Java-21 bytecode)
+- Maven 3.9+
+
+Point `JAVA_HOME` at a JDK 21 install before building or running. For example:
+
+```bash
+# macOS + Homebrew:  brew install openjdk@21 && export JAVA_HOME="$(/usr/libexec/java_home -v 21)"
+# SDKMAN (any OS):   sdk install java 21-tem  && export JAVA_HOME="$(sdk home java 21-tem)"
+export JAVA_HOME=/path/to/your/jdk-21
+```
+
+## Run it
+
+```bash
+JAVA_HOME=$JAVA_HOME mvn spring-boot:run
+```
+
+The app starts on port 8080. Three commands cover the full lifecycle:
+
+**1. Start an underwriting run**
+
+```bash
+curl -s -X POST http://localhost:8080/applications \
+  -H "Content-Type: application/json" \
+  -d '{"id":"loan-demo","applicantName":"Jane Smith","amountCents":1500000,"annualIncomeCents":9000000}'
+```
+
+Expected response (202 Accepted):
+
+```json
+{"applicationId":"loan-demo","state":"AWAITING_APPROVAL"}
+```
+
+**2. Approve (or reject): human-in-the-loop gate**
+
+```bash
+curl -s -X POST http://localhost:8080/applications/loan-demo/approve \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"officer@bank","decision":"approved","comment":"within risk tolerance"}'
+```
+
+Expected response (200 OK):
+
+```json
+{"applicationId":"loan-demo","state":"COMPLETED"}
+```
+
+`decision` accepts `approved`, `rejected`, or `escalate`.
+
+**3. Get the audit bundle**
+
+```bash
+curl -s http://localhost:8080/applications/loan-demo/receipts | python3 -m json.tool
+```
+
+Expected response (200 OK):
+
+```json
+{
+  "applicationId": "loan-demo",
+  "verified": true,
+  "receipts": [ ... 4 receipts ... ]
+}
+```
+
+`verified: true` means every receipt hash in the bundle checks out. Mutating any receipt field causes the hash check to fail. On the approve-and-disburse path the bundle contains 4 receipts (credit bureau, account history, underwriting score, and disbursement). A declined or rejected run produces fewer receipts because no disbursement receipt is emitted.
+
+## The crash demo
+
+```bash
+bash scripts/demo.sh
+```
+
+The script:
+
+1. Builds the jar once (`mvn -DskipTests package`).
+2. Starts the app, submits application `loan-demo`, and waits until the checkpoint file appears on disk.
+3. Sends `kill -9` to the app process, a hard kill with no graceful shutdown.
+4. Restarts the app against the same state directories.
+5. Re-submits `loan-demo`. Because `CheckpointStore` still holds the `credit` and `history` checkpoints from the first run, the agent replays from disk and returns `AWAITING_APPROVAL` without calling the credit bureau again.
+6. Posts an officer approval; disbursement completes.
+7. Fetches the receipt bundle and confirms `verified: true` with four receipts.
+
+If `$JAVA_HOME` is not set, the script looks for the openjdk@21 Homebrew path automatically. If Java 21 is not found it exits early with instructions.
+
+## How it works
+
+| Guarantee | Class |
+|---|---|
+| Durability: each step is checkpointed to disk | `CheckpointStore` + `@DurableAgent` / `DurabilityContext` |
+| Resume: replay skips completed steps on restart | `CheckpointStore.load()` sets replay mode before re-running |
+| Signed receipts + verifiable audit bundle | `ReceiptFactory` (builds `ActionReceipt` with `receipt_hash`) / `AuditBundle.verify()` |
+| Human-in-the-loop approval gate | `ApprovalGate` (disk-backed, survives restart) |
+| Approval stamped on disbursement receipt | `UnderwritingRunner.resume()` calls `approvalGate.toApprovalBlock()` |
+
+The project depends on the published `dev.jamjet:*:0.3.1` Maven artifacts (JamJet Java runtime + AgentBoundary SDK). To wire a real LLM: add a Spring AI model starter, set `loan.llm.enabled=true`, and point a `ChatClient` at the underwriting logic. The `ActionReceiptAdvisor` (from `jamjet-cloud-spring-boot-starter`) will emit receipts automatically for every model call, routed through the same `DurableReceiptEmitter`.

--- a/examples/loan-underwriter-agent/pom.xml
+++ b/examples/loan-underwriter-agent/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>dev.jamjet</groupId>
+    <artifactId>loan-underwriter-agent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>loan-underwriter-agent</name>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>1.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Spring AI client-chat: provides ChatClient + advisor API. No model autoconfig. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-client-chat</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- JamJet dependencies -->
+        <dependency>
+            <groupId>dev.jamjet</groupId>
+            <artifactId>jamjet-runtime-instrument</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.jamjet</groupId>
+            <artifactId>jamjet-runtime-core</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.jamjet</groupId>
+            <artifactId>jamjet-cloud-sdk</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.jamjet</groupId>
+            <artifactId>jamjet-cloud-spring-boot-starter</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/loan-underwriter-agent/scripts/demo.sh
+++ b/examples/loan-underwriter-agent/scripts/demo.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Cross-process crash-recovery demo for the loan-underwriter-agent.
+#
+# What it proves:
+#   1. Durability: checkpoints survive a kill -9.
+#   2. Resume: restarting with the same state dirs replays from checkpoints;
+#              the credit pull is not repeated.
+#   3. Human gate: a human approval unblocks disbursement.
+#   4. Audit trail: the receipt bundle verifies (signed hash check passes).
+#
+# Applicant "loan-demo": credit = 831 (APPROVE path), history = 104 months.
+# Math.floorMod("loan-demo".hashCode(), 551) = 531 -> credit = 300 + 531 = 831.
+# ---------------------------------------------------------------------------
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OPENJDK21="/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home"
+
+# --- Java 21 check ----------------------------------------------------------
+if [[ -z "${JAVA_HOME:-}" ]]; then
+  if [[ -d "$OPENJDK21" ]]; then
+    export JAVA_HOME="$OPENJDK21"
+  fi
+fi
+
+JAVA_VERSION="$("${JAVA_HOME:-}/bin/java" -version 2>&1 | head -1 || true)"
+if [[ ! "$JAVA_VERSION" =~ 21 ]]; then
+  echo ""
+  echo "ERROR: Java 21 is required. Detected: ${JAVA_VERSION:-not found}"
+  echo ""
+  echo "  export JAVA_HOME=$OPENJDK21"
+  echo ""
+  exit 1
+fi
+
+# --- State dirs (fresh per run, same for both process starts) ---------------
+DEMO_DIR="${TMPDIR:-/tmp}/loan-demo-$$"
+CK="$DEMO_DIR/ck"
+AP="$DEMO_DIR/ap"
+RC="$DEMO_DIR/rc"
+LOG1="$DEMO_DIR/app1.log"
+LOG2="$DEMO_DIR/app2.log"
+APP_PID=""
+
+cleanup() {
+  if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+    kill -9 "$APP_PID" 2>/dev/null || true
+  fi
+  rm -rf "$DEMO_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$DEMO_DIR"
+
+# --- Build once -------------------------------------------------------------
+echo ""
+echo "==> Building (skipping tests)..."
+(cd "$REPO_DIR" && JAVA_HOME="$JAVA_HOME" mvn -q -DskipTests package)
+JAR="$(ls "$REPO_DIR"/target/loan-underwriter-agent-*.jar 2>/dev/null | head -1)"
+if [[ -z "$JAR" ]]; then
+  echo "ERROR: Could not find built jar under $REPO_DIR/target/"
+  exit 1
+fi
+echo "    Built: $JAR"
+
+# ---------------------------------------------------------------------------
+start_app() {
+  local logfile="$1"
+  APP_PID=""
+  JAVA_HOME="$JAVA_HOME" "$JAVA_HOME/bin/java" \
+    "-Dloan.checkpoint-dir=$CK" \
+    "-Dloan.approval-dir=$AP" \
+    "-Dloan.receipts-dir=$RC" \
+    -jar "$JAR" \
+    > "$logfile" 2>&1 &
+  APP_PID=$!
+}
+
+wait_ready() {
+  local logfile="$1"
+  local deadline=$(( $(date +%s) + 60 ))
+  while [[ $(date +%s) -lt $deadline ]]; do
+    if grep -q "Started LoanUnderwriterApplication" "$logfile" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo ""
+  echo "ERROR: App did not start within 60s. Last 20 log lines:"
+  tail -20 "$logfile"
+  exit 1
+}
+
+wait_checkpoint() {
+  local deadline=$(( $(date +%s) + 30 ))
+  while [[ $(date +%s) -lt $deadline ]]; do
+    if [[ -f "$CK/loan-demo.json" ]]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo ""
+  echo "ERROR: Checkpoint file $CK/loan-demo.json did not appear within 30s."
+  exit 1
+}
+
+pretty_json() {
+  if command -v jq &>/dev/null; then
+    jq .
+  else
+    python3 -m json.tool
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Starting app (process 1) with fresh state dirs..."
+start_app "$LOG1"
+wait_ready "$LOG1"
+echo "    PID=$APP_PID  state dirs=$DEMO_DIR"
+
+# --- Money shot 1: durability -----------------------------------------------
+echo ""
+echo ">>> MONEY SHOT 1: durability"
+echo "    Submitting application loan-demo (credit 831, qualifies for APPROVE path)..."
+RESP1=$(curl -s -X POST http://localhost:8080/applications \
+  -H "Content-Type: application/json" \
+  -d '{"id":"loan-demo","applicantName":"Jane Smith","amountCents":1500000,"annualIncomeCents":9000000}')
+echo "    Response: $RESP1"
+
+echo "    Waiting for checkpoint to appear on disk..."
+wait_checkpoint
+echo "    Checkpoint confirmed: $CK/loan-demo.json"
+
+# --- Hard-kill mid-flight ---------------------------------------------------
+echo ""
+echo "==> Killing app PID=$APP_PID with kill -9..."
+kill -9 "$APP_PID"
+# Wait for the process to actually die
+for i in $(seq 1 10); do
+  if ! kill -0 "$APP_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+echo "    Process hard-killed. Checkpoint and approval state survive on disk."
+APP_PID=""
+
+# --- Restart and resume from checkpoint ------------------------------------
+echo ""
+echo "==> Starting app (process 2), same state dirs, resuming from checkpoint..."
+start_app "$LOG2"
+wait_ready "$LOG2"
+echo "    PID=$APP_PID"
+
+echo ""
+echo ">>> RESUMED AFTER CRASH, no work repeated"
+echo "    Re-submitting loan-demo (same id)..."
+RESP2=$(curl -s -X POST http://localhost:8080/applications \
+  -H "Content-Type: application/json" \
+  -d '{"id":"loan-demo","applicantName":"Jane Smith","amountCents":1500000,"annualIncomeCents":9000000}')
+echo "    Response: $RESP2"
+
+STATE2=$(echo "$RESP2" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('state','?'))" 2>/dev/null || echo "?")
+if [[ "$STATE2" != "AWAITING_APPROVAL" ]]; then
+  echo "ERROR: expected state AWAITING_APPROVAL, got: $STATE2"
+  exit 1
+fi
+echo "    State = $STATE2  (credit pull was NOT repeated, resumed from checkpoint)"
+
+# --- Money shot 3: human-in-the-loop ----------------------------------------
+echo ""
+echo ">>> MONEY SHOT 3: human-in-the-loop"
+echo "    Officer approving disbursement..."
+RESP3=$(curl -s -X POST http://localhost:8080/applications/loan-demo/approve \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"officer@bank","decision":"approved","comment":"ok"}')
+echo "    Response: $RESP3"
+
+STATE3=$(echo "$RESP3" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('state','?'))" 2>/dev/null || echo "?")
+if [[ "$STATE3" != "COMPLETED" ]]; then
+  echo "ERROR: expected state COMPLETED after approval, got: $STATE3"
+  exit 1
+fi
+echo "    State = $STATE3"
+
+# --- Money shot 2: governance -----------------------------------------------
+echo ""
+echo ">>> MONEY SHOT 2: governance, fetching audit bundle..."
+RECEIPTS=$(curl -s http://localhost:8080/applications/loan-demo/receipts)
+echo "$RECEIPTS" | pretty_json
+
+VERIFIED=$(echo "$RECEIPTS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('verified','?'))" 2>/dev/null || echo "?")
+COUNT=$(echo "$RECEIPTS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('receipts',[])))" 2>/dev/null || echo "?")
+
+echo ""
+echo "    verified = $VERIFIED"
+echo "    receipt count = $COUNT"
+
+if [[ "$VERIFIED" != "True" && "$VERIFIED" != "true" ]]; then
+  echo "WARNING: audit bundle did not verify (verified=$VERIFIED)"
+fi
+
+echo ""
+echo "==> Demo complete."
+echo "    All three guarantees exercised:"
+echo "    1. Durability: checkpoint survived kill -9, no repeated credit pull"
+echo "    2. Governance: audit bundle verified=$VERIFIED with $COUNT signed receipts"
+echo "    3. Human gate: officer approval unblocked disbursement, stamped on receipt"

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/LoanUnderwriterApplication.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/LoanUnderwriterApplication.java
@@ -1,0 +1,11 @@
+package dev.jamjet.loan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LoanUnderwriterApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(LoanUnderwriterApplication.class, args);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/approval/ApprovalGate.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/approval/ApprovalGate.java
@@ -1,0 +1,177 @@
+package dev.jamjet.loan.approval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.jamjet.cloud.agentboundary.Approval;
+import dev.jamjet.loan.domain.RunState;
+import dev.jamjet.runtime.core.event.ApprovalDecision;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Disk-backed human-in-the-loop approval gate. A run that reaches a guarded action
+ * (e.g. {@code disbursement.disburse}) suspends by writing a pending approval record;
+ * an out-of-band {@link #decide} call records the human decision. Because every read
+ * re-reads the on-disk record, a fresh {@code ApprovalGate} (after a process restart)
+ * observes prior state: suspend/await/resume survives restart.
+ *
+ * <p>Each run is stored as {@code <baseDir>/<runId>.approval.json}. Writes are atomic
+ * (temp file + {@code ATOMIC_MOVE}, mirroring {@code CheckpointStore}), so a crash
+ * mid-write cannot corrupt an existing record.
+ *
+ * <p>The lifecycle mirrors the runtime event kinds:
+ * {@code requireApproval} → {@code EventKind.ToolApprovalRequired};
+ * {@code decide} → {@code EventKind.ApprovalReceived}.
+ */
+public final class ApprovalGate {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<LinkedHashMap<String, String>> MAP_TYPE =
+            new TypeReference<>() {};
+    private static final String APPROVAL_EXT = ".approval.json";
+
+    // Record field keys.
+    private static final String K_RUN_ID    = "runId";
+    private static final String K_TOOL_NAME = "toolName";
+    private static final String K_APPROVER  = "approver";
+    private static final String K_STATE     = "state";
+    private static final String K_USER_ID   = "userId";
+    private static final String K_DECISION  = "decision";
+    private static final String K_COMMENT   = "comment";
+    private static final String K_APPROVED_AT = "approvedAt";
+
+    private final Path baseDir;
+
+    public ApprovalGate(Path baseDir) {
+        try {
+            Files.createDirectories(baseDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot create approval directory: " + baseDir, e);
+        }
+        this.baseDir = baseDir;
+    }
+
+    /**
+     * Suspend the run pending human approval of {@code toolName}. Persists a pending
+     * record in state {@link RunState#AWAITING_APPROVAL}. Mirrors
+     * {@code EventKind.ToolApprovalRequired}.
+     *
+     * <p>Idempotent-safe: if a record already exists for {@code runId} and it already
+     * carries a terminal decision (approved or rejected), this method returns without
+     * overwriting it. This makes a redundant {@code start()}/{@code requireApproval}
+     * call after a process restart safe: a human's prior decision is preserved.
+     */
+    public void requireApproval(String runId, String toolName, String approver) {
+        RunState existing = stateOf(runId);
+        if (existing != null && existing != RunState.AWAITING_APPROVAL) {
+            // A decision has already been recorded; do not overwrite it.
+            return;
+        }
+        Map<String, String> record = new LinkedHashMap<>();
+        record.put(K_RUN_ID, runId);
+        record.put(K_TOOL_NAME, toolName);
+        record.put(K_APPROVER, approver);
+        record.put(K_STATE, RunState.AWAITING_APPROVAL.name());
+        write(runId, record);
+    }
+
+    /**
+     * Record a human decision against a pending run. Mirrors {@code EventKind.ApprovalReceived}.
+     * State mapping: APPROVED → RUNNING; REJECTED → FAILED; ESCALATE → AWAITING_APPROVAL.
+     */
+    public void decide(String runId, String userId, ApprovalDecision decision, String comment) {
+        Map<String, String> record = read(runId);
+        if (record == null) {
+            throw new IllegalStateException("No pending approval for run: " + runId);
+        }
+        record.put(K_USER_ID, userId);
+        record.put(K_DECISION, decision.getValue());
+        record.put(K_COMMENT, comment);
+        record.put(K_APPROVED_AT, Instant.now().toString());
+        record.put(K_STATE, stateFor(decision).name());
+        write(runId, record);
+    }
+
+    /** The persisted run state, or {@code null} if no record exists for {@code runId}. */
+    public RunState stateOf(String runId) {
+        Map<String, String> record = read(runId);
+        if (record == null) {
+            return null;
+        }
+        String state = record.get(K_STATE);
+        return state == null ? null : RunState.valueOf(state);
+    }
+
+    /** True iff a decision has been recorded and it is APPROVED. */
+    public boolean isCleared(String runId) {
+        Map<String, String> record = read(runId);
+        if (record == null) {
+            return false;
+        }
+        String decision = record.get(K_DECISION);
+        return decision != null && ApprovalDecision.fromValue(decision) == ApprovalDecision.APPROVED;
+    }
+
+    /**
+     * Build an AgentBoundary {@link Approval} block from the persisted decision, suitable
+     * for stamping onto the guarded action's receipt. Returns {@code null} if no decision
+     * has been recorded yet.
+     */
+    public Approval toApprovalBlock(String runId) {
+        Map<String, String> record = read(runId);
+        if (record == null || record.get(K_DECISION) == null) {
+            return null;
+        }
+        Approval.Approver approver = new Approval.Approver(record.get(K_USER_ID), null, "approver");
+        return new Approval(approver, record.get(K_APPROVED_AT), record.get(K_COMMENT));
+    }
+
+    private static RunState stateFor(ApprovalDecision decision) {
+        return switch (decision) {
+            case APPROVED -> RunState.RUNNING;
+            case REJECTED -> RunState.FAILED;
+            case ESCALATE -> RunState.AWAITING_APPROVAL;
+        };
+    }
+
+    private Path pathFor(String runId) {
+        return baseDir.resolve(runId + APPROVAL_EXT);
+    }
+
+    private Map<String, String> read(String runId) {
+        Path target = pathFor(runId);
+        if (!Files.exists(target)) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(target.toFile(), MAP_TYPE);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load approval for run: " + runId, e);
+        }
+    }
+
+    private void write(String runId, Map<String, String> record) {
+        Path target = pathFor(runId);
+        try {
+            Path tmp = Files.createTempFile(baseDir, ".ap-" + runId + "-", ".tmp");
+            try {
+                MAPPER.writerWithDefaultPrettyPrinter().writeValue(tmp.toFile(), record);
+                Files.move(tmp, target,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                try { Files.deleteIfExists(tmp); } catch (IOException ignored) {}
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to save approval for run: " + runId, e);
+        }
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/config/Beans.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/config/Beans.java
@@ -1,0 +1,96 @@
+package dev.jamjet.loan.config;
+
+import dev.jamjet.loan.approval.ApprovalGate;
+import dev.jamjet.loan.durable.CheckpointStore;
+import dev.jamjet.loan.durable.UnderwritingAgent;
+import dev.jamjet.loan.durable.UnderwritingRunner;
+import dev.jamjet.loan.receipt.DurableReceiptEmitter;
+import dev.jamjet.loan.receipt.ReceiptFactory;
+import dev.jamjet.loan.service.AccountHistoryService;
+import dev.jamjet.loan.service.CreditBureauService;
+import dev.jamjet.loan.service.DisbursementService;
+import dev.jamjet.loan.service.MockAccountHistory;
+import dev.jamjet.loan.service.MockCreditBureau;
+import dev.jamjet.loan.service.MockDisbursement;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Path;
+
+@Configuration
+public class Beans {
+
+    @Bean
+    public CreditBureauService creditBureauService() {
+        return new MockCreditBureau();
+    }
+
+    @Bean
+    public AccountHistoryService accountHistoryService() {
+        return new MockAccountHistory();
+    }
+
+    @Bean
+    public DisbursementService disbursementService() {
+        return new MockDisbursement();
+    }
+
+    /**
+     * Single shared, disk-backed emitter. Both UnderwritingAgent and UnderwritingRunner receive
+     * this same instance so that all receipts (credit, history, score, disbursement) for a given
+     * application persist under one directory and reload into one bundle. Persisting to disk is
+     * what makes the audit bundle survive a process crash: an in-memory emitter would lose every
+     * pre-crash receipt.
+     */
+    @Bean
+    public DurableReceiptEmitter durableReceiptEmitter(
+            @Value("${loan.receipts-dir}") String receiptsDir) {
+        return new DurableReceiptEmitter(Path.of(receiptsDir));
+    }
+
+    /**
+     * Single shared factory. Same instance injected into both agent and runner so that
+     * receipts carry a consistent system/environment label.
+     */
+    @Bean
+    public ReceiptFactory receiptFactory(
+            @Value("${spring.application.name:loan-underwriter}") String system,
+            @Value("${loan.environment:dev}") String environment) {
+        return new ReceiptFactory(system, environment);
+    }
+
+    @Bean
+    public CheckpointStore checkpointStore(
+            @Value("${loan.checkpoint-dir}") String checkpointDir) {
+        return new CheckpointStore(Path.of(checkpointDir));
+    }
+
+    @Bean
+    public ApprovalGate approvalGate(
+            @Value("${loan.approval-dir}") String approvalDir) {
+        return new ApprovalGate(Path.of(approvalDir));
+    }
+
+    @Bean
+    public UnderwritingAgent underwritingAgent(
+            CreditBureauService creditBureauService,
+            AccountHistoryService accountHistoryService,
+            DurableReceiptEmitter durableReceiptEmitter,
+            ReceiptFactory receiptFactory) {
+        return new UnderwritingAgent(creditBureauService, accountHistoryService,
+                durableReceiptEmitter, receiptFactory);
+    }
+
+    @Bean
+    public UnderwritingRunner underwritingRunner(
+            UnderwritingAgent underwritingAgent,
+            CheckpointStore checkpointStore,
+            ApprovalGate approvalGate,
+            DisbursementService disbursementService,
+            DurableReceiptEmitter durableReceiptEmitter,
+            ReceiptFactory receiptFactory) {
+        return new UnderwritingRunner(underwritingAgent, checkpointStore, approvalGate,
+                disbursementService, durableReceiptEmitter, receiptFactory);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/config/ChatClientConfig.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/config/ChatClientConfig.java
@@ -1,0 +1,50 @@
+package dev.jamjet.loan.config;
+
+import dev.jamjet.cloud.agentboundary.ActionReceiptEmitter;
+import dev.jamjet.cloud.spring.ActionReceiptAdvisor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+
+/**
+ * OFF-BY-DEFAULT configuration for the real LLM path.
+ *
+ * <p>When you add a model starter (e.g. {@code spring-ai-starter-model-openai}),
+ * set {@code loan.llm.enabled=true} in {@code application.properties} and supply
+ * the relevant API key (e.g. {@code OPENAI_API_KEY}), every tool call the model
+ * makes emits an AgentBoundary receipt automatically via {@link ActionReceiptAdvisor}.
+ *
+ * <p>By default (no property set, no model starter on the classpath) this config
+ * is completely inert: {@code @ConditionalOnProperty} prevents the class from being
+ * processed, and {@code @ConditionalOnBean(ChatModel.class)} on the bean method adds
+ * a second guard so that even if the property is set, the bean is only created when a
+ * real {@link ChatModel} implementation is present. The default context load and all
+ * deterministic demo tests (Part A) are entirely unaffected.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "loan.llm", name = "enabled", havingValue = "true")
+public class ChatClientConfig {
+
+    /**
+     * Build a {@link ChatClient} wired with {@link ActionReceiptAdvisor} so that
+     * every model tool call emits a signed AgentBoundary receipt.
+     *
+     * <p>This bean is only created when a {@link ChatModel} bean is present on the
+     * context (i.e. a model starter has been added to the classpath and configured).
+     */
+    @Bean
+    @ConditionalOnBean(ChatModel.class)
+    public ChatClient chatClient(
+            ChatModel chatModel,
+            Environment environment,
+            ActionReceiptEmitter emitter) {
+        return ChatClient.builder(chatModel)
+                .defaultAdvisors(new ActionReceiptAdvisor(environment, emitter, Ordered.LOWEST_PRECEDENCE))
+                .build();
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/Decision.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/Decision.java
@@ -1,0 +1,18 @@
+package dev.jamjet.loan.domain;
+
+import java.util.List;
+
+public record Decision(
+        String applicationId,
+        Outcome outcome,
+        int riskScore,
+        List<String> reasons
+) {
+    public Decision {
+        reasons = List.copyOf(reasons);
+    }
+
+    public enum Outcome {
+        APPROVE, DECLINE, REFER
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/LoanApplication.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/LoanApplication.java
@@ -1,0 +1,8 @@
+package dev.jamjet.loan.domain;
+
+public record LoanApplication(
+        String id,
+        String applicantName,
+        long amountCents,
+        long annualIncomeCents
+) {}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/RunState.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/domain/RunState.java
@@ -1,0 +1,5 @@
+package dev.jamjet.loan.domain;
+
+public enum RunState {
+    RUNNING, AWAITING_APPROVAL, COMPLETED, FAILED, DECLINED
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/CheckpointStore.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/CheckpointStore.java
@@ -1,0 +1,111 @@
+package dev.jamjet.loan.durable;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.jamjet.runtime.instrument.DurabilityContext;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+
+/**
+ * Persists and rehydrates {@link DurabilityContext} checkpoint state to disk.
+ * Each run is stored as {@code <baseDir>/<runId>.json}: a JSON object whose
+ * keys are checkpoint IDs in insertion order and whose values are the raw recorded
+ * results.
+ *
+ * <p>Values are stored as their native JSON form (NOT {@code String.valueOf}), so a
+ * recorded {@code int} round-trips back as a JSON integer and rehydrates as an
+ * {@link Integer}. This is what lets a checkpoint survive a process restart: an
+ * {@code int}-returning {@code @Checkpoint} method unboxes the replayed {@code Integer}
+ * cleanly instead of hitting a {@code ClassCastException} on a {@code String}. Only
+ * primitive/JSON-scalar checkpoints are persisted here (the loan pipeline records ints);
+ * non-primitive results (e.g. the scoring {@code Decision}) are recomputed on resume and
+ * never written.
+ *
+ * <p><b>Caveat:</b> rehydration is JSON-scalar fidelity only. A persisted JSON integer
+ * comes back as {@link Integer}; a string comes back as {@link String}. Complex objects
+ * are intentionally out of scope and must not be checkpointed through this store.
+ *
+ * <p>Writes are atomic: the payload is written to a temp file in the same
+ * directory, then renamed with {@code ATOMIC_MOVE}, so a crash mid-write cannot
+ * corrupt an existing checkpoint file.
+ */
+public class CheckpointStore {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<LinkedHashMap<String, Object>> MAP_TYPE =
+            new TypeReference<>() {};
+    private static final String CHECKPOINT_EXT = ".json";
+
+    private final Path baseDir;
+
+    public CheckpointStore(Path baseDir) {
+        try {
+            Files.createDirectories(baseDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot create checkpoint directory: " + baseDir, e);
+        }
+        this.baseDir = baseDir;
+    }
+
+    /**
+     * Saves all recorded checkpoints from {@code ctx} under {@code runId}.
+     * Existing file for the same runId is replaced atomically.
+     *
+     * @param runId stable run identifier; must be a plain name with no path separators (it becomes the file name).
+     * @param ctx   the durability context whose recorded results will be persisted.
+     */
+    public void save(String runId, DurabilityContext ctx) {
+        LinkedHashMap<String, Object> snapshot = new LinkedHashMap<>();
+        for (String id : ctx.getCheckpointIds()) {
+            // Store the raw recorded result so primitives round-trip with their JSON type
+            // (an int comes back as an Integer, not the String "720"). The loan pipeline only
+            // checkpoints JSON scalars (ints); complex results are recomputed on resume, never persisted.
+            snapshot.put(id, ctx.getRecordedResult(id));
+        }
+
+        Path target = baseDir.resolve(runId + CHECKPOINT_EXT);
+        try {
+            Path tmp = Files.createTempFile(baseDir, ".cp-" + runId + "-", ".tmp");
+            try {
+                MAPPER.writeValue(tmp.toFile(), snapshot);
+                Files.move(tmp, target,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                // Best-effort cleanup of the temp file on failure.
+                try { Files.deleteIfExists(tmp); } catch (IOException ignored) {}
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to save checkpoint for run: " + runId, e);
+        }
+    }
+
+    /**
+     * Loads checkpoint state for {@code runId} and returns a {@link DurabilityContext}
+     * pre-populated with all recorded values and set to replay mode.
+     * Returns {@code null} if no checkpoint exists for this runId.
+     */
+    public DurabilityContext load(String runId) {
+        Path target = baseDir.resolve(runId + CHECKPOINT_EXT);
+        if (!Files.exists(target)) {
+            return null;
+        }
+        try {
+            LinkedHashMap<String, Object> snapshot = MAPPER.readValue(target.toFile(), MAP_TYPE);
+            DurabilityContext ctx = DurabilityContext.create();
+            for (var entry : snapshot.entrySet()) {
+                ctx.recordResult(entry.getKey(), entry.getValue());
+            }
+            ctx.setReplayMode(true);
+            return ctx;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load checkpoint for run: " + runId, e);
+        }
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/UnderwritingAgent.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/UnderwritingAgent.java
@@ -1,0 +1,143 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.cloud.agentboundary.ActionReceiptEmitter;
+import dev.jamjet.loan.domain.Decision;
+import dev.jamjet.loan.domain.Decision.Outcome;
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.receipt.CollectingReceiptEmitter;
+import dev.jamjet.loan.receipt.ReceiptFactory;
+import dev.jamjet.loan.service.AccountHistoryService;
+import dev.jamjet.loan.service.CreditBureauService;
+import dev.jamjet.runtime.instrument.DurabilityContext;
+import dev.jamjet.runtime.instrument.annotations.Checkpoint;
+import dev.jamjet.runtime.instrument.annotations.DurableAgent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DurableAgent("loan-underwriting")
+public class UnderwritingAgent {
+
+    private static final int SCORE_HARD_DECLINE = 580;
+    private static final int SCORE_APPROVE_MIN  = 680;
+    private static final int MIN_HISTORY_MONTHS  = 24;
+
+    private static final String TOOL_CREDIT  = "credit_bureau.score";
+    private static final String TOOL_HISTORY = "account_history.months";
+    private static final String TOOL_SCORE   = "underwriting.score";
+
+    private final CreditBureauService creditService;
+    private final AccountHistoryService historyService;
+    private final ActionReceiptEmitter emitter;
+    private final ReceiptFactory factory;
+
+    /**
+     * Convenience constructor for tests and simple wiring that do not need receipt
+     * observation. Receipts are still emitted into a private {@link CollectingReceiptEmitter}
+     * but no caller holds a reference to it, so they are effectively discarded.
+     */
+    public UnderwritingAgent(CreditBureauService creditService, AccountHistoryService historyService) {
+        this(creditService, historyService,
+             new CollectingReceiptEmitter(),
+             new ReceiptFactory("loan-underwriter", "dev"));
+    }
+
+    /**
+     * Full constructor. Receipts for every guarded action are emitted to {@code emitter}
+     * (any {@link ActionReceiptEmitter}, in-memory for tests or disk-backed in production)
+     * using {@code factory} to build them.
+     */
+    public UnderwritingAgent(
+            CreditBureauService creditService,
+            AccountHistoryService historyService,
+            ActionReceiptEmitter emitter,
+            ReceiptFactory factory) {
+        this.creditService = creditService;
+        this.historyService = historyService;
+        this.emitter = emitter;
+        this.factory = factory;
+    }
+
+    private static dev.jamjet.runtime.instrument.DurabilityContext requireContext() {
+        var ctx = dev.jamjet.runtime.instrument.DurabilityContext.current();
+        if (ctx == null) {
+            throw new IllegalStateException(
+                "No DurabilityContext bound to this thread; wrap the call in DurabilityContext.setCurrent(...)/clear().");
+        }
+        return ctx;
+    }
+
+    @Checkpoint("credit")
+    public int pullCredit(LoanApplication app) {
+        return requireContext().replayOrExecute("credit", () -> {
+            int value = creditService.score(app);
+            emitter.emit(factory.forToolCall(
+                app.id(),
+                TOOL_CREDIT,
+                "{\"applicationId\":\"" + app.id() + "\"}",
+                String.valueOf(value)));
+            return value;
+        });
+    }
+
+    @Checkpoint("history")
+    public int pullHistory(LoanApplication app) {
+        return requireContext().replayOrExecute("history", () -> {
+            int value = historyService.monthsHistory(app);
+            emitter.emit(factory.forToolCall(
+                app.id(),
+                TOOL_HISTORY,
+                "{\"applicationId\":\"" + app.id() + "\"}",
+                String.valueOf(value)));
+            return value;
+        });
+    }
+
+    /**
+     * Compute the underwriting decision and emit its receipt.
+     *
+     * <p>Deliberately NOT a durable {@code @Checkpoint}: the decision is a pure function of
+     * {@code creditScore} + {@code monthsHistory} (both already durable) and is cheap to
+     * recompute, so persisting it buys nothing. Keeping it out of the {@link DurabilityContext}
+     * also guarantees the non-primitive {@link Decision} never reaches the on-disk
+     * {@link CheckpointStore}, so a checkpoint reloaded after a restart only ever holds JSON
+     * scalars and rehydrates without a {@code ClassCastException}. The receipt is still emitted
+     * once per call (idempotent at the receipt-id level once persisted via a durable emitter).
+     */
+    public Decision score(LoanApplication app, int creditScore, int monthsHistory) {
+        List<String> reasons = new ArrayList<>();
+        Outcome outcome;
+
+        if (creditScore < SCORE_HARD_DECLINE) {
+            outcome = Outcome.DECLINE;
+            reasons.add("credit score " + creditScore + " below " + SCORE_HARD_DECLINE);
+        } else if (creditScore >= SCORE_APPROVE_MIN
+                && monthsHistory >= MIN_HISTORY_MONTHS
+                && app.amountCents() * 5 <= app.annualIncomeCents() * 2) {
+            outcome = Outcome.APPROVE;
+            reasons.add("credit score " + creditScore + " meets threshold of " + SCORE_APPROVE_MIN);
+            reasons.add("account history " + monthsHistory + " months meets minimum of " + MIN_HISTORY_MONTHS);
+            reasons.add("loan amount within 40% of annual income");
+        } else {
+            outcome = Outcome.REFER;
+            if (creditScore < SCORE_APPROVE_MIN) {
+                reasons.add("credit score " + creditScore + " is borderline (below " + SCORE_APPROVE_MIN + ")");
+            }
+            if (monthsHistory < MIN_HISTORY_MONTHS) {
+                reasons.add("thin history: " + monthsHistory + " months (minimum " + MIN_HISTORY_MONTHS + ")");
+            }
+            if (app.amountCents() * 5 > app.annualIncomeCents() * 2) {
+                reasons.add("high amount-to-income: loan " + app.amountCents()
+                        + " exceeds 40% of annual income " + app.annualIncomeCents());
+            }
+        }
+
+        Decision decision = new Decision(app.id(), outcome, creditScore, reasons);
+        emitter.emit(factory.forToolCall(
+            app.id(),
+            TOOL_SCORE,
+            "{\"creditScore\":" + creditScore + ",\"monthsHistory\":" + monthsHistory + "}",
+            decision.outcome().name()));
+        return decision;
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/UnderwritingRunner.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/durable/UnderwritingRunner.java
@@ -1,0 +1,188 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.cloud.agentboundary.ActionReceiptEmitter;
+import dev.jamjet.cloud.agentboundary.Approval;
+import dev.jamjet.loan.approval.ApprovalGate;
+import dev.jamjet.loan.domain.Decision;
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.domain.RunState;
+import dev.jamjet.loan.receipt.ReceiptFactory;
+import dev.jamjet.loan.service.DisbursementService;
+import dev.jamjet.runtime.instrument.DurabilityContext;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Orchestrates a single human-in-the-loop underwriting run.
+ *
+ * <p>{@link #start} runs the durable credit → history → score pipeline (each step
+ * checkpointed via {@link CheckpointStore}) and then <em>suspends</em> at the disbursement
+ * step by registering a pending approval with the {@link ApprovalGate}. It does not
+ * disburse. A human records a decision out of band ({@code gate.decide(...)}); a later
+ * {@link #resume} call either disburses (if approved) or fails (if rejected).
+ *
+ * <p>Disbursement is guarded against repetition two ways: the run id is tracked in a
+ * {@code completed} set so {@link #resume} short-circuits once done, and the underlying
+ * {@link DisbursementService} is idempotent by application id. The disbursement receipt is
+ * emitted exactly once, carrying the {@link Approval} block from {@link ApprovalGate#toApprovalBlock}.
+ *
+ * <p>Cross-restart note: the tracked-application map and completed-set are in-memory; after
+ * a restart, call start(app) again (it resumes from the durable CheckpointStore) before resume().
+ */
+public final class UnderwritingRunner {
+
+    private static final String TOOL_DISBURSE = "disbursement.disburse";
+    private static final String DEFAULT_APPROVER = "approver@bank";
+
+    private final UnderwritingAgent agent;
+    private final CheckpointStore checkpoints;
+    private final ApprovalGate approvalGate;
+    private final DisbursementService disbursement;
+    private final ActionReceiptEmitter emitter;
+    private final ReceiptFactory factory;
+
+    // Run id is the loan application id throughout (one run per application here).
+    private final Map<String, LoanApplication> applications = new ConcurrentHashMap<>();
+    // In-process only (not persisted). After a process restart, completion is re-established
+    // by calling start() again before resume(); the idempotent DisbursementService prevents double-pay.
+    private final Set<String> completed = ConcurrentHashMap.newKeySet();
+    // Tracks runs that were hard-declined by the underwriting scorer. Persisted as in-memory
+    // only; after a restart, start() re-derives the decision (score is a pure function of the
+    // already-durable credit + history values) and re-populates this set.
+    private final Set<String> declined = ConcurrentHashMap.newKeySet();
+
+    public UnderwritingRunner(
+            UnderwritingAgent agent,
+            CheckpointStore checkpoints,
+            ApprovalGate approvalGate,
+            DisbursementService disbursement,
+            ActionReceiptEmitter emitter,
+            ReceiptFactory factory) {
+        this.agent = agent;
+        this.checkpoints = checkpoints;
+        this.approvalGate = approvalGate;
+        this.disbursement = disbursement;
+        this.emitter = emitter;
+        this.factory = factory;
+    }
+
+    /**
+     * Run the durable underwriting pipeline for {@code app}, persisting a checkpoint per
+     * step, then gate on the underwriting decision:
+     * <ul>
+     *   <li>DECLINE: terminal immediately. No approval is requested, no disbursement possible.
+     *       Returns {@link RunState#DECLINED}.</li>
+     *   <li>REFER or APPROVE: suspend pending human approval. Returns
+     *       {@link RunState#AWAITING_APPROVAL} without disbursing.</li>
+     * </ul>
+     * The credit, history, and score receipts are emitted in all cases.
+     */
+    public RunState start(LoanApplication app) {
+        String runId = app.id();
+        applications.put(runId, app);
+
+        // Resume an in-flight context in replay mode if one was checkpointed; else fresh.
+        DurabilityContext ctx = checkpoints.load(runId);
+        if (ctx == null) {
+            ctx = DurabilityContext.create();
+        }
+        DurabilityContext.setCurrent(ctx);
+        Decision decision;
+        try {
+            int credit = agent.pullCredit(app);
+            checkpoints.save(runId, ctx);
+            int history = agent.pullHistory(app);
+            checkpoints.save(runId, ctx);
+            // score is a pure recompute (not a durable @Checkpoint), so it adds nothing to the
+            // context and there is nothing new to persist after it; this also keeps the
+            // non-primitive Decision out of the on-disk checkpoint.
+            decision = agent.score(app, credit, history);
+        } finally {
+            DurabilityContext.clear();
+        }
+
+        // Hard decline: terminal. Do not ask for approval, do not allow disbursement.
+        if (decision.outcome() == Decision.Outcome.DECLINE) {
+            declined.add(runId);
+            return RunState.DECLINED;
+        }
+
+        // REFER or APPROVE: suspend at the guarded disbursement step pending human sign-off.
+        approvalGate.requireApproval(runId, TOOL_DISBURSE, DEFAULT_APPROVER);
+        return RunState.AWAITING_APPROVAL;
+    }
+
+    /**
+     * Resume a suspended run once a human decision has been recorded.
+     * <ul>
+     *   <li>Declined (hard-decline from the scorer): returns {@link RunState#DECLINED}
+     *       immediately with no disbursement. A declined run can never be resumed into
+     *       disbursement.</li>
+     *   <li>Approved: disburse once (idempotent), emit the disbursement receipt with the
+     *       approval block stamped, mark {@link RunState#COMPLETED}.</li>
+     *   <li>Rejected (or any non-approved terminal state): {@link RunState#FAILED}, no
+     *       disbursement, no receipt.</li>
+     * </ul>
+     * Calling {@code resume} again after completion is a no-op that returns COMPLETED and
+     * does not disburse a second time.
+     */
+    public RunState resume(String runId) {
+        // A hard-decline is terminal: no disbursement path exists.
+        if (declined.contains(runId)) {
+            return RunState.DECLINED;
+        }
+
+        if (completed.contains(runId)) {
+            return RunState.COMPLETED;
+        }
+
+        // Reject calls for completely unknown runs: no approval record and not tracked in-process.
+        RunState gateState = approvalGate.stateOf(runId);
+        if (gateState == null && !applications.containsKey(runId)) {
+            throw new IllegalStateException(
+                    "Unknown or unstarted run: " + runId + ". Call start() first.");
+        }
+
+        if (!approvalGate.isCleared(runId)) {
+            // Not approved: surface the gate's state. A recorded rejection maps to FAILED.
+            return gateState == RunState.FAILED ? RunState.FAILED : gateState;
+        }
+
+        LoanApplication app = applications.get(runId);
+        if (app == null) {
+            throw new IllegalStateException("No application tracked for run: " + runId);
+        }
+
+        // Idempotent disbursement (service is keyed by application id).
+        String reference = disbursement.disburse(runId, app.amountCents());
+
+        // Stamp the human approval onto the disbursement receipt.
+        Approval approval = approvalGate.toApprovalBlock(runId);
+        emitter.emit(factory.forToolCall(
+                runId,
+                TOOL_DISBURSE,
+                "{\"applicationId\":\"" + runId + "\",\"amountCents\":" + app.amountCents() + "}",
+                reference,
+                approval));
+
+        completed.add(runId);
+        return RunState.COMPLETED;
+    }
+
+    /**
+     * Best-effort current state for {@code runId}: DECLINED for a hard-decline, COMPLETED
+     * once disbursed, otherwise the approval gate's persisted state (AWAITING_APPROVAL,
+     * RUNNING, FAILED), or {@code null} if unknown.
+     */
+    public RunState stateOf(String runId) {
+        if (declined.contains(runId)) {
+            return RunState.DECLINED;
+        }
+        if (completed.contains(runId)) {
+            return RunState.COMPLETED;
+        }
+        return approvalGate.stateOf(runId);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/AuditBundle.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/AuditBundle.java
@@ -1,0 +1,94 @@
+package dev.jamjet.loan.receipt;
+
+import dev.jamjet.cloud.agentboundary.ActionReceipt;
+import dev.jamjet.cloud.agentboundary.Execution;
+import dev.jamjet.cloud.agentboundary.ReceiptHashes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An ordered, immutable collection of {@link ActionReceipt}s for one loan application,
+ * with independent hash verification.
+ *
+ * <p>{@link #verify()} recomputes each receipt's {@code receipt_hash} from the same
+ * canonical content the SDK hashes (version, receipt_id, issued_at, actor, agent, tool,
+ * target, arguments_hash, policy, approval, execution) and compares it to the stored
+ * {@code receipt_hash}. The bundle verifies only if every receipt matches.
+ */
+public final class AuditBundle {
+
+    private final List<ActionReceipt> receipts;
+
+    public AuditBundle(List<ActionReceipt> receipts) {
+        this.receipts = List.copyOf(Objects.requireNonNull(receipts, "receipts must not be null"));
+    }
+
+    /** The receipts in emission order; immutable. */
+    public List<ActionReceipt> receipts() {
+        return receipts;
+    }
+
+    /**
+     * Recompute every receipt's {@code receipt_hash} over its canonical content and compare
+     * to the stored value.
+     *
+     * <p>An empty bundle vacuously returns true; callers that require receipts to be present
+     * should check receipts().isEmpty() separately.
+     *
+     * @return {@code true} iff all receipts recompute to their stored {@code receipt_hash}
+     */
+    public boolean verify() {
+        for (ActionReceipt r : receipts) {
+            String recomputed = ReceiptHashes.computeReceiptHash(
+                r.version(), r.receiptId(), r.issuedAt(),
+                r.actor(), r.agent(), r.tool(), r.target(),
+                r.argumentsHash(), r.policy(), r.approval(), r.execution());
+            if (!recomputed.equals(r.receiptHash())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Test-only tamper injection: returns a copy whose receipt[idx] has a forged result_ref
+     * while keeping the original receipt_hash, so verify() detects the tamper. Not part of
+     * the public API.
+     *
+     * <p>The mutated field is {@link Execution#resultRef()} ({@code execution.result_ref}),
+     * which {@link ReceiptFactory} uses to record the tool output. Because {@code execution}
+     * is part of the canonical content fed to {@code receipt_hash}, the resulting receipt's
+     * stored hash no longer matches its content, so {@link #verify()} returns {@code false}.
+     *
+     * @param idx      index of the receipt to tamper
+     * @param newValue the forged tool output to write into {@code execution.result_ref}
+     * @return a new tampered {@link AuditBundle}
+     */
+    AuditBundle withMutatedOutput(int idx, String newValue) {
+        List<ActionReceipt> mutated = new ArrayList<>(receipts);
+        ActionReceipt original = mutated.get(idx);
+        Execution oldExec = original.execution();
+        Execution forgedExec = new Execution(
+            oldExec.status(), oldExec.completedAt(), oldExec.errorCode(), newValue);
+
+        // Rebuild the receipt with the forged execution but the ORIGINAL receipt_hash retained.
+        ActionReceipt tampered = new ActionReceipt(
+            original.version(),
+            original.receiptId(),
+            original.issuedAt(),
+            original.actor(),
+            original.agent(),
+            original.tool(),
+            original.target(),
+            original.argumentsHash(),
+            original.policy(),
+            original.approval(),
+            forgedExec,
+            original.receiptHash()   // stale hash from before the mutation; this is the tamper
+        );
+        mutated.set(idx, tampered);
+        return new AuditBundle(mutated);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/CollectingReceiptEmitter.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/CollectingReceiptEmitter.java
@@ -1,0 +1,49 @@
+package dev.jamjet.loan.receipt;
+
+import dev.jamjet.cloud.agentboundary.ActionReceipt;
+import dev.jamjet.cloud.agentboundary.ActionReceiptEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Thread-safe {@link ActionReceiptEmitter} that collects receipts in memory, grouped by
+ * loan application id, preserving emission order.
+ *
+ * <p>The grouping key is read from {@code target.resource_id}, the same field
+ * {@link ReceiptFactory} writes the {@code applicationId} into. Receipts whose
+ * {@code target.resource_id} is null are ignored for grouping (they cannot be addressed
+ * by {@link #bundleFor(String)}).
+ */
+public final class CollectingReceiptEmitter implements ActionReceiptEmitter {
+
+    private final Map<String, List<ActionReceipt>> byApplication = new ConcurrentHashMap<>();
+
+    @Override
+    public void emit(ActionReceipt receipt) {
+        if (receipt == null) {
+            return;
+        }
+        if (receipt.target() == null) {
+            return;
+        }
+        String applicationId = receipt.target().resourceId();
+        if (applicationId == null) {
+            return;
+        }
+        byApplication
+            .computeIfAbsent(applicationId, k -> new CopyOnWriteArrayList<>())
+            .add(receipt);
+    }
+
+    /**
+     * Return an ordered, immutable {@link AuditBundle} of all receipts emitted for the
+     * given application id (empty bundle if none).
+     */
+    public AuditBundle bundleFor(String applicationId) {
+        List<ActionReceipt> receipts = byApplication.getOrDefault(applicationId, List.of());
+        return new AuditBundle(receipts);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/DurableReceiptEmitter.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/DurableReceiptEmitter.java
@@ -1,0 +1,109 @@
+package dev.jamjet.loan.receipt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.jamjet.cloud.agentboundary.ActionReceipt;
+import dev.jamjet.cloud.agentboundary.ActionReceiptEmitter;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Disk-backed {@link ActionReceiptEmitter}. Each receipt is written as a JSON file under
+ * {@code <receiptsDir>/<applicationId>/<receiptId>.json}, so the audit trail survives the
+ * process that produced it, including a {@code kill -9}.
+ *
+ * <p>This is what makes the post-crash audit bundle COMPLETE: an in-memory emitter loses
+ * every pre-crash receipt when the process dies, and replayed steps do not re-emit (emission
+ * happens inside the durable supplier, which is skipped on replay). Persisting each receipt
+ * to disk means a fresh process can reconstruct the full bundle by re-reading the directory.
+ *
+ * <p>Writes are atomic (temp file + {@code ATOMIC_MOVE}) and keyed by {@code receiptId}, so a
+ * re-emitted receipt (same logical step after a crash + resume, given {@link ReceiptFactory}'s
+ * deterministic ids) overwrites its file rather than creating a duplicate. The grouping key is
+ * read from {@code target.resource_id}, the same field {@link ReceiptFactory} writes the
+ * {@code applicationId} into.
+ */
+public final class DurableReceiptEmitter implements ActionReceiptEmitter {
+
+    private static final String EXT = ".json";
+
+    /** Records carry {@code @JsonProperty} on every component, so a plain mapper roundtrips them. */
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+    private final Path receiptsDir;
+
+    public DurableReceiptEmitter(Path receiptsDir) {
+        try {
+            Files.createDirectories(receiptsDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot create receipts directory: " + receiptsDir, e);
+        }
+        this.receiptsDir = receiptsDir;
+    }
+
+    @Override
+    public void emit(ActionReceipt receipt) {
+        if (receipt == null || receipt.target() == null) {
+            return;
+        }
+        String applicationId = receipt.target().resourceId();
+        String receiptId = receipt.receiptId();
+        if (applicationId == null || applicationId.isBlank() || receiptId == null || receiptId.isBlank()) {
+            // Cannot address this receipt by application; skip persisting it (mirrors
+            // CollectingReceiptEmitter, which also ignores ungrouped receipts).
+            return;
+        }
+
+        Path appDir = receiptsDir.resolve(applicationId);
+        try {
+            Files.createDirectories(appDir);
+            Path tgt = appDir.resolve(receiptId + EXT);
+            Path tmp = Files.createTempFile(appDir, ".rc-" + receiptId + "-", ".tmp");
+            try {
+                MAPPER.writeValue(tmp.toFile(), receipt);
+                // Keyed by receiptId so a re-emit overwrites (idempotent).
+                Files.move(tmp, tgt,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                try { Files.deleteIfExists(tmp); } catch (IOException ignored) {}
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to persist receipt " + receiptId + " for " + applicationId, e);
+        }
+    }
+
+    /**
+     * Read every persisted receipt for {@code applicationId}, deserialize it, and return them
+     * in a deterministic order (by {@code issued_at}, then {@code receipt_id}). Returns an empty
+     * bundle if the application directory does not exist.
+     */
+    public AuditBundle bundleFor(String applicationId) {
+        Path appDir = receiptsDir.resolve(applicationId);
+        if (!Files.isDirectory(appDir)) {
+            return new AuditBundle(List.of());
+        }
+
+        List<ActionReceipt> receipts = new ArrayList<>();
+        try (Stream<Path> files = Files.list(appDir)) {
+            for (Path p : files.filter(f -> f.getFileName().toString().endsWith(EXT)).toList()) {
+                receipts.add(MAPPER.readValue(p.toFile(), ActionReceipt.class));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read receipts for application: " + applicationId, e);
+        }
+
+        // Best-effort order: by issuedAt, then receiptId. Same-millisecond receipts tie-break on id (lexicographic), not strict emission order. Fine for the one-call-per-tool pipeline.
+        receipts.sort(Comparator
+                .comparing(ActionReceipt::issuedAt)
+                .thenComparing(ActionReceipt::receiptId));
+        return new AuditBundle(receipts);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/ReceiptFactory.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/receipt/ReceiptFactory.java
@@ -1,0 +1,159 @@
+package dev.jamjet.loan.receipt;
+
+import dev.jamjet.cloud.agentboundary.ActionReceipt;
+import dev.jamjet.cloud.agentboundary.Actor;
+import dev.jamjet.cloud.agentboundary.ActorType;
+import dev.jamjet.cloud.agentboundary.Agent;
+import dev.jamjet.cloud.agentboundary.Approval;
+import dev.jamjet.cloud.agentboundary.Environment;
+import dev.jamjet.cloud.agentboundary.Execution;
+import dev.jamjet.cloud.agentboundary.ExecutionStatus;
+import dev.jamjet.cloud.agentboundary.Policy;
+import dev.jamjet.cloud.agentboundary.PolicyDecision;
+import dev.jamjet.cloud.agentboundary.ReceiptHashes;
+import dev.jamjet.cloud.agentboundary.Target;
+import dev.jamjet.cloud.agentboundary.Tool;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Builds fully-valid AgentBoundary v0.1 {@link ActionReceipt}s for the loan
+ * underwriter's tool calls.
+ *
+ * <p>Construction mirrors
+ * {@code dev.jamjet.cloud.spring.ActionReceiptAdvisor#after(..)}: every
+ * sub-record the advisor sets is set here, the {@code arguments_hash} and
+ * {@code receipt_hash} are computed via {@link ReceiptHashes}, and the receipt
+ * is built with {@code policy.decision = ALLOW} and {@code execution.status = SUCCESS}.
+ *
+ * <p>Two deliberate differences from the advisor, both within the spec:
+ * <ul>
+ *   <li><b>applicationId carrier:</b> we put the loan {@code applicationId} into
+ *       {@link Target#resourceId()} ({@code target.resource_id}). The advisor passes
+ *       {@code null} there; the spec defines {@code resource_id} as the identifier of
+ *       the resource the action affected, which is exactly the loan application. Using
+ *       an existing receipt field avoids adding any field to the SDK records and lets
+ *       the emitter group receipts by re-reading {@code target.resourceId()}.</li>
+ *   <li><b>tool output:</b> we record the tool result in
+ *       {@link Execution#resultRef()} ({@code execution.result_ref}). The advisor has no
+ *       result at intercept time so it passes {@code null}; here we have the output, and
+ *       {@code result_ref} is the spec's slot for "a reference to the action's result".
+ *       Because {@code execution} feeds {@code receipt_hash}, mutating this field is what
+ *       the tamper test detects.</li>
+ * </ul>
+ */
+public final class ReceiptFactory {
+
+    private static final String ACTOR_ID = "loan-underwriter-agent";
+    private static final String AGENT_FRAMEWORK = "jamjet-runtime-java";
+    private static final String AGENT_FRAMEWORK_VERSION = "0.3.1";
+    private static final String AGENT_MODEL = "deterministic-mock";
+
+    private final String system;
+    private final Environment environment;
+
+    /**
+     * @param system      the target system name (e.g. {@code "loan-underwriter"});
+     *                    recorded in {@code target.system}
+     * @param environment one of {@code "prod"}, {@code "staging"}, {@code "dev"}
+     *                    (case-insensitive); anything else falls back to {@code dev}
+     */
+    public ReceiptFactory(String system, String environment) {
+        if (system == null || system.isBlank()) {
+            throw new IllegalArgumentException("system must not be blank");
+        }
+        this.system = system;
+        this.environment = resolveEnvironment(environment);
+    }
+
+    /**
+     * Build a fully-valid Action Receipt for a single tool call.
+     *
+     * @param applicationId loan application id; carried in {@code target.resource_id}
+     * @param toolName       the tool/capability invoked (e.g. {@code credit_bureau.score})
+     * @param argumentsJson  raw JSON arguments string (hashed into {@code arguments_hash})
+     * @param output         the tool result; recorded in {@code execution.result_ref}
+     * @return a validated {@link ActionReceipt} with a correct {@code receipt_hash}
+     */
+    public ActionReceipt forToolCall(String applicationId, String toolName, String argumentsJson, String output) {
+        return forToolCall(applicationId, toolName, argumentsJson, output, null);
+    }
+
+    /**
+     * Build a fully-valid Action Receipt for a single tool call, with an optional
+     * {@code approval} block stamped onto the receipt.
+     *
+     * <p>Identical to the 4-arg overload except that {@code approval} is recorded as the
+     * receipt's approval sub-record. Because {@code approval} is part of the canonical
+     * content fed to {@code receipt_hash} (see {@link ReceiptHashes#computeReceiptHash}),
+     * a receipt carrying an approval block still verifies: the hash is computed over the
+     * same content the bundle re-hashes.
+     *
+     * @param applicationId loan application id; carried in {@code target.resource_id}
+     * @param toolName       the tool/capability invoked (e.g. {@code disbursement.disburse})
+     * @param argumentsJson  raw JSON arguments string (hashed into {@code arguments_hash})
+     * @param output         the tool result; recorded in {@code execution.result_ref}
+     * @param approval       human-in-the-loop approval block, or {@code null} for none
+     * @return a validated {@link ActionReceipt} with a correct {@code receipt_hash}
+     */
+    public ActionReceipt forToolCall(
+            String applicationId,
+            String toolName,
+            String argumentsJson,
+            String output,
+            Approval approval) {
+        String argsHash = ReceiptHashes.computeArgumentsHash(argumentsJson);
+        // Deterministic receipt_id derived from (applicationId, toolName). Each tool runs once
+        // per application here, so there is no legitimate collision; a re-executed step (e.g.
+        // after a crash + resume) produces the SAME id, so a disk-backed emitter overwrites it
+        // rather than appending a duplicate. The id is still inside receipt_hash, so the receipt
+        // verifies: deterministic is just as valid as random.
+        String receiptId = UUID.nameUUIDFromBytes(
+                (applicationId + "|" + toolName).getBytes(StandardCharsets.UTF_8)).toString();
+        String issuedAt = Instant.now().toString();
+        String completedAt = Instant.now().toString();
+
+        Actor actor = new Actor(ActorType.AGENT, ACTOR_ID, null);
+        Agent agent = new Agent(AGENT_FRAMEWORK, AGENT_FRAMEWORK_VERSION, AGENT_MODEL, null);
+        // tool.name == tool.capability for these single-purpose tools (mirrors the advisor,
+        // which sets capability = tc.name()).
+        Tool tool = new Tool(toolName, null, toolName);
+        // applicationId carried in target.resource_id (see class doc).
+        Target target = new Target(system, environment, applicationId);
+        Policy policy = new Policy("default.allow", "1", PolicyDecision.ALLOW);
+        // tool output carried in execution.result_ref (see class doc); part of receipt_hash.
+        Execution execution = new Execution(ExecutionStatus.SUCCESS, completedAt, null, output);
+
+        // receipt_hash = SHA-256 of canonical JSON of all receipt fields EXCEPT receipt_hash.
+        // The approval block (when present) is part of that canonical content.
+        String receiptHash = ReceiptHashes.computeReceiptHash(
+            ActionReceipt.CURRENT_VERSION, receiptId, issuedAt,
+            actor, agent, tool, target, argsHash, policy, approval, execution);
+
+        return new ActionReceipt(
+            ActionReceipt.CURRENT_VERSION,
+            receiptId,
+            issuedAt,
+            actor,
+            agent,
+            tool,
+            target,
+            argsHash,
+            policy,
+            approval,
+            execution,
+            receiptHash
+        );
+    }
+
+    private static Environment resolveEnvironment(String environment) {
+        if (environment == null) {
+            return Environment.DEV;
+        }
+        if ("prod".equalsIgnoreCase(environment)) return Environment.PROD;
+        if ("staging".equalsIgnoreCase(environment)) return Environment.STAGING;
+        return Environment.DEV;
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/AccountHistoryService.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/AccountHistoryService.java
@@ -1,0 +1,7 @@
+package dev.jamjet.loan.service;
+
+import dev.jamjet.loan.domain.LoanApplication;
+
+public interface AccountHistoryService {
+    int monthsHistory(LoanApplication app);
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/CreditBureauService.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/CreditBureauService.java
@@ -1,0 +1,7 @@
+package dev.jamjet.loan.service;
+
+import dev.jamjet.loan.domain.LoanApplication;
+
+public interface CreditBureauService {
+    int score(LoanApplication app);
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/DisbursementService.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/DisbursementService.java
@@ -1,0 +1,5 @@
+package dev.jamjet.loan.service;
+
+public interface DisbursementService {
+    String disburse(String applicationId, long amountCents);
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockAccountHistory.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockAccountHistory.java
@@ -1,0 +1,18 @@
+package dev.jamjet.loan.service;
+
+import dev.jamjet.loan.domain.LoanApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MockAccountHistory implements AccountHistoryService {
+    private static final Logger log = LoggerFactory.getLogger(MockAccountHistory.class);
+
+    private static final int MAX_HISTORY_MONTHS = 120; // 10 years
+
+    @Override
+    public int monthsHistory(LoanApplication app) {
+        log.info("account history CALLED for application {}", app.id());
+        // Deterministic stub: maps the application id into a months-of-history range [0, 120).
+        return Math.floorMod(app.id().hashCode(), MAX_HISTORY_MONTHS);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockCreditBureau.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockCreditBureau.java
@@ -1,0 +1,19 @@
+package dev.jamjet.loan.service;
+
+import dev.jamjet.loan.domain.LoanApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MockCreditBureau implements CreditBureauService {
+    private static final Logger log = LoggerFactory.getLogger(MockCreditBureau.class);
+
+    private static final int MIN_SCORE = 300;
+    private static final int SCORE_SPAN = 551; // count of distinct scores from 300..850 inclusive
+
+    @Override
+    public int score(LoanApplication app) {
+        log.info("credit bureau CALLED for application {}", app.id());
+        // Deterministic stub: maps the application id into the FICO range [300, 850].
+        return MIN_SCORE + Math.floorMod(app.id().hashCode(), SCORE_SPAN);
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockDisbursement.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/service/MockDisbursement.java
@@ -1,0 +1,15 @@
+package dev.jamjet.loan.service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MockDisbursement implements DisbursementService {
+    private final ConcurrentHashMap<String, String> ledger = new ConcurrentHashMap<>();
+    private final AtomicLong counter = new AtomicLong();
+
+    @Override
+    public String disburse(String applicationId, long amountCents) {
+        return ledger.computeIfAbsent(applicationId,
+                id -> "REF-" + id + "-" + counter.incrementAndGet());
+    }
+}

--- a/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/web/UnderwritingController.java
+++ b/examples/loan-underwriter-agent/src/main/java/dev/jamjet/loan/web/UnderwritingController.java
@@ -1,0 +1,105 @@
+package dev.jamjet.loan.web;
+
+import dev.jamjet.loan.approval.ApprovalGate;
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.domain.RunState;
+import dev.jamjet.loan.durable.UnderwritingRunner;
+import dev.jamjet.loan.receipt.AuditBundle;
+import dev.jamjet.loan.receipt.DurableReceiptEmitter;
+import dev.jamjet.runtime.core.event.ApprovalDecision;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/applications")
+public class UnderwritingController {
+
+    private final UnderwritingRunner runner;
+    private final ApprovalGate approvalGate;
+    private final DurableReceiptEmitter emitter;
+
+    public UnderwritingController(
+            UnderwritingRunner runner,
+            ApprovalGate approvalGate,
+            DurableReceiptEmitter emitter) {
+        this.runner = runner;
+        this.approvalGate = approvalGate;
+        this.emitter = emitter;
+    }
+
+    /**
+     * Start an underwriting run. The run suspends at the approval gate.
+     * Returns 202 Accepted with the current state (AWAITING_APPROVAL).
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public Map<String, Object> startApplication(@RequestBody LoanApplication app) {
+        RunState state = runner.start(app);
+        return Map.of(
+                "applicationId", app.id(),
+                "state", state.name()
+        );
+    }
+
+    /**
+     * Record a human decision and, if approved, disburse.
+     * Returns 200 OK with the resulting state (COMPLETED or FAILED).
+     */
+    @PostMapping("/{id}/approve")
+    public Map<String, Object> approve(
+            @PathVariable("id") String id,
+            @RequestBody ApproveRequest body) {
+        if (body.decision() == null || body.decision().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "decision is required (approved|rejected|escalate)");
+        }
+        ApprovalDecision decision;
+        try {
+            decision = ApprovalDecision.fromValue(body.decision());
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "unknown decision: " + body.decision() + " (expected approved|rejected|escalate)");
+        }
+        approvalGate.decide(id, body.userId(), decision, body.comment());
+        RunState state = runner.resume(id);
+        return Map.of(
+                "applicationId", id,
+                "state", state.name()
+        );
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, Object> handleUnknownRun(IllegalStateException ex) {
+        return Map.of("error", ex.getMessage());
+    }
+
+    /**
+     * Return the audit bundle for an application: verified flag and the full receipt list.
+     * Returns 200 OK. Each receipt is serialized via Jackson using the @JsonProperty
+     * annotations on the ActionReceipt record and its sub-records.
+     */
+    @GetMapping("/{id}/receipts")
+    public Map<String, Object> receipts(@PathVariable("id") String id) {
+        AuditBundle bundle = emitter.bundleFor(id);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("applicationId", id);
+        response.put("verified", bundle.verify());
+        response.put("receipts", bundle.receipts());
+        return response;
+    }
+
+    /** Request body for the approve endpoint. */
+    record ApproveRequest(String userId, String decision, String comment) {}
+}

--- a/examples/loan-underwriter-agent/src/main/resources/application.yml
+++ b/examples/loan-underwriter-agent/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: loan-underwriter
+  ai:
+    openai:
+      # Optional. The Spring AI receipt path (ChatClientConfig) only activates when loan.llm.enabled=true AND a model starter is on the classpath.
+      api-key: ${OPENAI_API_KEY:disabled}
+loan:
+  checkpoint-dir: ${java.io.tmpdir}/loan-checkpoints
+  approval-dir: ${java.io.tmpdir}/loan-approvals
+  # Disk-backed action receipts. Persisting here is what makes the audit bundle survive a
+  # process crash; a restart re-reads this directory to reconstruct the full bundle.
+  receipts-dir: ${java.io.tmpdir}/loan-receipts

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/ContextLoadsTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/ContextLoadsTest.java
@@ -1,0 +1,12 @@
+package dev.jamjet.loan;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ContextLoadsTest {
+    @Test
+    void contextLoads() {
+        // Passes only when the Spring context starts with all beans wired.
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/approval/ApprovalGateTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/approval/ApprovalGateTest.java
@@ -1,0 +1,49 @@
+package dev.jamjet.loan.approval;
+
+import dev.jamjet.loan.domain.RunState;
+import dev.jamjet.runtime.core.event.ApprovalDecision;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApprovalGateTest {
+    @Test
+    void runIsAwaitingUntilDecisionArrives(@TempDir Path dir) {
+        var gate = new ApprovalGate(dir);
+        gate.requireApproval("run-1", "disbursement.disburse", "approver@bank");
+        assertEquals(RunState.AWAITING_APPROVAL, gate.stateOf("run-1"));
+        assertFalse(gate.isCleared("run-1"));
+
+        gate.decide("run-1", "officer@bank", ApprovalDecision.APPROVED, "looks good");
+        assertTrue(gate.isCleared("run-1"));
+        assertEquals(RunState.RUNNING, gate.stateOf("run-1"));
+    }
+
+    @Test
+    void rejectionBlocksDisbursement(@TempDir Path dir) {
+        var gate = new ApprovalGate(dir);
+        gate.requireApproval("run-2", "disbursement.disburse", "approver@bank");
+        gate.decide("run-2", "officer@bank", ApprovalDecision.REJECTED, "income unverified");
+        assertFalse(gate.isCleared("run-2"));
+        assertEquals(RunState.FAILED, gate.stateOf("run-2"));
+    }
+
+    @Test
+    void pendingStateSurvivesReload(@TempDir Path dir) {
+        new ApprovalGate(dir).requireApproval("run-3", "disbursement.disburse", "a@bank");
+        // A fresh gate instance (simulating a process restart) sees the pending request.
+        assertEquals(RunState.AWAITING_APPROVAL, new ApprovalGate(dir).stateOf("run-3"));
+    }
+
+    @Test
+    void requireApprovalDoesNotEraseAnExistingDecision(@TempDir Path dir) {
+        var gate = new ApprovalGate(dir);
+        gate.requireApproval("run-x", "disbursement.disburse", "approver@bank");
+        gate.decide("run-x", "officer@bank", ApprovalDecision.APPROVED, "ok");
+        // A redundant requireApproval (e.g. after a restart + re-start) must NOT wipe the decision.
+        gate.requireApproval("run-x", "disbursement.disburse", "approver@bank");
+        assertTrue(gate.isCleared("run-x"), "prior APPROVED decision must survive a redundant requireApproval");
+        assertEquals(RunState.RUNNING, gate.stateOf("run-x"));
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/AgentEmitsReceiptsTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/AgentEmitsReceiptsTest.java
@@ -1,0 +1,30 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.receipt.*;
+import dev.jamjet.runtime.instrument.DurabilityContext;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AgentEmitsReceiptsTest {
+    @Test
+    void everyGuardedActionProducesAReceipt() {
+        var emitter = new CollectingReceiptEmitter();
+        var factory = new ReceiptFactory("loan-underwriter", "test");
+        var agent = new UnderwritingAgent(app -> 720, app -> 36, emitter, factory);
+        var app = new LoanApplication("app-7", "Grace", 20_000, 90_000);
+
+        var ctx = DurabilityContext.create();
+        DurabilityContext.setCurrent(ctx);
+        try {
+            agent.pullCredit(app);
+            agent.pullHistory(app);
+        } finally {
+            DurabilityContext.clear();
+        }
+
+        var bundle = emitter.bundleFor("app-7");
+        assertEquals(2, bundle.receipts().size());
+        assertTrue(bundle.verify());
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/CheckpointStoreTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/CheckpointStoreTest.java
@@ -1,0 +1,64 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.runtime.instrument.DurabilityContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CheckpointStoreTest {
+    @Test
+    void savesAndRehydratesInReplayMode(@TempDir Path dir) {
+        var store = new CheckpointStore(dir);
+        var ctx = DurabilityContext.create();
+        DurabilityContext.setCurrent(ctx);
+        try {
+            ctx.replayOrExecute("credit", () -> "720");
+            ctx.replayOrExecute("history", () -> "36");
+            store.save("run-1", ctx);
+        } finally {
+            DurabilityContext.clear();
+        }
+
+        var resumed = store.load("run-1");
+        assertNotNull(resumed);
+        assertTrue(resumed.isReplayMode());
+        // Supplier must NOT run on replay: sentinel proves the cached value is returned.
+        String credit = resumed.replayOrExecute("credit", () -> { throw new AssertionError("re-ran"); });
+        assertEquals("720", credit);
+        assertEquals(java.util.List.of("credit", "history"), resumed.getCheckpointIds());
+    }
+
+    @Test
+    void loadReturnsNullForUnknownRun(@TempDir Path dir) {
+        assertNull(new CheckpointStore(dir).load("nope"));
+    }
+
+    @Test
+    void roundtripsPrimitiveIntAcrossAFreshStore(@TempDir Path dir) {
+        // Record an int checkpoint and persist it.
+        var store = new CheckpointStore(dir);
+        var ctx = DurabilityContext.create();
+        DurabilityContext.setCurrent(ctx);
+        try {
+            int credit = ctx.replayOrExecute("credit", () -> 720);
+            assertEquals(720, credit);
+            store.save("run-int", ctx);
+        } finally {
+            DurabilityContext.clear();
+        }
+
+        // Reload via a FRESH store (simulates a process restart with empty memory).
+        var resumed = new CheckpointStore(dir).load("run-int");
+        assertNotNull(resumed);
+        assertTrue(resumed.isReplayMode());
+
+        // The rehydrated value must be an Integer (NOT the String "720"), so the agent's
+        // int-returning checkpoint unboxes cleanly without ClassCastException.
+        Object raw = resumed.getRecordedResult("credit");
+        assertInstanceOf(Integer.class, raw, "checkpoint must rehydrate as Integer, not String");
+
+        // Supplier must NOT run on replay; the cached Integer is returned and unboxes to int.
+        assertEquals(720, (int) resumed.replayOrExecute("credit", () -> { throw new AssertionError("re-ran"); }));
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/UnderwritingAgentResumeTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/UnderwritingAgentResumeTest.java
@@ -1,0 +1,61 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.service.AccountHistoryService;
+import dev.jamjet.loan.service.CreditBureauService;
+import dev.jamjet.runtime.instrument.DurabilityContext;
+import org.junit.jupiter.api.Test;
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnderwritingAgentResumeTest {
+    @Test
+    void resumeDoesNotRepeatCompletedCheckpoints() {
+        var creditCalls = new AtomicInteger();
+        CreditBureauService credit = app -> { creditCalls.incrementAndGet(); return 720; };
+        AccountHistoryService history = app -> 36;
+        var agent = new UnderwritingAgent(credit, history);
+        var app = new LoanApplication("app-1", "Ada", 25_000, 60_000);
+
+        // First pass: run the credit step, persist into a context, simulate crash before scoring.
+        var ctx = DurabilityContext.create();
+        DurabilityContext.setCurrent(ctx);
+        try {
+            agent.pullCredit(app);
+        } finally {
+            DurabilityContext.clear();
+        }
+        assertEquals(1, creditCalls.get());
+
+        // Resume: rehydrate ctx in replay mode and run the full pipeline.
+        ctx.setReplayMode(true);
+        DurabilityContext.setCurrent(ctx);
+        try {
+            agent.pullCredit(app);          // replays: must NOT call the service again
+            agent.pullHistory(app);
+        } finally {
+            DurabilityContext.clear();
+        }
+        assertEquals(1, creditCalls.get(), "credit pull must not repeat on resume");
+    }
+
+    @Test
+    void scoreAppliesDeterministicRule() {
+        var agent = new UnderwritingAgent(app -> 720, app -> 36);
+        var ctx = DurabilityContext.create();   // non-replay: suppliers run
+        DurabilityContext.setCurrent(ctx);
+        try {
+            // APPROVE: credit>=680, history>=24, amount 20k <= 40% of 90k (=36k)
+            var approve = agent.score(new dev.jamjet.loan.domain.LoanApplication("a", "n", 20_000, 90_000), 720, 36);
+            assertEquals(dev.jamjet.loan.domain.Decision.Outcome.APPROVE, approve.outcome());
+            // DECLINE: credit below 580
+            var decline = agent.score(new dev.jamjet.loan.domain.LoanApplication("b", "n", 20_000, 90_000), 500, 36);
+            assertEquals(dev.jamjet.loan.domain.Decision.Outcome.DECLINE, decline.outcome());
+            // REFER: mid credit (580<=score<680)
+            var refer = agent.score(new dev.jamjet.loan.domain.LoanApplication("c", "n", 20_000, 90_000), 650, 36);
+            assertEquals(dev.jamjet.loan.domain.Decision.Outcome.REFER, refer.outcome());
+        } finally {
+            DurabilityContext.clear();
+        }
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/UnderwritingRunnerTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/durable/UnderwritingRunnerTest.java
@@ -1,0 +1,180 @@
+package dev.jamjet.loan.durable;
+
+import dev.jamjet.loan.approval.ApprovalGate;
+import dev.jamjet.loan.domain.LoanApplication;
+import dev.jamjet.loan.domain.RunState;
+import dev.jamjet.loan.receipt.AuditBundle;
+import dev.jamjet.loan.receipt.CollectingReceiptEmitter;
+import dev.jamjet.loan.receipt.ReceiptFactory;
+import dev.jamjet.loan.service.AccountHistoryService;
+import dev.jamjet.loan.service.CreditBureauService;
+import dev.jamjet.loan.service.DisbursementService;
+import dev.jamjet.runtime.core.event.ApprovalDecision;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnderwritingRunnerTest {
+
+    /** Counting, idempotent-by-application-id disbursement fake. */
+    private static final class CountingDisbursement implements DisbursementService {
+        final AtomicInteger calls = new AtomicInteger();
+        private final ConcurrentHashMap<String, String> ledger = new ConcurrentHashMap<>();
+
+        @Override
+        public String disburse(String applicationId, long amountCents) {
+            calls.incrementAndGet();
+            return ledger.computeIfAbsent(applicationId, id -> "REF-" + id);
+        }
+    }
+
+    private UnderwritingRunner newRunner(Path cpDir, Path apDir,
+                                         CollectingReceiptEmitter emitter,
+                                         DisbursementService disbursement) {
+        CreditBureauService credit = app -> 720;
+        AccountHistoryService history = app -> 36;
+        ReceiptFactory factory = new ReceiptFactory("loan-underwriter", "dev");
+        UnderwritingAgent agent = new UnderwritingAgent(credit, history, emitter, factory);
+        CheckpointStore checkpoints = new CheckpointStore(cpDir);
+        ApprovalGate gate = new ApprovalGate(apDir);
+        return new UnderwritingRunner(agent, checkpoints, gate, disbursement, emitter, factory);
+    }
+
+    private static boolean hasDisbursementReceipt(AuditBundle bundle) {
+        return bundle.receipts().stream()
+                .anyMatch(r -> "disbursement.disburse".equals(r.tool().name()));
+    }
+
+    @Test
+    void startSuspendsForApprovalAndDoesNotDisburse(@TempDir Path cpDir, @TempDir Path apDir) {
+        var emitter = new CollectingReceiptEmitter();
+        var disbursement = new CountingDisbursement();
+        var runner = newRunner(cpDir, apDir, emitter, disbursement);
+        var app = new LoanApplication("app-start", "Ada", 20_000, 90_000);
+
+        RunState state = runner.start(app);
+
+        assertEquals(RunState.AWAITING_APPROVAL, state);
+        assertEquals(0, disbursement.calls.get(), "must not disburse before approval");
+        assertFalse(hasDisbursementReceipt(emitter.bundleFor("app-start")),
+                "no disbursement receipt before approval");
+    }
+
+    @Test
+    void approvedResumeDisbursesOnceWithStampedApprovalAndVerifies(@TempDir Path cpDir, @TempDir Path apDir) {
+        var emitter = new CollectingReceiptEmitter();
+        var disbursement = new CountingDisbursement();
+        var runner = newRunner(cpDir, apDir, emitter, disbursement);
+        var app = new LoanApplication("app-ok", "Ada", 20_000, 90_000);
+
+        assertEquals(RunState.AWAITING_APPROVAL, runner.start(app));
+
+        // Human approves out of band.
+        var gate = new ApprovalGate(apDir);
+        gate.decide("app-ok", "officer@bank", ApprovalDecision.APPROVED, "ok");
+
+        RunState resumed = runner.resume("app-ok");
+        assertEquals(RunState.COMPLETED, resumed);
+        assertEquals(1, disbursement.calls.get(), "approved resume disburses exactly once");
+
+        AuditBundle bundle = emitter.bundleFor("app-ok");
+        var disbursementReceipt = bundle.receipts().stream()
+                .filter(r -> "disbursement.disburse".equals(r.tool().name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected a disbursement receipt"));
+        assertNotNull(disbursementReceipt.approval(), "disbursement receipt carries the approval block");
+        assertEquals("officer@bank", disbursementReceipt.approval().approver().id());
+        assertTrue(bundle.verify(), "bundle still verifies with the approval block stamped");
+
+        // Idempotency: a second resume must not disburse again.
+        RunState resumedAgain = runner.resume("app-ok");
+        assertEquals(RunState.COMPLETED, resumedAgain);
+        assertEquals(1, disbursement.calls.get(), "second resume must not disburse again");
+        // And it must not emit a duplicate disbursement receipt.
+        long disbursementReceipts = emitter.bundleFor("app-ok").receipts().stream()
+                .filter(r -> "disbursement.disburse".equals(r.tool().name()))
+                .count();
+        assertEquals(1, disbursementReceipts, "exactly one disbursement receipt");
+    }
+
+    @Test
+    void persistedCheckpointHoldsOnlyPrimitivesNotTheDecision(@TempDir Path cpDir, @TempDir Path apDir) {
+        var emitter = new CollectingReceiptEmitter();
+        var runner = newRunner(cpDir, apDir, emitter, new CountingDisbursement());
+        var app = new LoanApplication("app-cp", "Ada", 20_000, 90_000);
+
+        runner.start(app);
+
+        // The on-disk checkpoint must rehydrate cleanly across a fresh store and contain
+        // only the int checkpoints (credit, history): never the non-primitive Decision.
+        var reloaded = new CheckpointStore(cpDir).load("app-cp");
+        assertNotNull(reloaded, "checkpoint must have been persisted");
+        assertEquals(java.util.List.of("credit", "history"), reloaded.getCheckpointIds(),
+                "only credit and history are durable; the Decision is recomputed, never persisted");
+        assertInstanceOf(Integer.class, reloaded.getRecordedResult("credit"));
+        assertInstanceOf(Integer.class, reloaded.getRecordedResult("history"));
+    }
+
+    /**
+     * A declined application (credit score below 580) must terminate in start() with
+     * RunState.DECLINED. No approval must be requested, and no disbursement receipt may
+     * appear. A subsequent resume() must not disburse either.
+     *
+     * <p>Verified score: "app-ok".hashCode() = -1634616714;
+     * Math.floorMod(-1634616714, 551) = 108; credit = 300 + 108 = 408 (DECLINE).
+     */
+    @Test
+    void declinedApplicationTerminatesWithNoApprovalAndNoDisbursement(
+            @TempDir Path cpDir, @TempDir Path apDir) {
+        var emitter = new CollectingReceiptEmitter();
+        var disbursement = new CountingDisbursement();
+
+        // Use the real MockCreditBureau so the formula (300 + floorMod(hash, 551)) applies.
+        ReceiptFactory factory = new ReceiptFactory("loan-underwriter", "dev");
+        CreditBureauService credit = new dev.jamjet.loan.service.MockCreditBureau();
+        AccountHistoryService history = new dev.jamjet.loan.service.MockAccountHistory();
+        UnderwritingAgent agent = new UnderwritingAgent(credit, history, emitter, factory);
+        CheckpointStore checkpoints = new CheckpointStore(cpDir);
+        ApprovalGate gate = new ApprovalGate(apDir);
+        var runner = new UnderwritingRunner(agent, checkpoints, gate, disbursement, emitter, factory);
+
+        // "app-ok" -> credit = 408 -> DECLINE
+        var app = new LoanApplication("app-ok", "Bob", 20_000, 90_000);
+        RunState state = runner.start(app);
+
+        assertEquals(RunState.DECLINED, state, "start() must return DECLINED for a hard-decline application");
+        assertNull(gate.stateOf("app-ok"), "approval gate must not have been touched for a declined application");
+        assertEquals(0, disbursement.calls.get(), "declined application must not trigger disbursement");
+        assertFalse(hasDisbursementReceipt(emitter.bundleFor("app-ok")),
+                "declined application must not produce a disbursement receipt");
+
+        // resume() on a declined run must also not disburse
+        RunState resumed = runner.resume("app-ok");
+        assertEquals(RunState.DECLINED, resumed, "resume() on a declined run must return DECLINED");
+        assertEquals(0, disbursement.calls.get(), "resume() on a declined run must not disburse");
+    }
+
+    @Test
+    void rejectedResumeFailsAndDoesNotDisburse(@TempDir Path cpDir, @TempDir Path apDir) {
+        var emitter = new CollectingReceiptEmitter();
+        var disbursement = new CountingDisbursement();
+        var runner = newRunner(cpDir, apDir, emitter, disbursement);
+        var app = new LoanApplication("app-no", "Ada", 20_000, 90_000);
+
+        assertEquals(RunState.AWAITING_APPROVAL, runner.start(app));
+
+        var gate = new ApprovalGate(apDir);
+        gate.decide("app-no", "officer@bank", ApprovalDecision.REJECTED, "income unverified");
+
+        RunState resumed = runner.resume("app-no");
+        assertEquals(RunState.FAILED, resumed);
+        assertEquals(0, disbursement.calls.get(), "rejected run must not disburse");
+        assertFalse(hasDisbursementReceipt(emitter.bundleFor("app-no")),
+                "no disbursement receipt for a rejected run");
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/receipt/AuditBundleTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/receipt/AuditBundleTest.java
@@ -1,0 +1,50 @@
+package dev.jamjet.loan.receipt;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuditBundleTest {
+
+    @Test
+    void bundlePreservesOrderAndVerifies() {
+        var emitter = new CollectingReceiptEmitter();
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+        emitter.emit(factory.forToolCall("app-1", "credit_bureau.score", "{\"id\":\"app-1\"}", "720"));
+        emitter.emit(factory.forToolCall("app-1", "disbursement.disburse", "{\"amount\":25000}", "ref-9"));
+
+        AuditBundle bundle = emitter.bundleFor("app-1");
+        assertEquals(2, bundle.receipts().size());
+        assertEquals("credit_bureau.score", bundle.receipts().get(0).tool().name());
+        assertTrue(bundle.verify(), "every receipt_hash must recompute to its stored value");
+    }
+
+    @Test
+    void receiptIdIsDeterministicPerAppAndTool() {
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+        // Same (applicationId, toolName) -> same receipt_id, so a re-executed step overwrites
+        // rather than duplicates. Differing args/output must not change the id.
+        var first = factory.forToolCall("app-9", "credit_bureau.score", "{\"a\":1}", "720");
+        var second = factory.forToolCall("app-9", "credit_bureau.score", "{\"a\":2}", "999");
+        assertEquals(first.receiptId(), second.receiptId(),
+                "receipt_id must be a pure function of (applicationId, toolName)");
+        // Different tool -> different id.
+        var other = factory.forToolCall("app-9", "account_history.months", "{\"a\":1}", "36");
+        assertNotEquals(first.receiptId(), other.receiptId());
+        // Different app -> different id.
+        var otherApp = factory.forToolCall("app-X", "credit_bureau.score", "{\"a\":1}", "720");
+        assertNotEquals(first.receiptId(), otherApp.receiptId());
+        // Deterministic-id receipts still verify.
+        var bundle = new AuditBundle(java.util.List.of(first, other));
+        assertTrue(bundle.verify());
+    }
+
+    @Test
+    void tamperingBreaksVerification() {
+        var emitter = new CollectingReceiptEmitter();
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+        emitter.emit(factory.forToolCall("app-2", "disbursement.disburse", "{\"amount\":1}", "ref-1"));
+        AuditBundle bundle = emitter.bundleFor("app-2");
+        AuditBundle tampered = bundle.withMutatedOutput(0, "ref-HACKED");
+        assertFalse(tampered.verify(), "mutated output must fail hash verification");
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/receipt/DurableReceiptEmitterTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/receipt/DurableReceiptEmitterTest.java
@@ -1,0 +1,70 @@
+package dev.jamjet.loan.receipt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DurableReceiptEmitterTest {
+
+    @Test
+    void emptyBundleWhenNoReceiptsOnDisk(@TempDir Path dir) {
+        var emitter = new DurableReceiptEmitter(dir);
+        var bundle = emitter.bundleFor("nobody");
+        assertTrue(bundle.receipts().isEmpty());
+        assertTrue(bundle.verify(), "an empty bundle vacuously verifies");
+    }
+
+    @Test
+    void receiptsSurviveAFreshEmitterAndStillVerify(@TempDir Path dir) {
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+
+        // Process 1: emit two distinct receipts for one application to disk.
+        var emitter1 = new DurableReceiptEmitter(dir);
+        emitter1.emit(factory.forToolCall("app-d", "credit_bureau.score", "{\"id\":\"app-d\"}", "720"));
+        emitter1.emit(factory.forToolCall("app-d", "account_history.months", "{\"id\":\"app-d\"}", "36"));
+
+        // Process 2 (simulated restart): a brand-new emitter with empty memory reads from disk.
+        var emitter2 = new DurableReceiptEmitter(dir);
+        var bundle = emitter2.bundleFor("app-d");
+
+        // MAKE-OR-BREAK: ActionReceipt survived the JSON disk roundtrip with its hash intact.
+        assertEquals(2, bundle.receipts().size(), "both receipts must reload from disk");
+        assertTrue(bundle.verify(), "reloaded bundle must verify (hashes recompute to stored values)");
+    }
+
+    @Test
+    void reEmittingTheSameLogicalReceiptIsIdempotent(@TempDir Path dir) {
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+
+        var emitter = new DurableReceiptEmitter(dir);
+        emitter.emit(factory.forToolCall("app-idem", "credit_bureau.score", "{\"id\":\"app-idem\"}", "720"));
+        // Re-execute the SAME step (same app + tool). The deterministic receipt_id means this
+        // overwrites the existing file rather than creating a second one.
+        emitter.emit(factory.forToolCall("app-idem", "credit_bureau.score", "{\"id\":\"app-idem\"}", "720"));
+
+        var reloaded = new DurableReceiptEmitter(dir);
+        var bundle = reloaded.bundleFor("app-idem");
+        assertEquals(1, bundle.receipts().size(), "re-emitting the same logical receipt must not duplicate");
+        assertTrue(bundle.verify());
+    }
+
+    @Test
+    void bundleIsOrderedDeterministically(@TempDir Path dir) {
+        var factory = new ReceiptFactory("loan-underwriter", "dev");
+        var emitter = new DurableReceiptEmitter(dir);
+        // Emit in non-sorted order; bundleFor must return a stable, deterministic order
+        // regardless of filesystem listing order.
+        emitter.emit(factory.forToolCall("app-ord", "credit_bureau.score", "{}", "720"));
+        emitter.emit(factory.forToolCall("app-ord", "account_history.months", "{}", "36"));
+        emitter.emit(factory.forToolCall("app-ord", "underwriting.score", "{}", "APPROVE"));
+
+        var a = new DurableReceiptEmitter(dir).bundleFor("app-ord").receipts();
+        var b = new DurableReceiptEmitter(dir).bundleFor("app-ord").receipts();
+        assertEquals(a.stream().map(r -> r.receiptId()).toList(),
+                     b.stream().map(r -> r.receiptId()).toList(),
+                     "ordering must be deterministic across reads");
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/service/MockServicesTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/service/MockServicesTest.java
@@ -1,0 +1,59 @@
+package dev.jamjet.loan.service;
+
+import dev.jamjet.loan.domain.LoanApplication;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MockServicesTest {
+    @Test
+    void creditScoreIsDeterministicPerApplicant() {
+        var svc = new MockCreditBureau();
+        var app = new LoanApplication("app-1", "Ada Lovelace", 25_000, 60_000);
+        int first = svc.score(app);
+        assertEquals(first, svc.score(app), "same applicant -> same score");
+        assertTrue(first >= 300 && first <= 850, "score in FICO range, was " + first);
+    }
+
+    @Test
+    void accountHistoryIsDeterministicPerApplicant() {
+        var svc = new MockAccountHistory();
+        var app = new dev.jamjet.loan.domain.LoanApplication("app-1", "Ada", 25_000, 60_000);
+        int first = svc.monthsHistory(app);
+        assertEquals(first, svc.monthsHistory(app), "same applicant -> same history");
+        assertTrue(first >= 0 && first < 120, "history in [0,120) months, was " + first);
+    }
+
+    /**
+     * Regression guard: the demo and e2e applicant ids must produce a non-DECLINE credit score
+     * (>= 580) so the demo exercises the full approval-to-disbursement money-shot path.
+     *
+     * <p>Verified by formula: credit = 300 + Math.floorMod(id.hashCode(), 551).
+     * <ul>
+     *   <li>"loan-demo": floorMod = 531, credit = 831 (APPROVE)</li>
+     *   <li>"loan-e2e":  floorMod = 411, credit = 711 (APPROVE)</li>
+     *   <li>"app-ok":    floorMod = 108, credit = 408 (DECLINE) -- used in unit test only</li>
+     * </ul>
+     */
+    @Test
+    void demoAndE2eApplicantsHaveNonDeclineCreditScores() {
+        var bureau = new MockCreditBureau();
+        var appDemo = new dev.jamjet.loan.domain.LoanApplication("loan-demo", "Jane Smith", 1_500_000, 9_000_000);
+        var appE2e  = new dev.jamjet.loan.domain.LoanApplication("loan-e2e",  "Ada",        20_000,    90_000);
+        var appDecline = new dev.jamjet.loan.domain.LoanApplication("app-ok", "Bob", 20_000, 90_000);
+
+        assertTrue(bureau.score(appDemo) >= 580,
+                "loan-demo must not be a hard-decline; score was " + bureau.score(appDemo));
+        assertTrue(bureau.score(appE2e) >= 580,
+                "loan-e2e must not be a hard-decline; score was " + bureau.score(appE2e));
+        assertTrue(bureau.score(appDecline) < 580,
+                "app-ok is used as the decline test case and must be below 580; score was " + bureau.score(appDecline));
+    }
+
+    @Test
+    void disbursementIsIdempotentByApplicationId() {
+        var svc = new MockDisbursement();
+        var ref1 = svc.disburse("app-1", 25_000);
+        var ref2 = svc.disburse("app-1", 25_000);
+        assertEquals(ref1, ref2, "same application id must not double-disburse");
+    }
+}

--- a/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/web/UnderwritingFlowTest.java
+++ b/examples/loan-underwriter-agent/src/test/java/dev/jamjet/loan/web/UnderwritingFlowTest.java
@@ -1,0 +1,67 @@
+package dev.jamjet.loan.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import java.io.IOException;
+import java.nio.file.Files;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UnderwritingFlowTest {
+    @Autowired MockMvc mvc;
+
+    @DynamicPropertySource
+    static void tempDirs(DynamicPropertyRegistry registry) throws IOException {
+        registry.add("loan.checkpoint-dir", () -> createTmp("ck"));
+        registry.add("loan.approval-dir", () -> createTmp("ap"));
+        registry.add("loan.receipts-dir", () -> createTmp("rc"));
+    }
+    private static String createTmp(String prefix) {
+        try { return Files.createTempDirectory(prefix).toString(); }
+        catch (IOException e) { throw new RuntimeException(e); }
+    }
+
+    @Test
+    void startThenApproveThenVerifiableBundle() throws Exception {
+        // "loan-e2e": Math.floorMod("loan-e2e".hashCode(), 551) = 411 -> credit = 711 (APPROVE).
+        // history = Math.floorMod("loan-e2e".hashCode(), 120) = 83 months. Amount*5=100000 <= income*2=180000 OK.
+
+        // 1. Start a run -> suspends at the approval gate.
+        mvc.perform(post("/applications").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"id\":\"loan-e2e\",\"applicantName\":\"Ada\",\"amountCents\":20000,\"annualIncomeCents\":90000}"))
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.state").value("AWAITING_APPROVAL"));
+
+        // 2. Approve -> disbursement runs.
+        mvc.perform(post("/applications/loan-e2e/approve").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"officer@bank\",\"decision\":\"approved\",\"comment\":\"ok\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.state").value("COMPLETED"));
+
+        // 3. Audit bundle is present and verifies.
+        mvc.perform(get("/applications/loan-e2e/receipts"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.verified").value(true))
+            .andExpect(jsonPath("$.receipts.length()").value(org.hamcrest.Matchers.greaterThanOrEqualTo(3)));
+    }
+
+    @Test
+    void unknownDecisionReturns400() throws Exception {
+        // start a run so the id exists
+        mvc.perform(post("/applications").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"id\":\"app-400\",\"applicantName\":\"Bob\",\"amountCents\":1000,\"annualIncomeCents\":50000}"))
+            .andExpect(status().isAccepted());
+        // a bogus decision string must be a 400, not a 500
+        mvc.perform(post("/applications/app-400/approve").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"x\",\"decision\":\"YES_PLEASE\",\"comment\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `examples/loan-underwriter-agent/`, a runnable Spring Boot (Java 21) example that demonstrates the three JVM guarantees Spring AI and LangChain4j do not provide:

- **Durability** - underwriting steps checkpoint to disk. Kill the process mid-run, restart, and it resumes from the last checkpoint without re-pulling credit.
- **Governance** - every guarded action emits a signed AgentBoundary `ActionReceipt`. The audit bundle is rebuilt from disk after a crash and cryptographically verifies (tamper-evident).
- **Human-in-the-loop** - an approval gate suspends before disbursement; the disbursement receipt carries the signed approval block. Disbursement is gated on the underwriting decision (a DECLINE never disburses).

Built on the published `dev.jamjet:*:0.3.1` artifacts (JamJet Java runtime + AgentBoundary SDK). External services are mocked, so it clones and runs with no accounts and no model API key. `scripts/demo.sh` performs a real `kill -9` and shows the resume + verified bundle end to end.

Also adds a Java section to `examples/README.md`.

## Test plan

- [ ] `cd examples/loan-underwriter-agent && JAVA_HOME=<jdk-21> mvn test` - 29 tests pass
- [ ] `JAVA_HOME=<jdk-21> mvn spring-boot:run`, then the three curl commands in the README (start -> approve -> receipts) return `AWAITING_APPROVAL` -> `COMPLETED` -> `verified: true`
- [ ] `bash scripts/demo.sh` - process is hard-killed mid-run, resumes without repeating the credit pull, approves, and the bundle verifies with 4 receipts

Requires JDK 21 (the JamJet artifacts are Java-21 bytecode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive loan-underwriter example application demonstrating durable, human-approved workflows with automatic recovery from crashes and cryptographically verifiable audit trails.

* **Documentation**
  * Added README and runnable demo script showing how to start applications, record approvals via HTTP, verify receipt integrity, and resume processing after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->