### PR TITLE
fix(cloud/middleware): keep regex PII floor when Presidio is active; green the CI

### DIFF
--- a/sdk/python/jamjet/cloud/middleware/__init__.py
+++ b/sdk/python/jamjet/cloud/middleware/__init__.py
@@ -5,23 +5,27 @@ Phase 1 ships the substrate plus the PII pre-LLM middleware. Phases 2 (cache)
 and 3 (fallback) extend the same Protocol; the chain order is fixed at
 PII -> cache -> fallback.
 """
+
 from __future__ import annotations
+
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
 
-class MiddlewareOutcome(str, Enum):
+class MiddlewareOutcome(str, Enum):  # noqa: UP042  (str+Enum kept intentionally; StrEnum would change str() of members)
     """The terminal disposition of a single LLM-call attempt. Phase 1 emits
     PASSTHROUGH / BLOCKED / DETECTOR_ERROR. CACHE_HIT / CACHE_UNAVAILABLE
     are reserved for Phase 2; FALLBACK is reserved for Phase 3 — they're
     declared here so the SDK can adopt them without an enum change."""
-    PASSTHROUGH = "passthrough"            # no middleware short-circuited; original() ran
-    BLOCKED = "blocked"                    # a middleware raised before original()
-    DETECTOR_ERROR = "detector_error"      # detector threw; fail-open path took the call
-    CACHE_HIT = "cache_hit"                # Phase 2
+
+    PASSTHROUGH = "passthrough"  # no middleware short-circuited; original() ran
+    BLOCKED = "blocked"  # a middleware raised before original()
+    DETECTOR_ERROR = "detector_error"  # detector threw; fail-open path took the call
+    CACHE_HIT = "cache_hit"  # Phase 2
     CACHE_UNAVAILABLE = "cache_unavailable"  # Phase 2
-    FALLBACK = "fallback"                  # Phase 3
+    FALLBACK = "fallback"  # Phase 3
 
 
 @dataclass
@@ -34,11 +38,12 @@ class CallContext:
     Two telemetry fields (middleware_fired, middleware_outcome) accumulate
     as the chain runs and are read by the patcher's post-response code to
     populate the `middleware` extension on the AgentBoundary receipt."""
-    provider: str                                    # "openai" | "anthropic"
-    model: str                                       # "gpt-4o", "claude-haiku-4-5", ...
+
+    provider: str  # "openai" | "anthropic"
+    model: str  # "gpt-4o", "claude-haiku-4-5", ...
     messages: list[dict[str, Any]] = field(default_factory=list)
     tools: list[dict[str, Any]] = field(default_factory=list)
-    system: str | None = None                        # extracted, not mutated by PII middleware
+    system: str | None = None  # extracted, not mutated by PII middleware
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
     middleware_fired: list[str] = field(default_factory=list)
     middleware_outcome: MiddlewareOutcome | None = None

--- a/sdk/python/jamjet/cloud/middleware/chain.py
+++ b/sdk/python/jamjet/cloud/middleware/chain.py
@@ -1,9 +1,13 @@
 """Fixed-order chain runner. Composes middlewares as nested closures and
 exposes a single `run()` entrypoint that the patcher calls per LLM call."""
+
 from __future__ import annotations
+
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
+
 from jamjet.cloud.middleware import CallContext, PreCallMiddleware, Response
 
 
@@ -12,6 +16,7 @@ class Chain:
     """Ordered list of middlewares plus a runner. Build once at configure()
     time; reuse for every patched call. Thread-safe iff each middleware is
     thread-safe (the chain itself holds no per-call state)."""
