### PR TITLE
feat(sdk): approvals CLI + release prep (0.10.0 / runtime 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## 0.10.0 — 2026-06-12
+
+### SDK
+
+- `jamjet approvals EXECUTION_ID` — table of pending (node_id, tool_name, approver) and decided (node_id, status, user_id, comment) entries; friendly empty-state message when nothing is on record.
+- `jamjet approve EXECUTION_ID --decision approved|rejected` — posts to the runtime approve endpoint, prints resolved node_id on success; `--node-id` and `--comment` are optional. Validated decision values give a clean parameter error instead of a traceback. HTTP 4xx from the server prints the `error` field and exits 1 without a traceback.
+- `client.list_approvals(execution_id)` — GETs `/executions/{id}/approvals`, returns `{"pending": [...], "decided": [...]}`.
+- `client.approve()` gains an optional `node_id` parameter; the runtime infers the node when exactly one approval is pending.
+- `jamjet --version` reads the installed package version via `importlib.metadata` instead of the hardcoded string.
+
+---
+
+## Runtime 0.4.0 — 2026-06-12
+
+### Added
+- Approval/HITL loop end-to-end: nodes gated by `require_approval_for` policy park durably; `POST /executions/:id/approve` resumes or fails them through the normal scheduler path; rejected approvals fail closed with decider and comment recorded in the event log.
+- `GET /executions/:id/approvals` returns `{"pending": [...], "decided": [...]}` with node_id, tool_name, approver, context, and sequence for each entry.
+- `jamjet_approve` MCP tool routes through the same approve path.
+- Validated approve API contract: 409 when nothing is pending or already decided or the execution is terminal; 400 when the node is ambiguous (multiple pending without a node_id); response includes the resolved node_id.
+- OTel GenAI semantic conventions emitted on model-node spans (model, system, input/output tokens, finish reason).
+- SQLite `BEGIN IMMEDIATE` on read-then-write transactions to prevent SQLITE_BUSY under concurrent worker load.
+
+---
+
 ## 0.8.3 — 2026-05-11
 
 ### Added

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/jamjet-labs/jamjet"

--- a/runtime/agents/Cargo.toml
+++ b/runtime/agents/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
 tokio = { workspace = true }
 sqlx = { workspace = true }
 reqwest = { workspace = true }

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -15,19 +15,19 @@ name = "jamjet-server"
 path = "src/main.rs"
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
-jamjet-agents = { path = "../agents", version = "=0.3.2" }
-jamjet-audit = { path = "../audit", version = "=0.3.2" }
-jamjet-scheduler = { path = "../scheduler", version = "=0.3.2" }
-jamjet-protocols = { path = "../protocols", version = "=0.3.2" }
-jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.2" }
-jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.2" }
-jamjet-worker = { path = "../workers", version = "=0.3.2" }
-jamjet-models = { path = "../models", version = "=0.3.2" }
-jamjet-timers = { path = "../timers", version = "=0.3.2" }
-jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
+jamjet-agents = { path = "../agents", version = "=0.4.0" }
+jamjet-audit = { path = "../audit", version = "=0.4.0" }
+jamjet-scheduler = { path = "../scheduler", version = "=0.4.0" }
+jamjet-protocols = { path = "../protocols", version = "=0.4.0" }
+jamjet-mcp = { path = "../protocols/mcp", version = "=0.4.0" }
+jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.4.0" }
+jamjet-worker = { path = "../workers", version = "=0.4.0" }
+jamjet-models = { path = "../models", version = "=0.4.0" }
+jamjet-timers = { path = "../timers", version = "=0.4.0" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.4.0" }
 tokio = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/runtime/audit/Cargo.toml
+++ b/runtime/audit/Cargo.toml
@@ -11,10 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
-jamjet-policy = { path = "../policy", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
+jamjet-policy = { path = "../policy", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/ir/Cargo.toml
+++ b/runtime/ir/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/runtime/models/Cargo.toml
+++ b/runtime/models/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.4.0" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/runtime/policy/Cargo.toml
+++ b/runtime/policy/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
-jamjet-agents = { path = "../agents", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
+jamjet-agents = { path = "../agents", version = "=0.4.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/protocols/a2a/Cargo.toml
+++ b/runtime/protocols/a2a/Cargo.toml
@@ -16,8 +16,8 @@ jamjet-a2a = { version = "0.1", features = ["client", "server", "federation"] }
 jamjet-a2a-types = "0.1"
 
 # Internal workspace crates
-jamjet-protocols = { path = "..", version = "=0.3.2" }
-jamjet-agents = { path = "../../agents", version = "=0.3.2" }
+jamjet-protocols = { path = "..", version = "=0.4.0" }
+jamjet-agents = { path = "../../agents", version = "=0.4.0" }
 
 # Only deps needed by adapter.rs
 tokio = { workspace = true }

--- a/runtime/protocols/mcp/Cargo.toml
+++ b/runtime/protocols/mcp/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-protocols = { path = "..", version = "=0.3.2" }
+jamjet-protocols = { path = "..", version = "=0.4.0" }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { workspace = true }

--- a/runtime/scheduler/Cargo.toml
+++ b/runtime/scheduler/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/runtime/state/Cargo.toml
+++ b/runtime/state/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/runtime/timers/Cargo.toml
+++ b/runtime/timers/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/runtime/workers/Cargo.toml
+++ b/runtime/workers/Cargo.toml
@@ -11,16 +11,16 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-jamjet-core = { path = "../core", version = "=0.3.2" }
-jamjet-ir = { path = "../ir", version = "=0.3.2" }
-jamjet-models = { path = "../models", version = "=0.3.2" }
-jamjet-state = { path = "../state", version = "=0.3.2" }
-jamjet-policy = { path = "../policy", version = "=0.3.2" }
-jamjet-agents = { path = "../agents", version = "=0.3.2" }
-jamjet-mcp = { path = "../protocols/mcp", version = "=0.3.2" }
-jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.3.2" }
-jamjet-telemetry = { path = "../telemetry", version = "=0.3.2" }
-jamjet-scheduler = { path = "../scheduler", version = "=0.3.2" }
+jamjet-core = { path = "../core", version = "=0.4.0" }
+jamjet-ir = { path = "../ir", version = "=0.4.0" }
+jamjet-models = { path = "../models", version = "=0.4.0" }
+jamjet-state = { path = "../state", version = "=0.4.0" }
+jamjet-policy = { path = "../policy", version = "=0.4.0" }
+jamjet-agents = { path = "../agents", version = "=0.4.0" }
+jamjet-mcp = { path = "../protocols/mcp", version = "=0.4.0" }
+jamjet-a2a-proto = { path = "../protocols/a2a", version = "=0.4.0" }
+jamjet-telemetry = { path = "../telemetry", version = "=0.4.0" }
+jamjet-scheduler = { path = "../scheduler", version = "=0.4.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import importlib.metadata
 import json
 import sys
 import time
@@ -89,7 +90,11 @@ def _print_logo() -> None:
 def _version_callback(value: bool) -> None:
     if value:
         _print_logo()
-        typer.echo("\nJamJet v0.1.1  —  agent-native workflow runtime")
+        try:
+            ver = importlib.metadata.version("jamjet")
+        except importlib.metadata.PackageNotFoundError:
+            ver = "unknown"
+        typer.echo(f"\nJamJet v{ver}  —  agent-native workflow runtime")
         raise typer.Exit()
 
 
@@ -2069,6 +2074,108 @@ def _effect_size_label(d: float) -> str:
         return "medium"
     else:
         return "large"
+
+
+# ── approvals ─────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def approvals(
+    execution_id: str = typer.Argument(..., help="Execution ID (exec_...)"),
+    runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
+) -> None:
+    """List pending and decided approvals for an execution."""
+
+    async def _approvals() -> None:
+        async with _client(runtime) as c:
+            data = await c.list_approvals(execution_id)
+
+        pending = data.get("pending", [])
+        decided = data.get("decided", [])
+
+        if not pending and not decided:
+            console.print(f"[dim]No approvals on {execution_id}.[/dim]")
+            return
+
+        if pending:
+            t = Table(title=f"Pending approvals — {execution_id}")
+            t.add_column("Node", style="bold")
+            t.add_column("Tool")
+            t.add_column("Approver")
+            t.add_column("Seq", style="dim", justify="right")
+            for entry in pending:
+                t.add_row(
+                    entry.get("node_id", "—"),
+                    entry.get("tool_name", "—"),
+                    entry.get("approver", "—"),
+                    str(entry.get("sequence", "")),
+                )
+            console.print(t)
+
+        if decided:
+            d = Table(title="Decided")
+            d.add_column("Node", style="bold")
+            d.add_column("Status")
+            d.add_column("User")
+            d.add_column("Comment")
+            d.add_column("Seq", style="dim", justify="right")
+            for entry in decided:
+                comment = entry.get("comment", "")
+                d.add_row(
+                    entry.get("node_id", "—"),
+                    entry.get("status", "—"),
+                    entry.get("user_id", "—"),
+                    comment if comment else "—",
+                    str(entry.get("sequence", "")),
+                )
+            console.print(d)
+
+    asyncio.run(_approvals())
+
+
+# ── approve ───────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def approve(
+    execution_id: str = typer.Argument(..., help="Execution ID (exec_...)"),
+    decision: str = typer.Option(..., "--decision", "-d", help="approved or rejected"),
+    node_id: str | None = typer.Option(None, "--node-id", help="Node to approve (inferred when one is pending)"),
+    comment: str | None = typer.Option(None, "--comment", "-c", help="Optional comment"),
+    runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
+) -> None:
+    """Approve or reject a pending HITL gate on an execution."""
+    if decision not in ("approved", "rejected"):
+        raise typer.BadParameter(
+            f"'{decision}' is not a valid decision. Use 'approved' or 'rejected'.",
+            param_hint="--decision",
+        )
+
+    async def _approve() -> None:
+        import httpx
+
+        async with _client(runtime) as c:
+            try:
+                result = await c.approve(
+                    execution_id,
+                    decision,
+                    node_id=node_id,
+                    comment=comment,
+                )
+            except httpx.HTTPStatusError as exc:
+                try:
+                    msg = exc.response.json().get("error") or exc.response.text
+                except Exception:
+                    msg = exc.response.text
+                console.print(f"[red]Error:[/red] {msg}")
+                raise typer.Exit(1) from exc
+
+        resolved = result.get("node_id", "?")
+        accepted = result.get("accepted", decision == "approved")
+        status_str = "[green]approved[/green]" if accepted else "[red]rejected[/red]"
+        console.print(f"{status_str}  node=[bold]{resolved}[/bold]  execution={execution_id}")
+
+    asyncio.run(_approve())
 
 
 if __name__ == "__main__":

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -129,15 +129,28 @@ class JamjetClient:
         self,
         execution_id: str,
         decision: str,
+        node_id: str | None = None,
         comment: str | None = None,
         state_patch: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"decision": decision}
+        if node_id:
+            body["node_id"] = node_id
         if comment:
             body["comment"] = comment
         if state_patch:
             body["state_patch"] = state_patch
         r = await self._client.post(f"/executions/{execution_id}/approve", json=body)
+        r.raise_for_status()
+        return r.json()
+
+    async def list_approvals(self, execution_id: str) -> dict[str, Any]:
+        """Pending and decided approvals for an execution.
+
+        Returns ``{"pending": [...], "decided": [...]}`` as served by
+        ``GET /executions/{id}/approvals``.
+        """
+        r = await self._client.get(f"/executions/{execution_id}/approvals")
         r.raise_for_status()
         return r.json()
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.9.1"
+version = "0.10.0"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/tests/test_approvals.py
+++ b/sdk/python/tests/test_approvals.py
@@ -1,0 +1,225 @@
+"""Tests for approval client methods and CLI commands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from jamjet.cli.main import app
+from jamjet.client import JamjetClient
+
+runner = CliRunner()
+
+BASE = "http://localhost:7700"
+
+# ---------------------------------------------------------------------------
+# Client tests
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_approve_sends_node_id_when_given() -> None:
+    """approve() includes node_id in the request body when provided."""
+    route = respx.post(f"{BASE}/executions/exec-1/approve").respond(
+        200,
+        json={"execution_id": "exec-1", "node_id": "gated", "accepted": True},
+    )
+
+    async with JamjetClient(base_url=BASE) as c:
+        result = await c.approve("exec-1", "approved", node_id="gated")
+
+    assert route.called
+    body = json.loads(route.calls[0].request.content)
+    assert body["decision"] == "approved"
+    assert body["node_id"] == "gated"
+    assert result["node_id"] == "gated"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_approve_omits_node_id_when_not_given() -> None:
+    """approve() omits node_id from the body when not supplied."""
+    route = respx.post(f"{BASE}/executions/exec-1/approve").respond(
+        200,
+        json={"execution_id": "exec-1", "node_id": "inferred", "accepted": True},
+    )
+
+    async with JamjetClient(base_url=BASE) as c:
+        await c.approve("exec-1", "approved")
+
+    body = json.loads(route.calls[0].request.content)
+    assert "node_id" not in body
+    assert body["decision"] == "approved"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_approvals_returns_parsed_dict() -> None:
+    """list_approvals() GETs /executions/{id}/approvals and returns the body."""
+    payload = {
+        "pending": [
+            {
+                "node_id": "gated",
+                "tool_name": "payments.transfer",
+                "approver": "human",
+                "context": {},
+                "sequence": 3,
+            }
+        ],
+        "decided": [
+            {
+                "node_id": "old",
+                "status": "approved",
+                "user_id": "u1",
+                "sequence": 1,
+            }
+        ],
+    }
+    route = respx.get(f"{BASE}/executions/exec-1/approvals").respond(200, json=payload)
+
+    async with JamjetClient(base_url=BASE) as c:
+        result = await c.list_approvals("exec-1")
+
+    assert route.called
+    assert result["pending"][0]["node_id"] == "gated"
+    assert result["decided"][0]["status"] == "approved"
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — jamjet approvals
+# ---------------------------------------------------------------------------
+
+
+def _approvals_client(pending: list, decided: list):
+    """Return a patched _client() whose list_approvals returns the given data."""
+    fake = AsyncMock()
+    fake.list_approvals = AsyncMock(return_value={"pending": pending, "decided": decided})
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    return fake
+
+
+def test_approvals_renders_pending_and_decided() -> None:
+    """jamjet approvals renders both pending and decided entries."""
+    pending = [
+        {
+            "node_id": "gated",
+            "tool_name": "payments.transfer",
+            "approver": "human",
+            "context": {},
+            "sequence": 3,
+        }
+    ]
+    decided = [
+        {
+            "node_id": "old",
+            "status": "approved",
+            "user_id": "u1",
+            "sequence": 1,
+        }
+    ]
+    fake = _approvals_client(pending, decided)
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["approvals", "exec-1"])
+
+    assert result.exit_code == 0, result.output
+    assert "gated" in result.output
+    assert "payments.transfer" in result.output
+    assert "old" in result.output
+    assert "approved" in result.output
+
+
+def test_approvals_shows_empty_state_message() -> None:
+    """jamjet approvals shows a friendly message when there is nothing pending."""
+    fake = _approvals_client([], [])
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["approvals", "exec-1"])
+
+    assert result.exit_code == 0, result.output
+    # Should not raise and should print something useful
+    assert result.output.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — jamjet approve
+# ---------------------------------------------------------------------------
+
+
+def _approve_client(response: dict):
+    fake = AsyncMock()
+    fake.approve = AsyncMock(return_value=response)
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+    return fake
+
+
+def test_approve_without_node_id_prints_resolved_node() -> None:
+    """jamjet approve prints resolved node_id on success."""
+    fake = _approve_client({"execution_id": "exec-1", "node_id": "gated", "accepted": True})
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["approve", "exec-1", "--decision", "approved"])
+
+    assert result.exit_code == 0, result.output
+    assert "gated" in result.output
+    fake.approve.assert_awaited_once()
+    call_kwargs = fake.approve.call_args
+    # node_id should not be passed when not specified
+    assert call_kwargs.kwargs.get("node_id") is None
+
+
+def test_approve_with_node_id_and_comment_passes_both() -> None:
+    """jamjet approve --node-id X --comment Y sends both to client."""
+    fake = _approve_client({"execution_id": "exec-1", "node_id": "gated", "accepted": True})
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(
+            app,
+            ["approve", "exec-1", "--decision", "approved", "--node-id", "gated", "--comment", "no"],
+        )
+
+    assert result.exit_code == 0, result.output
+    call_kwargs = fake.approve.call_args
+    assert call_kwargs.kwargs.get("node_id") == "gated"
+    assert call_kwargs.kwargs.get("comment") == "no"
+
+
+def test_approve_409_exits_nonzero_with_error_text() -> None:
+    """jamjet approve exits 1 on 409 and prints the server error, not a traceback."""
+    error_body = {"error": "no pending approval on this execution"}
+
+    # Build a real httpx.HTTPStatusError the CLI handler will catch
+    request = httpx.Request("POST", f"{BASE}/executions/exec-1/approve")
+    response = httpx.Response(409, json=error_body, request=request)
+    http_error = httpx.HTTPStatusError("409", request=request, response=response)
+
+    fake = AsyncMock()
+    fake.approve = AsyncMock(side_effect=http_error)
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("jamjet.cli.main._client", return_value=fake):
+        result = runner.invoke(app, ["approve", "exec-1", "--decision", "approved"])
+
+    assert result.exit_code != 0
+    assert "no pending approval" in result.output
+    # Must not be a traceback dump
+    assert "Traceback" not in result.output
+
+
+def test_approve_invalid_decision_fails_cleanly() -> None:
+    """jamjet approve --decision maybe produces a parameter error, not a traceback."""
+    result = runner.invoke(app, ["approve", "exec-1", "--decision", "maybe"])
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    # Should mention the invalid value or expected values
+    output = result.output + (result.stderr or "")
+    assert "maybe" in output or "approved" in output or "rejected" in output


### PR DESCRIPTION
## Summary

- `client.list_approvals()` GETs `/executions/:id/approvals`, returns `{"pending": [...], "decided": [...]}`
- `client.approve()` gains an optional `node_id` parameter; the runtime infers the node when exactly one approval is pending
- `jamjet approvals EXECUTION_ID` renders pending (node_id, tool_name, approver) and decided (node_id, status, user_id, comment) as Rich tables with a friendly empty-state message
- `jamjet approve EXECUTION_ID --decision approved|rejected` posts to the runtime, prints resolved node_id on success; invalid decision values give a clean typer.BadParameter; HTTP 4xx from the server prints the `error` field and exits 1 without a traceback; `--node-id` and `--comment` are optional
- `jamjet --version` reads the installed package version via `importlib.metadata` instead of the hardcoded "v0.1.1" string
- SDK version bump 0.9.1 -> 0.10.0; runtime workspace 0.3.2 -> 0.4.0 (all internal Cargo.toml cross-refs updated)
- CHANGELOG entries for SDK 0.10.0 and Runtime 0.4.0; OTel GenAI semantic conventions confirmed new in 0.4.0 (`cabea3b` was not in `crates-v0.3.2`)

## Test plan

- [ ] 9 new tests in `tests/test_approvals.py` — all pass; 799 total tests pass with no regressions
- [ ] `ruff check` and `ruff format --check` clean
- [ ] `cargo fmt --all -- --check` clean; `cargo test --workspace` passes
- [ ] Verify `jamjet approvals exec-id` and `jamjet approve exec-id --decision approved` against a live runtime with a parked node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `jamjet approvals` and `jamjet approve` CLI commands for managing human-in-the-loop approvals.
  * Added `client.list_approvals()` method and optional `node_id` parameter to approval flow.
  * Updated `--version` to report installed package version dynamically.

* **Chores**
  * Bumped SDK to version 0.10.0 and Runtime to 0.4.0 with durability improvements and SQLite transaction locking enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->