### PR TITLE
docs: ops/monitoring fleet example

### DIFF
--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -1,13 +1,104 @@
-# Fleet example
+# Fleet example: an ops/monitoring fleet
 
-One YAML file declaring two strategy agents and one explicit workflow, each on
-its own cron schedule, runnable on the local runtime with no cloud.
+One YAML file (`fleet.yaml`) declares three scheduled units that run on the local
+runtime, no cloud:
+
+| Unit | Kind | Schedule | Trigger shown |
+| --- | --- | --- | --- |
+| `morning_briefing` | agent (plan-and-execute) | `0 8 * * *` (daily 08:00 UTC) | cron + manual |
+| `reconciler` | agent (react) | `30 14 * * 1-5` (weekdays 14:30 UTC) | cron + sibling ref |
+| `healthcheck` | workflow (explicit graph) | `*/15 * * * *` (every 15 min) | cron |
+
+It exercises all three ways a unit can run: a cron schedule, an on-demand
+`jamjet run`, and one agent referencing another (`reconciler` uses
+`agent:morning_briefing`).
+
+## Prerequisites
 
 ```bash
-jamjet dev                          # local runtime; embeds the cron scheduler in dev
-jamjet deploy examples/fleet/fleet.yaml
-jamjet run examples/fleet/fleet.yaml researcher --input '{"topic": "agents"}'
+pip install "jamjet>=0.9.0"
+export ANTHROPIC_API_KEY="sk-ant-..."   # or use Ollama, see "Run offline" below
 ```
 
-Offline: start Ollama (`ollama serve`) and set the agents' `model:` to a local
-model name (e.g. `llama3.1`); no API key or internet required.
+## 1. Start the local runtime
+
+```bash
+jamjet dev
+```
+
+In dev mode this also starts the in-process cron scheduler, so deployed schedules
+fire locally. State is a local SQLite file under `.jamjet/`.
+
+## 2. Deploy the fleet
+
+```bash
+jamjet deploy fleet.yaml
+```
+
+This registers all three units and installs a cron job for each. You will see a
+summary like:
+
+```
+registered morning_briefing v0.1.0
+registered reconciler v0.1.0
+registered healthcheck v0.1.0
+scheduled morning_briefing [0 8 * * *] next=2026-06-07T08:00:00+00:00
+scheduled reconciler [30 14 * * 1-5] next=2026-06-09T14:30:00+00:00
+scheduled healthcheck [*/15 * * * *] next=2026-06-06T12:15:00+00:00
+```
+
+## 3. Inspect the installed schedules
+
+```bash
+curl -s http://localhost:7700/cron | jq
+```
+
+Each job shows its `cron_expression` and an advancing `next_run_at`. The
+`healthcheck` job (every 15 min) is the quickest way to watch the scheduler fire
+an execution:
+
+```bash
+curl -s http://localhost:7700/executions | jq '.executions[].workflow_id'
+```
+
+## 4. Run one unit on demand
+
+You do not have to wait for a schedule. Run any unit by name:
+
+```bash
+jamjet run fleet.yaml morning_briefing --input '{"focus": "infrastructure"}'
+```
+
+`jamjet run` registers every unit in the file, then starts the one you name. For
+a single-unit file the name is optional; with multiple units you must pick one
+(omitting it lists the available units).
+
+## Run offline (Ollama)
+
+No API key, no internet:
+
+```bash
+ollama serve
+ollama pull llama3.1
+```
+
+Set `model:` in `fleet.yaml` (in `defaults` and the `healthcheck` node) to a local
+model name such as `llama3.1`, then `jamjet deploy fleet.yaml` as above. State,
+worker, and scheduler are all local, so the whole fleet runs air-gapped.
+
+## What runs today vs what is deferred
+
+This example is honest about the current (0.9.0) runtime:
+
+- **Runs today:** authoring the fleet, `jamjet deploy`, `jamjet run <unit>`, cron
+  scheduling and firing, and each agent's LLM reasoning. Cron is 5-field and
+  **UTC only**.
+- **Deferred:** tool calls (`tool:web_search`, `tool:ledger_query`) are surfaced
+  to the agent by **name** in its prompt; they are validated at compile time but
+  are not executed by the runtime yet. Sibling references (`agent:morning_briefing`)
+  are likewise validated but not invoked synchronously yet. The embedded cron
+  scheduler is dev-only and cron jobs are global (single-tenant); a dedicated
+  production cron process is a follow-up.
+
+See the guide at https://docs.jamjet.dev/open-source/multi-agent-fleets for the
+full reference.

