### PR TITLE
fix: bump module __version__ to 0.10.0; drop em dashes from new strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## 0.10.0 — 2026-06-12
+## 0.10.0 - 2026-06-12
 
 ### SDK
 
-- `jamjet approvals EXECUTION_ID` — table of pending (node_id, tool_name, approver) and decided (node_id, status, user_id, comment) entries; friendly empty-state message when nothing is on record.
-- `jamjet approve EXECUTION_ID --decision approved|rejected` — posts to the runtime approve endpoint, prints resolved node_id on success; `--node-id` and `--comment` are optional. Validated decision values give a clean parameter error instead of a traceback. HTTP 4xx from the server prints the `error` field and exits 1 without a traceback.
-- `client.list_approvals(execution_id)` — GETs `/executions/{id}/approvals`, returns `{"pending": [...], "decided": [...]}`.
+- `jamjet approvals EXECUTION_ID` - table of pending (node_id, tool_name, approver) and decided (node_id, status, user_id, comment) entries; friendly empty-state message when nothing is on record.
+- `jamjet approve EXECUTION_ID --decision approved|rejected` - posts to the runtime approve endpoint, prints resolved node_id on success; `--node-id` and `--comment` are optional. Validated decision values give a clean parameter error instead of a traceback. HTTP 4xx from the server prints the `error` field and exits 1 without a traceback.
+- `client.list_approvals(execution_id)` - GETs `/executions/{id}/approvals`, returns `{"pending": [...], "decided": [...]}`.
 - `client.approve()` gains an optional `node_id` parameter; the runtime infers the node when exactly one approval is pending.
 - `jamjet --version` reads the installed package version via `importlib.metadata` instead of the hardcoded string.
 
 ---
 
-## Runtime 0.4.0 — 2026-06-12
+## Runtime 0.4.0 - 2026-06-12
 
 ### Added
 - Approval/HITL loop end-to-end: nodes gated by `require_approval_for` policy park durably; `POST /executions/:id/approve` resumes or fails them through the normal scheduler path; rejected approvals fail closed with decider and comment recorded in the event log.

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -115,4 +115,4 @@ def __dir__() -> list[str]:  # noqa: ANN201
     return list(set(globals()) | set(__all__))
 
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -94,7 +94,7 @@ def _version_callback(value: bool) -> None:
             ver = importlib.metadata.version("jamjet")
         except importlib.metadata.PackageNotFoundError:
             ver = "unknown"
-        typer.echo(f"\nJamJet v{ver}  —  agent-native workflow runtime")
+        typer.echo(f"\nJamJet v{ver} - agent-native workflow runtime")
         raise typer.Exit()
 
 
@@ -107,7 +107,7 @@ class OutputFormat(enum.StrEnum):
 
 app = typer.Typer(
     name="jamjet",
-    help="JamJet — agent-native workflow runtime CLI",
+    help="JamJet - agent-native workflow runtime CLI",
     no_args_is_help=True,
 )
 


### PR DESCRIPTION
Follow-up to #84 (review fixes landed after the merge): jamjet.__version__ was still 0.9.1 which would ship wrong in the 0.10.0 wheel, plus em dashes removed from the new CLI strings and changelog entries per voice rules. Needed before tagging python-sdk-v0.10.0.