+
     middlewares: list[PreCallMiddleware] = field(default_factory=list)
 
     def run(
@@ -23,15 +28,19 @@ class Chain:
         middleware short-circuits. Middlewares execute in declaration order;
         each one wraps the next via a `next` continuation it must invoke (or
         explicitly skip to short-circuit)."""
+
         # Compose nested closures right-to-left so middleware[0] is outermost.
         def make_step(i: int) -> Callable[[CallContext], Response]:
             if i == len(self.middlewares):
                 return terminal
             current = self.middlewares[i]
             nxt = make_step(i + 1)
+
             def step(c: CallContext) -> Response:
                 return current(c, nxt)
+
             return step
+
         return make_step(0)(ctx)
 
 
@@ -64,6 +73,7 @@ def build_chain(policy: dict[str, Any]) -> Chain:
     if redact_rules:
         # Local import to avoid a circular reference at module-load time.
         from jamjet.cloud.middleware.pii import PIIMiddleware
+
         middlewares.append(PIIMiddleware(rules=redact_rules))
 
     return Chain(middlewares=middlewares)

--- a/sdk/python/jamjet/cloud/middleware/context.py
+++ b/sdk/python/jamjet/cloud/middleware/context.py
@@ -2,10 +2,12 @@
 The patcher uses these to convert vendor SDK call args into a portable shape
 the middleware chain can operate on, then back into vendor shape for the
 terminal call."""
-from __future__ import annotations
-from typing import Any
-from jamjet.cloud.middleware import CallContext
 
+from __future__ import annotations
+
+from typing import Any
+
+from jamjet.cloud.middleware import CallContext
 
 _OPENAI_TOP_LEVEL = {"model", "messages", "tools"}
 _ANTHROPIC_TOP_LEVEL = {"model", "messages", "tools", "system"}

--- a/sdk/python/jamjet/cloud/middleware/pii.py
+++ b/sdk/python/jamjet/cloud/middleware/pii.py
@@ -4,11 +4,14 @@ Reuses the same six PII types the existing ingress-side
 `jamjet.cloud.redaction` module already recognises. The detector layer is
 pluggable: RegexDetector is always available; PresidioDetector wraps the
 optional `presidio-analyzer` dependency (pip install jamjet[pii])."""
+
 from __future__ import annotations
+
 import fnmatch
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,20 +23,20 @@ _logger = logging.getLogger("jamjet.cloud.middleware.pii")
 # Patterns intentionally mirror jamjet.cloud.redaction.DEFAULT_PII_TYPES so a
 # value redacted server-side is also redacted pre-LLM with the same matcher.
 _REGEX_PATTERNS: dict[str, re.Pattern[str]] = {
-    "EMAIL":         re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"),
-    "US_SSN":        re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
-    "CREDIT_CARD":   re.compile(r"\b(?:\d[ -]?){13,19}\b"),
-    "PHONE_NUMBER":  re.compile(r"\b(?:\+?1[ -]?)?\(?\d{3}\)?[ -.]?\d{3}[ -.]?\d{4}\b"),
-    "IP_ADDRESS":    re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
-    "IBAN_CODE":     re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b"),
+    "EMAIL": re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"),
+    "US_SSN": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "CREDIT_CARD": re.compile(r"\b(?:\d[ -]?){13,19}\b"),
+    "PHONE_NUMBER": re.compile(r"\b(?:\+?1[ -]?)?\(?\d{3}\)?[ -.]?\d{3}[ -.]?\d{4}\b"),
+    "IP_ADDRESS": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    "IBAN_CODE": re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b"),
 }
 
 
 @dataclass
 class PIIDetection:
-    type: str           # one of _REGEX_PATTERNS.keys()
-    value: str          # the matched substring (kept in-memory only, never logged)
-    start: int          # offset in the source string
+    type: str  # one of _REGEX_PATTERNS.keys()
+    value: str  # the matched substring (kept in-memory only, never logged)
+    start: int  # offset in the source string
     end: int
 
 
@@ -44,8 +47,7 @@ class PIIDetector(ABC):
     substituted by `[REDACTED:<TYPE>]` tokens."""
 
     @abstractmethod
-    def scan(self, text: str) -> list[PIIDetection]:
-        ...
+    def scan(self, text: str) -> list[PIIDetection]: ...
 
     def redact(self, text: str) -> str:
         detections = self.scan(text)
@@ -75,18 +77,17 @@ class RegexDetector(PIIDetector):
         detections: list[PIIDetection] = []
         for t in self._types:
             for m in _REGEX_PATTERNS[t].finditer(text):
-                detections.append(PIIDetection(type=t, value=m.group(0),
-                                               start=m.start(), end=m.end()))
+                detections.append(PIIDetection(type=t, value=m.group(0), start=m.start(), end=m.end()))
         return detections
 
 
 _PRESIDIO_TYPE_MAP = {
-    "EMAIL":        "EMAIL_ADDRESS",
-    "US_SSN":       "US_SSN",
-    "CREDIT_CARD":  "CREDIT_CARD",
+    "EMAIL": "EMAIL_ADDRESS",
+    "US_SSN": "US_SSN",
+    "CREDIT_CARD": "CREDIT_CARD",
     "PHONE_NUMBER": "PHONE_NUMBER",
-    "IP_ADDRESS":   "IP_ADDRESS",
-    "IBAN_CODE":    "IBAN_CODE",
+    "IP_ADDRESS": "IP_ADDRESS",
+    "IBAN_CODE": "IBAN_CODE",
 }
 
 
@@ -102,8 +103,7 @@ class PresidioDetector(PIIDetector):
             from presidio_analyzer import AnalyzerEngine
         except ImportError as e:
             raise ImportError(
-                "PresidioDetector requires `presidio-analyzer`. Install via: "
-                "pip install jamjet[pii]"
+                "PresidioDetector requires `presidio-analyzer`. Install via: pip install jamjet[pii]"
             ) from e
         unknown = [t for t in types if t not in _PRESIDIO_TYPE_MAP]
         if unknown:
@@ -120,21 +120,63 @@ class PresidioDetector(PIIDetector):
         reverse_map = {v: k for k, v in _PRESIDIO_TYPE_MAP.items()}
         for r in results:
             our_type = reverse_map.get(r.entity_type, r.entity_type)
-            out.append(PIIDetection(
-                type=our_type,
-                value=text[r.start : r.end],
-                start=r.start,
-                end=r.end,
-            ))
+            out.append(
+                PIIDetection(
+                    type=our_type,
+                    value=text[r.start : r.end],
+                    start=r.start,
+                    end=r.end,
+                )
+            )
         return out
 
 
+class CompositeDetector(PIIDetector):
+    """Runs every sub-detector and returns the UNION of their detections,
+    de-overlapped so redact() substitutes each span exactly once.
+
+    RegexDetector is always included as a floor. Presidio's NLP model has
+    higher recall for context-dependent entities (names, locations) but can
+    miss structured patterns the regex layer catches deterministically — e.g.
+    Presidio's `en_core_web_lg` returns nothing for the bare SSN
+    `123-45-6789`, which the regex US_SSN pattern matches. Unioning keeps the
+    deterministic floor so installing the higher-precision detector can never
+    regress detection below regex."""
+
+    def __init__(self, detectors: list[PIIDetector]) -> None:
+        if not detectors:
+            raise ValueError("CompositeDetector requires at least one detector")
+        self._detectors = list(detectors)
+
+    def scan(self, text: str) -> list[PIIDetection]:
+        merged: list[PIIDetection] = []
+        for det in self._detectors:
+            merged.extend(det.scan(text))
+        # De-overlap: sort by start, longest span first, then greedily keep
+        # detections that don't overlap one already kept. This leaves redact()
+        # operating on disjoint spans (it substitutes right-to-left).
+        merged.sort(key=lambda x: (x.start, -(x.end - x.start)))
+        kept: list[PIIDetection] = []
+        last_end = -1
+        for d in merged:
+            if d.start >= last_end:
+                kept.append(d)
+                last_end = d.end
+        return kept
+
+
 def _build_detector(types: list[str]) -> PIIDetector:
-    """Prefer Presidio when installed, fall back to regex."""
+    """RegexDetector is always the floor; Presidio is unioned on top for higher
+    recall when it is installed and initialises. If Presidio is absent or fails
+    to initialise (not installed, or its spaCy model cannot load), fall back to
+    regex only — PII must never be silently let through."""
+    regex = RegexDetector(types=types)
     try:
-        return PresidioDetector(types=types)
-    except ImportError:
-        return RegexDetector(types=types)
+        presidio = PresidioDetector(types=types)
+    except Exception as e:  # ImportError (not installed) or model-load failure
+        _logger.info("presidio detector unavailable (%r) — using regex floor only", e)
+        return regex
+    return CompositeDetector([regex, presidio])
 
 
 class PIIMiddleware:
@@ -150,10 +192,12 @@ class PIIMiddleware:
         # the type-list-per-rule is fixed.
         self._compiled = [(r, _build_detector(r["types"])) for r in rules]
 
-    def __call__(self, ctx: CallContext, next):  # type: ignore[no-untyped-def]
+    def __call__(self, ctx: CallContext, next: Callable[[CallContext], Any]) -> Any:
         rule, detector = self._match_rule(ctx)
         if rule is None:
             return next(ctx)
+        # _match_rule returns rule and detector together (or both None).
+        assert detector is not None
 
         scope: list[str] = rule.get("scope", ["messages", "tools"])
         on_detect: str = rule.get("on_detect", "block")
@@ -171,6 +215,7 @@ class PIIMiddleware:
 
         if on_detect == "block":
             from jamjet.cloud.exceptions import JamJetPIIBlocked
+
             types_detected = sorted({d.type for d in detections})
             # Sanitized evidence: types + count only; PII VALUE NEVER LOGGED.
             ctx.middleware_fired.append("pii.redact")
@@ -201,13 +246,13 @@ class PIIMiddleware:
         _logger.warning("pii rule has unknown on_detect: %r — failing open", on_detect)
         return next(ctx)
 
-    def _match_rule(self, ctx: CallContext):
+    def _match_rule(self, ctx: CallContext) -> tuple[dict[str, Any] | None, PIIDetector | None]:
         for rule, detector in self._compiled:
             if fnmatch.fnmatch(ctx.identifier, rule["match"]):
                 return rule, detector
         return None, None
 
-    def _scan_ctx(self, ctx: CallContext, detector: PIIDetector, scope: list[str]):
+    def _scan_ctx(self, ctx: CallContext, detector: PIIDetector, scope: list[str]) -> list[PIIDetection]:
         detections: list[PIIDetection] = []
         if "messages" in scope:
             for msg in ctx.messages:

--- a/sdk/python/tests/middleware/test_chain.py
+++ b/sdk/python/tests/middleware/test_chain.py
@@ -1,7 +1,7 @@
 from jamjet.cloud.middleware import (
-    PreCallMiddleware,
     CallContext,
     MiddlewareOutcome,
+    PreCallMiddleware,
 )
 
 
@@ -14,7 +14,7 @@ def test_protocol_and_outcome_types_importable():
     assert MiddlewareOutcome.FALLBACK.value == "fallback"
 
 
-from jamjet.cloud.middleware import Chain, CallContext
+from jamjet.cloud.middleware import Chain  # noqa: E402
 
 
 def _ctx() -> CallContext:
@@ -30,11 +30,13 @@ def test_empty_chain_invokes_terminal_unchanged():
 
 def test_passthrough_middleware_does_not_short_circuit():
     seen: list[str] = []
+
     def m(ctx, nxt):
         seen.append("before")
         result = nxt(ctx)
         seen.append("after")
         return result
+
     chain = Chain(middlewares=[m])
     out = chain.run(_ctx(), terminal=lambda c: "terminal_called")
     assert out == "terminal_called"
@@ -43,25 +45,31 @@ def test_passthrough_middleware_does_not_short_circuit():
 
 def test_short_circuit_skips_terminal():
     terminal_was_called = False
+
     def terminal(c):
         nonlocal terminal_was_called
         terminal_was_called = True
         return "should-not-see-this"
+
     def short_circuit(ctx, nxt):
         return "synthesized"
+
     chain = Chain(middlewares=[short_circuit])
     assert chain.run(_ctx(), terminal=terminal) == "synthesized"
     assert terminal_was_called is False
 
 
 def test_raise_propagates_through_chain():
-    class CustomBlocked(Exception):
+    class CustomBlockedError(Exception):
         pass
+
     def blocker(ctx, nxt):
-        raise CustomBlocked("block reason")
+        raise CustomBlockedError("block reason")
+
     chain = Chain(middlewares=[blocker])
     import pytest
-    with pytest.raises(CustomBlocked, match="block reason"):
+
+    with pytest.raises(CustomBlockedError, match="block reason"):
         chain.run(_ctx(), terminal=lambda c: "never")
 
 
@@ -69,6 +77,7 @@ def test_mutation_propagates_to_terminal():
     def redactor(ctx, nxt):
         ctx.messages = [{"role": "user", "content": "[REDACTED]"}]
         return nxt(ctx)
+
     chain = Chain(middlewares=[redactor])
     out = chain.run(_ctx(), terminal=lambda c: c.messages[-1]["content"])
     assert out == "[REDACTED]"
@@ -76,6 +85,7 @@ def test_mutation_propagates_to_terminal():
 
 def test_fixed_order_executes_pii_then_cache_then_fallback():
     order: list[str] = []
+
     def m(name):
         def _inner(ctx, nxt):
             order.append(f"{name}:enter")
@@ -83,34 +93,44 @@ def test_fixed_order_executes_pii_then_cache_then_fallback():
                 return nxt(ctx)
             finally:
                 order.append(f"{name}:exit")
+
         return _inner
+
     chain = Chain(middlewares=[m("pii"), m("cache"), m("fallback")])
     chain.run(_ctx(), terminal=lambda c: None)
     assert order == [
-        "pii:enter", "cache:enter", "fallback:enter",
-        "fallback:exit", "cache:exit", "pii:exit",
+        "pii:enter",
+        "cache:enter",
+        "fallback:enter",
+        "fallback:exit",
+        "cache:exit",
+        "pii:exit",
     ]
 
 
-import os
-from jamjet.cloud.middleware import build_chain
+from jamjet.cloud.middleware import build_chain  # noqa: E402
 
 
 def test_build_chain_returns_empty_when_flag_disabled(monkeypatch):
     monkeypatch.delenv("JAMJET_MIDDLEWARE_ENABLED", raising=False)
-    policy = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"]}
-    ]}
+    policy = {
+        "version": 1,
+        "rules": [
+            {"match": "openai:*", "action": "redact", "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"]}
+        ],
+    }
     chain = build_chain(policy)
     assert len(chain.middlewares) == 0  # flag off -> chain is empty -> no behaviour change
 
 
 def test_build_chain_returns_empty_when_no_middleware_rules(monkeypatch):
     monkeypatch.setenv("JAMJET_MIDDLEWARE_ENABLED", "1")
