### PR TITLE
Make YAML workflows execute end to end

### DIFF
--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -24,6 +24,8 @@ jamjet-scheduler = { path = "../scheduler", version = "=0.3.1" }
 jamjet-protocols = { path = "../protocols", version = "=0.3.1" }
 jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.1" }
 jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.1" }
+jamjet-worker = { path = "../workers", version = "=0.3.1" }
+jamjet-models = { path = "../models", version = "=0.3.1" }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -104,6 +104,29 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move { scheduler.run().await });
     info!("Scheduler started");
 
+    // In dev mode (or when JAMJET_EMBED_WORKERS is set), run an in-process worker
+    // pool so submitted workflows actually execute. In production, run dedicated
+    // worker processes against the same state backend instead. The base backend
+    // claims across all tenants, so workers drain every execution's queue.
+    if config.dev_mode || std::env::var("JAMJET_EMBED_WORKERS").is_ok() {
+        let model_registry = Arc::new(jamjet_models::registry::registry_from_env());
+        let pool = jamjet_worker::default_pool(state.backend.clone())
+            .with_executor(
+                "model",
+                Arc::new(jamjet_worker::ModelNodeExecutor::new(
+                    model_registry.clone(),
+                )),
+            )
+            .with_executor(
+                "eval",
+                Arc::new(jamjet_worker::EvalExecutor::new(model_registry.clone())),
+            );
+        // Detaching the handles lets the workers run for the lifetime of the process
+        // (same pattern as the scheduler above).
+        let _worker_handles = pool.spawn();
+        info!("Embedded worker pool started (dev mode)");
+    }
+
     let router = build_router_with_opts(state, config.dev_mode);
     let addr = format!("{}:{}", config.bind, config.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -221,8 +221,18 @@ async fn start_execution(
     );
     backend.append_event(event).await?;
 
-    // Immediately enqueue the start node as a work item.
-    let queue_type = "general".to_string();
+    // Immediately enqueue the start node as a work item, routed to the queue its
+    // kind requires (e.g. a Model start node -> the "model" queue), mirroring the
+    // scheduler's logic for chained nodes.
+    let queue_type = def
+        .ir
+        .get("nodes")
+        .and_then(|nodes| nodes.get(&start_node))
+        .and_then(|node| node.get("kind"))
+        .and_then(|kind| serde_json::from_value::<jamjet_core::node::NodeKind>(kind.clone()).ok())
+        .and_then(|k| serde_json::to_value(k.queue_type()).ok())
+        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| "general".to_string());
     let sched_event = jamjet_state::Event::new(
         execution_id.clone(),
         2,

--- a/runtime/api/tests/execution_e2e.rs
+++ b/runtime/api/tests/execution_e2e.rs
@@ -1,0 +1,183 @@
+//! End-to-end execution regression test.
+//!
+//! Submitting a workflow must drive it to a terminal state. This guards the
+//! scheduler + worker-pool wiring and the scheduler's completion detection,
+//! which previously left every execution stuck in `running` forever (the worker
+//! pool was never spawned and no code emitted `WorkflowCompleted`).
+
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::{StateBackend, WorkItem, WorkflowDefinition};
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, SqliteBackend, DEFAULT_TENANT};
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workflow_runs_to_completion() {
+    // A temp-file SQLite DB shared across the scheduler, worker pool, and this
+    // test. (`:memory:` would give each pool connection its own database, so it
+    // cannot be shared.)
+    let db_path = std::env::temp_dir().join(format!("jjtest-{}.db", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+    let backend: Arc<dyn StateBackend> = Arc::new(
+        SqliteBackend::open(&url)
+            .await
+            .expect("open sqlite backend"),
+    );
+
+    // A trivial single-node workflow: a condition node that terminates (edge to
+    // the "end" sentinel). The worker runs it via the no-op stub, after which the
+    // scheduler must detect completion.
+    let ir = serde_json::json!({
+        "workflow_id": "e2e-completion",
+        "version": "0.1.0",
+        "name": null,
+        "description": null,
+        "state_schema": "",
+        "start_node": "route",
+        "nodes": {
+            "route": {
+                "id": "route",
+                "kind": { "type": "condition", "branches": [] },
+                "retry_policy": null,
+                "node_timeout_secs": null,
+                "description": null,
+                "labels": {}
+            }
+        },
+        "edges": [ { "from": "route", "to": "end", "condition": null } ],
+        "retry_policies": {},
+        "timeouts": {},
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {},
+        "labels": {}
+    });
+
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: "e2e-completion".into(),
+            version: "0.1.0".into(),
+            ir,
+            created_at: chrono::Utc::now(),
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
+
+    // Create the execution and enqueue the start node (mimics POST /executions).
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "e2e-completion".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        })
+        .await
+        .expect("create_execution");
+
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "e2e-completion".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            2,
+            EventKind::NodeScheduled {
+                node_id: "route".into(),
+                queue_type: "general".into(),
+            },
+        ))
+        .await
+        .expect("append NodeScheduled");
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: execution_id.clone(),
+            node_id: "route".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({
+                "workflow_id": "e2e-completion",
+                "workflow_version": "0.1.0",
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    // Spawn the scheduler + worker pool against the shared backend.
+    let scheduler = jamjet_scheduler::Scheduler::new(backend.clone())
+        .with_poll_interval(Duration::from_millis(25));
+    let sched_handle = tokio::spawn(async move { scheduler.run().await });
+    let worker_handles = jamjet_worker::default_pool(backend.clone()).spawn();
+
+    // Wait for a terminal state, bounded by a hard timeout so the test can never
+    // hang the suite even if completion detection regresses.
+    let poll_backend = backend.clone();
+    let exec_id = execution_id.clone();
+    let wait = async move {
+        loop {
+            let exec = poll_backend
+                .get_execution(&exec_id)
+                .await
+                .expect("get_execution")
+                .expect("execution exists");
+            if matches!(
+                exec.status,
+                WorkflowStatus::Completed | WorkflowStatus::Failed
+            ) {
+                return exec.status;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
+    let result = tokio::time::timeout(Duration::from_secs(20), wait).await;
+
+    // Stop the background loops and clean up the temp DB.
+    sched_handle.abort();
+    for h in worker_handles {
+        h.abort();
+    }
+    // Diagnostics if we did not reach a terminal state.
+    if result.is_err() {
+        let events = backend.get_events(&execution_id).await.unwrap_or_default();
+        let kinds: Vec<String> = events.iter().map(|e| format!("{:?}", e.kind)).collect();
+        eprintln!("E2E TIMEOUT — {} events: {:#?}", events.len(), kinds);
+        if let Ok(Some(e)) = backend.get_execution(&execution_id).await {
+            eprintln!("E2E final stored status: {:?}", e.status);
+        }
+    }
+
+    let _ = std::fs::remove_file(&db_path);
+
+    let status = result.ok();
+    assert_eq!(
+        status,
+        Some(WorkflowStatus::Completed),
+        "workflow should run to completion (got {status:?})"
+    );
+}

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -337,8 +337,62 @@ impl Scheduler {
             debug!(execution_id = %execution_id, enqueued, "Dispatch complete");
         }
 
+        // Completion detection: if nothing is in flight (no scheduled/running nodes)
+        // and nothing new was dispatched this tick, the execution has reached a
+        // terminal state. Emit the terminal event and flip the stored status so the
+        // execution drops out of the running set on the next tick (fires once).
+        if enqueued == 0 && scheduled.is_empty() {
+            let (status, event_kind) = if terminal_failed.is_empty() {
+                (
+                    jamjet_core::workflow::WorkflowStatus::Completed,
+                    EventKind::WorkflowCompleted {
+                        final_state: build_final_state(&events),
+                    },
+                )
+            } else {
+                let mut failed: Vec<String> =
+                    terminal_failed.iter().map(|n| n.to_string()).collect();
+                failed.sort();
+                (
+                    jamjet_core::workflow::WorkflowStatus::Failed,
+                    EventKind::WorkflowFailed {
+                        error: format!("node(s) failed terminally: {}", failed.join(", ")),
+                    },
+                )
+            };
+
+            let seq = self.backend.latest_sequence(execution_id).await? + 1;
+            self.backend
+                .append_event(jamjet_state::Event::new(
+                    execution_id.clone(),
+                    seq,
+                    event_kind,
+                ))
+                .await?;
+            info!(execution_id = %execution_id, ?status, "Execution reached terminal state");
+            self.backend
+                .update_execution_status(execution_id, status)
+                .await?;
+        }
+
         Ok(())
     }
+}
+
+/// Merge the `state_patch`es from all `NodeCompleted` events into the final
+/// state object reported on `WorkflowCompleted`.
+fn build_final_state(events: &[jamjet_state::Event]) -> serde_json::Value {
+    let mut state = serde_json::Map::new();
+    for event in events {
+        if let EventKind::NodeCompleted { state_patch, .. } = &event.kind {
+            if let serde_json::Value::Object(patch) = state_patch {
+                for (k, v) in patch {
+                    state.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    serde_json::Value::Object(state)
 }
 
 /// Check if a node is runnable: all its predecessors are completed and

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -24,7 +24,13 @@ impl SqliteBackend {
     /// `database_url` is a SQLx-compatible URL, e.g. `sqlite:///path/to/db.sqlite3`.
     /// The database file is created automatically if it does not exist.
     pub async fn connect(database_url: &str) -> Result<Self, sqlx::Error> {
-        let opts = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true);
+        let opts = SqliteConnectOptions::from_str(database_url)?
+            .create_if_missing(true)
+            // WAL + a busy timeout let the scheduler, worker pool, API, and audit
+            // log share one SQLite file without spurious SQLITE_BUSY errors under
+            // concurrency. (Ignored for in-memory databases.)
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_secs(5));
         let pool = SqlitePool::connect_with(opts).await?;
         Ok(Self { pool })
     }

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -442,20 +442,35 @@ impl StateBackend for SqliteBackend {
         let kind_json = serde_json::to_string(&event.kind)?;
         let created_at = event.created_at.to_rfc3339();
 
+        // Assign the sequence atomically inside a transaction so concurrent
+        // appends to the same execution cannot compute the same number and
+        // collide on UNIQUE(execution_id, sequence). The caller-supplied
+        // sequence is advisory; the database is the source of truth.
+        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        let seq_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&execution_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let sequence: i64 = seq_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
         sqlx::query(
             r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at)
                VALUES (?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution_id)
-        .bind(event.sequence)
+        .bind(sequence)
         .bind(&kind_json)
         .bind(&created_at)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+        tx.commit().await.map_err(map_db_err)?;
 
-        Ok(event.sequence)
+        Ok(sequence)
     }
 
     #[instrument(skip(self), fields(execution_id = %execution_id))]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -404,21 +404,36 @@ impl StateBackend for TenantScopedSqliteBackend {
         let kind_json = serde_json::to_string(&event.kind)?;
         let created_at = event.created_at.to_rfc3339();
 
+        // Assign the sequence atomically (see SqliteBackend::append_event). The
+        // MAX is scoped to the execution only (not the tenant), so it agrees with
+        // the base backend's sequence even when an execution's events carry mixed
+        // tenant_id rows (scheduler/worker run on the base backend in dev).
+        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        let seq_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&execution_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let sequence: i64 = seq_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
         sqlx::query(
             r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at, tenant_id)
                VALUES (?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution_id)
-        .bind(event.sequence)
+        .bind(sequence)
         .bind(&kind_json)
         .bind(&created_at)
         .bind(&self.tenant_id.0)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+        tx.commit().await.map_err(map_db_err)?;
 
-        Ok(event.sequence)
+        Ok(sequence)
     }
 
     #[instrument(skip(self), fields(tenant = %self.tenant_id, execution_id = %execution_id))]

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -371,27 +371,40 @@ impl Worker {
                     node_def.policy.as_ref(),
                 );
                 warn!(execution_id = %execution_id, node_id, %reason, %policy_scope, "Policy blocked node");
-                let seq = self.backend.latest_sequence(execution_id).await.ok()? + 1;
-                let _ = self
-                    .backend
-                    .append_event(jamjet_state::Event::new(
-                        execution_id.clone(),
-                        seq,
-                        EventKind::PolicyViolation {
-                            node_id: node_id.to_string(),
-                            rule: reason.clone(),
-                            decision: "blocked".to_string(),
-                            policy_scope,
-                        },
-                    ))
-                    .await;
+                // Best-effort audit. The block is enforced regardless of whether
+                // recording the violation succeeds: fail closed, never open.
+                if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
+                    let _ = self
+                        .backend
+                        .append_event(jamjet_state::Event::new(
+                            execution_id.clone(),
+                            latest + 1,
+                            EventKind::PolicyViolation {
+                                node_id: node_id.to_string(),
+                                rule: reason.clone(),
+                                decision: "blocked".to_string(),
+                                policy_scope,
+                            },
+                        ))
+                        .await;
+                }
                 Some(Err(format!("policy blocked: {reason}").into()))
             }
 
             PolicyDecision::RequireApproval { approver } => {
                 info!(execution_id = %execution_id, node_id, %approver, "Node requires approval");
                 let tool_name = ctx.tool_name.unwrap_or_else(|| node_id.to_string());
-                let seq = self.backend.latest_sequence(execution_id).await.ok()? + 1;
+                // If we cannot record the approval requirement, fail closed rather
+                // than letting the node run unapproved.
+                let seq = match self.backend.latest_sequence(execution_id).await {
+                    Ok(s) => s + 1,
+                    Err(e) => {
+                        return Some(Err(format!(
+                            "approval required but could not be recorded: {e}"
+                        )
+                        .into()))
+                    }
+                };
                 let _ = self
                     .backend
                     .append_event(jamjet_state::Event::new(

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -541,8 +541,17 @@ def run(
             workflow_ref = workflow
             workflow_version: str | None = None
             # If given a workflow file, compile and register it first, then run by its id.
-            if os.path.isfile(workflow) and workflow.endswith((".yaml", ".yml", ".py")):
+            if os.path.isfile(workflow):
+                if not workflow.endswith((".yaml", ".yml", ".py")):
+                    console.print("[red]Unsupported workflow file. Use .yaml, .yml, or .py[/red]")
+                    raise typer.Exit(1)
                 ir = _load_workflow_ir(workflow)
+                # The runtime requires string workflow_id/version; a YAML value
+                # like `version: 1.0` parses as a number, which fails registration.
+                if ir.get("workflow_id") is not None:
+                    ir["workflow_id"] = str(ir["workflow_id"])
+                if ir.get("version") is not None:
+                    ir["version"] = str(ir["version"])
                 await c.create_workflow(ir)
                 workflow_ref = str(ir.get("workflow_id") or workflow)
                 workflow_version = ir.get("version")

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -487,6 +487,28 @@ def validate(
 # ── run ───────────────────────────────────────────────────────────────────────
 
 
+def _load_workflow_ir(path: str) -> dict[str, Any]:
+    """Compile a workflow file (.yaml/.yml/.py) to its IR dict."""
+    from jamjet.workflow.ir_compiler import compile_yaml
+
+    if path.endswith((".yaml", ".yml")):
+        with open(path) as fh:
+            return compile_yaml(fh.read())
+    if path.endswith(".py"):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("_wf_module", path)
+        mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        from jamjet.workflow.workflow import Workflow
+
+        wf = next((v for v in vars(mod).values() if isinstance(v, Workflow)), None)
+        if wf is None:
+            raise ValueError("No Workflow instance found in module.")
+        return wf.compile()
+    raise ValueError("Unsupported workflow file type. Use .yaml, .yml, or .py")
+
+
 @app.command()
 def run(
     workflow: str = typer.Argument(..., help="Workflow id or path to workflow.yaml"),
@@ -511,10 +533,27 @@ def run(
     json_output = output == OutputFormat.json
 
     async def _run() -> None:
+        import os
+
         start_time_us = time.monotonic_ns() // 1000
 
         async with _client(runtime) as c:
-            result = await c.start_execution(workflow_id=workflow, input=input_data)
+            workflow_ref = workflow
+            workflow_version: str | None = None
+            # If given a workflow file, compile and register it first, then run by its id.
+            if os.path.isfile(workflow) and workflow.endswith((".yaml", ".yml", ".py")):
+                ir = _load_workflow_ir(workflow)
+                await c.create_workflow(ir)
+                workflow_ref = str(ir.get("workflow_id") or workflow)
+                workflow_version = ir.get("version")
+                if not json_output:
+                    console.print(
+                        f"[dim]Registered[/dim] [bold]{workflow_ref}[/bold] [dim]v{workflow_version or '?'}[/dim]"
+                    )
+
+            result = await c.start_execution(
+                workflow_id=workflow_ref, input=input_data, workflow_version=workflow_version
+            )
             exec_id = result.get("execution_id", "unknown")
 
             if not json_output:

--- a/sdk/python/jamjet/workflow/ir_compiler.py
+++ b/sdk/python/jamjet/workflow/ir_compiler.py
@@ -155,9 +155,18 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
     nodes: dict[str, Any] = {}
     edges: list[dict[str, Any]] = []
 
+    # `end`-type nodes are not runtime node kinds; the runtime terminates an
+    # execution when a node's edge points at the literal target "end". Collect
+    # the end nodes so we can drop them and rewrite any edge or branch that
+    # targets one to the "end" sentinel (this also collapses named end nodes
+    # such as success/failure to the terminal target).
+    end_ids = frozenset(nid for nid, nd in raw_nodes.items() if isinstance(nd, dict) and nd.get("type") == "end")
+
     for node_id, node_data in raw_nodes.items():
         node_type = node_data.get("type", "tool")
-        kind = _yaml_node_to_kind(node_id, node_type, node_data)
+        if node_type == "end":
+            continue
+        kind = _yaml_node_to_kind(node_id, node_type, node_data, end_ids)
         nodes[node_id] = {
             "id": node_id,
             "kind": kind,
@@ -170,14 +179,14 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
         # Extract edges from "next" field
         next_val = node_data.get("next")
         if isinstance(next_val, str):
-            edges.append({"from": node_id, "to": next_val, "condition": None})
+            edges.append({"from": node_id, "to": _term(next_val, end_ids), "condition": None})
         elif isinstance(next_val, list):
             for edge in next_val:
                 if isinstance(edge, dict):
                     edges.append(
                         {
                             "from": node_id,
-                            "to": edge.get("to", "end"),
+                            "to": _term(edge.get("to", "end"), end_ids),
                             "condition": edge.get("when"),
                         }
                     )
@@ -191,7 +200,7 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
         "version": wf.get("version", "0.1.0"),
         "name": wf.get("name"),
         "description": wf.get("description"),
-        "state_schema": wf.get("state_schema", ""),
+        "state_schema": _state_schema_str(wf.get("state_schema", "")),
         "start_node": wf.get("start", next(iter(raw_nodes)) if raw_nodes else ""),
         "nodes": nodes,
         "edges": edges,
@@ -339,7 +348,25 @@ def _step_to_node_kind(step: StepDef) -> dict[str, Any]:
     }
 
 
-def _yaml_node_to_kind(node_id: str, node_type: str, data: dict[str, Any]) -> dict[str, Any]:
+def _term(target: Any, end_ids: frozenset) -> Any:
+    """Rewrite an edge/branch target that names an `end`-type node to the terminal sentinel."""
+    return "end" if target in end_ids else target
+
+
+def _state_schema_str(value: Any) -> str:
+    """The runtime IR ``state_schema`` is an opaque String; serialize an inline map to JSON."""
+    if isinstance(value, str):
+        return value
+    if value:
+        import json as _json
+
+        return _json.dumps(value)
+    return ""
+
+
+def _yaml_node_to_kind(
+    node_id: str, node_type: str, data: dict[str, Any], end_ids: frozenset = frozenset()
+) -> dict[str, Any]:
     """Convert a YAML node definition to a NodeKind dict."""
     if node_type == "model":
         return {
@@ -389,8 +416,15 @@ def _yaml_node_to_kind(node_id: str, node_type: str, data: dict[str, Any]) -> di
             "input_mapping": data.get("input", {}),
             "output_schema": data.get("output_schema", ""),
         }
-    if node_type == "condition":
-        return {"type": "condition", "branches": []}
+    if node_type in ("condition", "branch"):
+        branches: list[dict[str, Any]] = []
+        for cond in data.get("conditions", []) or []:
+            target = cond.get("next") or cond.get("to") or "end"
+            branches.append({"condition": cond.get("if") or cond.get("when"), "target": _term(target, end_ids)})
+        default = data.get("default")
+        if default is not None:
+            branches.append({"condition": None, "target": _term(default, end_ids)})
+        return {"type": "condition", "branches": branches}
     if node_type == "eval":
         return {
             "type": "eval",

--- a/sdk/python/jamjet/workflow/ir_compiler.py
+++ b/sdk/python/jamjet/workflow/ir_compiler.py
@@ -201,7 +201,7 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
         "name": wf.get("name"),
         "description": wf.get("description"),
         "state_schema": _state_schema_str(wf.get("state_schema", "")),
-        "start_node": wf.get("start", next(iter(raw_nodes)) if raw_nodes else ""),
+        "start_node": wf.get("start", next(iter(nodes)) if nodes else ""),
         "nodes": nodes,
         "edges": edges,
         "retry_policies": data.get("retry_policies", {}),


### PR DESCRIPTION
## Problem
The dev runtime accepted and scheduled workflow executions but never ran them, so `jamjet run workflow.yaml` left every execution stuck in `running`:
- The API server started the scheduler but no worker. `jamjet-worker` was not even a dependency of `jamjet-api`, so the worker pool and all node executors were dead code at runtime.
- Nothing emitted a terminal event, so even with a worker, executions never left `running`.
- The CLI never compiled or registered a YAML file before starting it (404).
- The YAML compiler emitted node kinds the runtime rejects (`end`, `branch`) and a `state_schema` map where the runtime expects a string.

## Runtime
- Spawn an in-process worker pool in dev mode (gated on `dev_mode` or `JAMJET_EMBED_WORKERS`) so submitted workflows execute. Production still runs dedicated worker processes.
- Detect graph completion in the scheduler and emit `WorkflowCompleted`/`WorkflowFailed` plus the terminal status.
- Route the start node to the queue its kind requires instead of always `general`.
- Fail closed when a policy block or approval cannot be recorded.
- Open SQLite with WAL and a busy timeout so the scheduler, workers, API, and audit log share one file cleanly.
- Add an end-to-end test that drives a workflow to completion (the scheduler crate had no tests).

## SDK
- `jamjet run` compiles and registers a `.yaml`/`.py` path before starting, passing the workflow version.
- The YAML compiler maps `end` nodes to the terminal edge target, compiles `branch` to the runtime `condition` kind, and serializes an inline `state_schema` map to a string.

## Verification
`cargo build` and `cargo test` green across the touched crates (incl. the new e2e test). `jamjet dev` + `jamjet run` runs a workflow to `completed` live.

## Follow-ups (not in this PR)
Event-sequence atomicity, snapshot/compaction wiring (currently full event-log replay), tenant threading for multi-tenant production, IR caching, create_workflow IR validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded worker pool can now run in development mode via configuration or environment variable
  * CLI supports compiling and executing workflows directly from YAML and Python files

* **Improvements**
  * Enhanced workflow execution completion detection when all nodes reach terminal state
  * Improved SQLite connection reliability with WAL mode and concurrent access handling
  * Refined policy enforcement behavior for blocked and approval-required decisions

* **Tests**
  * Added end-to-end test verifying workflow execution reaches completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->