### PR TITLE
feat: complete the approval/HITL loop (park, resume, reject)

### DIFF
--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -43,3 +43,7 @@ anyhow = { workspace = true }
 reqwest = { workspace = true }
 rust-embed = { workspace = true }
 mime_guess = { workspace = true }
+
+[dev-dependencies]
+tower = { workspace = true, features = ["util"] }
+http-body-util = "0.1"

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -47,3 +47,4 @@ mime_guess = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
+tracing-subscriber = { workspace = true }

--- a/runtime/api/src/approvals.rs
+++ b/runtime/api/src/approvals.rs
@@ -28,6 +28,8 @@ pub enum SubmitError {
     MultiplePending(Vec<String>),
     /// The named node has no outstanding approval request.
     NodeNotPending(String),
+    /// The execution is already terminal; a decision can no longer change it.
+    ExecutionTerminal(String),
     Backend(String),
 }
 
@@ -44,6 +46,10 @@ impl std::fmt::Display for SubmitError {
                 f,
                 "node '{n}' has no pending approval (unknown or already decided)"
             ),
+            Self::ExecutionTerminal(status) => write!(
+                f,
+                "execution is {status}; approvals can no longer be decided"
+            ),
             Self::Backend(e) => write!(f, "backend error: {e}"),
         }
     }
@@ -56,6 +62,30 @@ pub async fn submit_approval(
     execution_id: &ExecutionId,
     submission: ApprovalSubmission,
 ) -> Result<String, SubmitError> {
+    // Refuse decisions on terminal executions up front. The event-derived
+    // pending list can still show an undecided request after a cancellation
+    // (the fold intentionally ignores decisions for unheld nodes), so without
+    // this check an approve on a cancelled run would 200 while changing nothing.
+    let execution = backend
+        .get_execution(execution_id)
+        .await
+        .map_err(|e| SubmitError::Backend(e.to_string()))?;
+    let was_paused = match &execution {
+        Some(exec) => {
+            if matches!(
+                exec.status,
+                WorkflowStatus::Completed
+                    | WorkflowStatus::Failed
+                    | WorkflowStatus::Cancelled
+                    | WorkflowStatus::LimitExceeded
+            ) {
+                return Err(SubmitError::ExecutionTerminal(format!("{:?}", exec.status)));
+            }
+            exec.status == WorkflowStatus::Paused
+        }
+        None => false,
+    };
+
     let events = backend
         .get_events(execution_id)
         .await
@@ -102,14 +132,13 @@ pub async fn submit_approval(
         .await
         .map_err(|e| SubmitError::Backend(e.to_string()))?;
 
-    // Preserve the legacy paused -> running flip.
-    if let Ok(Some(exec)) = backend.get_execution(execution_id).await {
-        if exec.status == WorkflowStatus::Paused {
-            backend
-                .update_execution_status(execution_id, WorkflowStatus::Running)
-                .await
-                .map_err(|e| SubmitError::Backend(e.to_string()))?;
-        }
+    // Preserve the legacy paused -> running flip. Uses the pre-append status
+    // read; errors propagate rather than silently skipping the flip.
+    if was_paused {
+        backend
+            .update_execution_status(execution_id, WorkflowStatus::Running)
+            .await
+            .map_err(|e| SubmitError::Backend(e.to_string()))?;
     }
 
     Ok(node_id)

--- a/runtime/api/src/approvals.rs
+++ b/runtime/api/src/approvals.rs
@@ -1,0 +1,157 @@
+//! Validated approval submission, shared by the REST route and the MCP bridge.
+//!
+//! All approval decisions pass through `submit_approval` which folds the event log
+//! to verify something is actually pending before appending `ApprovalReceived`.
+//! The listing helper `approvals_view` builds the pending/decided payload for
+//! `GET /executions/:id/approvals`.
+
+use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
+use jamjet_state::approvals::{node_approval_status, pending_approvals, NodeApprovalStatus};
+use jamjet_state::backend::StateBackend;
+use jamjet_state::event::{ApprovalDecision, EventKind};
+use jamjet_state::Event;
+use std::sync::Arc;
+
+pub struct ApprovalSubmission {
+    pub node_id: Option<String>,
+    pub user_id: String,
+    pub decision: ApprovalDecision,
+    pub comment: Option<String>,
+    pub state_patch: Option<serde_json::Value>,
+}
+
+#[derive(Debug)]
+pub enum SubmitError {
+    /// Nothing is waiting for approval on this execution.
+    NoPending,
+    /// `node_id` omitted but several nodes are pending; caller must disambiguate.
+    MultiplePending(Vec<String>),
+    /// The named node has no outstanding approval request.
+    NodeNotPending(String),
+    Backend(String),
+}
+
+impl std::fmt::Display for SubmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoPending => write!(f, "no pending approval on this execution"),
+            Self::MultiplePending(nodes) => write!(
+                f,
+                "multiple approvals pending ({}); specify node_id",
+                nodes.join(", ")
+            ),
+            Self::NodeNotPending(n) => write!(
+                f,
+                "node '{n}' has no pending approval (unknown or already decided)"
+            ),
+            Self::Backend(e) => write!(f, "backend error: {e}"),
+        }
+    }
+}
+
+/// Validate against derived pending state, then append `ApprovalReceived`.
+/// Returns the resolved `node_id`.
+pub async fn submit_approval(
+    backend: &Arc<dyn StateBackend>,
+    execution_id: &ExecutionId,
+    submission: ApprovalSubmission,
+) -> Result<String, SubmitError> {
+    let events = backend
+        .get_events(execution_id)
+        .await
+        .map_err(|e| SubmitError::Backend(e.to_string()))?;
+    let pending = pending_approvals(&events);
+
+    let node_id = match submission.node_id.filter(|n| !n.is_empty()) {
+        Some(n) => {
+            if !pending.iter().any(|p| p.node_id == n) {
+                return Err(SubmitError::NodeNotPending(n));
+            }
+            n
+        }
+        None => match pending.as_slice() {
+            [] => return Err(SubmitError::NoPending),
+            [only] => only.node_id.clone(),
+            many => {
+                return Err(SubmitError::MultiplePending(
+                    many.iter().map(|p| p.node_id.clone()).collect(),
+                ))
+            }
+        },
+    };
+
+    let seq = backend
+        .latest_sequence(execution_id)
+        .await
+        .map_err(|e| SubmitError::Backend(e.to_string()))?
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            EventKind::ApprovalReceived {
+                node_id: node_id.clone(),
+                user_id: submission.user_id,
+                decision: submission.decision,
+                comment: submission.comment,
+                state_patch: submission.state_patch,
+            },
+        ))
+        .await
+        .map_err(|e| SubmitError::Backend(e.to_string()))?;
+
+    // Preserve the legacy paused -> running flip.
+    if let Ok(Some(exec)) = backend.get_execution(execution_id).await {
+        if exec.status == WorkflowStatus::Paused {
+            backend
+                .update_execution_status(execution_id, WorkflowStatus::Running)
+                .await
+                .map_err(|e| SubmitError::Backend(e.to_string()))?;
+        }
+    }
+
+    Ok(node_id)
+}
+
+/// Pending + decided approval view for `GET /executions/:id/approvals`.
+pub fn approvals_view(events: &[Event]) -> serde_json::Value {
+    let pending = pending_approvals(events);
+
+    // Collect every node that ever had a `ToolApprovalRequired`.
+    let mut nodes: Vec<String> = events
+        .iter()
+        .filter_map(|e| match &e.kind {
+            EventKind::ToolApprovalRequired { node_id, .. } => Some(node_id.clone()),
+            _ => None,
+        })
+        .collect();
+    nodes.sort();
+    nodes.dedup();
+
+    let decided: Vec<serde_json::Value> = nodes
+        .iter()
+        .filter(|n| !pending.iter().any(|p| &p.node_id == *n))
+        .map(|n| match node_approval_status(events, n) {
+            NodeApprovalStatus::Approved { user_id, sequence } => serde_json::json!({
+                "node_id": n,
+                "status": "approved",
+                "user_id": user_id,
+                "sequence": sequence,
+            }),
+            NodeApprovalStatus::Rejected {
+                user_id,
+                comment,
+                sequence,
+            } => serde_json::json!({
+                "node_id": n,
+                "status": "rejected",
+                "user_id": user_id,
+                "comment": comment,
+                "sequence": sequence,
+            }),
+            _ => serde_json::json!({ "node_id": n, "status": "unknown" }),
+        })
+        .collect();
+
+    serde_json::json!({ "pending": pending, "decided": decided })
+}

--- a/runtime/api/src/approvals.rs
+++ b/runtime/api/src/approvals.rs
@@ -85,6 +85,8 @@ pub async fn submit_approval(
         .await
         .map_err(|e| SubmitError::Backend(e.to_string()))?
         + 1;
+    // TOCTOU: a concurrent approve may have already appended a decision; the
+    // scheduler fold's held.remove gate makes the second event a no-op.
     backend
         .append_event(Event::new(
             execution_id.clone(),
@@ -149,6 +151,8 @@ pub fn approvals_view(events: &[Event]) -> serde_json::Value {
                 "comment": comment,
                 "sequence": sequence,
             }),
+            // Unreachable in practice: a node filtered out of `pending` has a
+            // decision by construction. Kept total so the view never panics.
             _ => serde_json::json!({ "node_id": n, "status": "unknown" }),
         })
         .collect();