-    policy = {"version": 1, "rules": [
-        {"match": "*delete*", "action": "block"},      # tool-call rule, NOT a middleware rule
-    ]}
+    policy = {
+        "version": 1,
+        "rules": [
+            {"match": "*delete*", "action": "block"},  # tool-call rule, NOT a middleware rule
+        ],
+    }
     chain = build_chain(policy)
     assert len(chain.middlewares) == 0
 
@@ -120,11 +140,18 @@ def test_build_chain_skips_unknown_action(monkeypatch):
     silently skip them in Phase 1 so a forward-compatible policy.yaml doesn't
     crash today."""
     monkeypatch.setenv("JAMJET_MIDDLEWARE_ENABLED", "1")
-    policy = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "cache", "ttl": 60},
-        {"match": "openai:*", "action": "fallback",
-         "on": [{"http_status": [503]}], "chain": ["openai:gpt-4o-mini"]},
-    ]}
+    policy = {
+        "version": 1,
+        "rules": [
+            {"match": "openai:*", "action": "cache", "ttl": 60},
+            {
+                "match": "openai:*",
+                "action": "fallback",
+                "on": [{"http_status": [503]}],
+                "chain": ["openai:gpt-4o-mini"],
+            },
+        ],
+    }
     chain = build_chain(policy)
     assert len(chain.middlewares) == 0
 
@@ -148,12 +175,14 @@ def test_configure_builds_chain_from_loaded_policy(monkeypatch, tmp_path):
         "version: 1\n"
         "rules:\n"
         '  - { match: "openai:*", action: redact, types: [EMAIL], '
-        'on_detect: block, scope: [messages] }\n'
+        "on_detect: block, scope: [messages] }\n"
     )
     import jamjet.cloud as cloud
+
     cloud.configure(policy_path=str(policy_yaml), telemetry=False, auto_patch=False)
 
     from jamjet.cloud.patcher import _runtime_state
+
     state = _runtime_state()
     assert len(state.middleware_chain.middlewares) == 1
 
@@ -163,7 +192,9 @@ def test_configure_with_no_middleware_rules_yields_empty_chain(monkeypatch, tmp_
     policy_yaml = tmp_path / "policy.yaml"
     policy_yaml.write_text("version: 1\nrules: []\n")
     import jamjet.cloud as cloud
+
     cloud.configure(policy_path=str(policy_yaml), telemetry=False, auto_patch=False)
 
     from jamjet.cloud.patcher import _runtime_state
+
     assert len(_runtime_state().middleware_chain.middlewares) == 0

--- a/sdk/python/tests/middleware/test_context.py
+++ b/sdk/python/tests/middleware/test_context.py
@@ -1,4 +1,3 @@
-from jamjet.cloud.middleware import CallContext
 from jamjet.cloud.middleware.context import (
     call_context_from_openai_kwargs,
     openai_kwargs_from_call_context,
@@ -19,8 +18,8 @@ def test_openai_kwargs_to_context():
     ctx = call_context_from_openai_kwargs(kwargs)
     assert ctx.provider == "openai"
     assert ctx.model == "gpt-4o-mini"
-    assert ctx.system == "be helpful"           # extracted from system message
-    assert len(ctx.messages) == 1               # system stripped from messages
+    assert ctx.system == "be helpful"  # extracted from system message
+    assert len(ctx.messages) == 1  # system stripped from messages
     assert ctx.messages[0]["role"] == "user"
     assert ctx.tools == kwargs["tools"]
     assert ctx.extra_kwargs == {"temperature": 0.7, "max_tokens": 256}
@@ -44,27 +43,31 @@ def test_context_round_trips_back_to_openai_kwargs():
 def test_round_trip_preserves_redacted_messages():
     """The whole point: middleware mutates ctx.messages; the rebuilt kwargs
     must reflect that mutation so the LLM only ever sees redacted content."""
-    ctx = call_context_from_openai_kwargs({
-        "model": "gpt-4o",
-        "messages": [{"role": "user", "content": "email me at alice@example.com"}],
-    })
+    ctx = call_context_from_openai_kwargs(
+        {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "email me at alice@example.com"}],
+        }
+    )
     ctx.messages = [{"role": "user", "content": "email me at [REDACTED:EMAIL]"}]
     rebuilt = openai_kwargs_from_call_context(ctx)
     assert rebuilt["messages"][0]["content"] == "email me at [REDACTED:EMAIL]"
 
 
 def test_no_system_message_yields_none():
-    ctx = call_context_from_openai_kwargs({
-        "model": "gpt-4o",
-        "messages": [{"role": "user", "content": "hi"}],
-    })
+    ctx = call_context_from_openai_kwargs(
+        {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
     assert ctx.system is None
     assert len(ctx.messages) == 1
 
 
-from jamjet.cloud.middleware.context import (
-    call_context_from_anthropic_kwargs,
+from jamjet.cloud.middleware.context import (  # noqa: E402  (staged mid-file import — pattern used throughout this file)
     anthropic_kwargs_from_call_context,
+    call_context_from_anthropic_kwargs,
 )
 
 
@@ -87,11 +90,13 @@ def test_anthropic_kwargs_to_context():
 
 
 def test_anthropic_context_round_trip_preserves_mutation():
-    ctx = call_context_from_anthropic_kwargs({
-        "model": "claude-haiku-4-5",
-        "system": "be helpful",
-        "messages": [{"role": "user", "content": "ssn 123-45-6789"}],
-    })
+    ctx = call_context_from_anthropic_kwargs(
+        {
+            "model": "claude-haiku-4-5",
+            "system": "be helpful",
+            "messages": [{"role": "user", "content": "ssn 123-45-6789"}],
+        }
+    )
     ctx.messages = [{"role": "user", "content": "ssn [REDACTED:US_SSN]"}]
     rebuilt = anthropic_kwargs_from_call_context(ctx)
     assert rebuilt["model"] == "claude-haiku-4-5"
@@ -100,9 +105,11 @@ def test_anthropic_context_round_trip_preserves_mutation():
 
 
 def test_anthropic_no_system_omits_key():
-    ctx = call_context_from_anthropic_kwargs({
-        "model": "claude-haiku-4-5",
-        "messages": [{"role": "user", "content": "hi"}],
-    })
+    ctx = call_context_from_anthropic_kwargs(
+        {
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
     rebuilt = anthropic_kwargs_from_call_context(ctx)
     assert "system" not in rebuilt

--- a/sdk/python/tests/middleware/test_integration_anthropic.py
+++ b/sdk/python/tests/middleware/test_integration_anthropic.py
@@ -1,20 +1,24 @@
 """End-to-end: load a real policy YAML, build the middleware chain, invoke
 against a stub terminal mimicking the Anthropic Messages.create() shape.
 Asserts the system-prompt-never-scanned contract and the SSN block path."""
+
 import textwrap
+
 import pytest
 import yaml
+
+from jamjet.cloud.exceptions import JamJetPIIBlocked
 from jamjet.cloud.middleware import build_chain
 from jamjet.cloud.middleware.context import (
-    call_context_from_anthropic_kwargs,
     anthropic_kwargs_from_call_context,
+    call_context_from_anthropic_kwargs,
 )
-from jamjet.cloud.exceptions import JamJetPIIBlocked
 
 
 @pytest.fixture
 def policy_anthropic_block():
-    return yaml.safe_load(textwrap.dedent("""\
+    return yaml.safe_load(
+        textwrap.dedent("""\
         version: 1
         rules:
           - match: "anthropic:*"
@@ -22,7 +26,8 @@ def policy_anthropic_block():
             types: [US_SSN]
             on_detect: block
             scope: [messages]
-    """))
+    """)
+    )
 
 
 def test_anthropic_call_with_ssn_is_blocked(monkeypatch, policy_anthropic_block):
@@ -39,6 +44,7 @@ def test_anthropic_call_with_ssn_is_blocked(monkeypatch, policy_anthropic_block)
     ctx = call_context_from_anthropic_kwargs(kwargs)
 
     terminal_call_count = 0
+
     def stub_terminal(c):
         nonlocal terminal_call_count
         terminal_call_count += 1
@@ -57,7 +63,8 @@ def test_anthropic_system_prompt_pii_is_not_scanned(monkeypatch):
     """The spec is explicit: system prompts are NEVER scanned, even when they
     contain PII. The call must proceed even with PII in the system kwarg."""
     monkeypatch.setenv("JAMJET_MIDDLEWARE_ENABLED", "1")
-    policy = yaml.safe_load(textwrap.dedent("""\
+    policy = yaml.safe_load(
+        textwrap.dedent("""\
         version: 1
         rules:
           - match: "anthropic:*"
@@ -65,7 +72,8 @@ def test_anthropic_system_prompt_pii_is_not_scanned(monkeypatch):
             types: [US_SSN]
             on_detect: block
             scope: [messages]
-    """))
+    """)
+    )
     chain = build_chain(policy)
 
     kwargs = {
@@ -77,6 +85,7 @@ def test_anthropic_system_prompt_pii_is_not_scanned(monkeypatch):
     ctx = call_context_from_anthropic_kwargs(kwargs)
 
     seen: list = []
+
     def stub_terminal(c):
         seen.append(anthropic_kwargs_from_call_context(c))
         return "stub-response"
@@ -90,7 +99,8 @@ def test_anthropic_system_prompt_pii_is_not_scanned(monkeypatch):
 
 def test_anthropic_call_with_replace_redacts_messages(monkeypatch):
     monkeypatch.setenv("JAMJET_MIDDLEWARE_ENABLED", "1")
-    policy = yaml.safe_load(textwrap.dedent("""\
+    policy = yaml.safe_load(
+        textwrap.dedent("""\
         version: 1
         rules:
           - match: "anthropic:claude-haiku-*"
@@ -98,7 +108,8 @@ def test_anthropic_call_with_replace_redacts_messages(monkeypatch):
             types: [EMAIL]
             on_detect: replace
             scope: [messages]
-    """))
+    """)
+    )
     chain = build_chain(policy)
 
     kwargs = {
@@ -110,6 +121,7 @@ def test_anthropic_call_with_replace_redacts_messages(monkeypatch):
     ctx = call_context_from_anthropic_kwargs(kwargs)
 
     seen: list = []
+
     def stub_terminal(c):
         seen.append(anthropic_kwargs_from_call_context(c))
         return "stub-response"

--- a/sdk/python/tests/middleware/test_integration_openai.py
+++ b/sdk/python/tests/middleware/test_integration_openai.py
@@ -6,16 +6,18 @@ the patcher's closure-captured `original` reference.
 
 The chain is what every production OpenAI call flows through after Task 6,
 so testing the chain directly proves the safety contract end-to-end."""
