### PR TITLE
feat(cloud-sdk): record_outcome + cache_inject enforcement (CZ-1b, CZ-6)

### DIFF
--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -102,4 +102,4 @@ __all__ = [
     "tool",
     "workflow",
 ]
-__version__ = "0.8.5"
+__version__ = "0.8.7"

--- a/sdk/python/jamjet/cloud/__init__.py
+++ b/sdk/python/jamjet/cloud/__init__.py
@@ -8,9 +8,9 @@ from typing import Any
 from .agent import Agent, agent, get_current_agent, set_default_agent
 from .approvals import request_approval as _request_approval
 from .budget import set_budget as _set_budget
-from .outcomes import record_outcome as _record_outcome
 from .config import get_config, set_config
 from .events import init_queue
+from .outcomes import record_outcome as _record_outcome
 from .patcher import patch_all, unpatch_all
 from .policy import get_evaluator
 from .propagation import extract_headers, inject_headers

--- a/sdk/python/jamjet/cloud/__init__.py
+++ b/sdk/python/jamjet/cloud/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from .agent import Agent, agent, get_current_agent, set_default_agent
 from .approvals import request_approval as _request_approval
 from .budget import set_budget as _set_budget
+from .outcomes import record_outcome as _record_outcome
 from .config import get_config, set_config
 from .events import init_queue
 from .patcher import patch_all, unpatch_all
