### PR TITLE
fix(cli): version-keyed server binary cache so upgrades fetch the new runtime (0.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## 0.10.2 - 2026-06-12
+
+### Fixed
+
+- `jamjet dev`: server binary cache is now keyed by SDK version (`~/.jamjet/bin/<version>/jamjet-server`) so upgrading via `pip install -U jamjet` always fetches the matching runtime binary. Previously a cached binary was reused indefinitely regardless of SDK version.
+- `jamjet approvals` table: title uses `-` instead of an em dash; missing comment cells render as empty instead of an em dash character.
+
+---
+
 ## 0.10.0 - 2026-06-12
 
 ### SDK

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -115,4 +115,4 @@ def __dir__() -> list[str]:  # noqa: ANN201
     return list(set(globals()) | set(__all__))
 
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -251,6 +251,22 @@ def init(
 # ── dev ──────────────────────────────────────────────────────────────────────
 
 
+def _sdk_version() -> str:
+    """Return the installed SDK version, or 'dev' for source checkouts."""
+    try:
+        return importlib.metadata.version("jamjet")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+def _server_cache_dir() -> str:
+    """Return the versioned binary cache directory: ~/.jamjet/bin/<sdk_version>."""
+    import os
+
+    version = _sdk_version()
+    return os.path.join(os.path.expanduser("~"), ".jamjet", "bin", version)
+
+
 def _find_server_binary() -> str:
     """Locate the jamjet-server binary, auto-downloading if necessary."""
     import os
@@ -275,13 +291,16 @@ def _find_server_binary() -> str:
         if os.path.isfile(path) and os.access(path, os.X_OK):
             return os.path.abspath(path)
 
-    # 3. Check ~/.jamjet/bin/ cache (previously auto-downloaded)
-    cache_dir = os.path.join(os.path.expanduser("~"), ".jamjet", "bin")
+    # 3. Check versioned cache: ~/.jamjet/bin/<sdk_version>/jamjet-server
+    # The flat legacy path (~/.jamjet/bin/jamjet-server) is intentionally ignored
+    # so that upgrading the SDK always fetches the matching runtime binary.
+    # Users can remove old flat binaries manually; we never delete them automatically.
+    cache_dir = _server_cache_dir()
     cached = os.path.join(cache_dir, "jamjet-server")
     if os.path.isfile(cached) and os.access(cached, os.X_OK):
         return cached
 
-    # 4. Auto-download from GitHub Releases
+    # 4. Auto-download from GitHub Releases into the versioned cache dir
     return _download_server_binary(cache_dir)
 
 
@@ -370,6 +389,7 @@ def _download_server_binary(cache_dir: str) -> str:
     os.replace(dest_tmp, dest)
     os.chmod(dest, os.stat(dest).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     console.print(f"[green]✓[/green] Runtime binary cached at {dest}")
+    console.print("[dim]Older cached binaries under ~/.jamjet/bin can be removed manually.[/dim]")
     return dest
 
 
@@ -2098,16 +2118,16 @@ def approvals(
             return
 
         if pending:
-            t = Table(title=f"Pending approvals — {execution_id}")
+            t = Table(title=f"Pending approvals - {execution_id}")
             t.add_column("Node", style="bold")
             t.add_column("Tool")
             t.add_column("Approver")
             t.add_column("Seq", style="dim", justify="right")
             for entry in pending:
                 t.add_row(
-                    entry.get("node_id", "—"),
-                    entry.get("tool_name", "—"),
-                    entry.get("approver", "—"),
+                    entry.get("node_id", "-"),
+                    entry.get("tool_name", "-"),
+                    entry.get("approver", "-"),
                     str(entry.get("sequence", "")),
                 )
             console.print(t)
@@ -2122,10 +2142,10 @@ def approvals(
             for entry in decided:
                 comment = entry.get("comment", "")
                 d.add_row(
-                    entry.get("node_id", "—"),
-                    entry.get("status", "—"),
-                    entry.get("user_id", "—"),
-                    comment if comment else "—",
+                    entry.get("node_id", "-"),
+                    entry.get("status", "-"),
+                    entry.get("user_id", "-"),
+                    comment if comment else "",
                     str(entry.get("sequence", "")),
                 )
             console.print(d)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.10.1"
+version = "0.10.2"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/python/tests/test_server_binary_cache.py
+++ b/sdk/python/tests/test_server_binary_cache.py
@@ -1,0 +1,145 @@
+"""Tests for versioned server binary cache logic in _find_server_binary."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from jamjet.cli.main import _find_server_binary, _server_cache_dir
+
+# ---------------------------------------------------------------------------
+# _server_cache_dir
+# ---------------------------------------------------------------------------
+
+
+def test_server_cache_dir_includes_sdk_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_server_cache_dir() returns ~/.jamjet/bin/<sdk_version>."""
+    monkeypatch.setattr(
+        "jamjet.cli.main._sdk_version",
+        lambda: "0.10.2",
+    )
+    monkeypatch.setenv("HOME", "/fakehome")
+    result = _server_cache_dir()
+    # Path ends with the version segment
+    assert result.endswith("0.10.2")
+    assert "/.jamjet/bin/" in result
+
+
+def test_server_cache_dir_falls_back_to_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When importlib.metadata raises, _server_cache_dir uses 'dev'."""
+    monkeypatch.setattr(
+        "jamjet.cli.main._sdk_version",
+        lambda: "dev",
+    )
+    result = _server_cache_dir()
+    assert result.endswith("dev")
+
+
+# ---------------------------------------------------------------------------
+# _find_server_binary — versioned path is used, legacy flat path is skipped
+# ---------------------------------------------------------------------------
+
+
+def test_find_server_binary_skips_legacy_flat_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    If ~/.jamjet/bin/jamjet-server (flat legacy) exists but the versioned path
+    does NOT exist, the downloader is called instead of returning the flat path.
+    """
+    # Create a fake home under tmp_path so expanduser is isolated.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    bin_dir = fake_home / ".jamjet" / "bin"
+    bin_dir.mkdir(parents=True)
+
+    # Write a flat legacy binary that should NOT be picked up.
+    legacy = bin_dir / "jamjet-server"
+    legacy.write_bytes(b"old-binary")
+    legacy.chmod(legacy.stat().st_mode | stat.S_IEXEC)
+
+    # Monkeypatch expanduser so ~/.jamjet resolves into fake_home.
+    original_expanduser = os.path.expanduser
+
+    def fake_expanduser(path: str) -> str:
+        if path.startswith("~"):
+            return str(fake_home) + path[1:]
+        return original_expanduser(path)
+
+    monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
+
+    # Pin SDK version so the versioned dir is predictable.
+    monkeypatch.setattr("jamjet.cli.main._sdk_version", lambda: "0.10.2")
+
+    # Monkeypatch shutil.which to return None (no system install).
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    # Capture whether _download_server_binary was called and with which dir.
+    download_calls: list[str] = []
+
+    def fake_download(cache_dir: str) -> str:
+        download_calls.append(cache_dir)
+        return str(bin_dir / "0.10.2" / "jamjet-server")
+
+    monkeypatch.setattr("jamjet.cli.main._download_server_binary", fake_download)
+
+    # Override os.getcwd so repo-relative candidates don't accidentally match.
+    monkeypatch.setattr(os, "getcwd", lambda: str(tmp_path))
+
+    _find_server_binary()
+
+    # The downloader must have been called (flat legacy was not returned).
+    assert len(download_calls) == 1, "Expected downloader to be called; flat legacy was returned instead."
+
+    # The cache_dir passed to the downloader must be the versioned path.
+    expected_suffix = os.path.join(".jamjet", "bin", "0.10.2")
+    assert download_calls[0].endswith(expected_suffix), (
+        f"Downloader called with {download_calls[0]!r}, expected suffix {expected_suffix!r}"
+    )
+
+
+def test_find_server_binary_uses_versioned_cache_when_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    When the versioned binary exists and is executable, it is returned directly
+    without calling the downloader.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    versioned_dir = fake_home / ".jamjet" / "bin" / "0.10.2"
+    versioned_dir.mkdir(parents=True)
+
+    versioned_bin = versioned_dir / "jamjet-server"
+    versioned_bin.write_bytes(b"versioned-binary")
+    versioned_bin.chmod(versioned_bin.stat().st_mode | stat.S_IEXEC)
+
+    original_expanduser = os.path.expanduser
+
+    def fake_expanduser(path: str) -> str:
+        if path.startswith("~"):
+            return str(fake_home) + path[1:]
+        return original_expanduser(path)
+
+    monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
+    monkeypatch.setattr("jamjet.cli.main._sdk_version", lambda: "0.10.2")
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr(os, "getcwd", lambda: str(tmp_path))
+
+    download_calls: list[str] = []
+
+    def fake_download(cache_dir: str) -> str:
+        download_calls.append(cache_dir)
+        return str(versioned_bin)
+
+    monkeypatch.setattr("jamjet.cli.main._download_server_binary", fake_download)
+
+    result = _find_server_binary()
+
+    assert download_calls == [], "Downloader should NOT have been called."
+    assert result == str(versioned_bin)

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1836,7 +1836,7 @@ wheels = [
 
 [[package]]
 name = "jamjet"
-version = "0.9.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "agentboundary" },


### PR DESCRIPTION
## Problem

`~/.jamjet/bin/jamjet-server` was a flat, unversioned path. Once downloaded it was never replaced, even after `pip install -U jamjet`. Verified today: a machine with a binary from June 4 kept running the old runtime after upgrading to 0.10.0. The new `jamjet approvals` and `jamjet approve` commands returned 404 because the June-4 binary predates those endpoints.

## Fix

Cache path is now `~/.jamjet/bin/<sdk_version>/jamjet-server`. `_sdk_version()` reads the installed package version via `importlib.metadata`; falls back to `"dev"` for source checkouts (preserving the legacy flat path lookup in that case is not needed -- source contributors hit step 2 instead).

- `_find_server_binary` step 3 checks the versioned path only; the legacy flat binary is ignored.
- `_download_server_binary` writes into the versioned dir. Download and tag-resolution logic unchanged.
- After a successful download, one hint line tells the user older flat binaries can be removed manually. No automatic deletion.

## Cosmetic

Em dashes in the `jamjet approvals` Rich table title and fallback cell values replaced with plain hyphens / empty strings (user-facing output rule).

## Tests

4 new unit tests in `tests/test_server_binary_cache.py`:
- `_server_cache_dir()` returns the version-suffixed path
- falls back to `"dev"` when `importlib.metadata` raises
- `_find_server_binary` skips a flat legacy binary and calls the downloader
- `_find_server_binary` returns a versioned binary directly without calling the downloader

Full suite: 816 passed, 8 skipped before and after.