-import os
+
 import textwrap
+
 import pytest
 import yaml
+
+from jamjet.cloud.exceptions import JamJetPIIBlocked, JamJetPolicyBlocked
 from jamjet.cloud.middleware import build_chain
 from jamjet.cloud.middleware.context import (
     call_context_from_openai_kwargs,
     openai_kwargs_from_call_context,
 )
-from jamjet.cloud.exceptions import JamJetPIIBlocked, JamJetPolicyBlocked
 
 
 def _load_policy_yaml(yaml_text: str) -> dict:
@@ -24,7 +26,8 @@ def _load_policy_yaml(yaml_text: str) -> dict:
 
 @pytest.fixture
 def policy_with_pii_block():
-    return _load_policy_yaml(textwrap.dedent("""\
+    return _load_policy_yaml(
+        textwrap.dedent("""\
         version: 1
         rules:
           - match: "openai:*"
@@ -32,12 +35,14 @@ def policy_with_pii_block():
             types: [EMAIL, US_SSN]
             on_detect: block
             scope: [messages]
-    """))
+    """)
+    )
 
 
 @pytest.fixture
 def policy_with_pii_replace():
-    return _load_policy_yaml(textwrap.dedent("""\
+    return _load_policy_yaml(
+        textwrap.dedent("""\
         version: 1
         rules:
           - match: "openai:*"
@@ -45,7 +50,8 @@ def policy_with_pii_replace():
             types: [EMAIL]
             on_detect: replace
             scope: [messages]
-    """))
+    """)
+    )
 
 
 def test_openai_call_with_pii_is_blocked(monkeypatch, policy_with_pii_block):