@@ -27,6 +28,7 @@ __all__ = [
     "inject_headers",
     "patch_all",
     "policy",
+    "record_outcome",
     "redact",
     "require_approval",
     "set_user_context",
@@ -179,4 +181,39 @@ def require_approval(
         action=action,
         context=context,
         timeout_seconds=timeout_seconds,
+    )
+
+
+def record_outcome(
+    trace_id: str,
+    outcome: str,
+    score: float | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Record the outcome of a completed trace run.
+
+    Requires the SDK to be configured via :func:`configure`.
+
+    Args:
+        trace_id: ID of the trace whose outcome is being recorded.
+        outcome:  One of ``'success'``, ``'failure'``, ``'approved'``,
+                  ``'rejected'``, ``'resolved'``, or ``'unresolved'``.
+        score:    Optional float in [0, 1] representing a quality score.
+        metadata: Optional free-form dict attached to the record.
+
+    Raises:
+        RuntimeError: When the SDK has not been configured.
+        ValueError: When *outcome* is invalid or *score* is out of range.
+        httpx.HTTPStatusError: When the API returns a non-2xx response.
+    """
+    cfg = get_config()
+    if not cfg.api_key:
+        raise RuntimeError("JamJet Cloud not configured. Call jamjet.configure() first.")
+    _record_outcome(
+        api_key=cfg.api_key,
+        api_url=cfg.api_url,
+        trace_id=trace_id,
+        outcome=outcome,
+        score=score,
+        metadata=metadata,
     )

--- a/sdk/python/jamjet/cloud/outcomes.py
+++ b/sdk/python/jamjet/cloud/outcomes.py
@@ -6,9 +6,7 @@ from typing import Any
 
 import httpx
 
-VALID_OUTCOMES = frozenset(
-    {"success", "failure", "approved", "rejected", "resolved", "unresolved"}
-)
+VALID_OUTCOMES = frozenset({"success", "failure", "approved", "rejected", "resolved", "unresolved"})
 
 
 def record_outcome(
@@ -36,16 +34,10 @@ def record_outcome(
         httpx.HTTPStatusError: When the API returns a non-2xx response.
     """
     if outcome not in VALID_OUTCOMES:
-        raise ValueError(
-            f"Invalid outcome {outcome!r}. Must be one of: "
-            + ", ".join(sorted(VALID_OUTCOMES))
-            + "."
-        )
+        raise ValueError(f"Invalid outcome {outcome!r}. Must be one of: " + ", ".join(sorted(VALID_OUTCOMES)) + ".")
     if score is not None:
         if not isinstance(score, (int, float)) or score < 0 or score > 1:
-            raise ValueError(
-                f"score must be a number between 0 and 1 (inclusive), got {score!r}."
-            )
+            raise ValueError(f"score must be a number between 0 and 1 (inclusive), got {score!r}.")
 
     payload: dict[str, Any] = {"trace_id": trace_id, "outcome": outcome}
     if score is not None:

--- a/sdk/python/jamjet/cloud/outcomes.py
+++ b/sdk/python/jamjet/cloud/outcomes.py
@@ -1,0 +1,65 @@
+"""Record trace outcomes against the JamJet Cloud API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+VALID_OUTCOMES = frozenset(
+    {"success", "failure", "approved", "rejected", "resolved", "unresolved"}
+)
+
+
+def record_outcome(
+    api_key: str,
+    api_url: str,
+    trace_id: str,
+    outcome: str,
+    score: float | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """POST an outcome record to ``/v1/outcomes``.
+
+    Args:
+        api_key:  Bearer token for the JamJet Cloud API.
+        api_url:  Base URL, e.g. ``https://api.jamjet.dev``.
+        trace_id: ID of the trace whose outcome is being recorded.
+        outcome:  One of ``success``, ``failure``, ``approved``, ``rejected``,
+                  ``resolved``, or ``unresolved``.
+        score:    Optional float in [0, 1] representing a quality score.
+        metadata: Optional free-form dict attached to the record.
+
+    Raises:
+        ValueError: When *outcome* is not one of the six valid values or
+                    *score* is outside the [0, 1] range.
+        httpx.HTTPStatusError: When the API returns a non-2xx response.
+    """
+    if outcome not in VALID_OUTCOMES:
+        raise ValueError(
+            f"Invalid outcome {outcome!r}. Must be one of: "
+            + ", ".join(sorted(VALID_OUTCOMES))
+            + "."
+        )
+    if score is not None:
+        if not isinstance(score, (int, float)) or score < 0 or score > 1:
+            raise ValueError(
+                f"score must be a number between 0 and 1 (inclusive), got {score!r}."
+            )
+
+    payload: dict[str, Any] = {"trace_id": trace_id, "outcome": outcome}
+    if score is not None:
+        payload["score"] = float(score)
+    if metadata is not None:
+        payload["metadata"] = metadata
+
+    resp = httpx.post(
+        f"{api_url.rstrip('/')}/v1/outcomes",
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        timeout=10,
+    )
+    resp.raise_for_status()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.8.6"
+version = "0.8.7"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/tests/cloud/test_outcomes.py
+++ b/sdk/python/tests/cloud/test_outcomes.py
@@ -1,0 +1,141 @@
+"""Tests for jamjet.cloud.outcomes.record_outcome."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import respx
+import httpx
+
+from jamjet.cloud.outcomes import record_outcome, VALID_OUTCOMES
+
+API_URL = "https://api.example.com"
+API_KEY = "jj_test_key"
+OUTCOMES_URL = f"{API_URL}/v1/outcomes"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path HTTP behaviour
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_posts_to_correct_url_with_bearer_auth() -> None:
+    route = respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+
+    record_outcome(API_KEY, API_URL, trace_id="trace_abc", outcome="success")
+
+    assert route.called
+    req: httpx.Request = route.calls[0].request
+    assert req.headers["authorization"] == f"Bearer {API_KEY}"
+    assert req.url.path == "/v1/outcomes"
+
+
+@respx.mock
+def test_request_body_minimal() -> None:
+    """Minimal call: only trace_id + outcome in body."""
+    route = respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+
+    record_outcome(API_KEY, API_URL, trace_id="trace_abc", outcome="success")
+
+    body: dict[str, Any] = json.loads(route.calls[0].request.content)
+    assert body == {"trace_id": "trace_abc", "outcome": "success"}
+
+
+@respx.mock
+def test_request_body_with_score_and_metadata() -> None:
+    route = respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+
+    record_outcome(
+        API_KEY,
+        API_URL,
+        trace_id="trace_xyz",
+        outcome="failure",
+        score=0.42,
+        metadata={"reason": "timeout", "retries": 3},
+    )
+
+    body: dict[str, Any] = json.loads(route.calls[0].request.content)
+    assert body["trace_id"] == "trace_xyz"
+    assert body["outcome"] == "failure"
+    assert body["score"] == pytest.approx(0.42)
+    assert body["metadata"] == {"reason": "timeout", "retries": 3}
+
+
+@respx.mock
+@pytest.mark.parametrize("outcome", sorted(VALID_OUTCOMES))
+def test_all_valid_outcomes_are_accepted(outcome: str) -> None:
+    respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+    record_outcome(API_KEY, API_URL, trace_id="t1", outcome=outcome)  # must not raise
+
+
+@respx.mock
+def test_score_boundary_zero_and_one_are_accepted() -> None:
+    respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+    record_outcome(API_KEY, API_URL, trace_id="t1", outcome="success", score=0)
+    respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+    record_outcome(API_KEY, API_URL, trace_id="t2", outcome="success", score=1)
+
+
+@respx.mock
+def test_raises_http_status_error_on_non_2xx() -> None:
+    respx.post(OUTCOMES_URL).respond(status_code=422)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        record_outcome(API_KEY, API_URL, trace_id="t1", outcome="success")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_raises_value_error_for_invalid_outcome() -> None:
+    with pytest.raises(ValueError, match="Invalid outcome"):
+        record_outcome(API_KEY, API_URL, trace_id="t1", outcome="wrong")
+
+
+def test_raises_value_error_for_score_below_zero() -> None:
+    with pytest.raises(ValueError, match="score must be a number between 0 and 1"):
+        record_outcome(API_KEY, API_URL, trace_id="t1", outcome="success", score=-0.1)
+
+
+def test_raises_value_error_for_score_above_one() -> None:
+    with pytest.raises(ValueError, match="score must be a number between 0 and 1"):
+        record_outcome(API_KEY, API_URL, trace_id="t1", outcome="success", score=1.01)
+
+
+# ---------------------------------------------------------------------------
+# __init__.py surface: the configure() → record_outcome() wrapper
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_public_wrapper_posts_with_configured_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """jamjet.cloud.record_outcome should pick up api_key / api_url from config."""
+    from jamjet.cloud import record_outcome as pub_record_outcome
+    from jamjet.cloud.config import set_config
+
+    set_config(api_key="jj_from_config", api_url=API_URL)
+
+    route = respx.post(OUTCOMES_URL).respond(status_code=200, json={"recorded": True})
+    pub_record_outcome(trace_id="trace_public", outcome="approved")
+
+    assert route.called
+    req = route.calls[0].request
+    assert req.headers["authorization"] == "Bearer jj_from_config"
+    body = json.loads(req.content)
+    assert body["trace_id"] == "trace_public"
+    assert body["outcome"] == "approved"
+
+
+def test_public_wrapper_raises_without_api_key() -> None:
+    from jamjet.cloud import record_outcome as pub_record_outcome
+    from jamjet.cloud.config import set_config
+
+    set_config(api_key=None)
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        pub_record_outcome(trace_id="t1", outcome="success")

--- a/sdk/python/tests/cloud/test_outcomes.py
+++ b/sdk/python/tests/cloud/test_outcomes.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import httpx
 import pytest
 import respx
-import httpx
 
-from jamjet.cloud.outcomes import record_outcome, VALID_OUTCOMES
+from jamjet.cloud.outcomes import VALID_OUTCOMES, record_outcome
 
 API_URL = "https://api.example.com"
 API_KEY = "jj_test_key"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1729,7 +1729,7 @@ wheels = [
 
 [[package]]
 name = "jamjet"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "agentboundary" },

--- a/sdk/typescript/packages/cloud/CHANGELOG.md
+++ b/sdk/typescript/packages/cloud/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0-alpha.2 — 2026-05-31
+
+### Added
+- `cache_inject` enforcement: safe-identical prompt-cache injection driven by
+  active cache_inject policies pulled from Cloud. Records `saved_cents` per call.
+
 ## 0.4.0-alpha.1 — 2026-05-18 (unreleased)
 
 ### Fixed

--- a/sdk/typescript/packages/cloud/package.json
+++ b/sdk/typescript/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jamjet/cloud",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "description": "JamJet engine — policy evaluation, budget enforcement, audit writing, approval queue. The shared brain across all JamJet adapters.",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdk/typescript/packages/cloud/package.json
+++ b/sdk/typescript/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jamjet/cloud",
-  "version": "0.4.0-alpha.2",
+  "version": "0.4.0-alpha.3",
   "description": "JamJet engine — policy evaluation, budget enforcement, audit writing, approval queue. The shared brain across all JamJet adapters.",
   "license": "Apache-2.0",
   "type": "module",

--- a/sdk/typescript/packages/cloud/src/cache-inject-fetch.ts
+++ b/sdk/typescript/packages/cloud/src/cache-inject-fetch.ts
@@ -1,0 +1,20 @@
+interface FetchOpts {
+  apiBase: string
+  token: string
+  fetchImpl?: typeof fetch
+}
+/** Pulls active cache_inject policy prefix-hashes from Cloud. Fail-open: any
+ * error returns [] so a cloud hiccup never breaks the user's LLM calls. */
+export async function fetchCacheInjectHashes(opts: FetchOpts): Promise<string[]> {
+  const f = opts.fetchImpl ?? fetch
+  try {
+    const res = await f(`${opts.apiBase}/v1/policies?kind=cache_inject&active=true`, {
+      headers: { Authorization: `Bearer ${opts.token}` },
+    })
+    if (!res.ok) return []
+    const body = (await res.json()) as { policies?: Array<{ pattern: string }> }
+    return (body.policies ?? []).map((p) => p.pattern).filter((h): h is string => typeof h === 'string')
+  } catch {
+    return []
+  }
+}

--- a/sdk/typescript/packages/cloud/src/cache-inject.ts
+++ b/sdk/typescript/packages/cloud/src/cache-inject.ts
@@ -1,0 +1,57 @@
+// Safe-identical prompt-cache injection. Anthropic prompt caches are
+// content-addressed, so adding `cache_control: { type: 'ephemeral' }` to a
+// stable prefix changes price, never output. Pure + idempotent.
+
+const EPHEMERAL = { type: 'ephemeral' } as const
+
+type Block = { type: string; text?: string; cache_control?: { type: 'ephemeral' } }
+
+function alreadyCached(content: unknown): boolean {
+  return Array.isArray(content) && content.some((b) => (b as Block)?.cache_control != null)
+}
+
+function toCachedBlocks(content: unknown): Block[] {
+  if (typeof content === 'string') {
+    return [{ type: 'text', text: content, cache_control: EPHEMERAL }]
+  }
+  if (Array.isArray(content)) {
+    const blocks = content.slice() as Block[]
+    const last = blocks.length - 1
+    if (last >= 0) {
+      const tail = blocks[last] as Block
+      blocks[last] = tail.text != null
+        ? { type: tail.type, text: tail.text, cache_control: EPHEMERAL }
+        : { type: tail.type, cache_control: EPHEMERAL }
+    }
+    return blocks
+  }
+  return content as Block[]
+}
+
+/**
+ * Returns a shallow-cloned args object with cache_control added to the system
+ * block (preferred) or the first user message. `injected` is false when there
+ * is nothing to cache or a cache_control is already present (idempotent).
+ */
+export function applyCacheInject(
+  args0: Record<string, unknown>,
+): { mutated: Record<string, unknown>; injected: boolean } {
+  const out = { ...args0 }
+
+  if (out.system != null) {
+    if (alreadyCached(out.system)) return { mutated: out, injected: false }
+    out.system = toCachedBlocks(out.system)
+    return { mutated: out, injected: true }
+  }
+
+  const messages = Array.isArray(out.messages) ? (out.messages as Array<Record<string, unknown>>) : []
+  const firstUser = messages.findIndex((m) => m.role === 'user')
+  if (firstUser === -1) return { mutated: out, injected: false }
+  const userMsg = messages[firstUser] as Record<string, unknown>
+  if (alreadyCached(userMsg.content)) return { mutated: out, injected: false }
+
+  const newMessages = messages.slice()
+  newMessages[firstUser] = { ...userMsg, content: toCachedBlocks(userMsg.content) }
+  out.messages = newMessages
+  return { mutated: out, injected: true }
+}

--- a/sdk/typescript/packages/cloud/src/cache-inject.ts
+++ b/sdk/typescript/packages/cloud/src/cache-inject.ts
@@ -10,6 +10,11 @@ function alreadyCached(content: unknown): boolean {
   return Array.isArray(content) && content.some((b) => (b as Block)?.cache_control != null)
 }
 
+function isInjectable(content: unknown): boolean {
+  return typeof content === 'string' || Array.isArray(content)
+}
+
+// Array branch: assumes text blocks; caches the last block per Anthropic's spec.
 function toCachedBlocks(content: unknown): Block[] {
   if (typeof content === 'string') {
     return [{ type: 'text', text: content, cache_control: EPHEMERAL }]
@@ -32,26 +37,29 @@ function toCachedBlocks(content: unknown): Block[] {
  * Returns a shallow-cloned args object with cache_control added to the system
  * block (preferred) or the first user message. `injected` is false when there
  * is nothing to cache or a cache_control is already present (idempotent).
+ * Non-injectable content (neither string nor array) is skipped.
  */
 export function applyCacheInject(
   args0: Record<string, unknown>,
 ): { mutated: Record<string, unknown>; injected: boolean } {
   const out = { ...args0 }
 
-  if (out.system != null) {
-    if (alreadyCached(out.system)) return { mutated: out, injected: false }
-    out.system = toCachedBlocks(out.system)
+  const sys = out.system
+  if (sys != null && isInjectable(sys)) {
+    if (alreadyCached(sys)) return { mutated: out, injected: false }
+    out.system = toCachedBlocks(sys)
     return { mutated: out, injected: true }
   }
 
   const messages = Array.isArray(out.messages) ? (out.messages as Array<Record<string, unknown>>) : []
   const firstUser = messages.findIndex((m) => m.role === 'user')
   if (firstUser === -1) return { mutated: out, injected: false }
-  const userMsg = messages[firstUser] as Record<string, unknown>
-  if (alreadyCached(userMsg.content)) return { mutated: out, injected: false }
+  const firstUserMsg = messages[firstUser] as Record<string, unknown>
+  const content = firstUserMsg.content
+  if (!isInjectable(content) || alreadyCached(content)) return { mutated: out, injected: false }
 
   const newMessages = messages.slice()
-  newMessages[firstUser] = { ...userMsg, content: toCachedBlocks(userMsg.content) }
+  newMessages[firstUser] = { ...firstUserMsg, content: toCachedBlocks(content) }
   out.messages = newMessages
   return { mutated: out, injected: true }
 }

--- a/sdk/typescript/packages/cloud/src/cache-inject.ts
+++ b/sdk/typescript/packages/cloud/src/cache-inject.ts
@@ -63,3 +63,17 @@ export function applyCacheInject(
   out.messages = newMessages
   return { mutated: out, injected: true }
 }
+
+/** Holds the prompt-prefix hashes for which an active cache_inject policy exists. */
+export class CacheInjectResolver {
+  private readonly hashes: Set<string>
+  constructor(prefixHashes: string[] = []) {
+    this.hashes = new Set(prefixHashes)
+  }
+  shouldInject(prefixHash: string | null | undefined): boolean {
+    return prefixHash != null && this.hashes.has(prefixHash)
+  }
+  get size(): number {
+    return this.hashes.size
+  }
+}

--- a/sdk/typescript/packages/cloud/src/cache-inject.ts
+++ b/sdk/typescript/packages/cloud/src/cache-inject.ts
@@ -14,21 +14,19 @@ function isInjectable(content: unknown): boolean {
   return typeof content === 'string' || Array.isArray(content)
 }
 
-// Array branch: assumes text blocks; caches the last block per Anthropic's spec.
+// Array branch: caches the last block per Anthropic's spec.
+// We cast to Record<string,unknown> for the spread so that exactOptionalPropertyTypes
+// doesn't complain about the optional `text?` field, while still preserving every
+// field of the original block (image source, document data, tool_result content, etc.).
 function toCachedBlocks(content: unknown): Block[] {
   if (typeof content === 'string') {
     return [{ type: 'text', text: content, cache_control: EPHEMERAL }]
   }
   if (Array.isArray(content)) {
-    const blocks = content.slice() as Block[]
+    const blocks = content.slice() as Array<Record<string, unknown>>
     const last = blocks.length - 1
-    if (last >= 0) {
-      const tail = blocks[last] as Block
-      blocks[last] = tail.text != null
-        ? { type: tail.type, text: tail.text, cache_control: EPHEMERAL }
-        : { type: tail.type, cache_control: EPHEMERAL }
-    }
-    return blocks
+    if (last >= 0) blocks[last] = { ...blocks[last], cache_control: EPHEMERAL }
+    return blocks as unknown as Block[]
   }
   return content as Block[]
 }

--- a/sdk/typescript/packages/cloud/src/client.ts
+++ b/sdk/typescript/packages/cloud/src/client.ts
@@ -13,6 +13,7 @@ export class Client {
   readonly transport: Transport
   readonly batcher: Batcher
   readonly _policy: PolicyEvaluator
+  // Mutable (not readonly): replaced by init.ts after the async cloud pull resolves.
   _cacheInject: CacheInjectResolver
   readonly _budget: BudgetManager
   readonly _governanceContext: GovernanceContext

--- a/sdk/typescript/packages/cloud/src/client.ts
+++ b/sdk/typescript/packages/cloud/src/client.ts
@@ -1,5 +1,6 @@
 import { Batcher } from './batcher.js'
 import { BudgetManager } from './budget.js'
+import { CacheInjectResolver } from './cache-inject.js'
 import type { ResolvedConfig } from './config.js'
 import { GovernanceContext } from './context.js'
 import { PolicyEvaluator } from './policy.js'
@@ -12,6 +13,7 @@ export class Client {
   readonly transport: Transport
   readonly batcher: Batcher
   readonly _policy: PolicyEvaluator
+  _cacheInject: CacheInjectResolver
   readonly _budget: BudgetManager
   readonly _governanceContext: GovernanceContext
 
@@ -33,6 +35,7 @@ export class Client {
       },
     })
     this._policy = new PolicyEvaluator()
+    this._cacheInject = new CacheInjectResolver()
     this._budget = new BudgetManager(config.maxCostUsd ?? null)
     this._governanceContext = new GovernanceContext()
   }

--- a/sdk/typescript/packages/cloud/src/enforcement.ts
+++ b/sdk/typescript/packages/cloud/src/enforcement.ts
@@ -1,6 +1,7 @@
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages'
 import type { Client } from './client.js'
 import type { AgentRef, UserContext } from './context.js'
+import { applyCacheInject } from './cache-inject.js'
 import { estimateCost } from './cost.js'
 import { JamjetPolicyBlocked } from './errors.js'
 import { Span } from './span.js'
@@ -76,6 +77,24 @@ function extractUsage(vendor: Vendor, response: unknown): { input: number; outpu
   return { input: Number(usage['input_tokens']) || 0, output: Number(usage['output_tokens']) || 0 }
 }
 
+function extractCacheRead(_vendor: Vendor, response: unknown): number {
+  const usage = ((response as Record<string, any>)?.usage ?? {}) as Record<string, unknown>
+  return Number(usage['cache_read_input_tokens'] ?? 0) || 0
+}
+
+// Per-MTok savings = input price − cache_read price; mirrors pricing.rs v_2026_05_17.
+const CACHE_SAVING_PER_MTOK: Record<string, number> = {
+  'claude-opus-4-7': 15.0 - 1.5,
+  'claude-sonnet-4-6': 3.0 - 0.3,
+  'claude-haiku-4-5': 1.0 - 0.1,
+  'claude-haiku-4-5-20251001': 1.0 - 0.1,
+}
+
+function cacheReadSavingsUsd(model: string, cacheReadTokens: number): number {
+  const per = CACHE_SAVING_PER_MTOK[model] ?? 0
+  return (cacheReadTokens / 1_000_000) * per
+}
+
 export async function runEnforcedCall(opts: EnforcedCallOptions): Promise<unknown> {
   const { client, vendor, original, args, override, computePromptPrefixHash } = opts
   const arg0 = (args[0] ?? {}) as Record<string, unknown>
@@ -133,12 +152,26 @@ export async function runEnforcedCall(opts: EnforcedCallOptions): Promise<unknow
   // the patchers rather than imported directly — keeps this file runtime-
   // agnostic and prevents `node:crypto` from leaking into the universal
   // bundle via `wrap.ts`. A failing hash MUST NEVER break an LLM call.
+  let prefixHash: string | undefined
   if (computePromptPrefixHash !== undefined) {
     try {
-      span.setPromptPrefixHash(computePromptPrefixHash(messages))
+      prefixHash = computePromptPrefixHash(messages)
+      span.setPromptPrefixHash(prefixHash)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`[jamjet] prompt prefix hash failed: ${msg}`)
+    }
+  }
+
+  // Cache injection: add cache_control to stable prompt prefix when policy matches.
+  // Safe-identical: Anthropic caches are content-addressed — price changes, output does not.
+  let cacheInjected = false
+  if (vendor === 'anthropic' && client._cacheInject.shouldInject(prefixHash)) {
+    const arg0obj = mutatedArgs[0] as Record<string, unknown>
+    const { mutated, injected } = applyCacheInject(arg0obj)
+    if (injected) {
+      mutatedArgs = [mutated, ...mutatedArgs.slice(1)]
+      cacheInjected = true
     }
   }
 
@@ -174,6 +207,19 @@ export async function runEnforcedCall(opts: EnforcedCallOptions): Promise<unknow
       span.outputTokens = usage.output
       span.costUsd = estimateCost(actualModel, usage.input, usage.output)
       client._budget.record(span.costUsd)
+
+      if (cacheInjected) {
+        const cacheRead = extractCacheRead(vendor, result)
+        const savedUsd = cacheReadSavingsUsd(actualModel, cacheRead)
+        span.payload = {
+          ...span.payload,
+          // Fractional cents intentional — Math.round would zero sub-cent per-call
+          // savings. Authoritative totals are recomputed server-side from
+          // cache_read_input_tokens; this is a secondary per-call annotation.
+          saved_cents: savedUsd * 100,
+          cache_injected: true,
+        }
+      }
     }
 
     span.finish('ok')

--- a/sdk/typescript/packages/cloud/src/governance.ts
+++ b/sdk/typescript/packages/cloud/src/governance.ts
@@ -2,6 +2,8 @@ import { type Client, getActive } from './client.js'
 import type { AgentRef, ScopeFrame, UserContext } from './context.js'
 import type { PolicyAction } from './policy.js'
 import { pollUntilResolved } from './approvals.js'
+import { recordOutcome as _recordOutcome } from './outcomes.js'
+import type { Outcome, RecordOutcomeOptions } from './outcomes.js'
 
 const NOT_INIT = 'JamJet Cloud not initialized. Call init() first.'
 
@@ -141,4 +143,23 @@ export async function requireApproval(
     ...(opts.pollIntervalMs !== undefined ? { pollIntervalMs: opts.pollIntervalMs } : {}),
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
   })
+}
+
+export { type Outcome, type RecordOutcomeOptions }
+
+/**
+ * Record the outcome of a completed trace run. Requires the SDK to be
+ * initialized via `init()`.
+ *
+ * @param traceId  ID of the trace whose outcome is being recorded.
+ * @param outcome  One of `'success' | 'failure' | 'approved' | 'rejected' | 'resolved' | 'unresolved'`.
+ * @param opts     Optional `score` (0–1) and free-form `metadata` object.
+ */
+export async function recordOutcome(
+  traceId: string,
+  outcome: Outcome,
+  opts: RecordOutcomeOptions = {},
+): Promise<void> {
+  const client = activeOrThrow()
+  return _recordOutcome(client.config.apiKey, client.config.apiUrl, traceId, outcome, opts)
 }

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -20,8 +20,9 @@ export {
   setUserContext,
   withUserContext,
   setProcessContext,
+  recordOutcome,
 } from './governance.js'
-export type { RequireApprovalOptions } from './governance.js'
+export type { RequireApprovalOptions, Outcome, RecordOutcomeOptions } from './governance.js'
 export type { AgentRef, UserContext } from './context.js'
 export type { PolicyAction, PolicyDecision } from './policy.js'
 export { PolicyEvaluator } from './policy.js'

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.4.0-alpha.2'
+export const VERSION = '0.4.0-alpha.3'
 
 export { init } from './init.js'
 export { wrap } from './wrap.js'

--- a/sdk/typescript/packages/cloud/src/index.ts
+++ b/sdk/typescript/packages/cloud/src/index.ts
@@ -1,4 +1,4 @@
-export const VERSION = '0.4.0-alpha.1'
+export const VERSION = '0.4.0-alpha.2'
 
 export { init } from './init.js'
 export { wrap } from './wrap.js'
@@ -71,3 +71,6 @@ export { detectPathMode } from './path-mode.js'
 export type { PathMode } from './path-mode.js'
 export { parseTraceparent, readTraceparent } from './trace-context.js'
 export type { Traceparent, TraceContextSource } from './trace-context.js'
+
+// Cache-inject enforcement (Phase A Token Intelligence).
+export { applyCacheInject, CacheInjectResolver } from './cache-inject.js'

--- a/sdk/typescript/packages/cloud/src/init.ts
+++ b/sdk/typescript/packages/cloud/src/init.ts
@@ -1,4 +1,6 @@
 import { Client, resetActive, setActive } from './client.js'
+import { fetchCacheInjectHashes } from './cache-inject-fetch.js'
+import { CacheInjectResolver } from './cache-inject.js'
 import { resolveConfig, type InitOptions } from './config.js'
 
 export async function init(opts: InitOptions): Promise<void> {
@@ -6,6 +8,8 @@ export async function init(opts: InitOptions): Promise<void> {
   await resetActive()
   const client = new Client(config)
   setActive(client)
+  void fetchCacheInjectHashes({ apiBase: config.apiUrl, token: config.apiKey })
+    .then((hashes) => { client._cacheInject = new CacheInjectResolver(hashes) })
   await readinessCheck(config.apiUrl, config.project, config.apiKey, config.debug)
 }
 

--- a/sdk/typescript/packages/cloud/src/outcomes.ts
+++ b/sdk/typescript/packages/cloud/src/outcomes.ts
@@ -1,0 +1,74 @@
+const VALID_OUTCOMES = new Set([
+  'success',
+  'failure',
+  'approved',
+  'rejected',
+  'resolved',
+  'unresolved',
+] as const)
+
+export type Outcome =
+  | 'success'
+  | 'failure'
+  | 'approved'
+  | 'rejected'
+  | 'resolved'
+  | 'unresolved'
+
+export interface RecordOutcomeOptions {
+  score?: number
+  metadata?: Record<string, unknown>
+}
+
+function isValidOutcome(value: string): value is Outcome {
+  return VALID_OUTCOMES.has(value as Outcome)
+}
+
+/**
+ * Record the outcome of a trace run.
+ *
+ * POSTs to `POST /v1/outcomes` on the JamJet Cloud API.
+ *
+ * @param apiKey   Bearer token.
+ * @param apiUrl   Base URL (e.g. `https://api.jamjet.dev`).
+ * @param traceId  The trace whose outcome is being recorded.
+ * @param outcome  One of the six outcome values.
+ * @param opts     Optional `score` (0–1) and free-form `metadata`.
+ */
+export async function recordOutcome(
+  apiKey: string,
+  apiUrl: string,
+  traceId: string,
+  outcome: Outcome,
+  opts: RecordOutcomeOptions = {},
+): Promise<void> {
+  if (!isValidOutcome(outcome)) {
+    throw new TypeError(
+      `Invalid outcome "${outcome}". Must be one of: ${[...VALID_OUTCOMES].join(', ')}.`,
+    )
+  }
+  if (opts.score !== undefined) {
+    if (typeof opts.score !== 'number' || opts.score < 0 || opts.score > 1) {
+      throw new RangeError(
+        `score must be a number between 0 and 1 (inclusive), got ${opts.score}.`,
+      )
+    }
+  }
+
+  const body: Record<string, unknown> = { trace_id: traceId, outcome }
+  if (opts.score !== undefined) body.score = opts.score
+  if (opts.metadata !== undefined) body.metadata = opts.metadata
+
+  const res = await fetch(`${apiUrl}/v1/outcomes`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    throw new Error(`JamJet recordOutcome failed: ${res.status} ${res.statusText}`)
+  }
+}

--- a/sdk/typescript/packages/cloud/tests/cache-inject-enforce.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject-enforce.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, it, expect } from 'vitest'
+import { Client, resetActive, setActive } from '../src/client.js'
+import { resolveConfig } from '../src/config.js'
+import { CacheInjectResolver } from '../src/cache-inject.js'
+import { runEnforcedCall } from '../src/enforcement.js'
+
+function makeClient(): Client {
+  const c = new Client(resolveConfig({ apiKey: 'jj_t', project: 'p' }))
+  setActive(c)
+  return c
+}
+
+const okResp = {
+  usage: { input_tokens: 1000, output_tokens: 20, cache_read_input_tokens: 1000 },
+  model: 'claude-sonnet-4-6',
+  content: [],
+}
+
+describe('cache_inject in runEnforcedCall', () => {
+  beforeEach(async () => {
+    await resetActive()
+  })
+  afterEach(async () => {
+    await resetActive()
+  })
+
+  it('injects cache_control on a matching prefix hash and records saved_cents', async () => {
+    const client = makeClient()
+    client._cacheInject = new CacheInjectResolver(['deadbeefcafef00d'])
+    let received: any
+    const original = async (args: any) => { received = args; return okResp }
+    let recorded: any
+    const orig = client.recordSpan.bind(client)
+    client.recordSpan = (e) => { recorded = e; return orig(e) }
+
+    await runEnforcedCall({
+      client, vendor: 'anthropic', original,
+      args: [{ model: 'claude-sonnet-4-6', system: 'stable preamble', messages: [{ role: 'user', content: 'hi' }] }],
+      computePromptPrefixHash: () => 'deadbeefcafef00d',
+    })
+
+    expect(Array.isArray(received.system)).toBe(true)
+    expect(received.system[0].cache_control).toEqual({ type: 'ephemeral' })
+    expect(recorded.payload?.saved_cents).toBeGreaterThan(0)
+  })
+
+  it('does not inject when the prefix hash does not match', async () => {
+    const client = makeClient()
+    client._cacheInject = new CacheInjectResolver(['somethingelse'])
+    let received: any
+    const original = async (args: any) => { received = args; return okResp }
+    await runEnforcedCall({
+      client, vendor: 'anthropic', original,
+      args: [{ model: 'claude-sonnet-4-6', system: 'stable preamble', messages: [] }],
+      computePromptPrefixHash: () => 'deadbeefcafef00d',
+    })
+    expect(received.system).toBe('stable preamble')
+  })
+})

--- a/sdk/typescript/packages/cloud/tests/cache-inject-fetch.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject-fetch.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchCacheInjectHashes } from '../src/cache-inject-fetch.js'
+
+describe('fetchCacheInjectHashes', () => {
+  it('returns prefix hashes (policy patterns) from the cloud', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({ policies: [{ pattern: 'aaaa1111' }, { pattern: 'bbbb2222' }] }) })) as any
+    const hashes = await fetchCacheInjectHashes({ apiBase: 'https://api.test', token: 'jj_t', fetchImpl: f })
+    expect(hashes).toEqual(['aaaa1111', 'bbbb2222'])
+    expect(f).toHaveBeenCalledWith('https://api.test/v1/policies?kind=cache_inject&active=true', expect.objectContaining({ headers: expect.any(Object) }))
+  })
+  it('returns [] and never throws on a failed fetch (fail-open)', async () => {
+    const f = vi.fn(async () => { throw new Error('network') }) as any
+    expect(await fetchCacheInjectHashes({ apiBase: 'https://api.test', token: 'jj_t', fetchImpl: f })).toEqual([])
+  })
+})

