### PR TITLE
Multi-agent YAML fleets with cron scheduling

### DIFF
--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -1,0 +1,13 @@
+# Fleet example
+
+One YAML file declaring two strategy agents and one explicit workflow, each on
+its own cron schedule, runnable on the local runtime with no cloud.
+
+```bash
+jamjet dev                          # local runtime; embeds the cron scheduler in dev
+jamjet deploy examples/fleet/fleet.yaml
+jamjet run examples/fleet/fleet.yaml researcher --input '{"topic": "agents"}'
+```
+
+Offline: start Ollama (`ollama serve`) and set the agents' `model:` to a local
+model name (e.g. `llama3.1`); no API key or internet required.

--- a/examples/fleet/fleet.yaml
+++ b/examples/fleet/fleet.yaml
@@ -1,0 +1,46 @@
+# A fleet: two strategy agents and one explicit workflow, all schedulable.
+#
+#   jamjet dev                       # start the local runtime (embeds cron in dev)
+#   jamjet deploy fleet.yaml         # register all units + install schedules
+#   jamjet run fleet.yaml researcher # run one unit on demand
+#
+# Fully local: SQLite state + in-process worker + in-process cron. Point models
+# at Ollama (no API key) for a fully offline run.
+version: 1
+
+defaults:
+  model: claude-sonnet-4-6
+  limits: { max_iterations: 4, max_cost_usd: 0.50, timeout_seconds: 120 }
+
+tools:
+  web_search:
+    description: "Search the web for recent information"
+    input_schema:
+      type: object
+      properties: { query: { type: string } }
+      required: [query]
+
+agents:
+  researcher:
+    strategy: plan-and-execute
+    goal: "Summarize the most important overnight AI news into a short brief"
+    uses:
+      - tool:web_search
+    schedule:
+      cron: "0 9 * * *"      # daily 09:00 UTC
+
+  reconciler:
+    strategy: react
+    goal: "Check yesterday's report for inconsistencies and list any found"
+    uses:
+      - agent:researcher     # may call the researcher as a tool
+    schedule:
+      cron: "30 14 * * 1-5"  # weekdays 14:30 UTC
+
+workflows:
+  heartbeat:
+    start: ping
+    nodes:
+      ping: { type: model, model: claude-haiku-4-5-20251001, next: end }
+    schedule:
+      cron: "*/15 * * * *"   # every 15 minutes

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -26,6 +26,7 @@ jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.1" }
 jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.1" }
 jamjet-worker = { path = "../workers", version = "=0.3.1" }
 jamjet-models = { path = "../models", version = "=0.3.1" }
+jamjet-timers = { path = "../timers", version = "=0.3.1" }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/runtime/api/src/cron.rs
+++ b/runtime/api/src/cron.rs
@@ -36,6 +36,11 @@ pub async fn create_cron(
     Json(body): Json<CreateCronRequest>,
 ) -> Result<(StatusCode, Json<Value>), ApiError> {
     let store = store(&state)?;
+    // Defaults to the SDK compiler's default workflow version ("0.1.0"), which is
+    // what `jamjet deploy` registers. This intentionally differs from
+    // start_execution's "1.0.0" fallback; reconciling one canonical default across
+    // the API is tracked as separate runtime work. The deploy flow always sends the
+    // version explicitly, so this default only applies to raw POST /cron callers.
     let version = body.workflow_version.unwrap_or_else(|| "0.1.0".into());
 
     // The target workflow must be registered (deploy registers first).
@@ -75,6 +80,13 @@ pub async fn create_cron(
 }
 
 /// `GET /cron` — list all cron jobs.
+///
+/// NOTE: cron jobs are GLOBAL, not tenant-scoped, in this version. The embedded
+/// cron scheduler is dev-only (a single `default` tenant) and the `cron_jobs`
+/// table has no tenant column, so listing returns all jobs. Tenant-scoped cron
+/// (a `tenant_id` column, filtered listing, and tenant context threaded through
+/// the scheduler to `/executions`) is part of the deferred runtime
+/// tenant-threading work.
 pub async fn list_cron(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
     let store = store(&state)?;
     let jobs = store.list_all().await.map_err(ApiError::Internal)?;

--- a/runtime/api/src/cron.rs
+++ b/runtime/api/src/cron.rs
@@ -1,0 +1,92 @@
+use crate::error::ApiError;
+use crate::state::AppState;
+use axum::{
+    extract::{Extension, Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::Utc;
+use jamjet_state::TenantId;
+use jamjet_timers::{cron_next, CronJob};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+#[derive(Deserialize)]
+pub struct CreateCronRequest {
+    name: String,
+    cron_expression: String,
+    workflow_id: String,
+    workflow_version: Option<String>,
+    input: Option<Value>,
+    enabled: Option<bool>,
+}
+
+fn store(state: &AppState) -> Result<&std::sync::Arc<jamjet_timers::CronStore>, ApiError> {
+    state
+        .cron_store
+        .as_ref()
+        .ok_or_else(|| ApiError::BadRequest("cron scheduling requires the sqlite backend".into()))
+}
+
+/// `POST /cron` — create or update a cron job.
+pub async fn create_cron(
+    State(state): State<AppState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Json(body): Json<CreateCronRequest>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    let store = store(&state)?;
+    let version = body.workflow_version.unwrap_or_else(|| "0.1.0".into());
+
+    // The target workflow must be registered (deploy registers first).
+    let backend = state.backend_for(&tenant_id);
+    backend
+        .get_workflow(&body.workflow_id, &version)
+        .await?
+        .ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "workflow {} v{} is not registered",
+                body.workflow_id, version
+            ))
+        })?;
+
+    // Validate the expression with the runtime's own parser.
+    let next_run_at = cron_next(&body.cron_expression, Utc::now())
+        .map_err(|e| ApiError::BadRequest(format!("invalid cron expression: {e}")))?;
+
+    let job = CronJob {
+        id: Uuid::new_v4(),
+        name: body.name.clone(),
+        cron_expression: body.cron_expression,
+        workflow_id: body.workflow_id,
+        workflow_version: version,
+        input: body.input.unwrap_or_else(|| json!({})),
+        enabled: body.enabled.unwrap_or(true),
+        last_run_at: None,
+        next_run_at,
+        created_at: Utc::now(),
+    };
+    store.upsert(&job).await.map_err(ApiError::Internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({ "name": job.name, "next_run_at": next_run_at.to_rfc3339() })),
+    ))
+}
+
+/// `GET /cron` — list all cron jobs.
+pub async fn list_cron(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
+    let store = store(&state)?;
+    let jobs = store.list_all().await.map_err(ApiError::Internal)?;
+    Ok(Json(json!({ "cron_jobs": jobs })))
+}
+
+/// `DELETE /cron/:name` — remove a cron job.
+pub async fn delete_cron(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let store = store(&state)?;
+    store.delete(&name).await.map_err(ApiError::Internal)?;
+    Ok(Json(json!({ "name": name, "deleted": true })))
+}

--- a/runtime/api/src/lib.rs
+++ b/runtime/api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod config;
+pub mod cron;
 pub mod error;
 pub mod mcp_bridge;
 pub mod oauth;

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> anyhow::Result<()> {
             audit,
             enricher,
             protocols: jamjet_api::state::default_protocol_registry(),
+            cron_store: None,
         }
     } else {
         // Determine database URL: env > config > SQLite dev default
@@ -96,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
             audit,
             enricher,
             protocols: jamjet_api::state::default_protocol_registry(),
+            cron_store: Some(Arc::new(jamjet_timers::CronStore::new(sqlite.pool()))),
         }
     };
 

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -129,6 +129,37 @@ async fn main() -> anyhow::Result<()> {
         info!("Embedded worker pool started (dev mode)");
     }
 
