### PR TITLE
Harden API handlers: validate workflow IR on register, stop panicking on serialize

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -142,6 +142,15 @@ async fn create_workflow(
         .ok_or_else(|| ApiError::BadRequest("ir.version is required".into()))?
         .to_string();
 
+    // Reject IR the runtime can't load. Without this, a structurally-broken
+    // definition is stored happily and only fails later when the scheduler tries
+    // to deserialize it — at which point the execution silently never schedules.
+    // (Reference resolution is deliberately left to the runtime: models/tools are
+    // resolved against the worker registry, not the IR maps, so we validate the
+    // shape here, not `validate_workflow`'s ref rules.)
+    serde_json::from_value::<jamjet_ir::WorkflowIr>(body.ir.clone())
+        .map_err(|e| ApiError::BadRequest(format!("invalid workflow IR: {e}")))?;
+
     let backend = state.backend_for(&tenant_id);
     let def = WorkflowDefinition {
         workflow_id: workflow_id.clone(),
@@ -308,7 +317,9 @@ async fn get_execution(
         .get_execution(&execution_id)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("execution {id}")))?;
-    Ok(Json(serde_json::to_value(execution).unwrap()))
+    Ok(Json(serde_json::to_value(execution).map_err(|e| {
+        ApiError::Internal(format!("serialize execution: {e}"))
+    })?))
 }
 
 async fn cancel_execution(
@@ -493,7 +504,9 @@ async fn get_agent(
         .await
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("agent {id}")))?;
-    Ok(Json(serde_json::to_value(agent).unwrap()))
+    Ok(Json(serde_json::to_value(agent).map_err(|e| {
+        ApiError::Internal(format!("serialize agent: {e}"))
+    })?))
 }
 
 async fn activate_agent(
@@ -549,7 +562,10 @@ async fn discover_agent(
         .map_err(ApiError::Internal)?;
     Ok((
         StatusCode::CREATED,
-        Json(serde_json::to_value(&agent).unwrap()),
+        Json(
+            serde_json::to_value(&agent)
+                .map_err(|e| ApiError::Internal(format!("serialize agent: {e}")))?,
+        ),
     ))
 }
 
@@ -715,7 +731,9 @@ async fn get_tenant(
         .get_tenant(&TenantId::from(id.as_str()))
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("tenant {id}")))?;
-    Ok(Json(serde_json::to_value(tenant).unwrap()))
+    Ok(Json(serde_json::to_value(tenant).map_err(|e| {
+        ApiError::Internal(format!("serialize tenant: {e}"))
+    })?))
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/tests/fixtures/hello_agent_ir.json
+++ b/runtime/api/tests/fixtures/hello_agent_ir.json
@@ -1,0 +1,38 @@
+{
+  "workflow_id": "demo",
+  "version": "0.1.0",
+  "name": null,
+  "description": null,
+  "state_schema": "{\"query\": \"str\", \"answer\": \"str\"}",
+  "start_node": "think",
+  "nodes": {
+    "think": {
+      "id": "think",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-haiku-4-5-20251001",
+        "prompt_ref": "Answer this question clearly and concisely:\n\n{{ state.query }}\n",
+        "output_schema": "",
+        "system_prompt": null
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": null,
+      "labels": {}
+    }
+  },
+  "edges": [
+    {
+      "from": "think",
+      "to": "end",
+      "condition": null
+    }
+  ],
+  "retry_policies": {},
+  "timeouts": {},
+  "models": {},
+  "tools": {},
+  "mcp_servers": {},
+  "remote_agents": {},
+  "labels": {}
+}

--- a/runtime/api/tests/workflow_validation.rs
+++ b/runtime/api/tests/workflow_validation.rs
@@ -1,0 +1,38 @@
+//! Guards the `POST /workflows` IR deserialize-check.
+//!
+//! `create_workflow` rejects any IR that cannot load into the runtime's
+//! `WorkflowIr` — otherwise a structurally-broken definition is stored happily
+//! and only fails later when the scheduler tries to deserialize it, leaving the
+//! execution stuck in `running` forever. These tests pin both directions: the
+//! canonical compiled workflow must pass, and incomplete IR must be rejected.
+
+use jamjet_ir::WorkflowIr;
+
+#[test]
+fn canonical_compiled_ir_deserializes() {
+    // The exact IR produced by `jamjet init hello-agent` + the YAML compiler
+    // (a `model` node whose `model_ref` is resolved by the worker registry, not
+    // the IR `models` map — which is why the check is a shape check, not
+    // `validate_workflow`'s stricter ref rules).
+    let json = include_str!("fixtures/hello_agent_ir.json");
+    let value: serde_json::Value = serde_json::from_str(json).expect("fixture is valid JSON");
+    let ir = serde_json::from_value::<WorkflowIr>(value);
+    assert!(
+        ir.is_ok(),
+        "compiled hello-agent IR must deserialize into WorkflowIr, else create_workflow \
+         would 400 a valid `jamjet run` workflow: {:?}",
+        ir.err()
+    );
+}
+
+#[test]
+fn structurally_broken_ir_is_rejected() {
+    // Has the workflow_id/version the handler extracts, but none of the rest of
+    // the IR — exactly the input the deserialize-check turns into a 400 instead
+    // of a silent, never-scheduling execution.
+    let value = serde_json::json!({ "workflow_id": "x", "version": "0.1.0" });
+    assert!(
+        serde_json::from_value::<WorkflowIr>(value).is_err(),
+        "incomplete IR must not deserialize into WorkflowIr"
+    );
+}


### PR DESCRIPTION
## What

Two robustness fixes to the runtime API handlers, from the runtime review backlog.

### 1. Validate workflow IR on registration

`POST /workflows` stored whatever JSON it was handed. A structurally-broken definition was accepted, then failed later when the scheduler tried to deserialize it — at which point the execution silently never schedules and sits in `running` forever.

It now deserializes the IR into the runtime's `WorkflowIr` up front and returns `400` if that fails.

This is deliberately a **shape check**, not `validate_workflow`'s reference rules. Model and tool refs are resolved by the worker registry, not the IR `models`/`tools` maps — the canonical compiled `hello-agent` workflow has a `model` node with `model_ref: claude-haiku-4-5-20251001` and an empty `models` map by design. Enforcing `validate_refs` here would `400` the primary `jamjet run` flow. A test pins the real compiled IR (captured as a fixture) so this check can never start rejecting valid workflows if `WorkflowIr` drifts.

### 2. Stop panicking on response serialization

Four handlers (`get_execution`, `get_agent`, `discover_agent`, `get_tenant`) used `serde_json::to_value(..).unwrap()`, which would panic the request on a serialize error. They now return `500` through `ApiError::Internal`, matching the existing `map_err(ApiError::Internal)` handlers.

## Tests

- `canonical_compiled_ir_deserializes` — the real `jamjet init hello-agent` IR loads into `WorkflowIr`.
- `structurally_broken_ir_is_rejected` — incomplete IR does not.

Verified: `cargo fmt --all --check` clean, api clippy clean, full api test suite green (existing 14 unit + `execution_e2e` + the 2 new).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for workflow creation with clearer validation error messages when workflow definitions are invalid.
  * Enhanced error reporting in API responses when internal serialization operations fail, providing more informative feedback.

* **Tests**
  * Added comprehensive integration tests for workflow validation and definition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->