### PR TITLE
Fold scheduler events incrementally instead of replaying the full log

### DIFF
--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -431,3 +431,187 @@ fn is_runnable(
         .filter(|e| e.to == node_id)
         .all(|e| completed.contains(&e.from))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jamjet_core::workflow::{WorkflowExecution, WorkflowStatus};
+    use jamjet_state::backend::WorkflowDefinition;
+    use jamjet_state::{Event, InMemoryBackend, DEFAULT_TENANT};
+
+    /// A linear two-node workflow: `a -> b -> end`, with `a` as the start node.
+    /// Both are condition nodes (the scheduler dispatches purely off edges, so the
+    /// concrete kind doesn't matter for these tests).
+    fn linear_ir() -> serde_json::Value {
+        let node = |id: &str| {
+            serde_json::json!({
+                "id": id,
+                "kind": { "type": "condition", "branches": [] },
+                "retry_policy": null,
+                "node_timeout_secs": null,
+                "description": null,
+                "labels": {}
+            })
+        };
+        serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": "a",
+            "nodes": { "a": node("a"), "b": node("b") },
+            "edges": [
+                { "from": "a", "to": "b", "condition": null },
+                { "from": "b", "to": "end", "condition": null }
+            ],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        })
+    }
+
+    async fn setup(ir: serde_json::Value) -> (Scheduler, Arc<dyn StateBackend>, ExecutionId) {
+        let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+        backend
+            .store_workflow(WorkflowDefinition {
+                workflow_id: "wf".into(),
+                version: "0.1.0".into(),
+                ir,
+                created_at: chrono::Utc::now(),
+                tenant_id: DEFAULT_TENANT.into(),
+            })
+            .await
+            .unwrap();
+        let exec_id = ExecutionId::new();
+        let now = chrono::Utc::now();
+        backend
+            .create_execution(WorkflowExecution {
+                execution_id: exec_id.clone(),
+                workflow_id: "wf".into(),
+                workflow_version: "0.1.0".into(),
+                status: WorkflowStatus::Running,
+                initial_input: serde_json::json!({}),
+                current_state: serde_json::json!({}),
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                session_type: None,
+            })
+            .await
+            .unwrap();
+        (Scheduler::new(backend.clone()), backend, exec_id)
+    }
+
+    async fn tick(s: &Scheduler, e: &ExecutionId) {
+        s.schedule_runnable_nodes(e, "wf", "0.1.0").await.unwrap();
+    }
+
+    /// Append an event the way a worker would: at the next per-execution sequence.
+    async fn append(b: &Arc<dyn StateBackend>, e: &ExecutionId, kind: EventKind) {
+        let seq = b.latest_sequence(e).await.unwrap() + 1;
+        b.append_event(Event::new(e.clone(), seq, kind))
+            .await
+            .unwrap();
+    }
+
+    async fn status(b: &Arc<dyn StateBackend>, e: &ExecutionId) -> WorkflowStatus {
+        b.get_execution(e).await.unwrap().unwrap().status
+    }
+
+    fn scheduled_nodes(events: &[Event]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|ev| match &ev.kind {
+                EventKind::NodeScheduled { node_id, .. } => Some(node_id.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn node_completed(node_id: &str, patch: serde_json::Value) -> EventKind {
+        EventKind::NodeCompleted {
+            node_id: node_id.into(),
+            output: serde_json::json!({}),
+            state_patch: patch,
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn schedules_in_dependency_order_and_completes() {
+        let (s, b, e) = setup(linear_ir()).await;
+
+        // Tick 1: only `a` (no predecessors) is runnable.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"a".to_string()),
+            "a should be scheduled first"
+        );
+        assert!(
+            !scheduled_nodes(&evs).contains(&"b".to_string()),
+            "b must wait for its predecessor a"
+        );
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
+
+        // Worker finishes `a`; tick 2 makes `b` runnable.
+        append(&b, &e, node_completed("a", serde_json::json!({ "x": 1 }))).await;
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"b".to_string()),
+            "b should be scheduled once a completes"
+        );
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
+
+        // Worker finishes `b`; tick 3 detects completion.
+        append(&b, &e, node_completed("b", serde_json::json!({ "y": 2 }))).await;
+        tick(&s, &e).await;
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Completed);
+
+        // Final state merges both nodes' patches in sequence order.
+        let evs = b.get_events(&e).await.unwrap();
+        let final_state = evs
+            .iter()
+            .find_map(|ev| match &ev.kind {
+                EventKind::WorkflowCompleted { final_state } => Some(final_state.clone()),
+                _ => None,
+            })
+            .expect("WorkflowCompleted should be emitted");
+        assert_eq!(final_state, serde_json::json!({ "x": 1, "y": 2 }));
+    }
+
+    #[tokio::test]
+    async fn terminal_node_failure_fails_the_workflow() {
+        let (s, b, e) = setup(linear_ir()).await;
+
+        tick(&s, &e).await; // schedules `a`
+        append(
+            &b,
+            &e,
+            EventKind::NodeFailed {
+                node_id: "a".into(),
+                error: "boom".into(),
+                attempt: 1,
+                retryable: false,
+            },
+        )
+        .await;
+
+        // `a` is terminally failed, `b` can never run, nothing is in flight.
+        tick(&s, &e).await;
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Failed);
+    }
+}

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -45,6 +45,11 @@ pub struct Scheduler {
     /// Registered IR is immutable per version, so this avoids re-fetching and
     /// re-deserializing it on every tick for every running execution.
     ir_cache: Mutex<HashMap<(String, String), Arc<WorkflowIr>>>,
+    /// Per-execution scheduling progress, folded incrementally from the event
+    /// log. Each tick reads only events appended since the last tick instead of
+    /// replaying the whole log. The entry is dropped when the execution reaches
+    /// a terminal state.
+    progress: Mutex<HashMap<ExecutionId, ExecProgress>>,
 }
 
 impl Scheduler {
@@ -53,6 +58,7 @@ impl Scheduler {
             backend,
             config: SchedulerConfig::default(),
             ir_cache: Mutex::new(HashMap::new()),
+            progress: Mutex::new(HashMap::new()),
         }
     }
 