+    // In dev mode (or when JAMJET_EMBED_CRON is set), run the cron scheduler in
+    // process so YAML-declared schedules fire. It POSTs to this server's own
+    // /executions endpoint. Production should run a dedicated cron process.
+    if (config.dev_mode || std::env::var("JAMJET_EMBED_CRON").is_ok())
+        && storage_backend != "memory"
+    {
+        let host = if config.bind == "0.0.0.0" {
+            "127.0.0.1".to_string()
+        } else {
+            config.bind.clone()
+        };
+        let self_url = format!("http://{}:{}", host, config.port);
+        let database_url = std::env::var("DATABASE_URL")
+            .ok()
+            .or_else(|| config.database_url.clone())
+            .unwrap_or_else(|| {
+                format!(
+                    "sqlite://{}",
+                    std::path::PathBuf::from(".jamjet").join("runtime.db").display()
+                )
+            });
+        match jamjet_state::SqliteBackend::open(&database_url).await {
+            Ok(b) => {
+                let cron = jamjet_timers::CronScheduler::new(b.pool(), self_url);
+                tokio::spawn(cron.run());
+                info!("Cron scheduler started (dev mode)");
+            }
+            Err(e) => tracing::warn!(error = %e, "cron scheduler: failed to open pool; skipping"),
+        }
+    }
+
     let router = build_router_with_opts(state, config.dev_mode);
     let addr = format!("{}:{}", config.bind, config.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -147,7 +147,9 @@ async fn main() -> anyhow::Result<()> {
             .unwrap_or_else(|| {
                 format!(
                     "sqlite://{}",
-                    std::path::PathBuf::from(".jamjet").join("runtime.db").display()
+                    std::path::PathBuf::from(".jamjet")
+                        .join("runtime.db")
+                        .display()
                 )
             });
         match jamjet_state::SqliteBackend::open(&database_url).await {

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1,11 +1,12 @@
 use crate::auth::{require_auth, require_write_role, AuthState};
+use crate::cron::{create_cron, delete_cron, list_cron};
 use crate::error::ApiError;
 use crate::state::AppState;
 use axum::{
     extract::{Extension, Path, Query, State},
     http::StatusCode,
     middleware,
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use chrono::Utc;
@@ -32,6 +33,9 @@ pub fn build_router_with_opts(state: AppState, dev_mode: bool) -> Router {
     let api_routes = Router::new()
         // Workflow definitions
         .route("/workflows", post(create_workflow))
+        // Cron schedules (local scheduling)
+        .route("/cron", post(create_cron).get(list_cron))
+        .route("/cron/:name", delete(delete_cron))
         // Executions
         .route("/executions", post(start_execution).get(list_executions))
         .route("/executions/:id", get(get_execution))

--- a/runtime/api/src/state.rs
+++ b/runtime/api/src/state.rs
@@ -24,6 +24,8 @@ pub struct AppState {
     pub enricher: Arc<AuditEnricher>,
     /// Protocol adapter registry — pre-loaded with MCP, A2A, and ANP adapters.
     pub protocols: ProtocolRegistry,
+    /// Cron job store — present only on the SQLite backend (local scheduling).
+    pub cron_store: Option<std::sync::Arc<jamjet_timers::CronStore>>,
 }
 
 impl AppState {

--- a/runtime/api/tests/cron_store_api.rs
+++ b/runtime/api/tests/cron_store_api.rs
@@ -1,0 +1,34 @@
+use jamjet_state::SqliteBackend;
+use jamjet_timers::{CronJob, CronStore};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn cron_store_roundtrip() {
+    let db = std::env::temp_dir().join(format!("jjcronapi-{}.db", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db.display());
+    let backend = SqliteBackend::open(&url).await.unwrap();
+    let store = CronStore::new(backend.pool());
+
+    let next = jamjet_timers::cron_next("0 9 * * *", chrono::Utc::now()).unwrap();
+    store
+        .upsert(&CronJob {
+            id: Uuid::new_v4(),
+            name: "researcher".into(),
+            cron_expression: "0 9 * * *".into(),
+            workflow_id: "researcher".into(),
+            workflow_version: "0.1.0".into(),
+            input: serde_json::json!({}),
+            enabled: true,
+            last_run_at: None,
+            next_run_at: next,
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let all = store.list_all().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].workflow_id, "researcher");
+
+    let _ = std::fs::remove_file(&db);
+}

--- a/runtime/api/tests/fixtures/fleet_researcher_ir.json
+++ b/runtime/api/tests/fixtures/fleet_researcher_ir.json
@@ -1,0 +1,325 @@
+{
+  "workflow_id": "researcher",
+  "version": "0.1.0",
+  "name": "researcher",
+  "description": "Summarize the most important overnight AI news into a short brief",
+  "state_schema": "",
+  "start_node": "__plan__",
+  "nodes": {
+    "__plan__": {
+      "id": "__plan__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You are an AI agent working on: Summarize the most important overnight AI news into a short brief\nAvailable tools: web_search\nGenerate a structured plan with up to 4 concrete steps. Output JSON: {\"steps\": [\"step 1\", \"step 2\", ...]}",
+        "output_schema": "__plan__",
+        "system_prompt": "You are a planning AI. Output valid JSON only."
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You are an AI agent working on: Summarize the most important overnight AI news into a short brief\nAvailable tools: web_search\nGenerate a structured plan with up to 4 concrete steps. Output JSON: {\"steps\": [\"step 1\", \"step 2\", ...]}",
+      "labels": {
+        "jamjet.strategy.node": "plan_generation",
+        "jamjet.strategy.event": "plan_generated"
+      }
+    },
+    "__cost_guard_0__": {
+      "id": "__cost_guard_0__",
+      "kind": {
+        "type": "condition",
+        "branches": [
+          {
+            "condition": "state.__cost_exceeded__",
+            "target": "__limit_exceeded__"
+          },
+          {
+            "condition": null,
+            "target": "__step_0__"
+          }
+        ],
+        "expression": "state.__cost_exceeded__ == true"
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": "state.__cost_exceeded__ == true",
+      "labels": {
+        "jamjet.strategy.node": "cost_guard",
+        "jamjet.strategy.iteration": "0"
+      }
+    },
+    "__step_0__": {
+      "id": "__step_0__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You are executing step 1 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 1 using the available tools. Record your result.",
+        "output_schema": "__step_0_output__",
+        "system_prompt": null
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You are executing step 1 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 1 using the available tools. Record your result.",
+      "labels": {
+        "jamjet.strategy.node": "step_executor",
+        "jamjet.strategy.event": "iteration_started",
+        "jamjet.strategy.iteration": "0"
+      }
+    },
+    "__cost_guard_1__": {
+      "id": "__cost_guard_1__",
+      "kind": {
+        "type": "condition",
+        "branches": [
+          {
+            "condition": "state.__cost_exceeded__",
+            "target": "__limit_exceeded__"
+          },
+          {
+            "condition": null,
+            "target": "__step_1__"
+          }
+        ],
+        "expression": "state.__cost_exceeded__ == true"
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": "state.__cost_exceeded__ == true",
+      "labels": {
+        "jamjet.strategy.node": "cost_guard",
+        "jamjet.strategy.iteration": "1"
+      }
+    },
+    "__step_1__": {
+      "id": "__step_1__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You are executing step 2 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 2 using the available tools. Record your result.",
+        "output_schema": "__step_1_output__",
+        "system_prompt": null
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You are executing step 2 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 2 using the available tools. Record your result.",
+      "labels": {
+        "jamjet.strategy.node": "step_executor",
+        "jamjet.strategy.event": "iteration_started",
+        "jamjet.strategy.iteration": "1"
+      }
+    },
+    "__cost_guard_2__": {
+      "id": "__cost_guard_2__",
+      "kind": {
+        "type": "condition",
+        "branches": [
+          {
+            "condition": "state.__cost_exceeded__",
+            "target": "__limit_exceeded__"
+          },
+          {
+            "condition": null,
+            "target": "__step_2__"
+          }
+        ],
+        "expression": "state.__cost_exceeded__ == true"
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": "state.__cost_exceeded__ == true",
+      "labels": {
+        "jamjet.strategy.node": "cost_guard",
+        "jamjet.strategy.iteration": "2"
+      }
+    },
+    "__step_2__": {
+      "id": "__step_2__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You are executing step 3 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 3 using the available tools. Record your result.",
+        "output_schema": "__step_2_output__",
+        "system_prompt": null
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You are executing step 3 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 3 using the available tools. Record your result.",
+      "labels": {
+        "jamjet.strategy.node": "step_executor",
+        "jamjet.strategy.event": "iteration_started",
+        "jamjet.strategy.iteration": "2"
+      }
+    },
+    "__cost_guard_3__": {
+      "id": "__cost_guard_3__",
+      "kind": {
+        "type": "condition",
+        "branches": [
+          {
+            "condition": "state.__cost_exceeded__",
+            "target": "__limit_exceeded__"
+          },
+          {
+            "condition": null,
+            "target": "__step_3__"
+          }
+        ],
+        "expression": "state.__cost_exceeded__ == true"
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": "state.__cost_exceeded__ == true",
+      "labels": {
+        "jamjet.strategy.node": "cost_guard",
+        "jamjet.strategy.iteration": "3"
+      }
+    },
+    "__step_3__": {
+      "id": "__step_3__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You are executing step 4 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 4 using the available tools. Record your result.",
+        "output_schema": "__step_3_output__",
+        "system_prompt": null
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You are executing step 4 of 4 for the goal: Summarize the most important overnight AI news into a short brief\nThe plan is: {{ state.__plan__ }}\nExecute step 4 using the available tools. Record your result.",
+      "labels": {
+        "jamjet.strategy.node": "step_executor",
+        "jamjet.strategy.event": "iteration_started",
+        "jamjet.strategy.iteration": "3"
+      }
+    },
+    "__finalize__": {
+      "id": "__finalize__",
+      "kind": {
+        "type": "model",
+        "model_ref": "claude-sonnet-4-6",
+        "prompt_ref": "You completed all steps for the goal: Summarize the most important overnight AI news into a short brief\nSynthesize the results from all steps into a final, well-structured response.",
+        "output_schema": "result",
+        "system_prompt": null
+      },
+      "retry_policy": "llm_default",
+      "node_timeout_secs": null,
+      "description": "You completed all steps for the goal: Summarize the most important overnight AI news into a short brief\nSynthesize the results from all steps into a final, well-structured response.",
+      "labels": {
+        "jamjet.strategy.node": "finalizer",
+        "jamjet.strategy.event": "strategy_completed"
+      }
+    },
+    "__limit_exceeded__": {
+      "id": "__limit_exceeded__",
+      "kind": {
+        "type": "limit_exceeded",
+        "description": "Strategy limit reached"
+      },
+      "retry_policy": null,
+      "node_timeout_secs": null,
+      "description": "Strategy limit exceeded \u2014 execution halted",
+      "labels": {
+        "jamjet.strategy.limit": "true"
+      }
+    }
+  },
+  "edges": [
+    {
+      "from": "__plan__",
+      "to": "__cost_guard_0__",
+      "condition": null
+    },
+    {
+      "from": "__step_0__",
+      "to": "__cost_guard_1__",
+      "condition": null
+    },
+    {
+      "from": "__cost_guard_0__",
+      "to": "__limit_exceeded__",
+      "condition": "state.__cost_exceeded__ == true"
+    },
+    {
+      "from": "__cost_guard_0__",
+      "to": "__step_0__",
+      "condition": null
+    },
+    {
+      "from": "__step_1__",
+      "to": "__cost_guard_2__",
+      "condition": null
+    },
+    {
+      "from": "__cost_guard_1__",
+      "to": "__limit_exceeded__",
+      "condition": "state.__cost_exceeded__ == true"
+    },
+    {
+      "from": "__cost_guard_1__",
+      "to": "__step_1__",
+      "condition": null
+    },
+    {
+      "from": "__step_2__",
+      "to": "__cost_guard_3__",
+      "condition": null
+    },
+    {
+      "from": "__cost_guard_2__",
+      "to": "__limit_exceeded__",
+      "condition": "state.__cost_exceeded__ == true"
+    },
+    {
+      "from": "__cost_guard_2__",
+      "to": "__step_2__",
+      "condition": null
+    },
+    {
+      "from": "__step_3__",
+      "to": "__finalize__",
+      "condition": null
+    },
+    {
+      "from": "__cost_guard_3__",
+      "to": "__limit_exceeded__",
+      "condition": "state.__cost_exceeded__ == true"
+    },
+    {
+      "from": "__cost_guard_3__",
+      "to": "__step_3__",
+      "condition": null
+    },
+    {
+      "from": "__finalize__",
+      "to": "end",
+      "condition": null
+    },
+    {
+      "from": "__limit_exceeded__",
+      "to": "end",
+      "condition": null
+    }
+  ],
+  "retry_policies": {},
+  "timeouts": {
+    "workflow_timeout": 120,
+    "heartbeat_interval": 30
+  },
+  "models": {},
+  "tools": {},
+  "mcp_servers": {},
+  "remote_agents": {},
+  "labels": {
+    "jamjet.strategy": "plan-and-execute",
+    "jamjet.agent.id": "researcher"
+  },
+  "strategy_metadata": {
+    "strategy_name": "plan-and-execute",
+    "strategy_config": {},
+    "limits": {
+      "max_iterations": 4,
+      "max_cost_usd": 0.5,
+      "timeout_seconds": 120
+    },
+    "agent_id": "researcher"
+  }
+}

--- a/runtime/api/tests/workflow_validation.rs
+++ b/runtime/api/tests/workflow_validation.rs
@@ -36,3 +36,19 @@ fn structurally_broken_ir_is_rejected() {
         "incomplete IR must not deserialize into WorkflowIr"
     );
 }
+
+#[test]
+fn fleet_agent_ir_registers() {
+    // A fleet agent that uses a catalog tool must still produce an IR the API
+    // can store (POST /workflows deserializes into WorkflowIr). Regression for
+    // the bug where catalog tool defs were embedded into the IR `tools` map
+    // with a shape ToolConfig can't deserialize.
+    let json = include_str!("fixtures/fleet_researcher_ir.json");
+    let value: serde_json::Value = serde_json::from_str(json).expect("parse fixture json");
+    let parsed = serde_json::from_value::<jamjet_ir::WorkflowIr>(value);
+    assert!(
+        parsed.is_ok(),
+        "fleet researcher IR must deserialize into WorkflowIr, got: {:?}",
+        parsed.err()
+    );
+}

--- a/runtime/core/src/node.rs
+++ b/runtime/core/src/node.rs
@@ -185,6 +185,13 @@ pub enum NodeKind {
         /// Input expression — which state field to evaluate (default: last node output).
         input_expr: Option<String>,
     },
+
+    /// Terminal node emitted by strategy compilers when an iteration or cost
+    /// limit is reached. The runtime records the workflow as `LimitExceeded`
+    /// and stops further execution. No fields are required — it is purely a
+    /// marker that carries optional descriptive metadata in the node's
+    /// `description` / `labels`.
+    LimitExceeded,
 }
 
 impl NodeKind {

--- a/runtime/timers/src/lib.rs
+++ b/runtime/timers/src/lib.rs
@@ -292,6 +292,25 @@ impl CronStore {
             .map_err(|e| format!("disable cron: {e}"))?;
         Ok(())
     }
+
+    /// List all cron jobs regardless of enabled/due state.
+    pub async fn list_all(&self) -> Result<Vec<CronJob>, String> {
+        let rows = sqlx::query("SELECT * FROM cron_jobs ORDER BY name ASC")
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| format!("list all cron jobs: {e}"))?;
+        rows.iter().map(row_to_cron).collect()
+    }
+
+    /// Permanently remove a cron job by name.
+    pub async fn delete(&self, name: &str) -> Result<(), String> {
+        sqlx::query("DELETE FROM cron_jobs WHERE name = ?")
+            .bind(name)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("delete cron: {e}"))?;
+        Ok(())
+    }
 }
 
 fn row_to_cron(row: &sqlx::sqlite::SqliteRow) -> Result<CronJob, String> {
@@ -532,5 +551,49 @@ mod tests {
     #[test]
     fn test_cron_bad_field_count() {
         assert!(cron_next("* * * *", Utc::now()).is_err());
+    }
+
+    async fn temp_store() -> (CronStore, std::path::PathBuf) {
+        let db = std::env::temp_dir().join(format!("jjcron-{}.db", Uuid::new_v4()));
+        let url = format!("sqlite://{}", db.display());
+        let backend = jamjet_state::SqliteBackend::open(&url)
+            .await
+            .expect("open sqlite");
+        (CronStore::new(backend.pool()), db)
+    }
+
+    fn sample_job(name: &str) -> CronJob {
+        CronJob {
+            id: Uuid::new_v4(),
+            name: name.into(),
+            cron_expression: "* * * * *".into(),
+            workflow_id: "wf".into(),
+            workflow_version: "0.1.0".into(),
+            input: serde_json::json!({}),
+            enabled: true,
+            last_run_at: None,
+            next_run_at: Utc::now() - chrono::Duration::minutes(1),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_list_all_and_delete() {
+        let (store, db) = temp_store().await;
+        store.upsert(&sample_job("a")).await.unwrap();
+        store.upsert(&sample_job("b")).await.unwrap();
+
+        let all = store.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let due = store.list_due().await.unwrap();
+        assert_eq!(due.len(), 2); // both are past-due
+
+        store.delete("a").await.unwrap();
+        let all = store.list_all().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].name, "b");
+
+        let _ = std::fs::remove_file(&db);
     }
 }

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -30,10 +30,11 @@ import enum
 import json
 import sys
 import time
-import yaml
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import yaml
 
 if TYPE_CHECKING:
     from jamjet.eval.grid import ComparisonResult
@@ -517,8 +518,7 @@ def deploy(
                     enabled=job.enabled,
                 )
                 console.print(
-                    f"[green]scheduled[/green] {job.name} "
-                    f"[{job.cron_expression}] next={res.get('next_run_at', '?')}"
+                    f"[green]scheduled[/green] {job.name} [{job.cron_expression}] next={res.get('next_run_at', '?')}"
                 )
 
     asyncio.run(_deploy())
@@ -552,9 +552,7 @@ def _load_workflow_ir(path: str) -> dict[str, Any]:
 @app.command()
 def run(
     workflow: str = typer.Argument(..., help="Workflow id or path to workflow.yaml"),
-    unit: str | None = typer.Argument(
-        None, help="For a fleet file, the unit (agent/workflow) to run"
-    ),
+    unit: str | None = typer.Argument(None, help="For a fleet file, the unit (agent/workflow) to run"),
     input: str | None = typer.Option(None, "--input", "-i", help="JSON input"),
     runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
     follow: bool = typer.Option(True, "--follow/--no-follow", help="Follow execution progress"),
@@ -604,15 +602,11 @@ def run(
                             target = next(iter(by_id))
                         else:
                             console.print(
-                                "[red]This file declares multiple units. "
-                                f"Pick one:[/red] {', '.join(sorted(by_id))}"
+                                f"[red]This file declares multiple units. Pick one:[/red] {', '.join(sorted(by_id))}"
                             )
                             raise typer.Exit(1)
                     if target not in by_id:
-                        console.print(
-                            f"[red]Unknown unit '{target}'.[/red] "
-                            f"Available: {', '.join(sorted(by_id))}"
-                        )
+                        console.print(f"[red]Unknown unit '{target}'.[/red] Available: {', '.join(sorted(by_id))}")
                         raise typer.Exit(1)
                     for ir in bundle.workflows:
                         ir["workflow_id"] = str(ir["workflow_id"])
@@ -635,8 +629,7 @@ def run(
                     workflow_version = ir.get("version")
                     if not json_output:
                         console.print(
-                            f"[dim]Registered[/dim] [bold]{workflow_ref}[/bold] "
-                            f"[dim]v{workflow_version or '?'}[/dim]"
+                            f"[dim]Registered[/dim] [bold]{workflow_ref}[/bold] [dim]v{workflow_version or '?'}[/dim]"
                         )
 
             result = await c.start_execution(

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -30,7 +30,9 @@ import enum
 import json
 import sys
 import time
+import yaml
 from collections.abc import Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -482,6 +484,44 @@ def validate(
     except Exception as e:
         console.print(f"[red]Validation error:[/red] {e}")
         raise typer.Exit(1)
+
+
+# ── deploy ────────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def deploy(
+    file: str = typer.Argument(..., help="Path to a fleet YAML (agents:/workflows:)"),
+    runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
+) -> None:
+    """Register every unit in a fleet file and install its cron schedules."""
+    from jamjet.workflow.bundle import compile_bundle
+
+    data = yaml.safe_load(Path(file).read_text())
+    bundle = compile_bundle(data)
+
+    async def _deploy() -> None:
+        async with _client(runtime) as c:
+            for ir in bundle.workflows:
+                ir["workflow_id"] = str(ir["workflow_id"])
+                ir["version"] = str(ir["version"])
+                await c.create_workflow(ir)
+                console.print(f"[green]registered[/green] {ir['workflow_id']} v{ir['version']}")
+            for job in bundle.cron_jobs:
+                res = await c.create_cron_job(
+                    name=job.name,
+                    cron_expression=job.cron_expression,
+                    workflow_id=job.workflow_id,
+                    workflow_version=job.workflow_version,
+                    input=job.input,
+                    enabled=job.enabled,
+                )
+                console.print(
+                    f"[green]scheduled[/green] {job.name} "
+                    f"[{job.cron_expression}] next={res.get('next_run_at', '?')}"
+                )
+
+    asyncio.run(_deploy())
 
 
 # ── run ───────────────────────────────────────────────────────────────────────

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -552,6 +552,9 @@ def _load_workflow_ir(path: str) -> dict[str, Any]:
 @app.command()
 def run(
     workflow: str = typer.Argument(..., help="Workflow id or path to workflow.yaml"),
+    unit: str | None = typer.Argument(
+        None, help="For a fleet file, the unit (agent/workflow) to run"
+    ),
     input: str | None = typer.Option(None, "--input", "-i", help="JSON input"),
     runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
     follow: bool = typer.Option(True, "--follow/--no-follow", help="Follow execution progress"),
@@ -585,20 +588,56 @@ def run(
                 if not workflow.endswith((".yaml", ".yml", ".py")):
                     console.print("[red]Unsupported workflow file. Use .yaml, .yml, or .py[/red]")
                     raise typer.Exit(1)
-                ir = _load_workflow_ir(workflow)
-                # The runtime requires string workflow_id/version; a YAML value
-                # like `version: 1.0` parses as a number, which fails registration.
-                if ir.get("workflow_id") is not None:
-                    ir["workflow_id"] = str(ir["workflow_id"])
-                if ir.get("version") is not None:
-                    ir["version"] = str(ir["version"])
-                await c.create_workflow(ir)
-                workflow_ref = str(ir.get("workflow_id") or workflow)
-                workflow_version = ir.get("version")
-                if not json_output:
-                    console.print(
-                        f"[dim]Registered[/dim] [bold]{workflow_ref}[/bold] [dim]v{workflow_version or '?'}[/dim]"
-                    )
+
+                data = None
+                if workflow.endswith((".yaml", ".yml")):
+                    data = yaml.safe_load(Path(workflow).read_text())
+
+                from jamjet.workflow.bundle import compile_bundle, is_bundle
+
+                if data is not None and is_bundle(data):
+                    bundle = compile_bundle(data)
+                    by_id = {ir["workflow_id"]: ir for ir in bundle.workflows}
+                    target = unit
+                    if target is None:
+                        if len(by_id) == 1:
+                            target = next(iter(by_id))
+                        else:
+                            console.print(
+                                "[red]This file declares multiple units. "
+                                f"Pick one:[/red] {', '.join(sorted(by_id))}"
+                            )
+                            raise typer.Exit(1)
+                    if target not in by_id:
+                        console.print(
+                            f"[red]Unknown unit '{target}'.[/red] "
+                            f"Available: {', '.join(sorted(by_id))}"
+                        )
+                        raise typer.Exit(1)
+                    for ir in bundle.workflows:
+                        ir["workflow_id"] = str(ir["workflow_id"])
+                        ir["version"] = str(ir["version"])
+                        await c.create_workflow(ir)
+                    workflow_ref = target
+                    workflow_version = str(by_id[target]["version"])
+                    if not json_output:
+                        console.print(f"[dim]Registered fleet; running[/dim] [bold]{target}[/bold]")
+                else:
+                    ir = _load_workflow_ir(workflow)
+                    # The runtime requires string workflow_id/version; a YAML value
+                    # like `version: 1.0` parses as a number, which fails registration.
+                    if ir.get("workflow_id") is not None:
+                        ir["workflow_id"] = str(ir["workflow_id"])
+                    if ir.get("version") is not None:
+                        ir["version"] = str(ir["version"])
+                    await c.create_workflow(ir)
+                    workflow_ref = str(ir.get("workflow_id") or workflow)
+                    workflow_version = ir.get("version")
+                    if not json_output:
+                        console.print(
+                            f"[dim]Registered[/dim] [bold]{workflow_ref}[/bold] "
+                            f"[dim]v{workflow_version or '?'}[/dim]"
+                        )
 
             result = await c.start_execution(
                 workflow_id=workflow_ref, input=input_data, workflow_version=workflow_version

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -52,6 +52,36 @@ class JamjetClient:
         r.raise_for_status()
         return r.json()
 
+    # ── Cron schedules ────────────────────────────────────────────────────
+
+    async def create_cron_job(
+        self,
+        name: str,
+        cron_expression: str,
+        workflow_id: str,
+        workflow_version: str | None = None,
+        input: dict[str, Any] | None = None,
+        enabled: bool = True,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "name": name,
+            "cron_expression": cron_expression,
+            "workflow_id": workflow_id,
+            "enabled": enabled,
+        }
+        if workflow_version:
+            body["workflow_version"] = workflow_version
+        if input is not None:
+            body["input"] = input
+        r = await self._client.post("/cron", json=body)
+        r.raise_for_status()
+        return r.json()
+
+    async def list_cron_jobs(self) -> dict[str, Any]:
+        r = await self._client.get("/cron")
+        r.raise_for_status()
+        return r.json()
+
     # ── Executions ────────────────────────────────────────────────────────
 
     async def start_execution(

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -38,8 +38,7 @@ def _validate_cron(expr: str) -> None:
     """Light client-side check; the runtime's cron_next is authoritative."""
     if not isinstance(expr, str) or len(expr.split()) != 5:
         raise ValueError(
-            f"cron expression must have 5 fields "
-            f"(minute hour day-of-month month day-of-week), got: {expr!r}"
+            f"cron expression must have 5 fields (minute hour day-of-month month day-of-week), got: {expr!r}"
         )
 
 
@@ -50,10 +49,7 @@ def _schedule_to_spec(unit_id: str, version: str, schedule: dict[str, Any]) -> C
     _validate_cron(cron)
     tz = schedule.get("timezone", "UTC")
     if tz != "UTC":
-        raise ValueError(
-            f"unit '{unit_id}': only timezone 'UTC' is supported in this version "
-            f"(got {tz!r})"
-        )
+        raise ValueError(f"unit '{unit_id}': only timezone 'UTC' is supported in this version (got {tz!r})")
     return CronSpec(
         name=unit_id,
         cron_expression=cron,
@@ -100,10 +96,7 @@ def _resolve_uses(
 
     for ref in uses or []:
         if not isinstance(ref, str) or ":" not in ref:
-            raise ValueError(
-                f"unit '{unit_id}': unknown ref {ref!r} "
-                f"(expected tool:/mcp:/agent:/workflow: prefix)"
-            )
+            raise ValueError(f"unit '{unit_id}': unknown ref {ref!r} (expected tool:/mcp:/agent:/workflow: prefix)")
         kind, _, name = ref.partition(":")
         if kind == "tool":
             if name not in tool_catalog:
@@ -120,10 +113,7 @@ def _resolve_uses(
             r.tool_names.append(name)
             r.sibling_refs.append(name)
         else:
-            raise ValueError(
-                f"unit '{unit_id}': unknown ref {ref!r} "
-                f"(expected tool:/mcp:/agent:/workflow: prefix)"
-            )
+            raise ValueError(f"unit '{unit_id}': unknown ref {ref!r} (expected tool:/mcp:/agent:/workflow: prefix)")
 
     return r
 
@@ -156,8 +146,12 @@ def _compile_agent_unit(
     )
 
     resolved = _resolve_uses(
-        unit_id, agent.get("uses", []), agent.get("tools", []),
-        tool_catalog, mcp_catalog, unit_ids,
+        unit_id,
+        agent.get("uses", []),
+        agent.get("tools", []),
+        tool_catalog,
+        mcp_catalog,
+        unit_ids,
     )
 
     compiled = compile_strategy(
@@ -206,26 +200,26 @@ def _compile_agent_unit(
 
 
 def _detect_cycle(graph: dict[str, list[str]]) -> list[str] | None:
-    WHITE, GREY, BLACK = 0, 1, 2
-    color = {n: WHITE for n in graph}
+    white, grey, black = 0, 1, 2
+    color = {n: white for n in graph}
     stack: list[str] = []
 
     def visit(n: str) -> list[str] | None:
-        color[n] = GREY
+        color[n] = grey
         stack.append(n)
         for m in graph.get(n, []):
-            if color.get(m, BLACK) == GREY:
-                return stack[stack.index(m):] + [m]
-            if color.get(m, BLACK) == WHITE:
+            if color.get(m, black) == grey:
+                return stack[stack.index(m) :] + [m]
+            if color.get(m, black) == white:
                 found = visit(m)
                 if found:
                     return found
         stack.pop()
-        color[n] = BLACK
+        color[n] = black
         return None
 
     for n in graph:
-        if color[n] == WHITE:
+        if color[n] == white:
             found = visit(n)
             if found:
                 return found
@@ -253,8 +247,12 @@ def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
     # Agent units.
     for uid, agent in agents.items():
         resolved = _resolve_uses(
-            uid, agent.get("uses", []), agent.get("tools", []),
-            tool_catalog, mcp_catalog, unit_ids,
+            uid,
+            agent.get("uses", []),
+            agent.get("tools", []),
+            tool_catalog,
+            mcp_catalog,
+            unit_ids,
         )
         sibling_graph[uid] = resolved.sibling_refs
         ir = _compile_agent_unit(uid, agent, defaults, tool_catalog, mcp_catalog, unit_ids)
@@ -279,6 +277,7 @@ def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
             "a2a": {"remote_agents": wf.get("remote_agents", {})},
         }
         from jamjet.workflow.ir_compiler import _compile_graph_yaml
+
         ir = _compile_graph_yaml(doc)
         ir["workflow_id"] = uid
         ir["version"] = str(ir["version"])

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -128,6 +128,83 @@ def _resolve_uses(
     return r
 
 
+def _compile_agent_unit(
+    unit_id: str,
+    agent: dict[str, Any],
+    defaults: dict[str, Any],
+    tool_catalog: dict[str, Any],
+    mcp_catalog: dict[str, Any],
+    unit_ids: set[str],
+) -> dict[str, Any]:
+    from jamjet.compiler.strategies import StrategyLimits, compile_strategy
+
+    strategy_name = agent.get("strategy")
+    goal = agent.get("goal")
+    model = agent.get("model") or defaults.get("model")
+    missing = [n for n, v in (("strategy", strategy_name), ("goal", goal), ("model", model)) if not v]
+    if missing:
+        raise ValueError(f"agent unit '{unit_id}' is missing required fields: {', '.join(missing)}")
+
+    limits_raw = {**defaults.get("limits", {}), **agent.get("limits", {})}
+    for lf in ("max_iterations", "max_cost_usd", "timeout_seconds"):
+        if lf not in limits_raw:
+            raise ValueError(f"agent unit '{unit_id}' limits is missing '{lf}'")
+    limits = StrategyLimits(
+        max_iterations=int(limits_raw["max_iterations"]),
+        max_cost_usd=float(limits_raw["max_cost_usd"]),
+        timeout_seconds=int(limits_raw["timeout_seconds"]),
+    )
+
+    resolved = _resolve_uses(
+        unit_id, agent.get("uses", []), agent.get("tools", []),
+        tool_catalog, mcp_catalog, unit_ids,
+    )
+
+    compiled = compile_strategy(
+        strategy_name=strategy_name,
+        strategy_config=agent.get("strategy_config", {}),
+        tools=resolved.tool_names,
+        model=model,
+        limits=limits,
+        goal=goal,
+        agent_id=unit_id,
+    )
+
+    nodes: dict[str, Any] = {}
+    for node_id, node_def in compiled["nodes"].items():
+        nodes[node_id] = {
+            "id": node_id,
+            "kind": node_def["kind"],
+            "retry_policy": node_def.get("retry_policy"),
+            "node_timeout_secs": node_def.get("node_timeout_secs"),
+            "description": node_def.get("description"),
+            "labels": node_def.get("labels", {}),
+        }
+
+    version = str(agent.get("version") or defaults.get("version") or "0.1.0")
+    return {
+        "workflow_id": unit_id,
+        "version": version,
+        "name": agent.get("name", unit_id),
+        "description": goal,
+        "state_schema": agent.get("state_schema", ""),
+        "start_node": compiled["start_node"],
+        "nodes": nodes,
+        "edges": compiled["edges"],
+        "retry_policies": {},
+        "timeouts": {"workflow_timeout": limits.timeout_seconds, "heartbeat_interval": 30},
+        "models": {},
+        "tools": resolved.ir_tools,
+        "mcp_servers": resolved.mcp_servers,
+        "remote_agents": {},
+        "labels": {
+            "jamjet.strategy": strategy_name,
+            "jamjet.agent.id": unit_id,
+        },
+        "strategy_metadata": compiled["strategy_metadata"],
+    }
+
+
 def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
     """Compile a fleet document into a CompiledBundle."""
     bundle = CompiledBundle()

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -188,8 +188,14 @@ def _compile_agent_unit(
         "retry_policies": {},
         "timeouts": {"workflow_timeout": limits.timeout_seconds, "heartbeat_interval": 30},
         "models": {},
-        "tools": resolved.ir_tools,
-        "mcp_servers": resolved.mcp_servers,
+        # The runtime IR `tools`/`mcp_servers` maps expect typed configs
+        # (ToolConfig with `kind`/`reference`, McpServerConfig with a typed
+        # `transport` enum) that differ from the catalog's human-authored
+        # shapes. Strategy agents convey tool names via the compiled prompt
+        # (`resolved.tool_names` → `compile_strategy`); deep tool/MCP IR
+        # wiring is deferred. Emit empty maps so POST /workflows succeeds.
+        "tools": {},
+        "mcp_servers": {},
         "remote_agents": {},
         "labels": {
             "jamjet.strategy": strategy_name,

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -1,0 +1,40 @@
+"""
+Compile a multi-unit ("fleet") YAML document into N workflow IRs plus cron specs.
+
+A fleet file has an ``agents:`` map (strategy-based units) and/or a
+``workflows:`` map (explicit node graphs). Both kinds compile to the same
+``WorkflowIr`` dict and share a top-level ``tools:``/``mcp:`` catalog. Any unit
+may carry a ``schedule:`` (5-field cron) that becomes a cron job.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CronSpec:
+    name: str
+    cron_expression: str
+    workflow_id: str
+    workflow_version: str
+    input: dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+
+
+@dataclass
+class CompiledBundle:
+    workflows: list[dict[str, Any]] = field(default_factory=list)
+    cron_jobs: list[CronSpec] = field(default_factory=list)
+
+
+def is_bundle(data: dict[str, Any]) -> bool:
+    """A multi-unit file has an ``agents:`` and/or ``workflows:`` (plural) map."""
+    return isinstance(data, dict) and ("agents" in data or "workflows" in data)
+
+
+def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
+    """Compile a fleet document into a CompiledBundle."""
+    bundle = CompiledBundle()
+    return bundle

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -34,6 +34,36 @@ def is_bundle(data: dict[str, Any]) -> bool:
     return isinstance(data, dict) and ("agents" in data or "workflows" in data)
 
 
+def _validate_cron(expr: str) -> None:
+    """Light client-side check; the runtime's cron_next is authoritative."""
+    if not isinstance(expr, str) or len(expr.split()) != 5:
+        raise ValueError(
+            f"cron expression must have 5 fields "
+            f"(minute hour day-of-month month day-of-week), got: {expr!r}"
+        )
+
+
+def _schedule_to_spec(unit_id: str, version: str, schedule: dict[str, Any]) -> CronSpec:
+    cron = schedule.get("cron")
+    if not cron:
+        raise ValueError(f"unit '{unit_id}' has a schedule with no 'cron' field")
+    _validate_cron(cron)
+    tz = schedule.get("timezone", "UTC")
+    if tz != "UTC":
+        raise ValueError(
+            f"unit '{unit_id}': only timezone 'UTC' is supported in this version "
+            f"(got {tz!r})"
+        )
+    return CronSpec(
+        name=unit_id,
+        cron_expression=cron,
+        workflow_id=unit_id,
+        workflow_version=version,
+        input=schedule.get("input", {}) or {},
+        enabled=bool(schedule.get("enabled", True)),
+    )
+
+
 def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
     """Compile a fleet document into a CompiledBundle."""
     bundle = CompiledBundle()

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -64,6 +64,70 @@ def _schedule_to_spec(unit_id: str, version: str, schedule: dict[str, Any]) -> C
     )
 
 
+@dataclass
+class _ResolvedUses:
+    tool_names: list[str] = field(default_factory=list)
+    ir_tools: dict[str, Any] = field(default_factory=dict)
+    mcp_servers: dict[str, Any] = field(default_factory=dict)
+    sibling_refs: list[str] = field(default_factory=list)
+
+
+def _tool_name(t: Any) -> str:
+    """Inline tools may be a {name,...} dict or a bare string name."""
+    if isinstance(t, dict):
+        name = t.get("name")
+        if not name:
+            raise ValueError(f"inline tool is missing a 'name': {t!r}")
+        return str(name)
+    return str(t)
+
+
+def _resolve_uses(
+    unit_id: str,
+    uses: list[str],
+    inline_tools: list[Any],
+    tool_catalog: dict[str, Any],
+    mcp_catalog: dict[str, Any],
+    unit_ids: set[str],
+) -> _ResolvedUses:
+    r = _ResolvedUses()
+
+    for t in inline_tools or []:
+        name = _tool_name(t)
+        r.tool_names.append(name)
+        if isinstance(t, dict):
+            r.ir_tools[name] = {k: v for k, v in t.items() if k != "name"}
+
+    for ref in uses or []:
+        if not isinstance(ref, str) or ":" not in ref:
+            raise ValueError(
+                f"unit '{unit_id}': unknown ref {ref!r} "
+                f"(expected tool:/mcp:/agent:/workflow: prefix)"
+            )
+        kind, _, name = ref.partition(":")
+        if kind == "tool":
+            if name not in tool_catalog:
+                raise ValueError(f"unit '{unit_id}': unknown tool '{name}' (not in top-level tools:)")
+            r.tool_names.append(name)
+            r.ir_tools[name] = tool_catalog[name]
+        elif kind == "mcp":
+            if name not in mcp_catalog:
+                raise ValueError(f"unit '{unit_id}': unknown mcp server '{name}' (not in top-level mcp.servers:)")
+            r.mcp_servers[name] = mcp_catalog[name]
+        elif kind in ("agent", "workflow"):
+            if name not in unit_ids:
+                raise ValueError(f"unit '{unit_id}': unknown unit '{name}' referenced via {ref!r}")
+            r.tool_names.append(name)
+            r.sibling_refs.append(name)
+        else:
+            raise ValueError(
+                f"unit '{unit_id}': unknown ref {ref!r} "
+                f"(expected tool:/mcp:/agent:/workflow: prefix)"
+            )
+
+    return r
+
+
 def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
     """Compile a fleet document into a CompiledBundle."""
     bundle = CompiledBundle()

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -205,7 +205,89 @@ def _compile_agent_unit(
     }
 
 
+def _detect_cycle(graph: dict[str, list[str]]) -> list[str] | None:
+    WHITE, GREY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in graph}
+    stack: list[str] = []
+
+    def visit(n: str) -> list[str] | None:
+        color[n] = GREY
+        stack.append(n)
+        for m in graph.get(n, []):
+            if color.get(m, BLACK) == GREY:
+                return stack[stack.index(m):] + [m]
+            if color.get(m, BLACK) == WHITE:
+                found = visit(m)
+                if found:
+                    return found
+        stack.pop()
+        color[n] = BLACK
+        return None
+
+    for n in graph:
+        if color[n] == WHITE:
+            found = visit(n)
+            if found:
+                return found
+    return None
+
+
 def compile_bundle(data: dict[str, Any]) -> CompiledBundle:
     """Compile a fleet document into a CompiledBundle."""
+    defaults = data.get("defaults", {})
+    tool_catalog = data.get("tools", {})
+    mcp_catalog = data.get("mcp", {}).get("servers", {})
+    agents = data.get("agents", {}) or {}
+    workflows = data.get("workflows", {}) or {}
+
+    # Unique ids across both maps.
+    unit_ids: set[str] = set()
+    for uid in list(agents) + list(workflows):
+        if uid in unit_ids:
+            raise ValueError(f"duplicate unit id '{uid}' (ids must be unique across agents: and workflows:)")
+        unit_ids.add(uid)
+
     bundle = CompiledBundle()
+    sibling_graph: dict[str, list[str]] = {uid: [] for uid in unit_ids}
+
+    # Agent units.
+    for uid, agent in agents.items():
+        resolved = _resolve_uses(
+            uid, agent.get("uses", []), agent.get("tools", []),
+            tool_catalog, mcp_catalog, unit_ids,
+        )
+        sibling_graph[uid] = resolved.sibling_refs
+        ir = _compile_agent_unit(uid, agent, defaults, tool_catalog, mcp_catalog, unit_ids)
+        bundle.workflows.append(ir)
+        if "schedule" in agent:
+            bundle.cron_jobs.append(_schedule_to_spec(uid, ir["version"], agent["schedule"]))
+
+    # Workflow units (explicit graphs) reuse the graph compiler with catalog access.
+    for uid, wf in workflows.items():
+        header = {"id": uid, "version": wf.get("version", defaults.get("version", "0.1.0"))}
+        for key in ("name", "description", "start", "state_schema", "labels"):
+            if key in wf:
+                header[key] = wf[key]
+        doc = {
+            "workflow": header,
+            "nodes": wf.get("nodes", {}),
+            "retry_policies": wf.get("retry_policies", {}),
+            "timeouts": wf.get("timeouts", {}),
+            "models": wf.get("models", {}),
+            "tools": tool_catalog,
+            "mcp": {"servers": mcp_catalog},
+            "a2a": {"remote_agents": wf.get("remote_agents", {})},
+        }
+        from jamjet.workflow.ir_compiler import _compile_graph_yaml
+        ir = _compile_graph_yaml(doc)
+        ir["workflow_id"] = uid
+        ir["version"] = str(ir["version"])
+        bundle.workflows.append(ir)
+        if "schedule" in wf:
+            bundle.cron_jobs.append(_schedule_to_spec(uid, ir["version"], wf["schedule"]))
+
+    cycle = _detect_cycle(sibling_graph)
+    if cycle:
+        raise ValueError(f"cycle in agent references: {' -> '.join(cycle)}")
+
     return bundle

--- a/sdk/python/jamjet/workflow/bundle.py
+++ b/sdk/python/jamjet/workflow/bundle.py
@@ -15,6 +15,8 @@ from typing import Any
 
 @dataclass
 class CronSpec:
+    """Cron registration payload for a single scheduled workflow unit."""
+
     name: str
     cron_expression: str
     workflow_id: str
@@ -25,6 +27,8 @@ class CronSpec:
 
 @dataclass
 class CompiledBundle:
+    """Output of compile_bundle: compiled workflow IRs and their associated cron jobs."""
+
     workflows: list[dict[str, Any]] = field(default_factory=list)
     cron_jobs: list[CronSpec] = field(default_factory=list)
 
@@ -43,6 +47,7 @@ def _validate_cron(expr: str) -> None:
 
 
 def _schedule_to_spec(unit_id: str, version: str, schedule: dict[str, Any]) -> CronSpec:
+    """Convert a unit's ``schedule:`` block to a CronSpec, validating the expression and timezone."""
     cron = schedule.get("cron")
     if not cron:
         raise ValueError(f"unit '{unit_id}' has a schedule with no 'cron' field")
@@ -62,6 +67,8 @@ def _schedule_to_spec(unit_id: str, version: str, schedule: dict[str, Any]) -> C
 
 @dataclass
 class _ResolvedUses:
+    """Resolved tool and MCP references for a single agent unit."""
+
     tool_names: list[str] = field(default_factory=list)
     ir_tools: dict[str, Any] = field(default_factory=dict)
     mcp_servers: dict[str, Any] = field(default_factory=dict)
@@ -86,6 +93,7 @@ def _resolve_uses(
     mcp_catalog: dict[str, Any],
     unit_ids: set[str],
 ) -> _ResolvedUses:
+    """Resolve a unit's ``uses:`` refs and inline ``tools:`` against the top-level catalogs."""
     r = _ResolvedUses()
 
     for t in inline_tools or []:
@@ -126,6 +134,7 @@ def _compile_agent_unit(
     mcp_catalog: dict[str, Any],
     unit_ids: set[str],
 ) -> dict[str, Any]:
+    """Compile a single strategy-based agent unit into a workflow IR dict."""
     from jamjet.compiler.strategies import StrategyLimits, compile_strategy
 
     strategy_name = agent.get("strategy")
@@ -206,11 +215,13 @@ def _compile_agent_unit(
 
 
 def _detect_cycle(graph: dict[str, list[str]]) -> list[str] | None:
+    """Return the first cycle found in the sibling-reference graph, or None if acyclic."""
     white, grey, black = 0, 1, 2
     color = {n: white for n in graph}
     stack: list[str] = []
 
     def visit(n: str) -> list[str] | None:
+        """DFS visitor; returns the cycle path if one is found starting from node n."""
         color[n] = grey
         stack.append(n)
         for m in graph.get(n, []):

--- a/sdk/python/jamjet/workflow/ir_compiler.py
+++ b/sdk/python/jamjet/workflow/ir_compiler.py
@@ -160,10 +160,7 @@ def _compile_graph_yaml(data: dict[str, Any]) -> dict[str, Any]:
     nodes: dict[str, Any] = {}
     edges: list[dict[str, Any]] = []
 
-    end_ids = frozenset(
-        nid for nid, nd in raw_nodes.items()
-        if isinstance(nd, dict) and nd.get("type") == "end"
-    )
+    end_ids = frozenset(nid for nid, nd in raw_nodes.items() if isinstance(nd, dict) and nd.get("type") == "end")
 
     for node_id, node_data in raw_nodes.items():
         node_type = node_data.get("type", "tool")
@@ -185,11 +182,13 @@ def _compile_graph_yaml(data: dict[str, Any]) -> dict[str, Any]:
         elif isinstance(next_val, list):
             for edge in next_val:
                 if isinstance(edge, dict):
-                    edges.append({
-                        "from": node_id,
-                        "to": _term(edge.get("to", "end"), end_ids),
-                        "condition": edge.get("when"),
-                    })
+                    edges.append(
+                        {
+                            "from": node_id,
+                            "to": _term(edge.get("to", "end"), end_ids),
+                            "condition": edge.get("when"),
+                        }
+                    )
                 elif edge == "end":
                     edges.append({"from": node_id, "to": "end", "condition": None})
         elif next_val == "end" or next_val is None:

--- a/sdk/python/jamjet/workflow/ir_compiler.py
+++ b/sdk/python/jamjet/workflow/ir_compiler.py
@@ -149,18 +149,21 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
         return _compile_agent_yaml(data)
 
     # ── Graph/workflow mode ───────────────────────────────────────────────────
+    return _compile_graph_yaml(data)
+
+
+def _compile_graph_yaml(data: dict[str, Any]) -> dict[str, Any]:
+    """Compile a graph-mode document (``workflow:`` header + ``nodes:``) to IR."""
     wf = data.get("workflow", {})
     raw_nodes = data.get("nodes", {})
 
     nodes: dict[str, Any] = {}
     edges: list[dict[str, Any]] = []
 
-    # `end`-type nodes are not runtime node kinds; the runtime terminates an
-    # execution when a node's edge points at the literal target "end". Collect
-    # the end nodes so we can drop them and rewrite any edge or branch that
-    # targets one to the "end" sentinel (this also collapses named end nodes
-    # such as success/failure to the terminal target).
-    end_ids = frozenset(nid for nid, nd in raw_nodes.items() if isinstance(nd, dict) and nd.get("type") == "end")
+    end_ids = frozenset(
+        nid for nid, nd in raw_nodes.items()
+        if isinstance(nd, dict) and nd.get("type") == "end"
+    )
 
     for node_id, node_data in raw_nodes.items():
         node_type = node_data.get("type", "tool")
@@ -176,20 +179,17 @@ def compile_yaml(yaml_content: str) -> dict[str, Any]:
             "labels": node_data.get("labels", {}),
         }
 
-        # Extract edges from "next" field
         next_val = node_data.get("next")
         if isinstance(next_val, str):
             edges.append({"from": node_id, "to": _term(next_val, end_ids), "condition": None})
         elif isinstance(next_val, list):
             for edge in next_val:
                 if isinstance(edge, dict):
-                    edges.append(
-                        {
-                            "from": node_id,
-                            "to": _term(edge.get("to", "end"), end_ids),
-                            "condition": edge.get("when"),
-                        }
-                    )
+                    edges.append({
+                        "from": node_id,
+                        "to": _term(edge.get("to", "end"), end_ids),
+                        "condition": edge.get("when"),
+                    })
                 elif edge == "end":
                     edges.append({"from": node_id, "to": "end", "condition": None})
         elif next_val == "end" or next_val is None:

--- a/sdk/python/tests/test_cli_deploy.py
+++ b/sdk/python/tests/test_cli_deploy.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock, patch
+from typer.testing import CliRunner
+from jamjet.cli.main import app
+
+runner = CliRunner()
+
+FLEET = """
+version: 1
+defaults:
+  model: claude-sonnet-4-6
+  limits: { max_iterations: 2, max_cost_usd: 0.2, timeout_seconds: 30 }
+agents:
+  researcher:
+    strategy: react
+    goal: brief
+    schedule: { cron: "0 9 * * *" }
+"""
+
+
+def test_deploy_registers_workflows_and_cron(tmp_path):
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    fake = AsyncMock()
+    fake.create_workflow = AsyncMock(return_value={"workflow_id": "researcher", "version": "0.1.0"})
+    fake.create_cron_job = AsyncMock(return_value={"name": "researcher", "next_run_at": "2026-06-06T09:00:00Z"})
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["deploy", str(f)])
+
+    assert result.exit_code == 0, result.output
+    fake.create_workflow.assert_awaited_once()
+    fake.create_cron_job.assert_awaited_once()
+    assert fake.create_cron_job.await_args.kwargs["name"] == "researcher"

--- a/sdk/python/tests/test_cli_deploy.py
+++ b/sdk/python/tests/test_cli_deploy.py
@@ -1,5 +1,7 @@
 from unittest.mock import AsyncMock, patch
+
 from typer.testing import CliRunner
+
 from jamjet.cli.main import app
 
 runner = CliRunner()
@@ -36,11 +38,14 @@ def test_deploy_registers_workflows_and_cron(tmp_path):
     assert fake.create_cron_job.await_args.kwargs["name"] == "researcher"
 
 
-MULTI = FLEET + """
+MULTI = (
+    FLEET
+    + """
   reconciler:
     strategy: react
     goal: reconcile
 """
+)
 
 
 def test_run_multi_unit_requires_selector(tmp_path):

--- a/sdk/python/tests/test_cli_deploy.py
+++ b/sdk/python/tests/test_cli_deploy.py
@@ -34,3 +34,38 @@ def test_deploy_registers_workflows_and_cron(tmp_path):
     fake.create_workflow.assert_awaited_once()
     fake.create_cron_job.assert_awaited_once()
     assert fake.create_cron_job.await_args.kwargs["name"] == "researcher"
+
+
+MULTI = FLEET + """
+  reconciler:
+    strategy: react
+    goal: reconcile
+"""
+
+
+def test_run_multi_unit_requires_selector(tmp_path):
+    f = tmp_path / "fleet.yaml"
+    f.write_text(MULTI)
+    fake = AsyncMock()
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["run", str(f)])
+    assert result.exit_code != 0
+    assert "researcher" in result.output and "reconciler" in result.output
+
+
+def test_run_multi_unit_with_selector_starts_one(tmp_path):
+    f = tmp_path / "fleet.yaml"
+    f.write_text(MULTI)
+    fake = AsyncMock()
+    fake.create_workflow = AsyncMock(return_value={})
+    fake.start_execution = AsyncMock(return_value={"execution_id": "exec_abc"})
+    fake.get_execution = AsyncMock(return_value={"status": "completed", "current_state": {}})
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["run", str(f), "reconciler", "--no-follow"])
+    assert result.exit_code == 0, result.output
+    assert fake.create_workflow.await_count == 2  # both units registered
+    assert fake.start_execution.await_args.kwargs["workflow_id"] == "reconciler"

--- a/sdk/python/tests/test_cli_deploy.py
+++ b/sdk/python/tests/test_cli_deploy.py
@@ -69,3 +69,32 @@ def test_run_multi_unit_with_selector_starts_one(tmp_path):
     assert result.exit_code == 0, result.output
     assert fake.create_workflow.await_count == 2  # both units registered
     assert fake.start_execution.await_args.kwargs["workflow_id"] == "reconciler"
+
+
+def test_run_single_unit_no_selector_auto_runs(tmp_path):
+    f = tmp_path / "solo.yaml"
+    f.write_text(FLEET)  # FLEET has exactly one unit: researcher
+    fake = AsyncMock()
+    fake.create_workflow = AsyncMock(return_value={})
+    fake.start_execution = AsyncMock(return_value={"execution_id": "exec_solo"})
+    fake.get_execution = AsyncMock(return_value={"status": "completed", "current_state": {}})
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["run", str(f), "--no-follow"])
+    assert result.exit_code == 0, result.output
+    assert fake.start_execution.await_args.kwargs["workflow_id"] == "researcher"
+
+
+def test_run_unknown_unit_errors(tmp_path):
+    f = tmp_path / "fleet.yaml"
+    f.write_text(MULTI)
+    fake = AsyncMock()
+    fake.create_workflow = AsyncMock(return_value={})
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["run", str(f), "ghost"])
+    assert result.exit_code != 0
+    assert "ghost" in result.output
+    assert "researcher" in result.output and "reconciler" in result.output

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -14,3 +14,20 @@ def test_compile_graph_yaml_builds_ir_from_a_graph_doc():
     assert ir["start_node"] == "extract"
     assert "extract" in ir["nodes"]
     assert {"from": "extract", "to": "end", "condition": None} in ir["edges"]
+
+
+from jamjet.workflow.bundle import CompiledBundle, CronSpec, compile_bundle, is_bundle
+
+
+def test_is_bundle_detects_plural_maps():
+    assert is_bundle({"agents": {}}) is True
+    assert is_bundle({"workflows": {}}) is True
+    assert is_bundle({"agent": {"id": "x"}}) is False
+    assert is_bundle({"workflow": {"id": "x"}, "nodes": {}}) is False
+
+
+def test_empty_bundle_returns_empty_lists():
+    bundle = compile_bundle({"agents": {}})
+    assert isinstance(bundle, CompiledBundle)
+    assert bundle.workflows == []
+    assert bundle.cron_jobs == []

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -100,7 +100,7 @@ def test_resolve_uses_bad_prefix_errors():
         _resolve_uses("a", ["banana:x"], [], {}, {}, {"a"})
 
 
-def test_compile_agent_unit_builds_ir_and_populates_mcp():
+def test_compile_agent_unit_builds_registration_safe_ir():
     tool_catalog = {"web_search": {"description": "s", "input_schema": {}}}
     mcp_catalog = {"github": {"url": "u", "transport": "streamable-http"}}
     from jamjet.workflow.bundle import _compile_agent_unit
@@ -118,10 +118,12 @@ def test_compile_agent_unit_builds_ir_and_populates_mcp():
         mcp_catalog=mcp_catalog,
         unit_ids={"researcher"},
     )
+    # IR tools/mcp_servers stay empty: the runtime resolves tools/models itself
+    # and these maps expect typed configs, not catalog defs. uses: refs are
+    # validated and surfaced to the strategy prompt by name.
+    assert ir["tools"] == {}
+    assert ir["mcp_servers"] == {}
     assert ir["workflow_id"] == "researcher"
-    assert ir["version"] == "0.1.0"
-    assert ir["mcp_servers"] == {"github": mcp_catalog["github"]}
-    assert "web_search" in ir["tools"]
     assert ir["labels"]["jamjet.agent.id"] == "researcher"
     assert ir["nodes"]  # strategy produced nodes
 

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -58,3 +58,40 @@ def test_schedule_to_spec_defaults_and_utc():
 def test_schedule_to_spec_rejects_non_utc():
     with pytest.raises(ValueError, match="UTC"):
         _schedule_to_spec("x", "0.1.0", {"cron": "0 9 * * *", "timezone": "America/New_York"})
+
+
+from jamjet.workflow.bundle import _resolve_uses
+
+
+def test_resolve_uses_splits_tools_mcp_and_siblings():
+    tool_catalog = {"web_search": {"description": "search", "input_schema": {}}}
+    mcp_catalog = {"github": {"url": "x", "transport": "streamable-http"}}
+    unit_ids = {"researcher", "reconciler"}
+    resolved = _resolve_uses(
+        unit_id="reconciler",
+        uses=["tool:web_search", "mcp:github", "agent:researcher"],
+        inline_tools=[{"name": "post", "description": "post", "input_schema": {}}],
+        tool_catalog=tool_catalog,
+        mcp_catalog=mcp_catalog,
+        unit_ids=unit_ids,
+    )
+    assert set(resolved.tool_names) == {"web_search", "post", "researcher"}
+    assert "github" in resolved.mcp_servers
+    assert "web_search" in resolved.ir_tools
+    assert "post" in resolved.ir_tools
+    assert resolved.sibling_refs == ["researcher"]
+
+
+def test_resolve_uses_unknown_tool_errors():
+    with pytest.raises(ValueError, match="unknown tool 'nope'"):
+        _resolve_uses("a", ["tool:nope"], [], {}, {}, {"a"})
+
+
+def test_resolve_uses_unknown_sibling_errors():
+    with pytest.raises(ValueError, match="unknown unit 'ghost'"):
+        _resolve_uses("a", ["agent:ghost"], [], {}, {}, {"a"})
+
+
+def test_resolve_uses_bad_prefix_errors():
+    with pytest.raises(ValueError, match="unknown ref"):
+        _resolve_uses("a", ["banana:x"], [], {}, {}, {"a"})

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -31,3 +31,30 @@ def test_empty_bundle_returns_empty_lists():
     assert isinstance(bundle, CompiledBundle)
     assert bundle.workflows == []
     assert bundle.cron_jobs == []
+
+
+import pytest
+from jamjet.workflow.bundle import _validate_cron, _schedule_to_spec
+
+
+def test_validate_cron_accepts_five_fields():
+    _validate_cron("0 9 * * *")  # no raise
+
+
+def test_validate_cron_rejects_wrong_field_count():
+    with pytest.raises(ValueError, match="5 fields"):
+        _validate_cron("* * * *")
+
+
+def test_schedule_to_spec_defaults_and_utc():
+    spec = _schedule_to_spec("researcher", "0.1.0", {"cron": "0 9 * * *"})
+    assert spec.name == "researcher"
+    assert spec.workflow_id == "researcher"
+    assert spec.workflow_version == "0.1.0"
+    assert spec.enabled is True
+    assert spec.input == {}
+
+
+def test_schedule_to_spec_rejects_non_utc():
+    with pytest.raises(ValueError, match="UTC"):
+        _schedule_to_spec("x", "0.1.0", {"cron": "0 9 * * *", "timezone": "America/New_York"})

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -1,3 +1,16 @@
+import httpx
+import pytest
+import respx
+
+from jamjet.client import JamjetClient
+from jamjet.workflow.bundle import (
+    CompiledBundle,
+    _resolve_uses,
+    _schedule_to_spec,
+    _validate_cron,
+    compile_bundle,
+    is_bundle,
+)
 from jamjet.workflow.ir_compiler import _compile_graph_yaml
 
 
@@ -16,9 +29,6 @@ def test_compile_graph_yaml_builds_ir_from_a_graph_doc():
     assert {"from": "extract", "to": "end", "condition": None} in ir["edges"]
 
 
-from jamjet.workflow.bundle import CompiledBundle, CronSpec, compile_bundle, is_bundle
-
-
 def test_is_bundle_detects_plural_maps():
     assert is_bundle({"agents": {}}) is True
     assert is_bundle({"workflows": {}}) is True
@@ -31,10 +41,6 @@ def test_empty_bundle_returns_empty_lists():
     assert isinstance(bundle, CompiledBundle)
     assert bundle.workflows == []
     assert bundle.cron_jobs == []
-
-
-import pytest
-from jamjet.workflow.bundle import _validate_cron, _schedule_to_spec
 
 
 def test_validate_cron_accepts_five_fields():
@@ -58,9 +64,6 @@ def test_schedule_to_spec_defaults_and_utc():
 def test_schedule_to_spec_rejects_non_utc():
     with pytest.raises(ValueError, match="UTC"):
         _schedule_to_spec("x", "0.1.0", {"cron": "0 9 * * *", "timezone": "America/New_York"})
-
-
-from jamjet.workflow.bundle import _resolve_uses
 
 
 def test_resolve_uses_splits_tools_mcp_and_siblings():
@@ -101,6 +104,7 @@ def test_compile_agent_unit_builds_ir_and_populates_mcp():
     tool_catalog = {"web_search": {"description": "s", "input_schema": {}}}
     mcp_catalog = {"github": {"url": "u", "transport": "streamable-http"}}
     from jamjet.workflow.bundle import _compile_agent_unit
+
     ir = _compile_agent_unit(
         unit_id="researcher",
         agent={
@@ -124,25 +128,35 @@ def test_compile_agent_unit_builds_ir_and_populates_mcp():
 
 def test_compile_agent_unit_requires_goal():
     from jamjet.workflow.bundle import _compile_agent_unit
+
     with pytest.raises(ValueError, match="goal"):
-        _compile_agent_unit("x", {"strategy": "react", "limits": {
-            "max_iterations": 1, "max_cost_usd": 0.1, "timeout_seconds": 10}},
-            {"model": "m"}, {}, {}, {"x"})
+        _compile_agent_unit(
+            "x",
+            {"strategy": "react", "limits": {"max_iterations": 1, "max_cost_usd": 0.1, "timeout_seconds": 10}},
+            {"model": "m"},
+            {},
+            {},
+            {"x"},
+        )
 
 
 def _fleet():
     return {
         "version": 1,
-        "defaults": {"model": "claude-sonnet-4-6",
-                     "limits": {"max_iterations": 3, "max_cost_usd": 0.5, "timeout_seconds": 60}},
+        "defaults": {
+            "model": "claude-sonnet-4-6",
+            "limits": {"max_iterations": 3, "max_cost_usd": 0.5, "timeout_seconds": 60},
+        },
         "tools": {"web_search": {"description": "s", "input_schema": {}}},
         "mcp": {"servers": {"github": {"url": "u", "transport": "streamable-http"}}},
         "agents": {
-            "researcher": {"strategy": "plan-and-execute", "goal": "brief",
-                           "uses": ["tool:web_search", "mcp:github"],
-                           "schedule": {"cron": "0 9 * * *"}},
-            "reconciler": {"strategy": "react", "goal": "reconcile",
-                           "uses": ["agent:researcher"]},
+            "researcher": {
+                "strategy": "plan-and-execute",
+                "goal": "brief",
+                "uses": ["tool:web_search", "mcp:github"],
+                "schedule": {"cron": "0 9 * * *"},
+            },
+            "reconciler": {"strategy": "react", "goal": "reconcile", "uses": ["agent:researcher"]},
         },
         "workflows": {
             "nightly_etl": {
@@ -176,11 +190,6 @@ def test_compile_bundle_cycle_errors():
         compile_bundle(data)
 
 
-import respx
-import httpx
-from jamjet.client import JamjetClient
-
-
 @respx.mock
 @pytest.mark.asyncio
 async def test_client_create_cron_job_posts_body():
@@ -189,15 +198,22 @@ async def test_client_create_cron_job_posts_body():
     )
     async with JamjetClient("http://localhost:7700") as c:
         res = await c.create_cron_job(
-            name="researcher", cron_expression="0 9 * * *",
-            workflow_id="researcher", workflow_version="0.1.0", input={"x": 1},
+            name="researcher",
+            cron_expression="0 9 * * *",
+            workflow_id="researcher",
+            workflow_version="0.1.0",
+            input={"x": 1},
         )
     assert res["name"] == "researcher"
     sent = route.calls[0].request
     import json as _j
+
     body = _j.loads(sent.content)
     assert body == {
-        "name": "researcher", "cron_expression": "0 9 * * *",
-        "workflow_id": "researcher", "enabled": True,
-        "workflow_version": "0.1.0", "input": {"x": 1},
+        "name": "researcher",
+        "cron_expression": "0 9 * * *",
+        "workflow_id": "researcher",
+        "enabled": True,
+        "workflow_version": "0.1.0",
+        "input": {"x": 1},
     }

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -128,3 +128,49 @@ def test_compile_agent_unit_requires_goal():
         _compile_agent_unit("x", {"strategy": "react", "limits": {
             "max_iterations": 1, "max_cost_usd": 0.1, "timeout_seconds": 10}},
             {"model": "m"}, {}, {}, {"x"})
+
+
+def _fleet():
+    return {
+        "version": 1,
+        "defaults": {"model": "claude-sonnet-4-6",
+                     "limits": {"max_iterations": 3, "max_cost_usd": 0.5, "timeout_seconds": 60}},
+        "tools": {"web_search": {"description": "s", "input_schema": {}}},
+        "mcp": {"servers": {"github": {"url": "u", "transport": "streamable-http"}}},
+        "agents": {
+            "researcher": {"strategy": "plan-and-execute", "goal": "brief",
+                           "uses": ["tool:web_search", "mcp:github"],
+                           "schedule": {"cron": "0 9 * * *"}},
+            "reconciler": {"strategy": "react", "goal": "reconcile",
+                           "uses": ["agent:researcher"]},
+        },
+        "workflows": {
+            "nightly_etl": {
+                "start": "extract",
+                "nodes": {"extract": {"type": "tool", "tool_ref": "pull", "next": "end"}},
+                "schedule": {"cron": "0 2 * * *"},
+            },
+        },
+    }
+
+
+def test_compile_bundle_full():
+    bundle = compile_bundle(_fleet())
+    ids = {ir["workflow_id"] for ir in bundle.workflows}
+    assert ids == {"researcher", "reconciler", "nightly_etl"}
+    names = {c.name for c in bundle.cron_jobs}
+    assert names == {"researcher", "nightly_etl"}
+
+
+def test_compile_bundle_duplicate_id_across_maps_errors():
+    data = _fleet()
+    data["workflows"]["researcher"] = {"start": "x", "nodes": {"x": {"type": "tool", "next": "end"}}}
+    with pytest.raises(ValueError, match="duplicate unit id 'researcher'"):
+        compile_bundle(data)
+
+
+def test_compile_bundle_cycle_errors():
+    data = _fleet()
+    data["agents"]["researcher"]["uses"] = ["agent:reconciler"]  # researcher<->reconciler
+    with pytest.raises(ValueError, match="cycle"):
+        compile_bundle(data)

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -95,3 +95,36 @@ def test_resolve_uses_unknown_sibling_errors():
 def test_resolve_uses_bad_prefix_errors():
     with pytest.raises(ValueError, match="unknown ref"):
         _resolve_uses("a", ["banana:x"], [], {}, {}, {"a"})
+
+
+def test_compile_agent_unit_builds_ir_and_populates_mcp():
+    tool_catalog = {"web_search": {"description": "s", "input_schema": {}}}
+    mcp_catalog = {"github": {"url": "u", "transport": "streamable-http"}}
+    from jamjet.workflow.bundle import _compile_agent_unit
+    ir = _compile_agent_unit(
+        unit_id="researcher",
+        agent={
+            "strategy": "plan-and-execute",
+            "goal": "summarize",
+            "uses": ["tool:web_search", "mcp:github"],
+            "limits": {"max_iterations": 3, "max_cost_usd": 0.5, "timeout_seconds": 60},
+        },
+        defaults={"model": "claude-sonnet-4-6"},
+        tool_catalog=tool_catalog,
+        mcp_catalog=mcp_catalog,
+        unit_ids={"researcher"},
+    )
+    assert ir["workflow_id"] == "researcher"
+    assert ir["version"] == "0.1.0"
+    assert ir["mcp_servers"] == {"github": mcp_catalog["github"]}
+    assert "web_search" in ir["tools"]
+    assert ir["labels"]["jamjet.agent.id"] == "researcher"
+    assert ir["nodes"]  # strategy produced nodes
+
+
+def test_compile_agent_unit_requires_goal():
+    from jamjet.workflow.bundle import _compile_agent_unit
+    with pytest.raises(ValueError, match="goal"):
+        _compile_agent_unit("x", {"strategy": "react", "limits": {
+            "max_iterations": 1, "max_cost_usd": 0.1, "timeout_seconds": 10}},
+            {"model": "m"}, {}, {}, {"x"})

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -174,3 +174,30 @@ def test_compile_bundle_cycle_errors():
     data["agents"]["researcher"]["uses"] = ["agent:reconciler"]  # researcher<->reconciler
     with pytest.raises(ValueError, match="cycle"):
         compile_bundle(data)
+
+
+import respx
+import httpx
+from jamjet.client import JamjetClient
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_client_create_cron_job_posts_body():
+    route = respx.post("http://localhost:7700/cron").mock(
+        return_value=httpx.Response(201, json={"name": "researcher", "next_run_at": "2026-06-06T09:00:00Z"})
+    )
+    async with JamjetClient("http://localhost:7700") as c:
+        res = await c.create_cron_job(
+            name="researcher", cron_expression="0 9 * * *",
+            workflow_id="researcher", workflow_version="0.1.0", input={"x": 1},
+        )
+    assert res["name"] == "researcher"
+    sent = route.calls[0].request
+    import json as _j
+    body = _j.loads(sent.content)
+    assert body == {
+        "name": "researcher", "cron_expression": "0 9 * * *",
+        "workflow_id": "researcher", "enabled": True,
+        "workflow_version": "0.1.0", "input": {"x": 1},
+    }

--- a/sdk/python/tests/test_fleet_compile.py
+++ b/sdk/python/tests/test_fleet_compile.py
@@ -1,0 +1,16 @@
+from jamjet.workflow.ir_compiler import _compile_graph_yaml
+
+
+def test_compile_graph_yaml_builds_ir_from_a_graph_doc():
+    data = {
+        "workflow": {"id": "etl", "version": "0.1.0", "start": "extract"},
+        "nodes": {
+            "extract": {"type": "tool", "tool_ref": "pull", "next": "end"},
+        },
+    }
+    ir = _compile_graph_yaml(data)
+    assert ir["workflow_id"] == "etl"
+    assert ir["version"] == "0.1.0"
+    assert ir["start_node"] == "extract"
+    assert "extract" in ir["nodes"]
+    assert {"from": "extract", "to": "end", "condition": None} in ir["edges"]


### PR DESCRIPTION
## Summary

One YAML file can now declare a fleet: multiple agents and explicit workflows, each with its own tools and an optional cron schedule. `jamjet deploy` registers every unit and installs its schedules; `jamjet run <file> <unit>` runs one on demand. Schedules actually fire now, because this wires the previously-dead `jamjet-timers` cron scheduler into the dev server. Everything runs on the local runtime with SQLite, no cloud dependency, and fully offline via Ollama.

What's in it:

- **SDK `compile_bundle`** (`sdk/python/jamjet/workflow/bundle.py`): an `agents:` map (strategy agents) and a `workflows:` map (explicit node graphs) sharing a top-level `tools:`/`mcp:` catalog. Agents reference tools via a typed `uses:` list (`tool:`/`mcp:`/`agent:`/`workflow:`) plus inline tools. Validates unknown refs, duplicate unit ids across both maps, cyclic sibling refs, non-UTC timezones, and bad cron. Backward compatible with single `agent:` and graph `workflow:`/`nodes:` files (the graph compiler was extracted into a reusable helper).
- **CLI**: new `jamjet deploy <file>` (register all units, then install schedules), and `jamjet run <file> [unit]` with unit selection for fleet files.
- **Runtime `/cron` API** (`runtime/api/src/cron.rs`): create/list/delete over `jamjet_timers::CronStore`, held on `AppState` (sqlite-only). `POST /cron` validates the expression with the runtime's own parser and checks the workflow is registered.
- **Cron scheduler revival** (`runtime/api/src/main.rs`): spawn `CronScheduler` in the dev server, gated on `dev_mode || JAMJET_EMBED_CRON`, sqlite-only, same pattern as the embedded worker. It fires due jobs by POSTing `/executions`.
- **Example**: `examples/fleet/fleet.yaml` (two scheduled agents and one scheduled workflow).

Two registration bugs were found by adding an end-to-end deserialize guard and are fixed here:

- Fleet agent IR no longer embeds catalog-shaped tool/mcp data into the IR `tools`/`mcp_servers` maps, which the runtime `WorkflowIr` could not deserialize (`POST /workflows` returned 400).
- Added the `limit_exceeded` node kind that all strategy compilers emit but the runtime `NodeKind` enum was missing. Without it, every strategy-agent IR failed to deserialize, so no strategy agent could ever register. It deserializes to a terminal marker that flows to `end`.

Deferred (not in this PR): synchronous sibling agent-to-agent invocation at runtime (refs are validated and surfaced to the prompt by name), non-UTC timezones, cross-file id namespacing, and a dedicated production cron process.

## Test plan

- SDK: `cd sdk/python && pytest tests/` (786 passed, 8 skipped)
- Runtime: `cd runtime && cargo test -p jamjet-api -p jamjet-timers -p jamjet-core` (all green), `cargo clippy` clean
- `examples/fleet/fleet.yaml` compiles via `compile_bundle` to 3 workflows and 3 cron jobs
- New regression guard `fleet_agent_ir_registers` deserializes a fleet agent's compiled IR into `WorkflowIr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet configuration support: define multiple agents and workflows in a single YAML file with individual schedules
  * Added cron job scheduling capabilities to create, list, and delete scheduled workflow executions
  * Added `jamjet deploy` command to deploy fleet configurations from YAML files
  * Enhanced `jamjet run` command to support fleet files with unit selection

* **Documentation**
  * Added example documentation for fleet configuration setup and usage

* **Tests**
  * Added comprehensive test coverage for cron scheduling, fleet compilation, and CLI deployment workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->