### PR TITLE
fix: Dockerfile base python 3.11 -> 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /build/runtime
 RUN cargo build --release --bin jamjet-server
 
 # ── Stage 3: Final image ────────────────────────────────────────────
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
The Docker image build fails at `pip install /tmp/sdk` because the runtime stage uses `python:3.11-slim-bookworm`, but `jamjet` and its `jamjet-engram` dependency require Python `>=3.12`. On 3.11, no `jamjet-engram` version resolves.

Surfaced when the first-ever `crates-v` tag (`crates-v0.3.2`) ran `docker-publish.yml`; the SDK and crates publishes themselves succeeded (jamjet 0.9.0 on PyPI, runtime crates 0.3.2 on crates.io).

Fix: use `python:3.12-slim-bookworm` (within engram's `>=3.12,<3.14` range; matches the CI test Python). No other changes.