@@ -61,6 +67,7 @@ def test_openai_call_with_pii_is_blocked(monkeypatch, policy_with_pii_block):
     ctx = call_context_from_openai_kwargs(kwargs)
 
     terminal_call_count = 0
+
     def stub_terminal(c):
         nonlocal terminal_call_count
         terminal_call_count += 1
@@ -68,8 +75,7 @@ def test_openai_call_with_pii_is_blocked(monkeypatch, policy_with_pii_block):
         rebuilt = openai_kwargs_from_call_context(c)
         # If we ever get here with PII intact, the safety contract is broken.
         for m in rebuilt["messages"]:
-            assert "alice@example.com" not in str(m.get("content", "")), \
-                "PII leaked through chain to terminal!"
+            assert "alice@example.com" not in str(m.get("content", "")), "PII leaked through chain to terminal!"
         return "stub-response"
 
     with pytest.raises(JamJetPIIBlocked):
@@ -96,6 +102,7 @@ def test_openai_call_with_pii_replaces(monkeypatch, policy_with_pii_replace):
     ctx = call_context_from_openai_kwargs(kwargs)
 
     seen_kwargs: list = []
+
     def stub_terminal(c):
         seen_kwargs.append(openai_kwargs_from_call_context(c))
         return "stub-response"
@@ -121,6 +128,7 @@ def test_openai_call_without_pii_passes_through_unchanged(monkeypatch, policy_wi
     ctx = call_context_from_openai_kwargs(kwargs)
 
     seen_kwargs: list = []
+
     def stub_terminal(c):
         seen_kwargs.append(openai_kwargs_from_call_context(c))
         return "ok"
@@ -144,6 +152,7 @@ def test_flag_off_yields_empty_chain_for_redact_rules(monkeypatch, policy_with_p
     ctx = call_context_from_openai_kwargs(kwargs)
 
     seen_kwargs: list = []
+
     def stub_terminal(c):
         seen_kwargs.append(openai_kwargs_from_call_context(c))
         return "ok"

--- a/sdk/python/tests/middleware/test_pii.py
+++ b/sdk/python/tests/middleware/test_pii.py
@@ -1,4 +1,9 @@
-from jamjet.cloud.middleware.pii import RegexDetector, PIIDetection
+import logging
+
+import pytest
+
+from jamjet.cloud.middleware import CallContext
+from jamjet.cloud.middleware.pii import PIIMiddleware, RegexDetector
 
 
 def test_regex_detector_finds_email():
@@ -43,10 +48,6 @@ def test_redact_in_place_substitutes_tokens():
     assert "[REDACTED:US_SSN]" in out
 
 
-import logging
-import pytest
-
-
 @pytest.fixture(autouse=True)
 def _pii_logs_at_warning(caplog):
     caplog.set_level(logging.WARNING, logger="jamjet.cloud.middleware.pii")
@@ -57,8 +58,10 @@ def test_presidio_detector_imports_only_when_extras_installed():
     clear error if presidio-analyzer is not installed (instead of an opaque
     ModuleNotFoundError deep in the call stack)."""
     from jamjet.cloud.middleware.pii import PresidioDetector
+
     try:
         import presidio_analyzer  # noqa: F401
+
         has_presidio = True
     except ImportError:
         has_presidio = False
@@ -72,13 +75,10 @@ def test_presidio_detector_imports_only_when_extras_installed():
         assert any(x.type == "EMAIL" for x in detections)
 
 
-from jamjet.cloud.middleware import CallContext
-from jamjet.cloud.middleware.pii import PIIMiddleware
-
-
 def _ctx_with_email() -> CallContext:
     return CallContext(
-        provider="openai", model="gpt-4o",
+        provider="openai",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "email alice@example.com"}],
         tools=[],
         system="be helpful",
@@ -87,10 +87,18 @@ def _ctx_with_email() -> CallContext:
 
 def test_pii_block_raises_jamjet_pii_blocked():
     from jamjet.cloud.exceptions import JamJetPIIBlocked
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"],
-    }])
+
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            }
+        ]
+    )
     with pytest.raises(JamJetPIIBlocked) as ei:
         mw(_ctx_with_email(), next=lambda c: "should-not-call-terminal")
     assert ei.value.rule_pattern == "openai:*"
@@ -103,20 +111,35 @@ def test_pii_block_also_caught_by_jamjet_policy_blocked():
     """Subclass semantics: existing `except JamJetPolicyBlocked` handlers
     must still catch PII blocks."""
     from jamjet.cloud.exceptions import JamJetPolicyBlocked
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"],
-    }])
+
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            }
+        ]
+    )
     with pytest.raises(JamJetPolicyBlocked):
         mw(_ctx_with_email(), next=lambda c: "should-not-call-terminal")
 
 
 def test_pii_block_ignores_non_matching_rules():
     """Rule matches `anthropic:*` but call is `openai:*` — pass through."""
-    mw = PIIMiddleware(rules=[{
-        "match": "anthropic:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"],
-    }])
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "anthropic:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            }
+        ]
+    )
     out = mw(_ctx_with_email(), next=lambda c: "passed-through")
     assert out == "passed-through"
 
@@ -125,49 +148,81 @@ def test_pii_block_skips_system_prompts():
     """Even with a matching rule including scope=[messages], the system
     prompt must never be scanned."""
     ctx = CallContext(
-        provider="openai", model="gpt-4o",
+        provider="openai",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "no pii here"}],
-        system="ops contact: alice@example.com",   # PII in system; must be ignored
+        system="ops contact: alice@example.com",  # PII in system; must be ignored
     )
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"],
-    }])
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            }
+        ]
+    )
     out = mw(ctx, next=lambda c: "passed-through")
     assert out == "passed-through"
 
 
 def test_pii_block_scans_tool_descriptions_when_scope_includes_tools():
     ctx = CallContext(
-        provider="openai", model="gpt-4o",
+        provider="openai",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "no pii"}],
-        tools=[{"type": "function", "function": {
-            "name": "lookup", "description": "lookup by email like alice@example.com",
-        }}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "lookup by email like alice@example.com",
+                },
+            }
+        ],
     )
     from jamjet.cloud.exceptions import JamJetPIIBlocked
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["tools"],
-    }])
+
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["tools"],
+            }
+        ]
+    )
     with pytest.raises(JamJetPIIBlocked):
         mw(ctx, next=lambda c: "should-not-pass-through")
 
 
 def test_pii_replace_substitutes_tokens_and_calls_terminal():
     seen_messages: list = []
+
     def terminal(c):
         seen_messages.append(c.messages[0]["content"])
         return "terminal-response"
 
     ctx = CallContext(
-        provider="openai", model="gpt-4o",
+        provider="openai",
+        model="gpt-4o",
         messages=[{"role": "user", "content": "email alice@example.com"}],
     )
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "replace", "scope": ["messages"],
-    }])
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "replace",
+                "scope": ["messages"],
+            }
+        ]
+    )
     out = mw(ctx, next=terminal)
     assert out == "terminal-response"
     assert seen_messages == ["email [REDACTED:EMAIL]"]
@@ -177,17 +232,30 @@ def test_pii_replace_substitutes_tokens_and_calls_terminal():
 
 def test_pii_replace_handles_multi_part_content():
     ctx = CallContext(
-        provider="openai", model="gpt-4o",
-        messages=[{"role": "user", "content": [
-            {"type": "text", "text": "ssn 123-45-6789"},
-            {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
-            {"type": "text", "text": "another email bob@example.com"},
-        ]}],
+        provider="openai",
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "ssn 123-45-6789"},
+                    {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+                    {"type": "text", "text": "another email bob@example.com"},
+                ],
+            }
+        ],
     )
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL", "US_SSN"], "on_detect": "replace", "scope": ["messages"],
-    }])
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL", "US_SSN"],
+                "on_detect": "replace",
+                "scope": ["messages"],
+            }
+        ]
+    )
     out = mw(ctx, next=lambda c: "ok")
     assert out == "ok"
     parts = ctx.messages[0]["content"]
@@ -202,17 +270,25 @@ def test_pii_detector_error_fails_open(caplog):
     from jamjet.cloud.middleware.pii import PIIDetector
 
     class BrokenDetector(PIIDetector):
-        def scan(self, text): raise RuntimeError("detector blew up")
+        def scan(self, text):
+            raise RuntimeError("detector blew up")
 
     from jamjet.cloud.middleware import CallContext
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL"], "on_detect": "block", "scope": ["messages"],
-    }])
+
+    mw = PIIMiddleware(
+        rules=[
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            }
+        ]
+    )
     # Override the compiled detector for this rule
     mw._compiled = [(mw._compiled[0][0], BrokenDetector())]
-    ctx = CallContext(provider="openai", model="gpt-4o",
-                      messages=[{"role": "user", "content": "hi alice@example.com"}])
+    ctx = CallContext(provider="openai", model="gpt-4o", messages=[{"role": "user", "content": "hi alice@example.com"}])
     out = mw(ctx, next=lambda c: "served-anyway")
     assert out == "served-anyway"
     assert any("pii detector error" in r.message for r in caplog.records)

--- a/sdk/python/tests/middleware/test_pii_property.py
+++ b/sdk/python/tests/middleware/test_pii_property.py
@@ -1,29 +1,55 @@
 """Property: for any input containing or not containing PII, after the PII
 middleware fires, the terminal call either NEVER runs (block path) or runs
 with a CallContext that contains zero detector hits (replace path)."""
-from hypothesis import given, strategies as st
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from jamjet.cloud.exceptions import JamJetPIIBlocked
 from jamjet.cloud.middleware import CallContext
 from jamjet.cloud.middleware.pii import (
-    PIIMiddleware, RegexDetector,
+    PIIMiddleware,
+    RegexDetector,
 )
-from jamjet.cloud.exceptions import JamJetPIIBlocked
+
+# Build each middleware ONCE at module load, not per hypothesis example: the
+# detector construction loads Presidio's NLP engine, which is far too slow to
+# repeat per example. The middleware holds no per-call state, so reuse is safe.
+_PII_TYPES = ["EMAIL", "US_SSN", "PHONE_NUMBER"]
+_BLOCK_MW = PIIMiddleware(
+    rules=[
+        {
+            "match": "openai:*",
+            "action": "redact",
+            "types": _PII_TYPES,
+            "on_detect": "block",
+            "scope": ["messages"],
+        }
+    ]
+)
+_REPLACE_MW = PIIMiddleware(
+    rules=[
+        {
+            "match": "openai:*",
+            "action": "redact",
+            "types": _PII_TYPES,
+            "on_detect": "replace",
+            "scope": ["messages"],
+        }
+    ]
+)
 
 
+@settings(deadline=None)  # per-example time is Presidio analysis, not the property under test
 @given(
-    base_text=st.text(alphabet=st.characters(blacklist_categories=("Cc",)),
-                      min_size=0, max_size=200),
+    base_text=st.text(alphabet=st.characters(blacklist_categories=("Cc",)), min_size=0, max_size=200),
 )
 def test_block_mode_never_passes_pii_to_terminal(base_text):
     """If the middleware doesn't raise, the terminal was called — and the
     terminal must have received content with no detector hits.
     If the middleware raises, the terminal was never called."""
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL", "US_SSN", "PHONE_NUMBER"],
-        "on_detect": "block", "scope": ["messages"],
-    }])
-    ctx = CallContext(provider="openai", model="gpt-4o",
-                      messages=[{"role": "user", "content": base_text}])
+    mw = _BLOCK_MW
+    ctx = CallContext(provider="openai", model="gpt-4o", messages=[{"role": "user", "content": base_text}])
     terminal_called_with = []
     try:
         mw(ctx, next=lambda c: terminal_called_with.append(c) or "ok")
@@ -40,16 +66,11 @@ def test_block_mode_never_passes_pii_to_terminal(base_text):
                     assert d.scan(content) == [], f"PII leaked through: {content!r}"
 
 
-@given(text=st.text(alphabet=st.characters(blacklist_categories=("Cc",)),
-                    min_size=0, max_size=200))
+@settings(deadline=None)  # per-example time is Presidio analysis, not the property under test
+@given(text=st.text(alphabet=st.characters(blacklist_categories=("Cc",)), min_size=0, max_size=200))
 def test_replace_mode_terminal_never_sees_pii(text):
-    mw = PIIMiddleware(rules=[{
-        "match": "openai:*", "action": "redact",
-        "types": ["EMAIL", "US_SSN", "PHONE_NUMBER"],
-        "on_detect": "replace", "scope": ["messages"],
-    }])
-    ctx = CallContext(provider="openai", model="gpt-4o",
-                      messages=[{"role": "user", "content": text}])
+    mw = _REPLACE_MW
+    ctx = CallContext(provider="openai", model="gpt-4o", messages=[{"role": "user", "content": text}])
     seen: list = []
     mw(ctx, next=lambda c: seen.append(c) or "ok")
 

--- a/sdk/python/tests/middleware/test_substrate_no_op.py
+++ b/sdk/python/tests/middleware/test_substrate_no_op.py
@@ -11,12 +11,14 @@ def test_no_op_when_flag_off_and_no_rules(monkeypatch):
         call_context_from_openai_kwargs,
         openai_kwargs_from_call_context,
     )
+
     chain = build_chain({"version": 1, "rules": []})
     kwargs = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
     ctx = call_context_from_openai_kwargs(kwargs)
 
     sentinel = object()
     rebuilt: dict = {}
+
     def terminal(c):
         rebuilt.update(openai_kwargs_from_call_context(c))
         return sentinel
@@ -32,8 +34,14 @@ def test_no_op_when_flag_on_but_only_tool_call_rules(monkeypatch):
     actions (block/require_approval/audit) must not change LLM-call behaviour."""
     monkeypatch.setenv("JAMJET_MIDDLEWARE_ENABLED", "1")
     from jamjet.cloud.middleware import build_chain
-    chain = build_chain({"version": 1, "rules": [
-        {"match": "*delete*", "action": "block"},
-        {"match": "payments.*", "action": "require_approval"},
-    ]})
+
+    chain = build_chain(
+        {
+            "version": 1,
+            "rules": [
+                {"match": "*delete*", "action": "block"},
+                {"match": "payments.*", "action": "require_approval"},
+            ],
+        }
+    )
     assert len(chain.middlewares) == 0

--- a/sdk/python/tests/test_policy_validate_redact.py
+++ b/sdk/python/tests/test_policy_validate_redact.py
@@ -1,67 +1,113 @@
 import pytest
+
 from jamjet.cloud.policy import validate
 
 
 def test_validate_accepts_redact_with_all_required_keys():
-    parsed = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "types": ["EMAIL", "US_SSN"], "on_detect": "block", "scope": ["messages", "tools"]},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL", "US_SSN"],
+                "on_detect": "block",
+                "scope": ["messages", "tools"],
+            },
+        ],
+    }
     validated = validate(parsed)
     assert validated["rules"][0]["action"] == "redact"
     assert validated["rules"][0]["types"] == ["EMAIL", "US_SSN"]
 
 
 def test_validate_accepts_redact_with_replace_action():