@@ -212,51 +218,38 @@ impl Scheduler {
             }
         };
 
-        // Load events to build the set of completed/scheduled/failed nodes.
-        let events = self.backend.get_events(execution_id).await?;
+        // Fold only the events appended since the last tick into the cached
+        // progress for this execution. Completed/failed nodes never revert and
+        // the IR is immutable, so replaying the whole event log every tick is
+        // pure overhead that grows with execution length — we apply just the
+        // delta instead, keeping a tick's cost bounded by the graph size.
+        let mut progress = self
+            .progress
+            .lock()
+            .unwrap()
+            .get(execution_id)
+            .cloned()
+            .unwrap_or_default();
 
-        let mut completed: HashSet<NodeId> = HashSet::new();
-        let mut scheduled: HashSet<NodeId> = HashSet::new();
-        let mut terminal_failed: HashSet<NodeId> = HashSet::new();
-
-        for event in &events {
-            match &event.kind {
-                EventKind::NodeCompleted { node_id, .. }
-                | EventKind::NodeSkipped { node_id, .. } => {
-                    completed.insert(node_id.clone());
-                    scheduled.remove(node_id);
-                }
-                EventKind::NodeScheduled { node_id, .. }
-                | EventKind::NodeStarted { node_id, .. } => {
-                    scheduled.insert(node_id.clone());
-                }
-                EventKind::NodeCancelled { node_id } => {
-                    completed.insert(node_id.clone());
-                    scheduled.remove(node_id);
-                }
-                EventKind::NodeFailed {
-                    node_id,
-                    retryable: false,
-                    ..
-                } => {
-                    terminal_failed.insert(node_id.clone());
-                    scheduled.remove(node_id);
-                }
-                EventKind::NodeFailed {
-                    node_id,
-                    retryable: true,
-                    ..
-                } => {
-                    // Will be re-queued by RetryScheduled event; remove from scheduled.
-                    scheduled.remove(node_id);
-                }
-                EventKind::RetryScheduled { node_id, .. } => {
-                    // Node will be re-queued; treat as scheduled.
-                    scheduled.insert(node_id.clone());
-                }
-                _ => {}
-            }
+        let new_events = self
+            .backend
+            .get_events_since(execution_id, progress.last_sequence)
+            .await?;
+        for event in &new_events {
+            progress.apply(event);
         }
+
+        // Write the advanced progress back before any early return below, so a
+        // tick that bails out (e.g. at the concurrency cap) doesn't have to
+        // re-read the same delta next time.
+        self.progress
+            .lock()
+            .unwrap()
+            .insert(execution_id.clone(), progress.clone());
+
+        let completed = &progress.completed;
+        let scheduled = &progress.scheduled;
+        let terminal_failed = &progress.terminal_failed;
 
         debug!(
             execution_id = %execution_id,
@@ -296,7 +289,7 @@ impl Scheduler {
             if terminal_failed.contains(node_id.as_str()) {
                 continue; // permanently failed
             }
-            if is_runnable(node_id, &ir, &completed, &scheduled) {
+            if is_runnable(node_id, &ir, completed, scheduled) {
                 // Serialize the QueueType variant name to snake_case string.
                 let queue_type = serde_json::to_value(node.kind.queue_type())
                     .ok()
@@ -365,7 +358,7 @@ impl Scheduler {
                 (
                     jamjet_core::workflow::WorkflowStatus::Completed,
                     EventKind::WorkflowCompleted {
-                        final_state: build_final_state(&events),
+                        final_state: serde_json::Value::Object(progress.final_state.clone()),
                     },
                 )
             } else {
@@ -392,26 +385,84 @@ impl Scheduler {
             self.backend
                 .update_execution_status(execution_id, status)
                 .await?;
+            // Execution is terminal; drop its progress so the cache doesn't grow
+            // without bound as executions complete.
+            self.progress.lock().unwrap().remove(execution_id);
         }
 
         Ok(())
     }
 }
 
-/// Merge the `state_patch`es from all `NodeCompleted` events into the final
-/// state object reported on `WorkflowCompleted`.
-fn build_final_state(events: &[jamjet_state::Event]) -> serde_json::Value {
-    let mut state = serde_json::Map::new();
-    for event in events {
-        if let EventKind::NodeCompleted { state_patch, .. } = &event.kind {
-            if let serde_json::Value::Object(patch) = state_patch {
-                for (k, v) in patch {
-                    state.insert(k.clone(), v.clone());
+/// Incrementally-folded scheduling state for a single execution.
+///
+/// Rebuilt lazily from the event log: each scheduler tick reads only events with
+/// a sequence greater than `last_sequence` and folds them in via [`ExecProgress::apply`].
+/// This makes a tick's cost a function of the workflow's graph size rather than
+/// the ever-growing length of its event log.
+#[derive(Default, Clone)]
+struct ExecProgress {
+    completed: HashSet<NodeId>,
+    scheduled: HashSet<NodeId>,
+    terminal_failed: HashSet<NodeId>,
+    /// `state_patch`es from completed nodes, merged in sequence order. This is
+    /// the `final_state` reported on `WorkflowCompleted`.
+    final_state: serde_json::Map<String, serde_json::Value>,
+    /// Highest event sequence already folded in.
+    last_sequence: jamjet_state::EventSequence,
+}
+
+impl ExecProgress {
+    /// Fold one event into the running state. Must be applied in sequence order.
+    fn apply(&mut self, event: &jamjet_state::Event) {
+        match &event.kind {
+            EventKind::NodeCompleted {
+                node_id,
+                state_patch,
+                ..
+            } => {
+                self.completed.insert(node_id.clone());
+                self.scheduled.remove(node_id);
+                if let serde_json::Value::Object(patch) = state_patch {
+                    for (k, v) in patch {
+                        self.final_state.insert(k.clone(), v.clone());
+                    }
                 }
             }
+            EventKind::NodeSkipped { node_id, .. } => {
+                self.completed.insert(node_id.clone());
+                self.scheduled.remove(node_id);
+            }
+            EventKind::NodeScheduled { node_id, .. } | EventKind::NodeStarted { node_id, .. } => {
+                self.scheduled.insert(node_id.clone());
+            }
+            EventKind::NodeCancelled { node_id } => {
+                self.completed.insert(node_id.clone());
+                self.scheduled.remove(node_id);
+            }
+            EventKind::NodeFailed {
+                node_id,
+                retryable: false,
+                ..
+            } => {
+                self.terminal_failed.insert(node_id.clone());
+                self.scheduled.remove(node_id);
+            }
+            EventKind::NodeFailed {
+                node_id,
+                retryable: true,
+                ..
+            } => {
+                // Re-queued by the subsequent RetryScheduled event.
+                self.scheduled.remove(node_id);
+            }
+            EventKind::RetryScheduled { node_id, .. } => {
+                self.scheduled.insert(node_id.clone());
+            }
+            _ => {}
         }
+        self.last_sequence = self.last_sequence.max(event.sequence);
     }
-    serde_json::Value::Object(state)
 }
 
 /// Check if a node is runnable: all its predecessors are completed and
@@ -575,11 +626,19 @@ mod tests {
             "b should be scheduled once a completes"
         );
         assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
+        assert!(
+            s.progress.lock().unwrap().contains_key(&e),
+            "progress should be cached while the execution is running"
+        );
 
         // Worker finishes `b`; tick 3 detects completion.
         append(&b, &e, node_completed("b", serde_json::json!({ "y": 2 }))).await;
         tick(&s, &e).await;
         assert_eq!(status(&b, &e).await, WorkflowStatus::Completed);
+        assert!(
+            !s.progress.lock().unwrap().contains_key(&e),
+            "progress should be dropped once the execution is terminal"
+        );
 
         // Final state merges both nodes' patches in sequence order.
         let evs = b.get_events(&e).await.unwrap();


### PR DESCRIPTION
## What

The scheduler rebuilt the completed / scheduled / terminal-failed node sets by reading and matching the **entire** event log for every running execution on every tick. So a single tick was O(events), and a full run was O(events^2) — the cost climbed as an execution accumulated history.

This caches per-execution scheduling progress on the scheduler and folds in only the events appended since the last tick (`get_events_since`), so a tick's cost is bounded by the workflow's graph size, not the length of its event log.

## Details

- New `ExecProgress` holds the `completed` / `scheduled` / `terminal_failed` sets plus the accumulated `final_state` and the highest sequence folded in.
- `WorkflowCompleted.final_state` is now accumulated as completed-node `state_patch`es arrive, in sequence order (same result as the old full-log merge), so `build_final_state` is gone.
- Progress is dropped from the cache when an execution reaches a terminal state, so the map doesn't grow without bound.
- Builds on the IR cache from #73.

## Tests

First commit adds the scheduler's first unit tests (the crate had none): dependency-ordered scheduling through to completion, and terminal-failure to `Failed`. They pass on the old full-replay code, then guard the refactor. The completion test also asserts the progress cache is populated while running and cleared once terminal.

Verified: `cargo fmt --all --check` clean, scheduler clippy clean, and the existing `execution_e2e` integration test (real worker pool + SQLite) still drives a workflow to completion through the rewritten scheduler.