--- a/runtime/api/src/error.rs
+++ b/runtime/api/src/error.rs
@@ -12,6 +12,9 @@ pub enum ApiError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    #[error("conflict: {0}")]
+    Conflict(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 
@@ -24,6 +27,7 @@ impl IntoResponse for ApiError {
         let (status, message) = match &self {
             Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            Self::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
             Self::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".into()),
             Self::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
         };

--- a/runtime/api/src/lib.rs
+++ b/runtime/api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod approvals;
 pub mod auth;
 pub mod config;
 pub mod cron;

--- a/runtime/api/src/mcp_bridge.rs
+++ b/runtime/api/src/mcp_bridge.rs
@@ -383,7 +383,7 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                 "Side effects: appends an ApprovalReceived event to the event log (with user_id 'mcp-client') and, if the execution is paused, ",
                 "resumes it to 'running' status so the next node can proceed. The decision is recorded in the immutable audit trail. ",
                 "Returns a JSON object with execution_id and accepted: true. ",
-                "Fails if execution_id is not found or if decision is not exactly 'approved' or 'rejected'. ",
+                "Fails if execution_id is not found, if decision is not exactly 'approved' or 'rejected', or if nothing is pending approval (or node_id does not match a pending approval). ",
                 "Related: use jamjet_get_events to see the ApprovalRequested event details before deciding."
             ).into()),
             input_schema: json!({
@@ -446,38 +446,27 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                 let eid = parse_execution_id(id_str)?;
                 let backend = s.backend_for(&tenant_id);
 
-                let seq = backend
-                    .latest_sequence(&eid)
-                    .await
-                    .map_err(|e| format!("{e}"))?
-                    + 1;
-                let event = Event::new(
-                    eid.clone(),
-                    seq,
-                    EventKind::ApprovalReceived {
-                        node_id,
+                let resolved_node = crate::approvals::submit_approval(
+                    &backend,
+                    &eid,
+                    crate::approvals::ApprovalSubmission {
+                        node_id: if node_id.is_empty() {
+                            None
+                        } else {
+                            Some(node_id)
+                        },
                         user_id: "mcp-client".into(),
                         decision,
                         comment,
                         state_patch: None,
                     },
-                );
-                backend
-                    .append_event(event)
-                    .await
-                    .map_err(|e| format!("{e}"))?;
-
-                if let Ok(Some(exec)) = backend.get_execution(&eid).await {
-                    if exec.status == WorkflowStatus::Paused {
-                        backend
-                            .update_execution_status(&eid, WorkflowStatus::Running)
-                            .await
-                            .map_err(|e| format!("{e}"))?;
-                    }
-                }
+                )
+                .await
+                .map_err(|e| e.to_string())?;
 
                 Ok(vec![McpContent::Text {
-                    text: json!({"execution_id": id_str, "accepted": true}).to_string(),
+                    text: json!({"execution_id": id_str, "node_id": resolved_node, "accepted": true})
+                        .to_string(),
                 }])
             }
         },

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -42,6 +42,10 @@ pub fn build_router_with_opts(state: AppState, dev_mode: bool) -> Router {
         .route("/executions/:id/cancel", post(cancel_execution))
         .route("/executions/:id/events", get(list_events))
         .route("/executions/:id/approve", post(approve_execution))
+        .route(
+            "/executions/:id/approvals",
+            get(list_approvals_for_execution),
+        )
         .route("/executions/:id/external-event", post(send_external_event))
         // Agents
         .route("/agents", post(register_agent).get(list_agents))
@@ -397,29 +401,39 @@ async fn approve_execution(
         other => return Err(ApiError::BadRequest(format!("unknown decision: {other}"))),
     };
 
-    let seq = backend.latest_sequence(&execution_id).await? + 1;
-    let event = jamjet_state::Event::new(
-        execution_id.clone(),
-        seq,
-        jamjet_state::EventKind::ApprovalReceived {
-            node_id: body.node_id.unwrap_or_default(),
+    let node_id = crate::approvals::submit_approval(
+        &backend,
+        &execution_id,
+        crate::approvals::ApprovalSubmission {
+            node_id: body.node_id,
             user_id: body.user_id.unwrap_or_else(|| "anonymous".into()),
             decision,
             comment: body.comment,
             state_patch: body.state_patch,
         },
-    );
-    backend.append_event(event).await?;
+    )
+    .await
+    .map_err(|e| match e {
+        crate::approvals::SubmitError::MultiplePending(_) => ApiError::BadRequest(e.to_string()),
+        crate::approvals::SubmitError::NoPending
+        | crate::approvals::SubmitError::NodeNotPending(_) => ApiError::Conflict(e.to_string()),
+        crate::approvals::SubmitError::Backend(msg) => ApiError::Internal(msg),
+    })?;
 
-    if let Ok(Some(exec)) = backend.get_execution(&execution_id).await {
-        if exec.status == WorkflowStatus::Paused {
-            backend
-                .update_execution_status(&execution_id, WorkflowStatus::Running)
-                .await?;
-        }
-    }
+    Ok(Json(
+        json!({ "execution_id": id, "node_id": node_id, "accepted": true }),
+    ))
+}
 
-    Ok(Json(json!({ "execution_id": id, "accepted": true })))
+async fn list_approvals_for_execution(
+    State(state): State<AppState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let backend = state.backend_for(&tenant_id);
+    let execution_id = parse_execution_id(&id)?;
+    let events = backend.get_events(&execution_id).await?;
+    Ok(Json(crate::approvals::approvals_view(&events)))
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -416,7 +416,8 @@ async fn approve_execution(
     .map_err(|e| match e {
         crate::approvals::SubmitError::MultiplePending(_) => ApiError::BadRequest(e.to_string()),
         crate::approvals::SubmitError::NoPending
-        | crate::approvals::SubmitError::NodeNotPending(_) => ApiError::Conflict(e.to_string()),
+        | crate::approvals::SubmitError::NodeNotPending(_)
+        | crate::approvals::SubmitError::ExecutionTerminal(_) => ApiError::Conflict(e.to_string()),
         crate::approvals::SubmitError::Backend(msg) => ApiError::Internal(msg),
     })?;
 

--- a/runtime/api/tests/approval_api.rs
+++ b/runtime/api/tests/approval_api.rs
@@ -389,3 +389,36 @@ async fn list_approvals_shows_pending_then_decided() {
     assert_eq!(decided[0]["node_id"], "a");
     assert_eq!(decided[0]["status"], "approved");
 }
+
+#[tokio::test]
+async fn approve_on_terminal_execution_returns_409() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    backend
+        .update_execution_status(&execution_id, WorkflowStatus::Cancelled)
+        .await
+        .expect("cancel execution");
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", Some("a")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("Cancelled"),
+        "expected terminal status in error, got: {error}"
+    );
+}

--- a/runtime/api/tests/approval_api.rs
+++ b/runtime/api/tests/approval_api.rs
@@ -1,0 +1,391 @@
+//! Validated approval API tests.
+//!
+//! Tests for POST /executions/:id/approve (validation against pending state)
+//! and GET /executions/:id/approvals (listing pending + decided approvals).
+//! Uses the in-memory backend + dev_mode router (no auth required).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::StateBackend;
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, InMemoryBackend};
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_state() -> AppState {
+    let backend = Arc::new(InMemoryBackend::new());
+    let backend_clone = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone() as Arc<dyn jamjet_state::StateBackend>,
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| {
+            backend_clone.clone() as Arc<dyn jamjet_state::StateBackend>
+        }),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+/// Create a fresh execution in the backend and return its ID string.
+async fn create_execution(backend: &Arc<dyn StateBackend>) -> ExecutionId {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "test-wf".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        })
+        .await
+        .expect("create_execution");
+
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "test-wf".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+
+    execution_id
+}
+
+/// Append a `ToolApprovalRequired` for the given node.
+async fn seed_approval_required(
+    backend: &Arc<dyn StateBackend>,
+    execution_id: &ExecutionId,
+    node_id: &str,
+) {
+    let seq = backend
+        .latest_sequence(execution_id)
+        .await
+        .expect("latest_sequence")
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            EventKind::ToolApprovalRequired {
+                node_id: node_id.into(),
+                tool_name: format!("tool_{node_id}"),
+                approver: "human".into(),
+                context: serde_json::json!({"action": node_id}),
+            },
+        ))
+        .await
+        .expect("append ToolApprovalRequired");
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn approve_body(decision: &str, node_id: Option<&str>) -> Body {
+    let mut map = serde_json::json!({ "decision": decision });
+    if let Some(n) = node_id {
+        map["node_id"] = serde_json::json!(n);
+    }
+    Body::from(serde_json::to_vec(&map).unwrap())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn approve_with_no_pending_returns_409() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", None))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("no pending approval"),
+        "expected 'no pending approval' in error, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn approve_unknown_node_returns_409() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", Some("zzz")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let json = body_json(resp.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("no pending approval"),
+        "expected 'no pending approval' in error for unknown node, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn approve_single_pending_infers_node() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", None))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["node_id"], "a", "inferred node_id must be 'a'");
+    assert_eq!(json["accepted"], true);
+
+    // Backend must have an ApprovalReceived for node "a".
+    let events = backend.get_events(&execution_id).await.unwrap();
+    let has_received = events
+        .iter()
+        .any(|e| matches!(&e.kind, EventKind::ApprovalReceived { node_id, .. } if node_id == "a"));
+    assert!(
+        has_received,
+        "ApprovalReceived for node 'a' must be in event log"
+    );
+}
+
+#[tokio::test]
+async fn approve_multiple_pending_requires_node_id() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    seed_approval_required(&backend, &execution_id, "b").await;
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", None))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("specify node_id"),
+        "expected 'specify node_id' in error, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn double_approve_returns_409() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let router = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    let id_str = execution_id.to_string();
+
+    // First approval — must succeed.
+    let resp1 = router
+        .clone()
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", Some("a")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    // Second identical approval — must 409.
+    let resp2 = router
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", Some("a")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp2.status(), StatusCode::CONFLICT);
+    let json = body_json(resp2.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("no pending approval"),
+        "double-approve error must mention 'no pending approval', got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn invalid_decision_returns_400() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    let id_str = execution_id.to_string();
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({"decision": "maybe"})).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp.into_body()).await;
+    let error = json["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("unknown decision") || error.contains("maybe"),
+        "expected decision error, got: {error}"
+    );
+}
+
+#[tokio::test]
+async fn list_approvals_shows_pending_then_decided() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let router = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    seed_approval_required(&backend, &execution_id, "b").await;
+    let id_str = execution_id.to_string();
+
+    // GET /executions/:id/approvals — both pending.
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::get(format!("/executions/{id_str}/approvals"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    let pending = json["pending"].as_array().expect("pending must be array");
+    assert_eq!(pending.len(), 2, "both nodes must be pending");
+    let pending_ids: Vec<&str> = pending
+        .iter()
+        .map(|p| p["node_id"].as_str().unwrap())
+        .collect();
+    assert!(pending_ids.contains(&"a"), "node 'a' must be pending");
+    assert!(pending_ids.contains(&"b"), "node 'b' must be pending");
+
+    // Each pending entry must have node_id, tool_name, approver.
+    for p in pending {
+        assert!(p["node_id"].is_string(), "pending entry missing node_id");
+        assert!(
+            p["tool_name"].is_string(),
+            "pending entry missing tool_name"
+        );
+        assert!(p["approver"].is_string(), "pending entry missing approver");
+    }
+
+    // Approve node "a".
+    let approve_resp = router
+        .clone()
+        .oneshot(
+            Request::post(format!("/executions/{id_str}/approve"))
+                .header("content-type", "application/json")
+                .body(approve_body("approved", Some("a")))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approve_resp.status(), StatusCode::OK);
+
+    // GET again — "a" decided, "b" still pending.
+    let resp2 = router
+        .oneshot(
+            Request::get(format!("/executions/{id_str}/approvals"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp2.status(), StatusCode::OK);
+    let json2 = body_json(resp2.into_body()).await;
+
+    let pending2 = json2["pending"].as_array().expect("pending must be array");
+    assert_eq!(pending2.len(), 1, "only node 'b' remains pending");
+    assert_eq!(pending2[0]["node_id"], "b");
+
+    let decided = json2["decided"].as_array().expect("decided must be array");
+    assert_eq!(decided.len(), 1, "node 'a' must be in decided");
+    assert_eq!(decided[0]["node_id"], "a");
+    assert_eq!(decided[0]["status"], "approved");
+}

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -12,6 +12,24 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
+/// Serializes the tests in this binary. Each test spawns a scheduler (25ms
+/// ticks) plus a 5-worker pool against its own temp SQLite DB; running three
+/// such stacks concurrently creates an fsync storm that stalls progress past
+/// the wait deadlines (observed: NodeStarted appended, next write starved for
+/// 10s+). Production self-heals via lease reclaim; tests must be deterministic.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Install a test-writer tracing subscriber so worker/scheduler `warn!`s
+/// (e.g. "Worker error: …") surface in failing-test output instead of being
+/// silently dropped. Controlled by RUST_LOG; no-op if already installed.
+fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init()
+        .ok();
+}
+
 /// Single tool node gated by a node-level require_approval policy, edge to end.
 ///
 /// NodeKind::Tool requires: tool_ref (String), input_mapping ({}), output_schema (String).
@@ -218,6 +236,8 @@ impl Harness {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gated_node_parks_without_dead_lettering() {
+    let _serial = SERIAL.lock().await;
+    init_tracing();
     let h = start().await;
 
     assert!(
@@ -225,7 +245,7 @@ async fn gated_node_parks_without_dead_lettering() {
             |ev| ev
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
-            10
+            30
         )
         .await,
         "ToolApprovalRequired should be emitted"
@@ -290,6 +310,8 @@ async fn gated_node_parks_without_dead_lettering() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn approved_node_resumes_and_completes() {
+    let _serial = SERIAL.lock().await;
+    init_tracing();
     let h = start().await;
 
     assert!(
@@ -297,7 +319,7 @@ async fn approved_node_resumes_and_completes() {
             |ev| ev
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
-            10
+            30
         )
         .await
     );
@@ -308,7 +330,7 @@ async fn approved_node_resumes_and_completes() {
             |ev| ev
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::WorkflowCompleted { .. })),
-            15
+            30
         )
         .await,
         "approved workflow should run to completion"
@@ -326,6 +348,8 @@ async fn approved_node_resumes_and_completes() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rejected_node_fails_workflow_with_reason() {
+    let _serial = SERIAL.lock().await;
+    init_tracing();
     let h = start().await;
 
     assert!(
@@ -333,7 +357,7 @@ async fn rejected_node_fails_workflow_with_reason() {
             |ev| ev
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
-            10
+            30
         )
         .await
     );
@@ -345,7 +369,7 @@ async fn rejected_node_fails_workflow_with_reason() {
             |ev| ev
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::WorkflowFailed { .. })),
-            15
+            30
         )
         .await,
         "rejected workflow should fail"

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -67,8 +67,11 @@ struct Harness {
 async fn start() -> Harness {
     let db_path = std::env::temp_dir().join(format!("jjtest-{}.db", Uuid::new_v4()));
     let url = format!("sqlite://{}", db_path.display());
-    let backend: Arc<dyn StateBackend> =
-        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite backend"));
+    let backend: Arc<dyn StateBackend> = Arc::new(
+        SqliteBackend::open(&url)
+            .await
+            .expect("open sqlite backend"),
+    );
 
     backend
         .store_workflow(WorkflowDefinition {
@@ -114,7 +117,10 @@ async fn start() -> Harness {
         .append_event(Event::new(
             execution_id.clone(),
             2,
-            EventKind::NodeScheduled { node_id: "gated".into(), queue_type: "general".into() },
+            EventKind::NodeScheduled {
+                node_id: "gated".into(),
+                queue_type: "general".into(),
+            },
         ))
         .await
         .expect("append NodeScheduled");
@@ -143,21 +149,34 @@ async fn start() -> Harness {
     let sched_handle = tokio::spawn(async move { scheduler.run().await });
     let worker_handles = jamjet_worker::default_pool(backend.clone()).spawn();
 
-    Harness { backend, execution_id, db_path, sched_handle, worker_handles }
+    Harness {
+        backend,
+        execution_id,
+        db_path,
+        sched_handle,
+        worker_handles,
+    }
 }
 
 impl Harness {
     async fn wait_for<F: Fn(&[Event]) -> bool>(&self, pred: F, secs: u64) -> bool {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(secs);
         loop {
-            let events = self.backend.get_events(&self.execution_id).await.unwrap_or_default();
+            let events = self
+                .backend
+                .get_events(&self.execution_id)
+                .await
+                .unwrap_or_default();
             if pred(&events) {
                 return true;
             }
             if tokio::time::Instant::now() > deadline {
                 eprintln!(
                     "WAIT TIMEOUT — events: {:#?}",
-                    events.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>()
+                    events
+                        .iter()
+                        .map(|e| format!("{:?}", e.kind))
+                        .collect::<Vec<_>>()
                 );
                 return false;
             }
@@ -166,7 +185,12 @@ impl Harness {
     }
 
     async fn approve(&self, decision: ApprovalDecision, comment: Option<&str>) {
-        let seq = self.backend.latest_sequence(&self.execution_id).await.unwrap() + 1;
+        let seq = self
+            .backend
+            .latest_sequence(&self.execution_id)
+            .await
+            .unwrap()
+            + 1;
         self.backend
             .append_event(Event::new(
                 self.execution_id.clone(),
@@ -198,7 +222,9 @@ async fn gated_node_parks_without_dead_lettering() {
 
     assert!(
         h.wait_for(
-            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            |ev| ev
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
             10
         )
         .await,
@@ -237,18 +263,27 @@ async fn gated_node_parks_without_dead_lettering() {
         .filter(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. }))
         .count();
     assert_eq!(
-        holds,
-        1,
+        holds, 1,
         "exactly one hold event — no retry loop, no duplicate from reclaimed items"
     );
     assert!(
-        !events
-            .iter()
-            .any(|e| matches!(e.kind, EventKind::NodeFailed { .. } | EventKind::NodeCompleted { .. })),
+        !events.iter().any(|e| matches!(
+            e.kind,
+            EventKind::NodeFailed { .. } | EventKind::NodeCompleted { .. }
+        )),
         "held node neither ran nor failed"
     );
-    let exec = h.backend.get_execution(&h.execution_id).await.unwrap().unwrap();
-    assert_eq!(exec.status, WorkflowStatus::Running, "execution stays running while parked");
+    let exec = h
+        .backend
+        .get_execution(&h.execution_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        exec.status,
+        WorkflowStatus::Running,
+        "execution stays running while parked"
+    );
 
     h.shutdown().await;
 }
@@ -259,7 +294,9 @@ async fn approved_node_resumes_and_completes() {
 
     assert!(
         h.wait_for(
-            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            |ev| ev
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
             10
         )
         .await
@@ -268,7 +305,9 @@ async fn approved_node_resumes_and_completes() {
 
     assert!(
         h.wait_for(
-            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::WorkflowCompleted { .. })),
+            |ev| ev
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::WorkflowCompleted { .. })),
             15
         )
         .await,
@@ -276,7 +315,9 @@ async fn approved_node_resumes_and_completes() {
     );
     let events = h.backend.get_events(&h.execution_id).await.unwrap();
     assert!(
-        events.iter().any(|e| matches!(&e.kind, EventKind::NodeCompleted { node_id, .. } if node_id == "gated")),
+        events.iter().any(
+            |e| matches!(&e.kind, EventKind::NodeCompleted { node_id, .. } if node_id == "gated")
+        ),
         "the gated node actually executed after approval"
     );
 
@@ -289,16 +330,21 @@ async fn rejected_node_fails_workflow_with_reason() {
 
     assert!(
         h.wait_for(
-            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            |ev| ev
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
             10
         )
         .await
     );
-    h.approve(ApprovalDecision::Rejected, Some("not in business hours")).await;
+    h.approve(ApprovalDecision::Rejected, Some("not in business hours"))
+        .await;
 
     assert!(
         h.wait_for(
-            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::WorkflowFailed { .. })),
+            |ev| ev
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::WorkflowFailed { .. })),
             15
         )
         .await,

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -13,10 +13,12 @@ use std::time::Duration;
 use uuid::Uuid;
 
 /// Serializes the tests in this binary. Each test spawns a scheduler (25ms
-/// ticks) plus a 5-worker pool against its own temp SQLite DB; running three
-/// such stacks concurrently creates an fsync storm that stalls progress past
-/// the wait deadlines (observed: NodeStarted appended, next write starved for
-/// 10s+). Production self-heals via lease reclaim; tests must be deterministic.
+/// ticks) plus a 5-worker pool, which is a lot of concurrent machinery per
+/// test; running three such stacks at once adds CPU/IO noise on top. The
+/// historical flake here (worker stranded its claimed item until lease
+/// reclaim) was a real bug: deferred SQLite transactions upgrading read->write
+/// bypass the busy handler (fixed with BEGIN IMMEDIATE in the state backend).
+/// The mutex stays as belt-and-braces so timing assertions are load-independent.
 static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Install a test-writer tracing subscriber so worker/scheduler `warn!`s

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -1,0 +1,329 @@
+//! End-to-end approval (HITL) regression tests.
+//!
+//! A node gated by `require_approval_for` must park (not run, not dead-letter),
+//! resume and complete after an approval event, and fail the workflow after a
+//! rejection. Guards the worker hold path + scheduler resume fold.
+
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::{StateBackend, WorkItem, WorkflowDefinition};
+use jamjet_state::event::{ApprovalDecision, EventKind};
+use jamjet_state::{Event, SqliteBackend, DEFAULT_TENANT};
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Single tool node gated by a node-level require_approval policy, edge to end.
+///
+/// NodeKind::Tool requires: tool_ref (String), input_mapping ({}), output_schema (String).
+/// The policy engine's EvaluationContext::from_node_kind reads tool_ref as the tool_name,
+/// which is then matched against require_approval_for: ["payments.*"].
+fn gated_ir() -> serde_json::Value {
+    serde_json::json!({
+        "workflow_id": "e2e-approval",
+        "version": "0.1.0",
+        "name": null,
+        "description": null,
+        "state_schema": "",
+        "start_node": "gated",
+        "nodes": {
+            "gated": {
+                "id": "gated",
+                "kind": {
+                    "type": "tool",
+                    "tool_ref": "payments.transfer",
+                    "input_mapping": {},
+                    "output_schema": ""
+                },
+                "retry_policy": null,
+                "node_timeout_secs": null,
+                "description": null,
+                "labels": {},
+                "policy": {
+                    "blocked_tools": [],
+                    "require_approval_for": ["payments.*"],
+                    "model_allowlist": []
+                }
+            }
+        },
+        "edges": [ { "from": "gated", "to": "end", "condition": null } ],
+        "retry_policies": {},
+        "timeouts": {},
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {},
+        "labels": {}
+    })
+}
+
+struct Harness {
+    backend: Arc<dyn StateBackend>,
+    execution_id: ExecutionId,
+    db_path: std::path::PathBuf,
+    sched_handle: tokio::task::JoinHandle<()>,
+    worker_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+async fn start() -> Harness {
+    let db_path = std::env::temp_dir().join(format!("jjtest-{}.db", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+    let backend: Arc<dyn StateBackend> =
+        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite backend"));
+
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: "e2e-approval".into(),
+            version: "0.1.0".into(),
+            ir: gated_ir(),
+            created_at: chrono::Utc::now(),
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
+
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "e2e-approval".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        })
+        .await
+        .expect("create_execution");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "e2e-approval".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            2,
+            EventKind::NodeScheduled { node_id: "gated".into(), queue_type: "general".into() },
+        ))
+        .await
+        .expect("append NodeScheduled");
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: execution_id.clone(),
+            node_id: "gated".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({
+                "workflow_id": "e2e-approval",
+                "workflow_version": "0.1.0",
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    let scheduler = jamjet_scheduler::Scheduler::new(backend.clone())
+        .with_poll_interval(Duration::from_millis(25));
+    let sched_handle = tokio::spawn(async move { scheduler.run().await });
+    let worker_handles = jamjet_worker::default_pool(backend.clone()).spawn();
+
+    Harness { backend, execution_id, db_path, sched_handle, worker_handles }
+}
+
+impl Harness {
+    async fn wait_for<F: Fn(&[Event]) -> bool>(&self, pred: F, secs: u64) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(secs);
+        loop {
+            let events = self.backend.get_events(&self.execution_id).await.unwrap_or_default();
+            if pred(&events) {
+                return true;
+            }
+            if tokio::time::Instant::now() > deadline {
+                eprintln!(
+                    "WAIT TIMEOUT — events: {:#?}",
+                    events.iter().map(|e| format!("{:?}", e.kind)).collect::<Vec<_>>()
+                );
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn approve(&self, decision: ApprovalDecision, comment: Option<&str>) {
+        let seq = self.backend.latest_sequence(&self.execution_id).await.unwrap() + 1;
+        self.backend
+            .append_event(Event::new(
+                self.execution_id.clone(),
+                seq,
+                EventKind::ApprovalReceived {
+                    node_id: "gated".into(),
+                    user_id: "e2e-tester".into(),
+                    decision,
+                    comment: comment.map(String::from),
+                    state_patch: None,
+                },
+            ))
+            .await
+            .expect("append ApprovalReceived");
+    }
+
+    async fn shutdown(self) {
+        self.sched_handle.abort();
+        for h in self.worker_handles {
+            h.abort();
+        }
+        let _ = std::fs::remove_file(&self.db_path);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gated_node_parks_without_dead_lettering() {
+    let h = start().await;
+
+    assert!(
+        h.wait_for(
+            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            10
+        )
+        .await,
+        "ToolApprovalRequired should be emitted"
+    );
+    // Let scheduler + workers churn; the hold must stay stable.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Simulate a lease-expiry reclaim: a second work item for the held node
+    // (what reclaim_expired_leases would re-enqueue after a worker crash).
+    // The worker must settle it without duplicating the hold event.
+    h.backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: h.execution_id.clone(),
+            node_id: "gated".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({
+                "workflow_id": "e2e-approval",
+                "workflow_version": "0.1.0",
+            }),
+            attempt: 1,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue duplicate work item");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let events = h.backend.get_events(&h.execution_id).await.unwrap();
+    let holds = events
+        .iter()
+        .filter(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. }))
+        .count();
+    assert_eq!(
+        holds,
+        1,
+        "exactly one hold event — no retry loop, no duplicate from reclaimed items"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::NodeFailed { .. } | EventKind::NodeCompleted { .. })),
+        "held node neither ran nor failed"
+    );
+    let exec = h.backend.get_execution(&h.execution_id).await.unwrap().unwrap();
+    assert_eq!(exec.status, WorkflowStatus::Running, "execution stays running while parked");
+
+    h.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approved_node_resumes_and_completes() {
+    let h = start().await;
+
+    assert!(
+        h.wait_for(
+            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            10
+        )
+        .await
+    );
+    h.approve(ApprovalDecision::Approved, None).await;
+
+    assert!(
+        h.wait_for(
+            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::WorkflowCompleted { .. })),
+            15
+        )
+        .await,
+        "approved workflow should run to completion"
+    );
+    let events = h.backend.get_events(&h.execution_id).await.unwrap();
+    assert!(
+        events.iter().any(|e| matches!(&e.kind, EventKind::NodeCompleted { node_id, .. } if node_id == "gated")),
+        "the gated node actually executed after approval"
+    );
+
+    h.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_node_fails_workflow_with_reason() {
+    let h = start().await;
+
+    assert!(
+        h.wait_for(
+            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            10
+        )
+        .await
+    );
+    h.approve(ApprovalDecision::Rejected, Some("not in business hours")).await;
+
+    assert!(
+        h.wait_for(
+            |ev| ev.iter().any(|e| matches!(e.kind, EventKind::WorkflowFailed { .. })),
+            15
+        )
+        .await,
+        "rejected workflow should fail"
+    );
+    let events = h.backend.get_events(&h.execution_id).await.unwrap();
+    let reason = events
+        .iter()
+        .find_map(|e| match &e.kind {
+            EventKind::NodeFailed { node_id, error, .. } if node_id == "gated" => {
+                Some(error.clone())
+            }
+            _ => None,
+        })
+        .expect("NodeFailed for the gated node");
+    assert!(
+        reason.contains("e2e-tester") && reason.contains("not in business hours"),
+        "NodeFailed reason should mention reviewer and comment; got: {reason}"
+    );
+    assert!(
+        !events.iter().any(
+            |e| matches!(&e.kind, EventKind::NodeCompleted { node_id, .. } if node_id == "gated")
+        ),
+        "rejected node never executed"
+    );
+
+    h.shutdown().await;
+}

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -410,6 +410,13 @@ struct ExecProgress {
     final_state: serde_json::Map<String, serde_json::Value>,
     /// Highest event sequence already folded in.
     last_sequence: jamjet_state::EventSequence,
+    /// Nodes parked waiting for a human approval decision. They stay in
+    /// `scheduled` too, so the dispatcher won't re-enqueue them; this set
+    /// exists for observability and the rejected/approved transitions.
+    held: HashSet<NodeId>,
+    /// Rejected approvals awaiting their `NodeFailed` emission, node -> reason.
+    /// Cleared when the corresponding `NodeFailed{retryable: false}` folds in.
+    rejected: std::collections::HashMap<NodeId, String>,
 }
 
 impl ExecProgress {
@@ -447,6 +454,8 @@ impl ExecProgress {
             } => {
                 self.terminal_failed.insert(node_id.clone());
                 self.scheduled.remove(node_id);
+                self.rejected.remove(node_id);
+                self.held.remove(node_id);
             }
             EventKind::NodeFailed {
                 node_id,
@@ -458,6 +467,36 @@ impl ExecProgress {
             }
             EventKind::RetryScheduled { node_id, .. } => {
                 self.scheduled.insert(node_id.clone());
+            }
+            EventKind::ToolApprovalRequired { node_id, .. } => {
+                self.held.insert(node_id.clone());
+            }
+            EventKind::ApprovalReceived {
+                node_id,
+                user_id,
+                decision,
+                comment,
+                ..
+            } => {
+                // Only act on decisions that resolve an actual hold; the API
+                // validates, but the fold must stay total and tolerant.
+                if self.held.remove(node_id) {
+                    match decision {
+                        jamjet_state::event::ApprovalDecision::Approved => {
+                            // Free the slot so is_runnable() re-dispatches
+                            // through the normal path.
+                            self.scheduled.remove(node_id);
+                        }
+                        jamjet_state::event::ApprovalDecision::Rejected => {
+                            let mut reason = format!("approval rejected by {user_id}");
+                            if let Some(c) = comment {
+                                reason.push_str(": ");
+                                reason.push_str(c);
+                            }
+                            self.rejected.insert(node_id.clone(), reason);
+                        }
+                    }
+                }
             }
             _ => {}
         }
@@ -672,5 +711,119 @@ mod tests {
         // `a` is terminally failed, `b` can never run, nothing is in flight.
         tick(&s, &e).await;
         assert_eq!(status(&b, &e).await, WorkflowStatus::Failed);
+    }
+
+    fn fold_events(kinds: Vec<EventKind>) -> ExecProgress {
+        let exec_id = ExecutionId::new();
+        let mut progress = ExecProgress::default();
+        for (i, kind) in kinds.into_iter().enumerate() {
+            progress.apply(&Event::new(exec_id.clone(), (i + 1) as i64, kind));
+        }
+        progress
+    }
+
+    #[test]
+    fn approval_required_marks_node_held() {
+        let progress = fold_events(vec![
+            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+        ]);
+        assert!(progress.held.contains("a"));
+        // Still in scheduled: nothing must re-enqueue a held node.
+        assert!(progress.scheduled.contains("a"));
+    }
+
+    #[test]
+    fn approval_approved_unblocks_node_for_rescheduling() {
+        let progress = fold_events(vec![
+            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+            EventKind::ApprovalReceived {
+                node_id: "a".into(),
+                user_id: "u".into(),
+                decision: jamjet_state::event::ApprovalDecision::Approved,
+                comment: None,
+                state_patch: None,
+            },
+        ]);
+        assert!(!progress.held.contains("a"));
+        // Removed from scheduled so is_runnable() can re-dispatch it.
+        assert!(!progress.scheduled.contains("a"));
+        assert!(progress.rejected.is_empty());
+    }
+
+    #[test]
+    fn approval_rejected_marks_node_for_failure() {
+        let progress = fold_events(vec![
+            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+            EventKind::ApprovalReceived {
+                node_id: "a".into(),
+                user_id: "alice".into(),
+                decision: jamjet_state::event::ApprovalDecision::Rejected,
+                comment: Some("too risky".into()),
+                state_patch: None,
+            },
+        ]);
+        assert!(!progress.held.contains("a"));
+        let reason = progress.rejected.get("a").expect("rejected entry");
+        assert!(reason.contains("alice"));
+        assert!(reason.contains("too risky"));
+    }
+
+    #[test]
+    fn node_failed_clears_rejected_marker() {
+        let progress = fold_events(vec![
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+            EventKind::ApprovalReceived {
+                node_id: "a".into(),
+                user_id: "u".into(),
+                decision: jamjet_state::event::ApprovalDecision::Rejected,
+                comment: None,
+                state_patch: None,
+            },
+            EventKind::NodeFailed {
+                node_id: "a".into(),
+                error: "approval rejected".into(),
+                attempt: 0,
+                retryable: false,
+            },
+        ]);
+        assert!(progress.rejected.is_empty());
+        assert!(progress.terminal_failed.contains("a"));
+    }
+
+    #[test]
+    fn approval_decision_without_hold_is_ignored() {
+        let progress = fold_events(vec![EventKind::ApprovalReceived {
+            node_id: "ghost".into(),
+            user_id: "u".into(),
+            decision: jamjet_state::event::ApprovalDecision::Approved,
+            comment: None,
+            state_patch: None,
+        }]);
+        assert!(progress.held.is_empty());
+        assert!(progress.rejected.is_empty());
+        assert!(progress.scheduled.is_empty());
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -247,6 +247,32 @@ impl Scheduler {
             .unwrap()
             .insert(execution_id.clone(), progress.clone());
 
+        // Fail nodes whose approval was rejected. Guarded by terminal_failed so
+        // the emission fires exactly once: the next tick folds the NodeFailed,
+        // which clears the `rejected` marker and inserts into terminal_failed.
+        for (node_id, reason) in progress
+            .rejected
+            .iter()
+            .filter(|(n, _)| !progress.terminal_failed.contains(n.as_str()))
+            .map(|(n, r)| (n.clone(), r.clone()))
+            .collect::<Vec<_>>()
+        {
+            let seq = self.backend.latest_sequence(execution_id).await? + 1;
+            self.backend
+                .append_event(jamjet_state::Event::new(
+                    execution_id.clone(),
+                    seq,
+                    EventKind::NodeFailed {
+                        node_id: node_id.clone(),
+                        error: reason,
+                        attempt: 0,
+                        retryable: false,
+                    },
+                ))
+                .await?;
+            info!(execution_id = %execution_id, node_id = %node_id, "Approval rejected — node failed");
+        }
+
         let completed = &progress.completed;
         let scheduled = &progress.scheduled;
         let terminal_failed = &progress.terminal_failed;
@@ -834,6 +860,58 @@ mod tests {
         assert!(progress.held.is_empty());
         assert!(progress.rejected.is_empty());
         assert!(progress.scheduled.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rejected_approval_fails_node_and_workflow() {
+        let (s, b, e) = setup(linear_ir()).await;
+
+        // Seed: node "a" scheduled, held, then rejected.
+        append(&b, &e, EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() }).await;
+        append(&b, &e, EventKind::ToolApprovalRequired {
+            node_id: "a".into(),
+            tool_name: "t".into(),
+            approver: "human".into(),
+            context: serde_json::json!({}),
+        }).await;
+        append(&b, &e, EventKind::ApprovalReceived {
+            node_id: "a".into(),
+            user_id: "alice".into(),
+            decision: jamjet_state::event::ApprovalDecision::Rejected,
+            comment: Some("nope".into()),
+            state_patch: None,
+        }).await;
+
+        // Tick 1: scheduler folds the rejection and emits NodeFailed.
+        tick(&s, &e).await;
+
+        let evs = b.get_events(&e).await.unwrap();
+        let failed: Vec<_> = evs.iter().filter(|ev| matches!(
+            &ev.kind,
+            EventKind::NodeFailed { node_id, retryable: false, .. } if node_id == "a"
+        )).collect();
+        assert_eq!(failed.len(), 1, "exactly one NodeFailed for the rejected node after tick 1");
+        if let EventKind::NodeFailed { error, .. } = &failed[0].kind {
+            assert!(error.contains("alice"), "reason must include decider: {error}");
+            assert!(error.contains("nope"), "reason must include comment: {error}");
+        }
+
+        // Tick 2: folds the NodeFailed, detects terminal state, emits WorkflowFailed.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            evs.iter().any(|ev| matches!(ev.kind, EventKind::WorkflowFailed { .. })),
+            "WorkflowFailed must be emitted"
+        );
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Failed);
+
+        // Tick 3: execution is terminal — must not duplicate NodeFailed.
+        // The execution is no longer Running so tick() won't visit it,
+        // but we call schedule_runnable_nodes directly to prove idempotence.
+        s.schedule_runnable_nodes(&e, "wf", "0.1.0").await.unwrap();
+        let evs = b.get_events(&e).await.unwrap();
+        let count = evs.iter().filter(|ev| matches!(&ev.kind, EventKind::NodeFailed { .. })).count();
+        assert_eq!(count, 1, "NodeFailed must not be duplicated on subsequent ticks");
     }
 
     #[test]

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -760,7 +760,10 @@ mod tests {
     #[test]
     fn approval_required_marks_node_held() {
         let progress = fold_events(vec![
-            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
             EventKind::ToolApprovalRequired {
                 node_id: "a".into(),
                 tool_name: "t".into(),
@@ -776,7 +779,10 @@ mod tests {
     #[test]
     fn approval_approved_unblocks_node_for_rescheduling() {
         let progress = fold_events(vec![
-            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
             EventKind::ToolApprovalRequired {
                 node_id: "a".into(),
                 tool_name: "t".into(),
@@ -800,7 +806,10 @@ mod tests {
     #[test]
     fn approval_rejected_marks_node_for_failure() {
         let progress = fold_events(vec![
-            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
             EventKind::ToolApprovalRequired {
                 node_id: "a".into(),
                 tool_name: "t".into(),
@@ -867,40 +876,74 @@ mod tests {
         let (s, b, e) = setup(linear_ir()).await;
 
         // Seed: node "a" scheduled, held, then rejected.
-        append(&b, &e, EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() }).await;
-        append(&b, &e, EventKind::ToolApprovalRequired {
-            node_id: "a".into(),
-            tool_name: "t".into(),
-            approver: "human".into(),
-            context: serde_json::json!({}),
-        }).await;
-        append(&b, &e, EventKind::ApprovalReceived {
-            node_id: "a".into(),
-            user_id: "alice".into(),
-            decision: jamjet_state::event::ApprovalDecision::Rejected,
-            comment: Some("nope".into()),
-            state_patch: None,
-        }).await;
+        append(
+            &b,
+            &e,
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
+        )
+        .await;
+        append(
+            &b,
+            &e,
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+        )
+        .await;
+        append(
+            &b,
+            &e,
+            EventKind::ApprovalReceived {
+                node_id: "a".into(),
+                user_id: "alice".into(),
+                decision: jamjet_state::event::ApprovalDecision::Rejected,
+                comment: Some("nope".into()),
+                state_patch: None,
+            },
+        )
+        .await;
 
         // Tick 1: scheduler folds the rejection and emits NodeFailed.
         tick(&s, &e).await;
 
         let evs = b.get_events(&e).await.unwrap();
-        let failed: Vec<_> = evs.iter().filter(|ev| matches!(
-            &ev.kind,
-            EventKind::NodeFailed { node_id, retryable: false, .. } if node_id == "a"
-        )).collect();
-        assert_eq!(failed.len(), 1, "exactly one NodeFailed for the rejected node after tick 1");
+        let failed: Vec<_> = evs
+            .iter()
+            .filter(|ev| {
+                matches!(
+                    &ev.kind,
+                    EventKind::NodeFailed { node_id, retryable: false, .. } if node_id == "a"
+                )
+            })
+            .collect();
+        assert_eq!(
+            failed.len(),
+            1,
+            "exactly one NodeFailed for the rejected node after tick 1"
+        );
         if let EventKind::NodeFailed { error, .. } = &failed[0].kind {
-            assert!(error.contains("alice"), "reason must include decider: {error}");
-            assert!(error.contains("nope"), "reason must include comment: {error}");
+            assert!(
+                error.contains("alice"),
+                "reason must include decider: {error}"
+            );
+            assert!(
+                error.contains("nope"),
+                "reason must include comment: {error}"
+            );
         }
 
         // Tick 2: folds the NodeFailed, detects terminal state, emits WorkflowFailed.
         tick(&s, &e).await;
         let evs = b.get_events(&e).await.unwrap();
         assert!(
-            evs.iter().any(|ev| matches!(ev.kind, EventKind::WorkflowFailed { .. })),
+            evs.iter()
+                .any(|ev| matches!(ev.kind, EventKind::WorkflowFailed { .. })),
             "WorkflowFailed must be emitted"
         );
         assert_eq!(status(&b, &e).await, WorkflowStatus::Failed);
@@ -910,14 +953,23 @@ mod tests {
         // but we call schedule_runnable_nodes directly to prove idempotence.
         s.schedule_runnable_nodes(&e, "wf", "0.1.0").await.unwrap();
         let evs = b.get_events(&e).await.unwrap();
-        let count = evs.iter().filter(|ev| matches!(&ev.kind, EventKind::NodeFailed { .. })).count();
-        assert_eq!(count, 1, "NodeFailed must not be duplicated on subsequent ticks");
+        let count = evs
+            .iter()
+            .filter(|ev| matches!(&ev.kind, EventKind::NodeFailed { .. }))
+            .count();
+        assert_eq!(
+            count, 1,
+            "NodeFailed must not be duplicated on subsequent ticks"
+        );
     }
 
     #[test]
     fn retryable_failure_clears_hold() {
         let progress = fold_events(vec![
-            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
             EventKind::ToolApprovalRequired {
                 node_id: "a".into(),
                 tool_name: "t".into(),
@@ -949,8 +1001,14 @@ mod tests {
                 provenance: None,
             },
         ]);
-        assert!(progress.held.is_empty(), "held must be cleared after retryable failure");
-        assert!(progress.completed.contains("a"), "node must be in completed after NodeCompleted");
+        assert!(
+            progress.held.is_empty(),
+            "held must be cleared after retryable failure"
+        );
+        assert!(
+            progress.completed.contains("a"),
+            "node must be in completed after NodeCompleted"
+        );
         assert!(progress.rejected.is_empty(), "rejected must be empty");
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -437,9 +437,10 @@ struct ExecProgress {
     final_state: serde_json::Map<String, serde_json::Value>,
     /// Highest event sequence already folded in.
     last_sequence: jamjet_state::EventSequence,
-    /// Nodes parked waiting for a human approval decision. They stay in
-    /// `scheduled` too, so the dispatcher won't re-enqueue them; this set
-    /// exists for observability and the rejected/approved transitions.
+    /// Nodes awaiting a human approval decision. This set does NOT keep the
+    /// node parked — that comes from the node remaining in `scheduled` (the
+    /// dispatcher won't re-enqueue it). `held` only gates which
+    /// `ApprovalReceived` decisions are acted on.
     held: HashSet<NodeId>,
     /// Rejected approvals awaiting their `NodeFailed` emission, node -> reason.
     /// Cleared when the corresponding `NodeFailed{retryable: false}` folds in.
@@ -459,6 +460,8 @@ impl ExecProgress {
             } => {
                 self.completed.insert(node_id.clone());
                 self.scheduled.remove(node_id);
+                // Stale-hold cleanup: a completed node no longer awaits approval.
+                self.held.remove(node_id);
                 if let serde_json::Value::Object(patch) = state_patch {
                     for (k, v) in patch {
                         self.final_state.insert(k.clone(), v.clone());
@@ -468,6 +471,8 @@ impl ExecProgress {
             EventKind::NodeSkipped { node_id, .. } => {
                 self.completed.insert(node_id.clone());
                 self.scheduled.remove(node_id);
+                // Stale-hold cleanup: a skipped node no longer awaits approval.
+                self.held.remove(node_id);
             }
             EventKind::NodeScheduled { node_id, .. } | EventKind::NodeStarted { node_id, .. } => {
                 self.scheduled.insert(node_id.clone());
@@ -495,10 +500,11 @@ impl ExecProgress {
             } => {
                 // Re-queued by the subsequent RetryScheduled event.
                 self.scheduled.remove(node_id);
-                // A hold is superseded by the re-queue; without this, a worker
-                // crash mid-hold leaves the node in `held` forever after its
-                // retry completes.
-                self.held.remove(node_id);
+                // Deliberately do NOT clear `held`: a lease reclaim can fire
+                // while the node is parked for approval, and the re-claimed
+                // worker settles quietly without re-emitting
+                // ToolApprovalRequired. Clearing the hold here would drop the
+                // eventual ApprovalReceived decision and wedge the execution.
             }
             EventKind::RetryScheduled { node_id, .. } => {
                 self.scheduled.insert(node_id.clone());
@@ -964,7 +970,12 @@ mod tests {
     }
 
     #[test]
-    fn retryable_failure_clears_hold() {
+    fn reclaimed_hold_still_resumes_on_approval() {
+        // Worker crashes mid-hold: the lease reclaim emits a retryable
+        // NodeFailed, the retry is re-queued, and the re-claimed worker sees
+        // the approval still Pending so it settles quietly — emitting nothing.
+        // The hold must survive all of that so the eventual approval still
+        // resumes the node instead of being silently dropped.
         let progress = fold_events(vec![
             EventKind::NodeScheduled {
                 node_id: "a".into(),
@@ -987,28 +998,69 @@ mod tests {
                 attempt: 1,
                 delay_ms: 1000,
             },
-            EventKind::NodeCompleted {
+            EventKind::ApprovalReceived {
                 node_id: "a".into(),
-                output: serde_json::json!({}),
-                state_patch: serde_json::json!({}),
-                duration_ms: 1,
-                gen_ai_system: None,
-                gen_ai_model: None,
-                input_tokens: None,
-                output_tokens: None,
-                finish_reason: None,
-                cost_usd: None,
-                provenance: None,
+                user_id: "u".into(),
+                decision: jamjet_state::event::ApprovalDecision::Approved,
+                comment: None,
+                state_patch: None,
             },
         ]);
         assert!(
             progress.held.is_empty(),
-            "held must be cleared after retryable failure"
+            "hold must be consumed by the approval"
         );
         assert!(
-            progress.completed.contains("a"),
-            "node must be in completed after NodeCompleted"
+            !progress.scheduled.contains("a"),
+            "approved node must leave `scheduled` so it is re-dispatchable"
         );
         assert!(progress.rejected.is_empty(), "rejected must be empty");
+    }
+
+    #[test]
+    fn reclaimed_hold_still_fails_on_rejection() {
+        let progress = fold_events(vec![
+            EventKind::NodeScheduled {
+                node_id: "a".into(),
+                queue_type: "general".into(),
+            },
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+            EventKind::NodeFailed {
+                node_id: "a".into(),
+                error: "worker crashed mid-hold".into(),
+                attempt: 0,
+                retryable: true,
+            },
+            EventKind::RetryScheduled {
+                node_id: "a".into(),
+                attempt: 1,
+                delay_ms: 1000,
+            },
+            EventKind::ApprovalReceived {
+                node_id: "a".into(),
+                user_id: "u".into(),
+                decision: jamjet_state::event::ApprovalDecision::Rejected,
+                comment: Some("no".into()),
+                state_patch: None,
+            },
+        ]);
+        let reason = progress.rejected.get("a").expect("rejected entry for a");
+        assert!(
+            reason.contains("u"),
+            "reason must include decider: {reason}"
+        );
+        assert!(
+            reason.contains("no"),
+            "reason must include comment: {reason}"
+        );
+        assert!(
+            progress.held.is_empty(),
+            "hold must be consumed by the rejection"
+        );
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -256,6 +256,7 @@ impl Scheduler {
             completed_nodes = completed.len(),
             scheduled_nodes = scheduled.len(),
             terminal_failed_nodes = terminal_failed.len(),
+            held_nodes = progress.held.len(),
             "Checking for runnable nodes"
         );
 
@@ -416,7 +417,9 @@ struct ExecProgress {
     held: HashSet<NodeId>,
     /// Rejected approvals awaiting their `NodeFailed` emission, node -> reason.
     /// Cleared when the corresponding `NodeFailed{retryable: false}` folds in.
-    rejected: std::collections::HashMap<NodeId, String>,
+    /// Note: a rejected node stays in `scheduled` (consuming a concurrency slot)
+    /// until the follow-up `NodeFailed` emission clears it.
+    rejected: HashMap<NodeId, String>,
 }
 
 impl ExecProgress {
@@ -446,6 +449,8 @@ impl ExecProgress {
             EventKind::NodeCancelled { node_id } => {
                 self.completed.insert(node_id.clone());
                 self.scheduled.remove(node_id);
+                self.held.remove(node_id);
+                self.rejected.remove(node_id);
             }
             EventKind::NodeFailed {
                 node_id,
@@ -464,6 +469,10 @@ impl ExecProgress {
             } => {
                 // Re-queued by the subsequent RetryScheduled event.
                 self.scheduled.remove(node_id);
+                // A hold is superseded by the re-queue; without this, a worker
+                // crash mid-hold leaves the node in `held` forever after its
+                // retry completes.
+                self.held.remove(node_id);
             }
             EventKind::RetryScheduled { node_id, .. } => {
                 self.scheduled.insert(node_id.clone());
@@ -825,5 +834,45 @@ mod tests {
         assert!(progress.held.is_empty());
         assert!(progress.rejected.is_empty());
         assert!(progress.scheduled.is_empty());
+    }
+
+    #[test]
+    fn retryable_failure_clears_hold() {
+        let progress = fold_events(vec![
+            EventKind::NodeScheduled { node_id: "a".into(), queue_type: "general".into() },
+            EventKind::ToolApprovalRequired {
+                node_id: "a".into(),
+                tool_name: "t".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+            EventKind::NodeFailed {
+                node_id: "a".into(),
+                error: "worker crashed mid-hold".into(),
+                attempt: 0,
+                retryable: true,
+            },
+            EventKind::RetryScheduled {
+                node_id: "a".into(),
+                attempt: 1,
+                delay_ms: 1000,
+            },
+            EventKind::NodeCompleted {
+                node_id: "a".into(),
+                output: serde_json::json!({}),
+                state_patch: serde_json::json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+            },
+        ]);
+        assert!(progress.held.is_empty(), "held must be cleared after retryable failure");
+        assert!(progress.completed.contains("a"), "node must be in completed after NodeCompleted");
+        assert!(progress.rejected.is_empty(), "rejected must be empty");
     }
 }

--- a/runtime/state/src/approvals.rs
+++ b/runtime/state/src/approvals.rs
@@ -1,0 +1,242 @@
+//! Approval-state derivation.
+//!
+//! Folds an execution's event log into per-node approval status. This is the
+//! single source of truth consumed by the worker (skip re-holding an approved
+//! node), the API (validate decisions, list pending approvals), and the
+//! scheduler tests. Events are the only persistent state: a node is pending
+//! iff its latest `ToolApprovalRequired` has no later `ApprovalReceived`.
+
+use crate::event::{ApprovalDecision, EventKind};
+use crate::{Event, EventSequence};
+use serde::Serialize;
+
+/// A `ToolApprovalRequired` that has not been decided yet.
+#[derive(Debug, Clone, Serialize)]
+pub struct PendingApproval {
+    pub node_id: String,
+    pub tool_name: String,
+    pub approver: String,
+    pub context: serde_json::Value,
+    pub sequence: EventSequence,
+}
+
+/// Approval status of a single node, derived from the event log.
+#[derive(Debug, Clone)]
+pub enum NodeApprovalStatus {
+    NotRequested,
+    Pending(PendingApproval),
+    Approved {
+        user_id: String,
+        sequence: EventSequence,
+    },
+    Rejected {
+        user_id: String,
+        comment: Option<String>,
+        sequence: EventSequence,
+    },
+}
+
+/// Fold events (must be in sequence order) into the status of `node_id`.
+pub fn node_approval_status(events: &[Event], node_id: &str) -> NodeApprovalStatus {
+    let mut status = NodeApprovalStatus::NotRequested;
+    for event in events {
+        match &event.kind {
+            EventKind::ToolApprovalRequired {
+                node_id: n,
+                tool_name,
+                approver,
+                context,
+            } if n == node_id => {
+                status = NodeApprovalStatus::Pending(PendingApproval {
+                    node_id: n.clone(),
+                    tool_name: tool_name.clone(),
+                    approver: approver.clone(),
+                    context: context.clone(),
+                    sequence: event.sequence,
+                });
+            }
+            EventKind::ApprovalReceived {
+                node_id: n,
+                user_id,
+                decision,
+                comment,
+                ..
+            } if n == node_id => {
+                // A decision only resolves an outstanding request.
+                if matches!(status, NodeApprovalStatus::Pending(_)) {
+                    status = match decision {
+                        ApprovalDecision::Approved => NodeApprovalStatus::Approved {
+                            user_id: user_id.clone(),
+                            sequence: event.sequence,
+                        },
+                        ApprovalDecision::Rejected => NodeApprovalStatus::Rejected {
+                            user_id: user_id.clone(),
+                            comment: comment.clone(),
+                            sequence: event.sequence,
+                        },
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+    status
+}
+
+/// All nodes whose latest `ToolApprovalRequired` is undecided.
+pub fn pending_approvals(events: &[Event]) -> Vec<PendingApproval> {
+    use std::collections::BTreeMap;
+    let mut by_node: BTreeMap<String, Option<PendingApproval>> = BTreeMap::new();
+    for event in events {
+        match &event.kind {
+            EventKind::ToolApprovalRequired {
+                node_id,
+                tool_name,
+                approver,
+                context,
+            } => {
+                by_node.insert(
+                    node_id.clone(),
+                    Some(PendingApproval {
+                        node_id: node_id.clone(),
+                        tool_name: tool_name.clone(),
+                        approver: approver.clone(),
+                        context: context.clone(),
+                        sequence: event.sequence,
+                    }),
+                );
+            }
+            EventKind::ApprovalReceived { node_id, .. } => {
+                if let Some(slot) = by_node.get_mut(node_id) {
+                    *slot = None;
+                }
+            }
+            _ => {}
+        }
+    }
+    by_node.into_values().flatten().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{ApprovalDecision, EventKind};
+    use crate::Event;
+    use jamjet_core::workflow::ExecutionId;
+
+    fn ev(seq: u64, kind: EventKind) -> Event {
+        Event::new(ExecutionId::new(), seq as EventSequence, kind)
+    }
+    fn required(seq: u64, node: &str) -> Event {
+        ev(
+            seq,
+            EventKind::ToolApprovalRequired {
+                node_id: node.into(),
+                tool_name: format!("tool_{node}"),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+        )
+    }
+    fn received(seq: u64, node: &str, decision: ApprovalDecision) -> Event {
+        ev(
+            seq,
+            EventKind::ApprovalReceived {
+                node_id: node.into(),
+                user_id: "tester".into(),
+                decision,
+                comment: Some("note".into()),
+                state_patch: None,
+            },
+        )
+    }
+
+    #[test]
+    fn no_events_means_not_requested() {
+        assert!(matches!(
+            node_approval_status(&[], "a"),
+            NodeApprovalStatus::NotRequested
+        ));
+        assert!(pending_approvals(&[]).is_empty());
+    }
+
+    #[test]
+    fn required_without_decision_is_pending() {
+        let events = vec![required(1, "a")];
+        match node_approval_status(&events, "a") {
+            NodeApprovalStatus::Pending(p) => {
+                assert_eq!(p.node_id, "a");
+                assert_eq!(p.tool_name, "tool_a");
+                assert_eq!(p.sequence, 1);
+            }
+            other => panic!("expected Pending, got {other:?}"),
+        }
+        assert_eq!(pending_approvals(&events).len(), 1);
+    }
+
+    #[test]
+    fn approved_resolves_pending() {
+        let events = vec![required(1, "a"), received(2, "a", ApprovalDecision::Approved)];
+        assert!(matches!(
+            node_approval_status(&events, "a"),
+            NodeApprovalStatus::Approved { .. }
+        ));
+        assert!(pending_approvals(&events).is_empty());
+    }
+
+    #[test]
+    fn rejected_resolves_pending_with_comment() {
+        let events = vec![required(1, "a"), received(2, "a", ApprovalDecision::Rejected)];
+        match node_approval_status(&events, "a") {
+            NodeApprovalStatus::Rejected {
+                user_id, comment, ..
+            } => {
+                assert_eq!(user_id, "tester");
+                assert_eq!(comment.as_deref(), Some("note"));
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_request_after_approval_is_pending_again() {
+        let events = vec![
+            required(1, "a"),
+            received(2, "a", ApprovalDecision::Approved),
+            required(3, "a"),
+        ];
+        assert!(matches!(
+            node_approval_status(&events, "a"),
+            NodeApprovalStatus::Pending(_)
+        ));
+    }
+
+    #[test]
+    fn decision_without_request_is_ignored() {
+        let events = vec![received(1, "a", ApprovalDecision::Approved)];
+        assert!(matches!(
+            node_approval_status(&events, "a"),
+            NodeApprovalStatus::NotRequested
+        ));
+    }
+
+    #[test]
+    fn per_node_isolation() {
+        let events = vec![
+            required(1, "a"),
+            required(2, "b"),
+            received(3, "a", ApprovalDecision::Approved),
+        ];
+        assert!(matches!(
+            node_approval_status(&events, "a"),
+            NodeApprovalStatus::Approved { .. }
+        ));
+        assert!(matches!(
+            node_approval_status(&events, "b"),
+            NodeApprovalStatus::Pending(_)
+        ));
+        let pending = pending_approvals(&events);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].node_id, "b");
+    }
+}

--- a/runtime/state/src/approvals.rs
+++ b/runtime/state/src/approvals.rs
@@ -107,6 +107,9 @@ pub fn pending_approvals(events: &[Event]) -> Vec<PendingApproval> {
                 );
             }
             EventKind::ApprovalReceived { node_id, .. } => {
+                // Intentional asymmetry: node_approval_status returns NotRequested for a
+                // decision with no prior request; here we simply leave the event with no
+                // effect. Both paths ignore orphan decisions by design.
                 if let Some(slot) = by_node.get_mut(node_id) {
                     *slot = None;
                 }
@@ -218,6 +221,16 @@ mod tests {
             node_approval_status(&events, "a"),
             NodeApprovalStatus::NotRequested
         ));
+    }
+
+    #[test]
+    fn pending_approvals_order_is_deterministic() {
+        // Insert "b" before "a" to verify BTreeMap lexicographic ordering, not insertion order.
+        let events = vec![required(1, "b"), required(2, "a")];
+        let pending = pending_approvals(&events);
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].node_id, "a");
+        assert_eq!(pending[1].node_id, "b");
     }
 
     #[test]

--- a/runtime/state/src/approvals.rs
+++ b/runtime/state/src/approvals.rs
@@ -179,7 +179,10 @@ mod tests {
 
     #[test]
     fn approved_resolves_pending() {
-        let events = vec![required(1, "a"), received(2, "a", ApprovalDecision::Approved)];
+        let events = vec![
+            required(1, "a"),
+            received(2, "a", ApprovalDecision::Approved),
+        ];
         assert!(matches!(
             node_approval_status(&events, "a"),
             NodeApprovalStatus::Approved { .. }
@@ -189,7 +192,10 @@ mod tests {
 
     #[test]
     fn rejected_resolves_pending_with_comment() {
-        let events = vec![required(1, "a"), received(2, "a", ApprovalDecision::Rejected)];
+        let events = vec![
+            required(1, "a"),
+            received(2, "a", ApprovalDecision::Rejected),
+        ];
         match node_approval_status(&events, "a") {
             NodeApprovalStatus::Rejected {
                 user_id, comment, ..

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -5,6 +5,7 @@
 // require explicit catch-all arms and duplicate destructuring.
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
+pub mod approvals;
 pub mod backend;
 pub mod budget;
 pub mod event;

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -446,7 +446,17 @@ impl StateBackend for SqliteBackend {
         // appends to the same execution cannot compute the same number and
         // collide on UNIQUE(execution_id, sequence). The caller-supplied
         // sequence is advisory; the database is the source of truth.
-        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        //
+        // BEGIN IMMEDIATE: take the write lock up front. A deferred BEGIN would
+        // open a read transaction at the SELECT and upgrade to a write at the
+        // INSERT — and SQLite never invokes the busy handler on that upgrade
+        // (only on fresh transactions), so any concurrent writer produces an
+        // instant SQLITE_BUSY that bypasses the 5s busy_timeout.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
         let seq_row = sqlx::query(
             "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
         )
@@ -627,7 +637,13 @@ impl StateBackend for SqliteBackend {
 
         // SQLite doesn't support UPDATE ... RETURNING with a subquery easily, so
         // we use a transaction: SELECT FOR UPDATE equivalent via exclusive transaction.
-        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        // BEGIN IMMEDIATE: see append_event — a deferred SELECT→UPDATE upgrade
+        // hits an instant SQLITE_BUSY (busy handler skipped) under concurrency.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
 
         // Build placeholders for queue_types IN clause
         let placeholders = queue_types

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -408,7 +408,13 @@ impl StateBackend for TenantScopedSqliteBackend {
         // MAX is scoped to the execution only (not the tenant), so it agrees with
         // the base backend's sequence even when an execution's events carry mixed
         // tenant_id rows (scheduler/worker run on the base backend in dev).
-        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        // BEGIN IMMEDIATE: a deferred SELECT→INSERT upgrade hits an instant
+        // SQLITE_BUSY (busy handler skipped) under concurrency.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
         let seq_row = sqlx::query(
             "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
         )
@@ -598,7 +604,13 @@ impl StateBackend for TenantScopedSqliteBackend {
         .await
         .map_err(map_db_err)?;
 
-        let mut tx = self.pool.begin().await.map_err(map_db_err)?;
+        // BEGIN IMMEDIATE: see SqliteBackend::append_event — a deferred
+        // SELECT→UPDATE upgrade hits an instant SQLITE_BUSY under concurrency.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
 
         let placeholders = queue_types
             .iter()

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -7,7 +7,8 @@ use jamjet_ir::workflow::{NodeDef, WorkflowIr};
 use jamjet_policy::autonomy::{AutonomyContext, AutonomyDecision, AutonomyEnforcer};
 use jamjet_policy::engine::node_kind_tag;
 use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
-use jamjet_state::backend::{StateBackend, WorkItem};
+use jamjet_state::approvals::NodeApprovalStatus;
+use jamjet_state::backend::{StateBackend, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
 use jamjet_state::event::EventKind;
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
@@ -174,7 +175,15 @@ impl Worker {
 
                     // Policy check.
                     if let Some(r) = self
-                        .check_policy(&execution_id, item_id, &node_id, &tenant_id, kind, node_def, &ir)
+                        .check_policy(
+                            &execution_id,
+                            item_id,
+                            &node_id,
+                            &tenant_id,
+                            kind,
+                            node_def,
+                            &ir,
+                        )
                         .await
                     {
                         heartbeat.abort();
@@ -337,11 +346,13 @@ impl Worker {
     /// `ToolApprovalRequired` exists and settle the work item cleanly so the
     /// lease never expires into the retry/dead-letter path. The scheduler's
     /// fold (`held` set) keeps the node parked until a decision event arrives.
+    /// The helper requires the FULL event log because a partial fold could
+    /// misreport NotRequested for an already-approved node.
     async fn hold_for_approval(
         &self,
         execution_id: &ExecutionId,
         node_id: &str,
-        item_id: uuid::Uuid,
+        item_id: WorkItemId,
         tool_name: String,
         approver: String,
         context: serde_json::Value,
@@ -350,13 +361,13 @@ impl Worker {
             Ok(events) => events,
             Err(e) => {
                 // Fail closed: never run an approval-gated node blind.
-                return Some(Err(
-                    format!("approval state unavailable; refusing to run unapproved: {e}").into(),
-                ));
+                return Some(Err(format!(
+                    "approval state unavailable; refusing to run unapproved: {e}"
+                )
+                .into()));
             }
         };
 
-        use jamjet_state::approvals::NodeApprovalStatus;
         match jamjet_state::approvals::node_approval_status(&events, node_id) {
             NodeApprovalStatus::Approved { .. } => {
                 info!(execution_id = %execution_id, node_id, "Approval satisfied — proceeding");
@@ -375,9 +386,10 @@ impl Worker {
                 let seq = match self.backend.latest_sequence(execution_id).await {
                     Ok(s) => s + 1,
                     Err(e) => {
-                        return Some(Err(
-                            format!("approval required but could not be recorded: {e}").into(),
-                        ))
+                        return Some(Err(format!(
+                            "approval required but could not be recorded: {e}"
+                        )
+                        .into()))
                     }
                 };
                 if let Err(e) = self
@@ -395,9 +407,10 @@ impl Worker {
                     .await
                 {
                     // Fail closed.
-                    return Some(Err(
-                        format!("approval required but could not be recorded: {e}").into(),
-                    ));
+                    return Some(Err(format!(
+                        "approval required but could not be recorded: {e}"
+                    )
+                    .into()));
                 }
                 if let Err(e) = self.backend.complete_work_item(item_id).await {
                     return Some(Err(format!("failed to settle held work item: {e}").into()));
@@ -413,7 +426,7 @@ impl Worker {
     async fn check_policy(
         &self,
         execution_id: &ExecutionId,
-        item_id: uuid::Uuid,
+        item_id: WorkItemId,
         node_id: &str,
         tenant_id: &str,
         kind: &NodeKind,
@@ -531,7 +544,7 @@ impl Worker {
     async fn check_autonomy(
         &self,
         execution_id: &ExecutionId,
-        item_id: uuid::Uuid,
+        item_id: WorkItemId,
         node_id: &str,
         kind: &NodeKind,
         budget: &BudgetState,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -174,7 +174,7 @@ impl Worker {
 
                     // Policy check.
                     if let Some(r) = self
-                        .check_policy(&execution_id, &node_id, &tenant_id, kind, node_def, &ir)
+                        .check_policy(&execution_id, item_id, &node_id, &tenant_id, kind, node_def, &ir)
                         .await
                     {
                         heartbeat.abort();
@@ -183,7 +183,7 @@ impl Worker {
 
                     // Autonomy check.
                     if let Some(r) = self
-                        .check_autonomy(&execution_id, &node_id, kind, &budget)
+                        .check_autonomy(&execution_id, item_id, &node_id, kind, &budget)
                         .await
                     {
                         heartbeat.abort();
@@ -327,11 +327,93 @@ impl Worker {
         Ok(())
     }
 
+    // ── Approval hold helper ──────────────────────────────────────────────────
+
+    /// Park a node pending human approval (or let it run if already approved).
+    ///
+    /// Consults the event log: an `ApprovalReceived{Approved}` with no newer
+    /// `ToolApprovalRequired` means the gate is satisfied — return None so the
+    /// caller proceeds to execute. Otherwise ensure exactly one outstanding
+    /// `ToolApprovalRequired` exists and settle the work item cleanly so the
+    /// lease never expires into the retry/dead-letter path. The scheduler's
+    /// fold (`held` set) keeps the node parked until a decision event arrives.
+    async fn hold_for_approval(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        item_id: uuid::Uuid,
+        tool_name: String,
+        approver: String,
+        context: serde_json::Value,
+    ) -> Option<Result<(), Box<dyn std::error::Error + Send + Sync>>> {
+        let events = match self.backend.get_events(execution_id).await {
+            Ok(events) => events,
+            Err(e) => {
+                // Fail closed: never run an approval-gated node blind.
+                return Some(Err(
+                    format!("approval state unavailable; refusing to run unapproved: {e}").into(),
+                ));
+            }
+        };
+
+        use jamjet_state::approvals::NodeApprovalStatus;
+        match jamjet_state::approvals::node_approval_status(&events, node_id) {
+            NodeApprovalStatus::Approved { .. } => {
+                info!(execution_id = %execution_id, node_id, "Approval satisfied — proceeding");
+                None
+            }
+            NodeApprovalStatus::Pending(_) | NodeApprovalStatus::Rejected { .. } => {
+                // Already requested (or decided rejected — scheduler owns the
+                // failure). Settle the item; emit nothing.
+                if let Err(e) = self.backend.complete_work_item(item_id).await {
+                    return Some(Err(format!("failed to settle held work item: {e}").into()));
+                }
+                Some(Ok(()))
+            }
+            NodeApprovalStatus::NotRequested => {
+                info!(execution_id = %execution_id, node_id, %approver, "Node requires approval");
+                let seq = match self.backend.latest_sequence(execution_id).await {
+                    Ok(s) => s + 1,
+                    Err(e) => {
+                        return Some(Err(
+                            format!("approval required but could not be recorded: {e}").into(),
+                        ))
+                    }
+                };
+                if let Err(e) = self
+                    .backend
+                    .append_event(jamjet_state::Event::new(
+                        execution_id.clone(),
+                        seq,
+                        EventKind::ToolApprovalRequired {
+                            node_id: node_id.to_string(),
+                            tool_name,
+                            approver,
+                            context,
+                        },
+                    ))
+                    .await
+                {
+                    // Fail closed.
+                    return Some(Err(
+                        format!("approval required but could not be recorded: {e}").into(),
+                    ));
+                }
+                if let Err(e) = self.backend.complete_work_item(item_id).await {
+                    return Some(Err(format!("failed to settle held work item: {e}").into()));
+                }
+                Some(Ok(()))
+            }
+        }
+    }
+
     // ── Policy check ──────────────────────────────────────────────────────────
 
+    #[allow(clippy::too_many_arguments)]
     async fn check_policy(
         &self,
         execution_id: &ExecutionId,
+        item_id: uuid::Uuid,
         node_id: &str,
         tenant_id: &str,
         kind: &NodeKind,
@@ -399,33 +481,16 @@ impl Worker {
             }
 
             PolicyDecision::RequireApproval { approver } => {
-                info!(execution_id = %execution_id, node_id, %approver, "Node requires approval");
                 let tool_name = ctx.tool_name.unwrap_or_else(|| node_id.to_string());
-                // If we cannot record the approval requirement, fail closed rather
-                // than letting the node run unapproved.
-                let seq = match self.backend.latest_sequence(execution_id).await {
-                    Ok(s) => s + 1,
-                    Err(e) => {
-                        return Some(Err(format!(
-                            "approval required but could not be recorded: {e}"
-                        )
-                        .into()))
-                    }
-                };
-                let _ = self
-                    .backend
-                    .append_event(jamjet_state::Event::new(
-                        execution_id.clone(),
-                        seq,
-                        EventKind::ToolApprovalRequired {
-                            node_id: node_id.to_string(),
-                            tool_name,
-                            approver,
-                            context: serde_json::json!({ "node_id": node_id }),
-                        },
-                    ))
-                    .await;
-                Some(Ok(()))
+                self.hold_for_approval(
+                    execution_id,
+                    node_id,
+                    item_id,
+                    tool_name,
+                    approver,
+                    serde_json::json!({ "node_id": node_id }),
+                )
+                .await
             }
         }
     }
@@ -466,6 +531,7 @@ impl Worker {
     async fn check_autonomy(
         &self,
         execution_id: &ExecutionId,
+        item_id: uuid::Uuid,
         node_id: &str,
         kind: &NodeKind,
         budget: &BudgetState,
@@ -509,21 +575,15 @@ impl Worker {
             AutonomyDecision::Proceed => None,
 
             AutonomyDecision::RequireToolApproval { tool_name } => {
-                let seq = self.backend.latest_sequence(execution_id).await.ok()? + 1;
-                let _ = self
-                    .backend
-                    .append_event(jamjet_state::Event::new(
-                        execution_id.clone(),
-                        seq,
-                        EventKind::ToolApprovalRequired {
-                            node_id: node_id.to_string(),
-                            tool_name,
-                            approver: "human".to_string(),
-                            context: serde_json::json!({ "agent_ref": agent_ref }),
-                        },
-                    ))
-                    .await;
-                Some(Ok(()))
+                self.hold_for_approval(
+                    execution_id,
+                    node_id,
+                    item_id,
+                    tool_name,
+                    "human".to_string(),
+                    serde_json::json!({ "agent_ref": agent_ref }),
+                )
+                .await
             }
 
             AutonomyDecision::EscalateLimit {

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -344,8 +344,10 @@ impl Worker {
     /// `ToolApprovalRequired` means the gate is satisfied — return None so the
     /// caller proceeds to execute. Otherwise ensure exactly one outstanding
     /// `ToolApprovalRequired` exists and settle the work item cleanly so the
-    /// lease never expires into the retry/dead-letter path. The scheduler's
-    /// fold (`held` set) keeps the node parked until a decision event arrives.
+    /// lease never expires into the retry/dead-letter path. The node stays
+    /// parked because it remains in the scheduler fold's `scheduled` set (so
+    /// it is never re-dispatched); the fold's `held` set only gates which
+    /// decision events are acted on.
     /// The helper requires the FULL event log because a partial fold could
     /// misreport NotRequested for an already-approved node.
     async fn hold_for_approval(
@@ -587,6 +589,10 @@ impl Worker {
         match decision {
             AutonomyDecision::Proceed => None,
 
+            // Currently unreachable at runtime: `AutonomyEnforcer.check` above
+            // is called with `tool_name: None` (pre-existing), so it never
+            // returns RequireToolApproval. The wiring is in place for when
+            // pending tool names are threaded through.
             AutonomyDecision::RequireToolApproval { tool_name } => {
                 self.hold_for_approval(
                     execution_id,


### PR DESCRIPTION
Approval-gated nodes now park durably and resume.

Before this PR, require_approval_for held a node by emitting ToolApprovalRequired and abandoning the claimed work item: the lease expired, the item retried, re-held, and eventually dead-lettered. Approving via POST /executions/:id/approve recorded an ApprovalReceived event that nothing consumed, so the execution stayed stuck forever. The same leak existed in the autonomy RequireToolApproval path (which additionally failed open on backend errors).

Now:
- The worker settles the work item cleanly when holding (both policy and autonomy paths, via a shared fail-closed helper) and proceeds when the event log shows a satisfied approval.
- The scheduler folds ToolApprovalRequired/ApprovalReceived: approved nodes re-enter the normal runnable path; rejected nodes fail terminally with the decider and comment in the reason, failing the workflow (same semantics as a policy block).
- POST /executions/:id/approve validates against derived pending state (409 when nothing is pending or already decided, 400 when node_id is ambiguous) and infers node_id when exactly one approval is pending.
- New GET /executions/:id/approvals lists pending + decided approvals.
- MCP jamjet_approve goes through the same validated path.

Parked approvals survive restarts: held state is derived entirely from the event log. No timeout in v1 (parked indefinitely by design); approver routing and Cloud-side wiring are separate work.

Also fixes a latent SQLite hazard the new e2e tests exposed: deferred transactions that upgrade read to write bypass SQLite's busy handler, so append_event/claim_work_item could fail instantly with SQLITE_BUSY under connection overlap, stranding a claimed item until lease reclaim. Those transactions now BEGIN IMMEDIATE so the busy_timeout applies.

Tests: approval-state fold unit tests (state), held/approved/rejected fold + rejected-emission tests (scheduler), 3 e2e tests (park without dead-letter including duplicate-work-item injection, approve-resume-complete, reject-fail-with-reason), 7 HTTP-level API tests. Full workspace suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval system for human-reviewed workflow nodes with resume/fail outcomes.
  * New endpoint to list execution approvals and enhanced approve endpoint returning the resolved node.
  * Approve requests accept optional comments and state patches; single-pending approval is auto-disambiguated.

* **Bug Fixes**
  * Proper 409 Conflict responses for invalid/duplicate/terminal approval attempts.
  * Scheduler/workers ensure held/rejected nodes emit a single terminal failure and preserve held state across retries.
  * Improved DB transaction behavior to reduce concurrency issues during event append and work claiming.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering approval flows and scheduler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->