-    parsed = {"version": 1, "rules": [
-        {"match": "anthropic:*", "action": "redact",
-         "types": ["EMAIL"], "on_detect": "replace", "scope": ["messages"]},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {
+                "match": "anthropic:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "replace",
+                "scope": ["messages"],
+            },
+        ],
+    }
     validated = validate(parsed)
     assert validated["rules"][0]["on_detect"] == "replace"
 
 
 def test_validate_rejects_redact_missing_types():
-    parsed = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "on_detect": "block", "scope": ["messages"]},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {"match": "openai:*", "action": "redact", "on_detect": "block", "scope": ["messages"]},
+        ],
+    }
     with pytest.raises(ValueError, match=r"redact.*types"):
         validate(parsed)
 
 
 def test_validate_rejects_unknown_pii_type():
-    parsed = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "types": ["MARTIAN_BANK_ACCOUNT"], "on_detect": "block", "scope": ["messages"]},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["MARTIAN_BANK_ACCOUNT"],
+                "on_detect": "block",
+                "scope": ["messages"],
+            },
+        ],
+    }
     with pytest.raises(ValueError, match=r"MARTIAN_BANK_ACCOUNT"):
         validate(parsed)
 
 
 def test_validate_rejects_invalid_on_detect():
-    parsed = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "types": ["EMAIL"], "on_detect": "ask_nicely", "scope": ["messages"]},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "ask_nicely",
+                "scope": ["messages"],
+            },
+        ],
+    }
     with pytest.raises(ValueError, match=r"on_detect"):
         validate(parsed)
 
 
 def test_validate_rejects_invalid_scope():
