### PR TITLE
feat(runtime): export OpenTelemetry GenAI spans + token-usage metric over OTLP

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -8,5 +8,8 @@ The runtime emits OpenTelemetry GenAI spans and the standard
 Langfuse, and other OTLP-compatible tools). When the variable is unset, the runtime
 logs locally and exports nothing.
 
-Set `JAMJET_CAPTURE_PROMPTS=true` to attach redacted prompt and completion text to
-spans (`gen_ai.prompt` / `gen_ai.completion`). It is off by default.
+Set `JAMJET_CAPTURE_PROMPTS=true` (or `=1`) to attach prompt and completion text to
+spans (`gen_ai.prompt` / `gen_ai.completion`). It is off by default. Today the text
+is only truncated when oversized; PII pattern masking (emails, tokens, credit-card
+numbers) is planned but not yet implemented, so treat captured text as raw and
+enable this only where that is acceptable.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,12 @@
+# JamJet Runtime
+
+## Observability
+
+The runtime emits OpenTelemetry GenAI spans and the standard
+`gen_ai.client.token.usage` metric. Set `OTEL_EXPORTER_OTLP_ENDPOINT` (for example
+`http://localhost:4317`) to export over OTLP to any collector or backend (Grafana,
+Langfuse, and other OTLP-compatible tools). When the variable is unset, the runtime
+logs locally and exports nothing.
+
+Set `JAMJET_CAPTURE_PROMPTS=true` to attach redacted prompt and completion text to
+spans (`gen_ai.prompt` / `gen_ai.completion`). It is off by default.

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -27,6 +27,7 @@ jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.2" }
 jamjet-worker = { path = "../workers", version = "=0.3.2" }
 jamjet-models = { path = "../models", version = "=0.3.2" }
 jamjet-timers = { path = "../timers", version = "=0.3.2" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -4,20 +4,18 @@ use jamjet_audit::{AuditEnricher, NoopAuditBackend, SqliteAuditBackend};
 use jamjet_state::{InMemoryBackend, SqliteBackend};
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Load .env if present
     dotenvy::dotenv().ok();
 
-    // Tracing
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
-        .with(tracing_subscriber::fmt::layer())
-        .init();
-
     let config = ApiConfig::default();
+
+    // Telemetry — installs OTLP trace + metric pipelines when
+    // OTEL_EXPORTER_OTLP_ENDPOINT is set, otherwise falls back to plain tracing.
+    let otel_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
+    jamjet_telemetry::init(config.dev_mode, otel_endpoint.as_deref());
     let storage_backend = std::env::var("STORAGE_BACKEND").unwrap_or_default();
     let storage_label = if storage_backend == "memory" {
         "memory"

--- a/runtime/telemetry/src/lib.rs
+++ b/runtime/telemetry/src/lib.rs
@@ -15,6 +15,50 @@
 /// no-ops if the global meter provider is not initialised.
 pub mod metrics {
     use opentelemetry::{global, KeyValue};
+    use crate::gen_ai_attrs;
+
+    /// Build the attribute set for a GenAI token-usage data point.
+    /// Pure + deterministic so it can be unit-tested without a meter provider.
+    pub fn gen_ai_metric_attrs(
+        system: &str,
+        request_model: &str,
+        operation: &str,
+        token_type: &str,
+    ) -> [KeyValue; 4] {
+        [
+            KeyValue::new(gen_ai_attrs::SYSTEM, system.to_string()),
+            KeyValue::new(gen_ai_attrs::REQUEST_MODEL, request_model.to_string()),
+            KeyValue::new(gen_ai_attrs::OPERATION_NAME, operation.to_string()),
+            KeyValue::new(gen_ai_attrs::TOKEN_TYPE, token_type.to_string()),
+        ]
+    }
+
+    /// Record the OTel-standard `gen_ai.client.token.usage` histogram.
+    ///
+    /// Records two data points (input and output) distinguished by the
+    /// `gen_ai.token.type` attribute, matching the OpenTelemetry GenAI metrics
+    /// spec. No-op unless a global meter provider is installed (via `init`).
+    pub fn gen_ai_token_usage(
+        system: &str,
+        request_model: &str,
+        operation: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        let meter = global::meter("jamjet");
+        let histogram = meter
+            .u64_histogram("gen_ai.client.token.usage")
+            .with_description("Number of tokens used by a model call")
+            .init();
+        histogram.record(
+            input_tokens,
+            &gen_ai_metric_attrs(system, request_model, operation, "input"),
+        );
+        histogram.record(
+            output_tokens,
+            &gen_ai_metric_attrs(system, request_model, operation, "output"),
+        );
+    }
 
     /// Record that a workflow execution was started.
     pub fn execution_started(workflow_id: &str) {
@@ -204,6 +248,10 @@ pub mod gen_ai_attrs {
     pub const SYSTEM: &str = "gen_ai.system";
     /// The model name requested (e.g. "claude-sonnet-4-6", "gpt-4o").
     pub const REQUEST_MODEL: &str = "gen_ai.request.model";
+    /// The GenAI operation name (e.g. "chat"). OTel GenAI semconv.
+    pub const OPERATION_NAME: &str = "gen_ai.operation.name";
+    /// The GenAI token type tag for the token-usage metric ("input" | "output").
+    pub const TOKEN_TYPE: &str = "gen_ai.token.type";
     /// The maximum tokens requested.
     pub const REQUEST_MAX_TOKENS: &str = "gen_ai.request.max_tokens";
     /// Sampling temperature (0.0–1.0).
@@ -356,4 +404,22 @@ pub fn record_execution_context(
     span.record(gen_ai_attrs::JAMJET_WORKFLOW_ID, workflow_id);
     span.record(gen_ai_attrs::JAMJET_NODE_ID, node_id);
     span.record(gen_ai_attrs::JAMJET_NODE_KIND, node_kind);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::metrics::gen_ai_metric_attrs;
+
+    #[test]
+    fn gen_ai_metric_attrs_carries_system_model_operation_and_token_type() {
+        let attrs = gen_ai_metric_attrs("anthropic", "claude-sonnet-4-6", "chat", "input");
+        let pairs: Vec<(String, String)> = attrs
+            .iter()
+            .map(|kv| (kv.key.as_str().to_string(), kv.value.to_string()))
+            .collect();
+        assert!(pairs.contains(&("gen_ai.system".into(), "anthropic".into())));
+        assert!(pairs.contains(&("gen_ai.request.model".into(), "claude-sonnet-4-6".into())));
+        assert!(pairs.contains(&("gen_ai.operation.name".into(), "chat".into())));
+        assert!(pairs.contains(&("gen_ai.token.type".into(), "input".into())));
+    }
 }

--- a/runtime/telemetry/src/lib.rs
+++ b/runtime/telemetry/src/lib.rs
@@ -14,8 +14,8 @@
 /// the OTLP metrics pipeline (when `otel_endpoint` is set). Metrics are
 /// no-ops if the global meter provider is not initialised.
 pub mod metrics {
-    use opentelemetry::{global, KeyValue};
     use crate::gen_ai_attrs;
+    use opentelemetry::{global, KeyValue};
 
     /// Build the attribute set for a GenAI token-usage data point.
     /// Pure + deterministic so it can be unit-tested without a meter provider.

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -10,7 +10,7 @@ use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
 use jamjet_state::backend::{StateBackend, WorkItem};
 use jamjet_state::budget::BudgetState;
 use jamjet_state::event::EventKind;
-use jamjet_telemetry::{gen_ai_attrs, record_gen_ai_usage};
+use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -119,6 +119,8 @@ impl Worker {
             "jamjet.node.kind" = tracing::field::Empty,
             "gen_ai.system" = tracing::field::Empty,
             "gen_ai.request.model" = tracing::field::Empty,
+            "gen_ai.response.model" = tracing::field::Empty,
+            "gen_ai.operation.name" = tracing::field::Empty,
             "gen_ai.usage.input_tokens" = tracing::field::Empty,
             "gen_ai.usage.output_tokens" = tracing::field::Empty,
             "gen_ai.response.finish_reasons" = tracing::field::Empty,
@@ -266,6 +268,11 @@ impl Worker {
                     exec_result.output_tokens,
                 ) {
                     record_gen_ai_usage(&node_span, system, model, input, output);
+                    node_span.record(gen_ai_attrs::OPERATION_NAME, "chat");
+                    // The executor surfaces the requested model; record it as the
+                    // response model too until a distinct response model is exposed.
+                    node_span.record(gen_ai_attrs::RESPONSE_MODEL, model.as_str());
+                    metrics::gen_ai_token_usage(system, model, "chat", input, output);
                 }
                 if let Some(finish_reason) = &exec_result.finish_reason {
                     node_span.record(


### PR DESCRIPTION
## Summary

Make the JamJet runtime export OpenTelemetry GenAI signals over OTLP so it plugs into existing OTel pipelines (Grafana, Langfuse, any OTLP backend). The `jamjet-telemetry` crate already had the GenAI attributes, OTLP exporters, and a span helper, and the worker already built a node span; this wires it up and aligns it to the standard.

- **telemetry:** add the standard `gen_ai.client.token.usage` histogram (`metrics::gen_ai_token_usage`, recorded twice with `gen_ai.token.type` = input/output) plus `gen_ai.operation.name` / `gen_ai.token.type` attribute constants.
- **worker:** emit that metric from the model path and record `gen_ai.operation.name` ("chat") and `gen_ai.response.model` on the node span.
- **api/server:** the server never installed the OTLP exporter (it did its own `tracing_subscriber` init). Now it calls `jamjet_telemetry::init(config.dev_mode, OTEL_EXPORTER_OTLP_ENDPOINT)`, so the spans the worker already emits actually export. Unset env var = unchanged local logging. Dropped the now-unused `tracing-subscriber` dep.
- **docs:** runtime README Observability section for `OTEL_EXPORTER_OTLP_ENDPOINT` and `JAMJET_CAPTURE_PROMPTS`.

When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, a model node produces a `jamjet.node` span with `gen_ai.*` attributes and a `gen_ai.client.token.usage` metric, exported to any OTLP collector.

Out of scope (noted): the Java runtime (fast-follow), the existing `jamjet.*` custom metrics (kept), and improving the best-effort prompt redactor.

## Test plan

- [x] `cargo test -p jamjet-telemetry -p jamjet-worker -p jamjet-api` green (24 tests; includes a new unit test on the metric attribute set)
- [x] `cargo clippy` + `cargo fmt --check` clean on the three crates
- [x] `init(None)` (env unset) preserves prior dev/prod logging; no behavior change for existing deployments
- [ ] Manual smoke (needs a collector): run the server with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`, execute a model node, confirm the `gen_ai.*` span + `gen_ai.client.token.usage` metric arrive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime now emits OpenTelemetry GenAI operation spans and token usage metrics, with export controlled via environment configuration.
  * Added optional prompt and completion text capture for telemetry spans when enabled.

* **Documentation**
  * Added comprehensive runtime observability documentation covering GenAI metrics, span attributes, and telemetry export configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->