--- a/sdk/typescript/packages/cloud/tests/cache-inject-fetch.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject-fetch.test.ts
@@ -12,4 +12,8 @@ describe('fetchCacheInjectHashes', () => {
     const f = vi.fn(async () => { throw new Error('network') }) as any
     expect(await fetchCacheInjectHashes({ apiBase: 'https://api.test', token: 'jj_t', fetchImpl: f })).toEqual([])
   })
+  it('returns [] when the response is not ok', async () => {
+    const f = vi.fn(async () => ({ ok: false, json: async () => ({}) })) as any
+    expect(await fetchCacheInjectHashes({ apiBase: 'https://api.test', token: 'jj_t', fetchImpl: f })).toEqual([])
+  })
 })

--- a/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { applyCacheInject } from '../src/cache-inject.js'
+
+describe('applyCacheInject', () => {
+  it('wraps a string system prompt into a text block with cache_control', () => {
+    const { mutated, injected } = applyCacheInject({
+      model: 'claude-sonnet-4-6',
+      system: 'You are a careful assistant.',
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    expect(injected).toBe(true)
+    expect(mutated.system).toEqual([
+      { type: 'text', text: 'You are a careful assistant.', cache_control: { type: 'ephemeral' } },
+    ])
+  })
+
+  it('falls back to the first user message when there is no system prompt', () => {
+    const { mutated, injected } = applyCacheInject({
+      model: 'claude-sonnet-4-6',
+      messages: [{ role: 'user', content: 'long stable preamble' }],
+    })
+    expect(injected).toBe(true)
+    const m0 = (mutated.messages as any[])[0]
+    expect(m0.content).toEqual([
+      { type: 'text', text: 'long stable preamble', cache_control: { type: 'ephemeral' } },
+    ])
+  })
+
+  it('is idempotent — no double injection when cache_control already present', () => {
+    const once = applyCacheInject({ system: 'x', messages: [] }).mutated
+    const twice = applyCacheInject(once)
+    expect(twice.injected).toBe(false)
+    expect(twice.mutated.system).toEqual(once.system)
+  })
+
+  it('no-ops with neither system nor user message', () => {
+    const { injected } = applyCacheInject({ messages: [] })
+    expect(injected).toBe(false)
+  })
+
+  it('does not mutate the input object', () => {
+    const input = { system: 'x', messages: [] }
+    applyCacheInject(input)
+    expect(input.system).toBe('x')
+  })
+})

--- a/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
@@ -43,4 +43,19 @@ describe('applyCacheInject', () => {
     applyCacheInject(input)
     expect(input.system).toBe('x')
   })
+
+  it('caches only the last block of an array system prompt', () => {
+    const { mutated, injected } = applyCacheInject({
+      system: [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }],
+      messages: [],
+    })
+    expect(injected).toBe(true)
+    const blocks = mutated.system as any[]
+    expect(blocks[0].cache_control).toBeUndefined()
+    expect(blocks[1].cache_control).toEqual({ type: 'ephemeral' })
+  })
+
+  it('no-ops when neither system nor first user message is injectable', () => {
+    expect(applyCacheInject({ system: 123 as unknown as string, messages: [] }).injected).toBe(false)
+  })
 })