-    parsed = {"version": 1, "rules": [
-        {"match": "openai:*", "action": "redact",
-         "types": ["EMAIL"], "on_detect": "block", "scope": ["system"]},  # system not allowed
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {
+                "match": "openai:*",
+                "action": "redact",
+                "types": ["EMAIL"],
+                "on_detect": "block",
+                "scope": ["system"],
+            },  # system not allowed
+        ],
+    }
     with pytest.raises(ValueError, match=r"scope"):
         validate(parsed)
 
 
 def test_validate_existing_tool_actions_unchanged():
     """Make sure adding `redact` validation didn't regress existing actions."""
-    parsed = {"version": 1, "rules": [
-        {"match": "*delete*", "action": "block"},
-        {"match": "payments.*", "action": "require_approval"},
-        {"match": "slack.*", "action": "audit"},
-    ]}
+    parsed = {
+        "version": 1,
+        "rules": [
+            {"match": "*delete*", "action": "block"},
+            {"match": "payments.*", "action": "require_approval"},
+            {"match": "slack.*", "action": "audit"},
+        ],
+    }
     validate(parsed)  # should not raise


### PR DESCRIPTION
## What was failing

`main` CI has been red since 2026-05-28. Root cause of the two failing PII tests:

- `_build_detector` *replaced* the regex detector with Presidio whenever `jamjet[pii]` was installed.
- Presidio's `en_core_web_lg` returns no match for a bare SSN like `123-45-6789` (confirmed: `presidio.scan("ssn 123-45-6789")` returns `[]`, while regex matches it).
- So with Presidio installed (the CI condition), a basic SSN slipped through pre-LLM. The tests passed locally only because presidio is not installed there, so the regex detector was silently used instead.