--- a/examples/fleet/fleet.yaml
+++ b/examples/fleet/fleet.yaml
@@ -1,17 +1,21 @@
-# A fleet: two strategy agents and one explicit workflow, all schedulable.
+# An ops/monitoring fleet: one YAML file, three scheduled units.
 #
-#   jamjet dev                       # start the local runtime (embeds cron in dev)
-#   jamjet deploy fleet.yaml         # register all units + install schedules
-#   jamjet run fleet.yaml researcher # run one unit on demand
+# Two strategy agents and one explicit workflow, each on its own cron schedule,
+# sharing a tools catalog. Runs on the local runtime (SQLite + in-process worker
+# + dev-embedded cron). Point models at Ollama for a fully offline run.
 #
-# Fully local: SQLite state + in-process worker + in-process cron. Point models
-# at Ollama (no API key) for a fully offline run.
+#   jamjet dev                                  # start the runtime (cron embedded in dev)
+#   jamjet deploy fleet.yaml                    # register all units + install schedules
+#   jamjet run fleet.yaml morning_briefing      # run one unit on demand
+#
+# See README.md for the full walkthrough and what runs today vs what is deferred.
 version: 1
 
 defaults:
   model: claude-sonnet-4-6
   limits: { max_iterations: 4, max_cost_usd: 0.50, timeout_seconds: 120 }
 
+# Shared tool catalog — referenced by agents via `uses: [tool:<name>]`.
 tools:
   web_search:
     description: "Search the web for recent information"
@@ -19,28 +23,42 @@ tools:
       type: object
       properties: { query: { type: string } }
       required: [query]
+  ledger_query:
+    description: "Query yesterday's ledger entries"
+    input_schema:
+      type: object
+      properties: { date: { type: string } }
+      required: [date]
 
 agents:
-  researcher:
+  # Daily 08:00 UTC: a short operational brief.
+  morning_briefing:
     strategy: plan-and-execute
-    goal: "Summarize the most important overnight AI news into a short brief"
+    goal: "Summarize the most important overnight events into a short brief."
     uses:
       - tool:web_search
     schedule:
-      cron: "0 9 * * *"      # daily 09:00 UTC
+      cron: "0 8 * * *"        # daily 08:00 UTC
 
+  # Weekdays 14:30 UTC: reconcile, and may call the briefing agent for context.
   reconciler:
     strategy: react
-    goal: "Check yesterday's report for inconsistencies and list any found"
+    goal: "Reconcile yesterday's ledger and list any inconsistencies found."
     uses:
-      - agent:researcher     # may call the researcher as a tool
+      - tool:ledger_query
+      - agent:morning_briefing   # sibling reference (validated at compile time)
     schedule:
-      cron: "30 14 * * 1-5"  # weekdays 14:30 UTC
+      cron: "30 14 * * 1-5"      # weekdays 14:30 UTC
 
 workflows:
-  heartbeat:
+  # Every 15 minutes: a tiny liveness check (explicit single-node graph).
+  healthcheck:
     start: ping
     nodes:
-      ping: { type: model, model: claude-haiku-4-5-20251001, next: end }
+      ping:
+        type: model
+        model: claude-haiku-4-5-20251001
+        prompt: "Reply with the single word: ok"
+        next: end
     schedule:
-      cron: "*/15 * * * *"   # every 15 minutes
+      cron: "*/15 * * * *"       # every 15 minutes


### PR DESCRIPTION
Expands `examples/fleet/` into a realistic ops/monitoring fleet that exercises all three triggers (cron, manual, sibling):

- `morning_briefing` agent (plan-and-execute, daily 08:00 UTC, uses `tool:web_search`)
- `reconciler` agent (react, weekdays 14:30 UTC, uses `tool:ledger_query` + `agent:morning_briefing`)
- `healthcheck` workflow (explicit graph, every 15 min)

Plus a walkthrough README: deploy, inspect `/cron`, on-demand `jamjet run`, the offline Ollama path, and an honest 'what runs today vs deferred' note (tools are prompt-name-level, sibling calls validated-not-invoked, UTC-only, cron global).

Verified: `compile_bundle` produces 3 workflows + 3 cron jobs. Pairs with the new docs guide at /open-source/multi-agent-fleets.