### PR TITLE
release: SDK 0.9.0 + runtime crates 0.3.2

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/jamjet-labs/jamjet"

--- a/runtime/agents/Cargo.toml
+++ b/runtime/agents/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
 tokio = { workspace = true }
 sqlx = { workspace = true }
 reqwest = { workspace = true }

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -15,18 +15,18 @@ name = "jamjet-server"
 path = "src/main.rs"
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
-jamjet-agents = { path = "../agents", version = "=0.3.1" }
-jamjet-audit = { path = "../audit", version = "=0.3.1" }
-jamjet-scheduler = { path = "../scheduler", version = "=0.3.1" }
-jamjet-protocols = { path = "../protocols", version = "=0.3.1" }
-jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.1" }
-jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.1" }
-jamjet-worker = { path = "../workers", version = "=0.3.1" }
-jamjet-models = { path = "../models", version = "=0.3.1" }
-jamjet-timers = { path = "../timers", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-agents = { path = "../agents", version = "=0.3.2" }
+jamjet-audit = { path = "../audit", version = "=0.3.2" }
+jamjet-scheduler = { path = "../scheduler", version = "=0.3.2" }
+jamjet-protocols = { path = "../protocols", version = "=0.3.2" }
+jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.2" }
+jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.2" }
+jamjet-worker = { path = "../workers", version = "=0.3.2" }
+jamjet-models = { path = "../models", version = "=0.3.2" }
+jamjet-timers = { path = "../timers", version = "=0.3.2" }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/runtime/audit/Cargo.toml
+++ b/runtime/audit/Cargo.toml
@@ -11,10 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
-jamjet-policy = { path = "../policy", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-policy = { path = "../policy", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/ir/Cargo.toml
+++ b/runtime/ir/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/runtime/models/Cargo.toml
+++ b/runtime/models/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-telemetry = { path = "../telemetry", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/runtime/policy/Cargo.toml
+++ b/runtime/policy/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
-jamjet-agents = { path = "../agents", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-agents = { path = "../agents", version = "=0.3.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/protocols/a2a/Cargo.toml
+++ b/runtime/protocols/a2a/Cargo.toml
@@ -16,8 +16,8 @@ jamjet-a2a = { version = "0.1", features = ["client", "server", "federation"] }
 jamjet-a2a-types = "0.1"
 
 # Internal workspace crates
-jamjet-protocols = { path = "..", version = "=0.3.1" }
-jamjet-agents = { path = "../../agents", version = "=0.3.1" }
+jamjet-protocols = { path = "..", version = "=0.3.2" }
+jamjet-agents = { path = "../../agents", version = "=0.3.2" }
 
 # Only deps needed by adapter.rs
 tokio = { workspace = true }

--- a/runtime/protocols/mcp/Cargo.toml
+++ b/runtime/protocols/mcp/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-protocols = { path = "..", version = "=0.3.1" }
+jamjet-protocols = { path = "..", version = "=0.3.2" }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { workspace = true }

--- a/runtime/scheduler/Cargo.toml
+++ b/runtime/scheduler/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/runtime/state/Cargo.toml
+++ b/runtime/state/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/timers/Cargo.toml
+++ b/runtime/timers/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/runtime/workers/Cargo.toml
+++ b/runtime/workers/Cargo.toml
@@ -11,16 +11,16 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.1" }
-jamjet-ir = { path = "../ir", version = "=0.3.1" }
-jamjet-models = { path = "../models", version = "=0.3.1" }
-jamjet-state = { path = "../state", version = "=0.3.1" }
-jamjet-policy = { path = "../policy", version = "=0.3.1" }
-jamjet-agents = { path = "../agents", version = "=0.3.1" }
-jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.1" }
-jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.1" }
-jamjet-telemetry = { path = "../telemetry", version = "=0.3.1" }
-jamjet-scheduler = { path = "../scheduler", version = "=0.3.1" }
+jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-models = { path = "../models", version = "=0.3.2" }
+jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-policy = { path = "../policy", version = "=0.3.2" }
+jamjet-agents = { path = "../agents", version = "=0.3.2" }
+jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.2" }
+jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.2" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
+jamjet-scheduler = { path = "../scheduler", version = "=0.3.2" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.9.0 — 2026-06-06
+
+### Added — Multi-agent YAML fleets + scheduling
+
+- One YAML file can declare a fleet: an `agents:` map (strategy agents) and a
+  `workflows:` map (explicit node graphs) sharing a top-level `tools:`/`mcp:`
+  catalog. Agents reference tools via a typed `uses:` list with `tool:`, `mcp:`,
+  `agent:`, and `workflow:` prefixes, plus inline `tools:`.
+- `jamjet deploy <file>` registers every unit in a fleet and installs its cron
+  schedules. `jamjet run <file> [unit]` runs one unit on demand; single-unit
+  files need no selector.
+- Per-unit `schedule: { cron: "..." }` installs a cron job through the runtime's
+  new `/cron` API; the bundled `jamjet-server` runs due jobs locally via a
+  dev-embedded scheduler. UTC only in this release.
+- `jamjet.workflow.bundle.compile_bundle` validates unknown refs, duplicate unit
+  ids, cyclic sibling refs, and cron expressions. Singular `agent:` and graph
+  `workflow:`/`nodes:` files continue to compile unchanged.
+- `JamjetClient.create_cron_job` and `list_cron_jobs`.
+- Example fleet at `examples/fleet/fleet.yaml`.
+
 ## 0.8.5 — 2026-05-14
 
 ### Added — Cloud Sync v0.1 Path B (direct-push)

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -102,4 +102,4 @@ __all__ = [
     "tool",
     "workflow",
 ]
-__version__ = "0.8.7"
+__version__ = "0.9.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.8.7"
+version = "0.9.0"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

Version bump to release the multi-agent YAML fleets + cron scheduling feature (merged in #76).

- **Python SDK `jamjet` 0.8.7 -> 0.9.0** (`pyproject.toml` + `jamjet/__init__.py`), with a CHANGELOG entry. Minor bump for the new backward-compatible feature (fleets, `jamjet deploy`/`run`, `/cron` client, `compile_bundle`).
- **Runtime crates 0.3.1 -> 0.3.2** (workspace version + all inter-crate version pins). 0.3.1 is already on crates.io, so a bump is required to publish the new runtime code (`/cron` API, `CronStore` methods, `NodeKind::LimitExceeded`).

Note on semver: `NodeKind` is not `#[non_exhaustive]`, so adding the `LimitExceeded` variant is technically additive-breaking for an external exhaustive matcher. These crates were first published days ago (0.3.1) with effectively one consumer (the runtime itself), so this ships as a patch (0.3.2). Worth marking `NodeKind` `#[non_exhaustive]` in a future change.

## Release tags (pushed after merge)

- `python-sdk-v0.9.0` -> builds the `jamjet` wheel to PyPI (trusted publishing) and the `jamjet-server` binaries (with `/cron` + cron scheduler) onto the GitHub Release.
- `crates-v0.3.2` -> publishes all runtime crates to crates.io and builds the docker image.

## Test plan

- No code changes; version strings + changelog only.
- `cargo build -p jamjet-api` resolves and compiles cleanly at 0.3.2 (all 14 workspace crates).
- CI (Python + Rust tests/lint) runs on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to version 0.3.2

* **New Features**
  * Added multi-agent YAML fleet format with shared tools and MCP catalog support
  * Added fleet deployment and execution commands
  * Added per-unit cron scheduling via new `/cron` API
  * Added cron job management APIs
  * Enhanced fleet validation for unknown references, duplicate unit IDs, cyclic dependencies, and cron expressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->