### PR TITLE
chore: gitignore strategy symlink (pattern was directory-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ progress-tracker.md
 REQUIREMENTS.md
 launch-plan.md
 CLAUDE.md
-strategy/
+strategy
 docs/superpowers/
 paper/
 


### PR DESCRIPTION
strategy/ moved to the local jamjet-hq vault and is now a symlink at the old path. The existing gitignore pattern had a trailing slash (directory-only) so the symlink showed as untracked. One-line fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` configuration for improved path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->