This is a safety regression: installing the "higher precision" detector made detection worse and let PII through.

## Fix

- `CompositeDetector` unions every detector and de-overlaps spans. Regex is always the floor; Presidio is additive and best-effort (if its model cannot load it falls back to regex instead of failing open). Installing Presidio can no longer regress detection below regex.
- Property tests: build the middleware once instead of per Hypothesis example, and drop the per-example deadline. The per-example time was Presidio engine construction, not the property under test (they were flaky on `main` too, independent of this change).
- Lint/format/mypy debt: the lint job stops at the failed `ruff format --check` step, so `ruff check` and `mypy` never ran on the middleware since it landed. Cleared it: ruff format, missing annotations, import placement, exception naming.

## Verification

Locally with `uv sync --all-extras` (presidio installed, matching CI):

- `ruff format --check .` clean
- `ruff check .` all passed
- `mypy jamjet/cloud` success
- `pytest` 766 passed, 1 xpassed

## Note

`uv.lock` is intentionally not touched. Two follow-ups worth filing separately: Presidio auto-downloads `en_core_web_lg` at runtime on first use (slow and network-dependent in CI), and the lint job should not silently skip `ruff check` / `mypy` when the format step fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced PII detection to intelligently combine multiple detection methods, including regex-based and Presidio-based detectors when available.

* **Improvements**
  * Improved type annotations for middleware components for better code clarity.
  * Optimized detection logic to eliminate overlapping redactions.

* **Tests**
  * Expanded test coverage for PII detection across various scenarios and message scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->