--- a/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { applyCacheInject } from '../src/cache-inject.js'
+import { CacheInjectResolver } from '../src/cache-inject.js'
 
 describe('applyCacheInject', () => {
   it('wraps a string system prompt into a text block with cache_control', () => {
@@ -57,5 +58,16 @@ describe('applyCacheInject', () => {
 
   it('no-ops when neither system nor first user message is injectable', () => {
     expect(applyCacheInject({ system: 123 as unknown as string, messages: [] }).injected).toBe(false)
+  })
+})
+
+describe('CacheInjectResolver', () => {
+  it('injects only for prefix hashes it was given', () => {
+    const r = new CacheInjectResolver(['aaaa1111', 'bbbb2222'])
+    expect(r.shouldInject('aaaa1111')).toBe(true)
+    expect(r.shouldInject('zzzz9999')).toBe(false)
+  })
+  it('empty resolver never injects', () => {
+    expect(new CacheInjectResolver([]).shouldInject('aaaa1111')).toBe(false)
   })
 })

--- a/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
+++ b/sdk/typescript/packages/cloud/tests/cache-inject.test.ts
@@ -59,6 +59,20 @@ describe('applyCacheInject', () => {
   it('no-ops when neither system nor first user message is injectable', () => {
     expect(applyCacheInject({ system: 123 as unknown as string, messages: [] }).injected).toBe(false)
   })
+
+  it('preserves non-text fields of the last block when caching an array message', () => {
+    const { mutated, injected } = applyCacheInject({
+      messages: [{ role: 'user', content: [
+        { type: 'text', text: 'analyze this' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+      ] }],
+    })
+    expect(injected).toBe(true)
+    const blocks = (mutated.messages as any[])[0].content as any[]
+    expect(blocks[1].source).toEqual({ type: 'base64', media_type: 'image/png', data: 'AAAA' })
+    expect(blocks[1].cache_control).toEqual({ type: 'ephemeral' })
+    expect(blocks[0].cache_control).toBeUndefined()
+  })
 })
 
 describe('CacheInjectResolver', () => {

--- a/sdk/typescript/packages/cloud/tests/outcomes.test.ts
+++ b/sdk/typescript/packages/cloud/tests/outcomes.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  createServer,
+  type Server,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { recordOutcome } from '../src/outcomes.js'
+import type { Outcome } from '../src/outcomes.js'
+
+function startMockServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler)
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port
+      resolve({ server, port })
+    })
+  })
+}
+
+describe('recordOutcome', () => {
+  let server: Server | undefined
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((r) => server!.close(() => r()))
+      server = undefined
+    }
+  })
+
+  it('POSTs to /v1/outcomes with bearer auth and correct body', async () => {
+    let capturedMethod = ''
+    let capturedPath = ''
+    let capturedAuth = ''
+    let capturedBody = ''
+    let port: number
+    ;({ server, port } = await startMockServer((req, res) => {
+      capturedMethod = req.method ?? ''
+      capturedPath = req.url ?? ''
+      capturedAuth = (req.headers.authorization as string) ?? ''
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        capturedBody = Buffer.concat(chunks).toString('utf-8')
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ recorded: true }))
+      })
+    }))
+
+    await recordOutcome('jj_key', `http://127.0.0.1:${port}`, 'trace_abc', 'success')
+
+    expect(capturedMethod).toBe('POST')
+    expect(capturedPath).toBe('/v1/outcomes')
+    expect(capturedAuth).toBe('Bearer jj_key')
+    const body = JSON.parse(capturedBody)
+    expect(body).toEqual({ trace_id: 'trace_abc', outcome: 'success' })
+  })
+
+  it('includes optional score and metadata in the body', async () => {
+    let capturedBody = ''
+    let port: number
+    ;({ server, port } = await startMockServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        capturedBody = Buffer.concat(chunks).toString('utf-8')
+        res.writeHead(200)
+        res.end(JSON.stringify({ recorded: true }))
+      })
+    }))
+
+    await recordOutcome('jj_key', `http://127.0.0.1:${port}`, 'trace_xyz', 'failure', {
+      score: 0.42,
+      metadata: { reason: 'timeout', retries: 3 },
+    })
+
+    const body = JSON.parse(capturedBody)
+    expect(body.trace_id).toBe('trace_xyz')
+    expect(body.outcome).toBe('failure')
+    expect(body.score).toBe(0.42)
+    expect(body.metadata).toEqual({ reason: 'timeout', retries: 3 })
+  })
+
+  it.each([
+    'success',
+    'failure',
+    'approved',
+    'rejected',
+    'resolved',
+    'unresolved',
+  ] satisfies Outcome[])('accepts valid outcome "%s"', async (outcome) => {
+    let port: number
+    ;({ server, port } = await startMockServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        res.writeHead(200)
+        res.end(JSON.stringify({ recorded: true }))
+      })
+    }))
+
+    await expect(
+      recordOutcome('k', `http://127.0.0.1:${port}`, 't1', outcome),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws TypeError for an invalid outcome string', async () => {
+    await expect(
+      recordOutcome('k', 'http://localhost', 't1', 'wrong' as Outcome),
+    ).rejects.toThrow(TypeError)
+    await expect(
+      recordOutcome('k', 'http://localhost', 't1', 'wrong' as Outcome),
+    ).rejects.toThrow(/Invalid outcome "wrong"/)
+  })
+
+  it('throws RangeError when score is below 0', async () => {
+    await expect(
+      recordOutcome('k', 'http://localhost', 't1', 'success', { score: -0.1 }),
+    ).rejects.toThrow(RangeError)
+    await expect(
+      recordOutcome('k', 'http://localhost', 't1', 'success', { score: -0.1 }),
+    ).rejects.toThrow(/score must be a number between 0 and 1/)
+  })
+
+  it('throws RangeError when score is above 1', async () => {
+    await expect(
+      recordOutcome('k', 'http://localhost', 't1', 'success', { score: 1.01 }),
+    ).rejects.toThrow(RangeError)
+  })
+
+  it('accepts score boundary values 0 and 1', async () => {
+    let port: number
+    ;({ server, port } = await startMockServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        res.writeHead(200)
+        res.end(JSON.stringify({ recorded: true }))
+      })
+    }))
+
+    await expect(
+      recordOutcome('k', `http://127.0.0.1:${port}`, 't1', 'success', { score: 0 }),
+    ).resolves.toBeUndefined()
+    await expect(
+      recordOutcome('k', `http://127.0.0.1:${port}`, 't1', 'success', { score: 1 }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws when server returns a non-2xx status', async () => {
+    let port: number
+    ;({ server, port } = await startMockServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        res.writeHead(422)
+        res.end()
+      })
+    }))
+
+    await expect(
+      recordOutcome('k', `http://127.0.0.1:${port}`, 't1', 'success'),
+    ).rejects.toThrow(/recordOutcome failed: 422/)
+  })
+})


### PR DESCRIPTION
Lands two cost-intelligence features in the TS and Python cloud SDKs.

## record_outcome / record_outcome (CZ-1b)
- New `recordOutcome` (TS) and `record_outcome` (Python) helpers. Both POST { trace_id, outcome, score?, metadata? } to POST /v1/outcomes with bearer auth.
- Validate the six outcome values and the 0..1 score range; clear errors on bad input or non-2xx.
- Pairs with the already-deployed /v1/outcomes + /v1/stats/outcomes endpoints to give cost-per-successful-run.

## cache_inject enforcement (CZ-6)
- Pull active cache_inject policies at init; CacheInjectResolver + client field.
- Inject cache_control on matching prefix hashes in runEnforcedCall and record saved_cents.
- Preserve non-text block fields when injecting; guard non-injectable content.

## Tests
- TS @jamjet/cloud: 273 passed, 4 skipped (vitest).
- Python cloud: 50 passed (pytest).
- Both run locally and in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `record_outcome()` function to both Python and TypeScript SDKs for recording trace outcomes with optional scoring and metadata
  * Introduced automatic cache injection enforcement in TypeScript SDK with cost savings tracking per API call

<!-- end of auto-generated comment: release notes by coderabbit.ai -->