### PR TITLE
feat(state,worker): atomic fenced turn-commit (durable engine, Track 2a)

### DIFF
--- a/runtime/api/src/mcp_bridge.rs
+++ b/runtime/api/src/mcp_bridge.rs
@@ -127,6 +127,7 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                     created_at: now,
                     lease_expires_at: None,
                     worker_id: None,
+                    lease_fence: 0,
                     tenant_id: tenant_id.0.clone(),
                 };
                 backend.enqueue_work_item(work_item).await.map_err(|e| format!("{e}"))?;

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -981,6 +981,10 @@ async fn fail_work_item(
 #[derive(Deserialize)]
 struct HeartbeatRequest {
     worker_id: String,
+    /// The lease fence the worker received when it claimed the item. A renew
+    /// presenting a stale fence (lease stolen / failed over) fails closed.
+    #[serde(default)]
+    lease_fence: i64,
 }
 
 /// `POST /work-items/:id/heartbeat` — renew the lease on a claimed work item.
@@ -993,7 +997,9 @@ async fn heartbeat_work_item(
     let item_id = Uuid::parse_str(&id)
         .map_err(|_| ApiError::BadRequest(format!("invalid work item id: {id}")))?;
     let backend = state.backend_for(&tenant_id);
-    backend.renew_lease(item_id, &body.worker_id).await?;
+    backend
+        .renew_lease(item_id, &body.worker_id, body.lease_fence)
+        .await?;
     Ok(Json(json!({ "renewed": true, "work_item_id": id })))
 }
 

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -274,6 +274,7 @@ async fn start_execution(
         created_at: now,
         lease_expires_at: None,
         worker_id: None,
+        lease_fence: 0,
         tenant_id: tenant_id.0.clone(),
     };
     backend.enqueue_work_item(work_item).await?;
@@ -948,6 +949,7 @@ async fn enqueue_work_item(
         created_at: Utc::now(),
         lease_expires_at: None,
         worker_id: None,
+        lease_fence: 0,
         tenant_id: tenant_id.0.clone(),
     };
     let item_id = backend.enqueue_work_item(item).await?;

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -159,6 +159,7 @@ async fn start() -> Harness {
             created_at: now,
             lease_expires_at: None,
             worker_id: None,
+            lease_fence: 0,
             tenant_id: DEFAULT_TENANT.into(),
         })
         .await
@@ -273,6 +274,7 @@ async fn gated_node_parks_without_dead_lettering() {
             created_at: chrono::Utc::now(),
             lease_expires_at: None,
             worker_id: None,
+            lease_fence: 0,
             tenant_id: DEFAULT_TENANT.into(),
         })
         .await

--- a/runtime/api/tests/execution_e2e.rs
+++ b/runtime/api/tests/execution_e2e.rs
@@ -124,6 +124,7 @@ async fn workflow_runs_to_completion() {
             created_at: now,
             lease_expires_at: None,
             worker_id: None,
+            lease_fence: 0,
             tenant_id: DEFAULT_TENANT.into(),
         })
         .await

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -359,6 +359,7 @@ impl Scheduler {
                     created_at: chrono::Utc::now(),
                     lease_expires_at: None,
                     worker_id: None,
+                    lease_fence: 0,
                     tenant_id: jamjet_state::DEFAULT_TENANT.to_string(),
                 };
                 self.backend.enqueue_work_item(item).await?;

--- a/runtime/state/migrations/0004_lease_fence.sql
+++ b/runtime/state/migrations/0004_lease_fence.sql
@@ -1,0 +1,18 @@
+-- Migration 0004: Lease Fencing
+--
+-- Adds a monotonic fence token to every work-item lease so a zombie worker
+-- (whose lease was stolen after a stall or failover) can never double-commit.
+-- lease_fence = store_identity.term * 4294967296 + lease_epoch.
+
+-- ── Store identity (failover generation) ──────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS store_identity (
+    id      INTEGER PRIMARY KEY CHECK (id = 1),  -- single-row table
+    term    INTEGER NOT NULL DEFAULT 0           -- bumped on every promotion
+);
+INSERT OR IGNORE INTO store_identity (id, term) VALUES (1, 0);
+
+-- ── Per-item lease fence ──────────────────────────────────────────────────────
+
+ALTER TABLE work_items ADD COLUMN lease_epoch INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE work_items ADD COLUMN lease_fence INTEGER NOT NULL DEFAULT 0;

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -30,6 +30,9 @@ pub enum StateBackendError {
     #[error("optimistic concurrency conflict: sequence mismatch for {0}")]
     SequenceConflict(String),
 
+    #[error("lease fence superseded for work item {0}: lease was stolen or store failed over")]
+    FenceLost(String),
+
     #[error("database error: {0}")]
     Database(String),
 
@@ -224,6 +227,11 @@ pub struct WorkItem {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub lease_expires_at: Option<chrono::DateTime<chrono::Utc>>,
     pub worker_id: Option<String>,
+    /// Monotonic lease fence: store term * 2^32 + per-item epoch. Minted on
+    /// every claim/reclaim; a leased-worker write that presents a stale fence
+    /// matches zero rows and fails closed.
+    #[serde(default)]
+    pub lease_fence: i64,
     /// Tenant that owns this work item.
     #[serde(default = "default_tenant_string")]
     pub tenant_id: String,

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -154,6 +154,19 @@ pub trait StateBackend: Send + Sync {
     /// Mark a work item as failed. The scheduler will decide whether to retry.
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()>;
 
+    /// Atomically settle a work item (status inferred from the terminal event
+    /// kind) and append the terminal event, in ONE transaction, gated by
+    /// `lease_fence`. A stale fence matches zero rows and returns `FenceLost`,
+    /// emitting nothing. Replaces the `complete_work_item` + `latest_sequence`
+    /// + `append_event` trio so a node completion is one fsync with no
+    /// crash window and no double-commit.
+    async fn commit_node_terminal(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        terminal_event: Event,
+    ) -> BackendResult<EventSequence>;
+
     /// Reclaim work items whose lease has expired (worker crashed or stalled).
     ///
     /// For each expired item:

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -139,8 +139,14 @@ pub trait StateBackend: Send + Sync {
         queue_types: &[&str],
     ) -> BackendResult<Option<WorkItem>>;
 
-    /// Renew the lease on a claimed work item (heartbeat).
-    async fn renew_lease(&self, item_id: WorkItemId, worker_id: &str) -> BackendResult<()>;
+    /// Renew the lease on a claimed work item (heartbeat). Fails closed if the
+    /// presented `lease_fence` no longer matches (lease stolen / failed over).
+    async fn renew_lease(
+        &self,
+        item_id: WorkItemId,
+        worker_id: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()>;
 
     /// Mark a work item as completed and release the lease.
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()>;

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -1,0 +1,96 @@
+//! Deterministic, cross-binary-stable hashing for idempotency keys and receipts.
+//!
+//! `canonical_json` recursively sorts object keys and serializes compactly, so two
+//! values that differ only in key order hash identically. This is stable across
+//! binaries for object/array/string/bool/integer JSON (the shape idempotency keys
+//! hash over). Full RFC-8785 ECMAScript number canonicalization (a JCS crate) is a
+//! drop-in hardening for receipt material (2i); it is not needed here.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Recursively canonicalize: object keys sorted lexicographically, no whitespace.
+pub fn canonical_json(value: &Value) -> String {
+    let mut out = String::new();
+    write_canonical(value, &mut out);
+    out
+}
+
+fn write_canonical(value: &Value, out: &mut String) {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                // serde_json::to_string on a string Value escapes correctly.
+                out.push_str(&Value::String((*k).clone()).to_string());
+                out.push(':');
+                write_canonical(&map[*k], out);
+            }
+            out.push('}');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        // Scalars: serde_json's Display is deterministic for these.
+        other => out.push_str(&other.to_string()),
+    }
+}
+
+/// Lowercase hex SHA-256 of the canonical JSON bytes.
+pub fn content_hash(value: &Value) -> String {
+    let canonical = canonical_json(value);
+    let digest = Sha256::digest(canonical.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_json_sorts_object_keys() {
+        let a = json!({ "b": 1, "a": 2, "c": { "y": 1, "x": 2 } });
+        assert_eq!(canonical_json(&a), r#"{"a":2,"b":1,"c":{"x":2,"y":1}}"#);
+    }
+
+    #[test]
+    fn canonical_json_is_key_order_independent() {
+        let a = json!({ "x": 1, "y": [1, 2, { "p": 1, "q": 2 }] });
+        let b = json!({ "y": [1, 2, { "q": 2, "p": 1 }], "x": 1 });
+        assert_eq!(canonical_json(&a), canonical_json(&b));
+    }
+
+    #[test]
+    fn content_hash_is_stable_and_order_independent() {
+        let a = json!({ "run": "r1", "segment": 0, "step": 3 });
+        let b = json!({ "step": 3, "run": "r1", "segment": 0 });
+        let h = content_hash(&a);
+        assert_eq!(h, content_hash(&b));
+        assert_eq!(h.len(), 64); // sha256 hex
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn content_hash_differs_on_value_change() {
+        let a = json!({ "step": 3 });
+        let b = json!({ "step": 4 });
+        assert_ne!(content_hash(&a), content_hash(&b));
+    }
+}

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
 pub mod approvals;
+pub mod hashing;
 pub mod backend;
 pub mod budget;
 pub mod event;
@@ -28,3 +29,4 @@ pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;
 pub use tenant::{Tenant, TenantId, TenantLimits, TenantStatus, DEFAULT_TENANT};
 pub use tenant_scoped::TenantScopedSqliteBackend;
+pub use hashing::{canonical_json, content_hash};

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -6,10 +6,10 @@
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
 pub mod approvals;
-pub mod hashing;
 pub mod backend;
 pub mod budget;
 pub mod event;
+pub mod hashing;
 pub mod materializer;
 pub mod memory;
 pub mod snapshot;
@@ -23,10 +23,10 @@ pub use backend::{
 };
 pub use budget::BudgetState;
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
+pub use hashing::{canonical_json, content_hash};
 pub use materializer::{apply_events, materialize, should_snapshot, MaterializedState};
 pub use memory::InMemoryBackend;
 pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;
 pub use tenant::{Tenant, TenantId, TenantLimits, TenantStatus, DEFAULT_TENANT};
 pub use tenant_scoped::TenantScopedSqliteBackend;
-pub use hashing::{canonical_json, content_hash};

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -337,7 +337,10 @@ impl StateBackend for InMemoryBackend {
         let seq = self.next_sequence.fetch_add(1, Ordering::SeqCst);
         let mut ev = terminal_event;
         ev.sequence = seq;
-        self.events.entry(ev.execution_id.clone()).or_default().push(ev);
+        self.events
+            .entry(ev.execution_id.clone())
+            .or_default()
+            .push(ev);
         Ok(seq)
     }
 

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -34,6 +34,10 @@ pub struct InMemoryBackend {
     tenants: DashMap<TenantId, Tenant>,
     /// Global event sequence counter (monotonic across all executions).
     next_sequence: AtomicI64,
+    /// Per-work-item lease epoch (bumped on each claim/reclaim/fail).
+    lease_epochs: DashMap<WorkItemId, i64>,
+    /// Store failover generation (settable to simulate promotion).
+    store_term: AtomicI64,
 }
 
 impl InMemoryBackend {
@@ -48,7 +52,14 @@ impl InMemoryBackend {
             tokens: DashMap::new(),
             tenants: DashMap::new(),
             next_sequence: AtomicI64::new(1),
+            lease_epochs: DashMap::new(),
+            store_term: AtomicI64::new(0),
         }
+    }
+
+    /// Simulate a store failover by bumping the in-memory store term.
+    pub fn bump_store_term(&self) -> i64 {
+        self.store_term.fetch_add(1, Ordering::SeqCst) + 1
     }
 }
 
@@ -231,7 +242,7 @@ impl StateBackend for InMemoryBackend {
         Ok(self
             .snapshots
             .get(execution_id)
-            .and_then(|r| r.value().last().cloned()))
+            .and_then(|r| r.value().iter().max_by_key(|s| s.at_sequence).cloned()))
     }
 
     // ── Work queue ───────────────────────────────────────────────────
@@ -247,11 +258,21 @@ impl StateBackend for InMemoryBackend {
         worker_id: &str,
         queue_types: &[&str],
     ) -> BackendResult<Option<WorkItem>> {
+        let term = self.store_term.load(Ordering::SeqCst);
         for mut entry in self.work_items.iter_mut() {
             let item = entry.value_mut();
             if item.worker_id.is_none() && queue_types.contains(&item.queue_type.as_str()) {
+                let new_epoch = self
+                    .lease_epochs
+                    .get(&item.id)
+                    .map(|e| *e.value())
+                    .unwrap_or(0)
+                    + 1;
+                self.lease_epochs.insert(item.id, new_epoch);
+                let fence = term * 4_294_967_296_i64 + new_epoch;
                 item.worker_id = Some(worker_id.to_string());
                 item.lease_expires_at = Some(Utc::now() + chrono::Duration::seconds(30));
+                item.lease_fence = fence;
                 return Ok(Some(item.clone()));
             }
         }
@@ -286,12 +307,44 @@ impl StateBackend for InMemoryBackend {
         Ok(())
     }
 
+    async fn commit_node_terminal(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        terminal_event: Event,
+    ) -> BackendResult<EventSequence> {
+        // Fenced settle: only the current holder (matching fence) may settle.
+        // Note: the fence check and remove are two DashMap operations rather than
+        // one atomic step. This is acceptable for the in-memory dev/test backend;
+        // the SQLite backends are the production path where atomicity is guaranteed
+        // by BEGIN IMMEDIATE.
+        match self.work_items.get(&item_id) {
+            Some(entry) if entry.lease_fence == lease_fence => {}
+            _ => return Err(StateBackendError::FenceLost(item_id.to_string())),
+        }
+        self.work_items.remove(&item_id);
+        let seq = self.next_sequence.fetch_add(1, Ordering::SeqCst);
+        let mut ev = terminal_event;
+        ev.sequence = seq;
+        self.events.entry(ev.execution_id.clone()).or_default().push(ev);
+        Ok(seq)
+    }
+
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()> {
         match self.work_items.get_mut(&item_id) {
             Some(mut entry) => {
                 entry.attempt += 1;
                 entry.worker_id = None;
                 entry.lease_expires_at = None;
+                // Bump epoch so any re-claim after a forced fail mints a
+                // strictly greater fence than the failed worker's stale token.
+                let next = self
+                    .lease_epochs
+                    .get(&item_id)
+                    .map(|e| *e.value())
+                    .unwrap_or(0)
+                    + 1;
+                self.lease_epochs.insert(item_id, next);
                 if let Some(obj) = entry.payload.as_object_mut() {
                     obj.insert(
                         "last_error".into(),
@@ -317,6 +370,14 @@ impl StateBackend for InMemoryBackend {
                     if item.attempt < item.max_attempts {
                         item.worker_id = None;
                         item.lease_expires_at = None;
+                        // Bump epoch so a re-claim mints a strictly greater fence.
+                        let next = self
+                            .lease_epochs
+                            .get(&item.id)
+                            .map(|e| *e.value())
+                            .unwrap_or(0)
+                            + 1;
+                        self.lease_epochs.insert(item.id, next);
                         result.retryable.push(item.clone());
                     } else {
                         to_dead_letter.push(item.clone());

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -258,17 +258,24 @@ impl StateBackend for InMemoryBackend {
         Ok(None)
     }
 
-    async fn renew_lease(&self, item_id: WorkItemId, worker_id: &str) -> BackendResult<()> {
+    async fn renew_lease(
+        &self,
+        item_id: WorkItemId,
+        worker_id: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()> {
         match self.work_items.get_mut(&item_id) {
             Some(mut entry) => {
-                if entry.worker_id.as_deref() == Some(worker_id) {
-                    entry.lease_expires_at = Some(Utc::now() + chrono::Duration::seconds(30));
-                    Ok(())
-                } else {
-                    Err(StateBackendError::NotFound(format!(
+                if entry.worker_id.as_deref() != Some(worker_id) {
+                    return Err(StateBackendError::FenceLost(format!(
                         "lease not held by {worker_id}"
-                    )))
+                    )));
                 }
+                if entry.lease_fence != lease_fence {
+                    return Err(StateBackendError::FenceLost(item_id.to_string()));
+                }
+                entry.lease_expires_at = Some(Utc::now() + chrono::Duration::seconds(30));
+                Ok(())
             }
             None => Err(StateBackendError::NotFound(item_id.to_string())),
         }

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -7,7 +7,7 @@ use crate::backend::{
     ApiToken, BackendResult, ReclaimResult, StateBackend, StateBackendError, WorkItem, WorkItemId,
     WorkflowDefinition,
 };
-use crate::event::{Event, EventSequence};
+use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
 use crate::tenant::{Tenant, TenantId};
 use async_trait::async_trait;
@@ -313,6 +313,17 @@ impl StateBackend for InMemoryBackend {
         lease_fence: i64,
         terminal_event: Event,
     ) -> BackendResult<EventSequence> {
+        // Validate terminal event kind BEFORE mutating state. A miswired
+        // caller (non-terminal event) fails loud instead of silently settling.
+        match &terminal_event.kind {
+            EventKind::NodeCompleted { .. } | EventKind::NodeFailed { .. } => {}
+            _ => {
+                return Err(StateBackendError::Database(
+                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
+                        .into(),
+                ))
+            }
+        }
         // Fenced settle: only the current holder (matching fence) may settle.
         // Note: the fence check and remove are two DashMap operations rather than
         // one atomic step. This is acceptable for the in-memory dev/test backend;

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -210,6 +210,7 @@ fn row_to_work_item(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkItem> {
         worker_id: row
             .try_get::<Option<String>, _>("worker_id")
             .map_err(map_db_err)?,
+        lease_fence: row.try_get::<i64, _>("lease_fence").unwrap_or(0),
         tenant_id,
     })
 }
@@ -1122,6 +1123,7 @@ mod tests {
             created_at: Utc::now(),
             lease_expires_at: None,
             worker_id: None,
+            lease_fence: 0,
             tenant_id: crate::tenant::DEFAULT_TENANT.to_string(),
         };
         let item_id = item.id;

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -830,9 +830,12 @@ impl StateBackend for SqliteBackend {
         let (status, set_completed_at) = match &terminal_event.kind {
             EventKind::NodeCompleted { .. } => ("completed", true),
             EventKind::NodeFailed { .. } => ("failed", false),
-            _ => return Err(StateBackendError::Database(
-                "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)".into(),
-            )),
+            _ => {
+                return Err(StateBackendError::Database(
+                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
+                        .into(),
+                ))
+            }
         };
 
         let mut tx = self

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -64,6 +64,41 @@ impl SqliteBackend {
     pub fn pool(&self) -> SqlitePool {
         self.pool.clone()
     }
+
+    /// The store's current failover generation. Bumped on promotion (and by the
+    /// test helper). A fence packs this above the per-item epoch.
+    async fn current_term(&self, tx: &mut sqlx::SqliteConnection) -> BackendResult<i64> {
+        let row = sqlx::query("SELECT term FROM store_identity WHERE id = 1")
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        row.try_get::<i64, _>("term").map_err(map_db_err)
+    }
+
+    /// Simulate a store failover by bumping the failover generation. Real
+    /// deployments bump this from the promotion coordinator (LiteFS lease epoch).
+    pub async fn bump_store_term(&self) -> BackendResult<i64> {
+        sqlx::query("UPDATE store_identity SET term = term + 1 WHERE id = 1")
+            .execute(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        let mut conn = self.pool.acquire().await.map_err(map_db_err)?;
+        self.current_term(&mut conn).await
+    }
+
+    /// Test helper: backdate a work item's lease so the stale-expiry path
+    /// fires on the next `claim_work_item` call. Not part of the StateBackend
+    /// trait; only used in tests / simulators.
+    pub async fn force_lease_expired_for_test(&self, item_id: uuid::Uuid) -> BackendResult<()> {
+        sqlx::query(
+            "UPDATE work_items SET lease_expires_at = '2020-01-01T00:00:00+00:00' WHERE id = ?",
+        )
+        .bind(item_id.to_string())
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+        Ok(())
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -625,10 +660,11 @@ impl StateBackend for SqliteBackend {
             return Ok(None);
         }
 
-        // Expire stale leases first
+        // Expire stale leases first; bump lease_epoch so a re-claim mints a
+        // strictly greater fence than the zombie worker's stale token.
         let now = Utc::now().to_rfc3339();
         sqlx::query(
-            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL \
+            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, lease_epoch = lease_epoch + 1 \
              WHERE status = 'claimed' AND lease_expires_at < ?",
         )
         .bind(&now)
@@ -674,12 +710,19 @@ impl StateBackend for SqliteBackend {
         let lease_expires_at = (Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
         let claimed_at = Utc::now().to_rfc3339();
 
+        let term = self.current_term(&mut tx).await?;
+        let current_epoch: i64 = row.try_get::<i64, _>("lease_epoch").unwrap_or(0);
+        let new_epoch = current_epoch + 1;
+        let new_fence = term * 4_294_967_296_i64 + new_epoch;
+
         sqlx::query(
-            "UPDATE work_items SET status = 'claimed', worker_id = ?, lease_expires_at = ?, claimed_at = ? WHERE id = ?",
+            "UPDATE work_items SET status = 'claimed', worker_id = ?, lease_expires_at = ?, claimed_at = ?, lease_epoch = ?, lease_fence = ? WHERE id = ?",
         )
         .bind(worker_id)
         .bind(&lease_expires_at)
         .bind(&claimed_at)
+        .bind(new_epoch)
+        .bind(new_fence)
         .bind(&item_id)
         .execute(&mut *tx)
         .await
@@ -687,9 +730,9 @@ impl StateBackend for SqliteBackend {
 
         tx.commit().await.map_err(map_db_err)?;
 
-        // Return item with updated fields
         let mut claimed = item;
         claimed.worker_id = Some(worker_id.to_string());
+        claimed.lease_fence = new_fence;
         claimed.lease_expires_at = Some(
             DateTime::parse_from_rfc3339(&lease_expires_at)
                 .map(|dt| dt.with_timezone(&Utc))
@@ -699,23 +742,29 @@ impl StateBackend for SqliteBackend {
     }
 
     #[instrument(skip(self), fields(item_id = %item_id, worker_id = worker_id))]
-    async fn renew_lease(&self, item_id: WorkItemId, worker_id: &str) -> BackendResult<()> {
+    async fn renew_lease(
+        &self,
+        item_id: WorkItemId,
+        worker_id: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()> {
         let lease_expires_at = (Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
         let id_str = item_id.to_string();
 
         let rows_affected = sqlx::query(
-            "UPDATE work_items SET lease_expires_at = ? WHERE id = ? AND worker_id = ? AND status = 'claimed'",
+            "UPDATE work_items SET lease_expires_at = ? WHERE id = ? AND worker_id = ? AND status = 'claimed' AND lease_fence = ?",
         )
         .bind(&lease_expires_at)
         .bind(&id_str)
         .bind(worker_id)
+        .bind(lease_fence)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?
         .rows_affected();
 
         if rows_affected == 0 {
-            return Err(StateBackendError::NotFound(id_str));
+            return Err(StateBackendError::FenceLost(id_str));
         }
         Ok(())
     }
@@ -820,7 +869,7 @@ impl StateBackend for SqliteBackend {
                     (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
 
                 sqlx::query(
-                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ? WHERE id = ?",
+                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ?, lease_epoch = lease_epoch + 1 WHERE id = ?",
                 )
                 .bind(new_attempt as i64)
                 .bind(&retry_after)

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -824,11 +824,15 @@ impl StateBackend for SqliteBackend {
         let created_at = terminal_event.created_at.to_rfc3339();
         let now = Utc::now().to_rfc3339();
 
-        // Settle status inferred from the terminal event kind.
+        // Validate terminal event kind BEFORE opening the transaction.
+        // A miswired caller (non-terminal event) fails loud instead of
+        // silently settling a non-terminal event as completed.
         let (status, set_completed_at) = match &terminal_event.kind {
             EventKind::NodeCompleted { .. } => ("completed", true),
             EventKind::NodeFailed { .. } => ("failed", false),
-            _ => ("completed", true),
+            _ => return Err(StateBackendError::Database(
+                "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)".into(),
+            )),
         };
 
         let mut tx = self

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -810,6 +810,91 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self, terminal_event), fields(item_id = %item_id, fence = lease_fence))]
+    async fn commit_node_terminal(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        terminal_event: Event,
+    ) -> BackendResult<EventSequence> {
+        let id_str = item_id.to_string();
+        let execution_id = execution_id_str(&terminal_event.execution_id);
+        let event_id = terminal_event.id.to_string();
+        let kind_json = serde_json::to_string(&terminal_event.kind)?;
+        let created_at = terminal_event.created_at.to_rfc3339();
+        let now = Utc::now().to_rfc3339();
+
+        // Settle status inferred from the terminal event kind.
+        let (status, set_completed_at) = match &terminal_event.kind {
+            EventKind::NodeCompleted { .. } => ("completed", true),
+            EventKind::NodeFailed { .. } => ("failed", false),
+            _ => ("completed", true),
+        };
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // 1) Fenced settle. Zero rows => stale fence => fail closed, emit nothing.
+        let rows = if set_completed_at {
+            sqlx::query(
+                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL WHERE id = ? AND lease_fence = ?",
+            )
+            .bind(status)
+            .bind(&now)
+            .bind(&id_str)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected()
+        } else {
+            sqlx::query(
+                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL WHERE id = ? AND lease_fence = ?",
+            )
+            .bind(status)
+            .bind(&id_str)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected()
+        };
+
+        if rows == 0 {
+            tx.rollback().await.map_err(map_db_err)?;
+            return Err(StateBackendError::FenceLost(id_str));
+        }
+
+        // 2) Assign the next sequence and append the event in the same transaction.
+        let seq_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&execution_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let sequence: i64 = seq_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at)
+               VALUES (?, ?, ?, ?, ?)"#,
+        )
+        .bind(&event_id)
+        .bind(&execution_id)
+        .bind(sequence)
+        .bind(&kind_json)
+        .bind(&created_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(sequence)
+    }
+
     #[instrument(skip(self))]
     async fn reclaim_expired_leases(&self) -> BackendResult<ReclaimResult> {
         let now = Utc::now().to_rfc3339();

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -665,24 +665,30 @@ impl StateBackend for TenantScopedSqliteBackend {
     }
 
     #[instrument(skip(self), fields(tenant = %self.tenant_id, item_id = %item_id))]
-    async fn renew_lease(&self, item_id: WorkItemId, worker_id: &str) -> BackendResult<()> {
+    async fn renew_lease(
+        &self,
+        item_id: WorkItemId,
+        worker_id: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()> {
         let lease_expires_at = (Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
         let id_str = item_id.to_string();
 
         let rows_affected = sqlx::query(
-            "UPDATE work_items SET lease_expires_at = ? WHERE id = ? AND worker_id = ? AND status = 'claimed' AND tenant_id = ?",
+            "UPDATE work_items SET lease_expires_at = ? WHERE id = ? AND worker_id = ? AND status = 'claimed' AND tenant_id = ? AND lease_fence = ?",
         )
         .bind(&lease_expires_at)
         .bind(&id_str)
         .bind(worker_id)
         .bind(&self.tenant_id.0)
+        .bind(lease_fence)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?
         .rows_affected();
 
         if rows_affected == 0 {
-            return Err(StateBackendError::NotFound(id_str));
+            return Err(StateBackendError::FenceLost(id_str));
         }
         Ok(())
     }

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -774,9 +774,12 @@ impl StateBackend for TenantScopedSqliteBackend {
         let (status, set_completed_at) = match &terminal_event.kind {
             EventKind::NodeCompleted { .. } => ("completed", true),
             EventKind::NodeFailed { .. } => ("failed", false),
-            _ => return Err(StateBackendError::Database(
-                "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)".into(),
-            )),
+            _ => {
+                return Err(StateBackendError::Database(
+                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
+                        .into(),
+                ))
+            }
         };
 
         let mut tx = self

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -165,6 +165,7 @@ fn row_to_work_item(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkItem> {
         worker_id: row
             .try_get::<Option<String>, _>("worker_id")
             .map_err(map_db_err)?,
+        lease_fence: row.try_get::<i64, _>("lease_fence").unwrap_or(0),
         tenant_id,
     })
 }

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -768,10 +768,15 @@ impl StateBackend for TenantScopedSqliteBackend {
         let created_at = terminal_event.created_at.to_rfc3339();
         let now = Utc::now().to_rfc3339();
 
+        // Validate terminal event kind BEFORE opening the transaction.
+        // A miswired caller (non-terminal event) fails loud instead of
+        // silently settling a non-terminal event as completed.
         let (status, set_completed_at) = match &terminal_event.kind {
             EventKind::NodeCompleted { .. } => ("completed", true),
             EventKind::NodeFailed { .. } => ("failed", false),
-            _ => ("completed", true),
+            _ => return Err(StateBackendError::Database(
+                "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)".into(),
+            )),
         };
 
         let mut tx = self

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -37,6 +37,15 @@ impl TenantScopedSqliteBackend {
     pub fn tenant_id(&self) -> &TenantId {
         &self.tenant_id
     }
+
+    /// The store's current failover generation (same table as SqliteBackend).
+    async fn current_term(&self, tx: &mut sqlx::SqliteConnection) -> BackendResult<i64> {
+        let row = sqlx::query("SELECT term FROM store_identity WHERE id = 1")
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        row.try_get::<i64, _>("term").map_err(map_db_err)
+    }
 }
 
 // ── Helpers (re-use sqlite.rs parsers) ────────────────────────────────────────
@@ -594,9 +603,10 @@ impl StateBackend for TenantScopedSqliteBackend {
         }
 
         let now = Utc::now().to_rfc3339();
-        // Expire stale leases for this tenant.
+        // Expire stale leases for this tenant; bump lease_epoch so a re-claim
+        // mints a strictly greater fence than any zombie worker's stale token.
         sqlx::query(
-            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL \
+            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, lease_epoch = lease_epoch + 1 \
              WHERE status = 'claimed' AND lease_expires_at < ? AND tenant_id = ?",
         )
         .bind(&now)
@@ -641,12 +651,19 @@ impl StateBackend for TenantScopedSqliteBackend {
         let lease_expires_at = (Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
         let claimed_at = Utc::now().to_rfc3339();
 
+        let term = self.current_term(&mut tx).await?;
+        let current_epoch: i64 = row.try_get::<i64, _>("lease_epoch").unwrap_or(0);
+        let new_epoch = current_epoch + 1;
+        let new_fence = term * 4_294_967_296_i64 + new_epoch;
+
         sqlx::query(
-            "UPDATE work_items SET status = 'claimed', worker_id = ?, lease_expires_at = ?, claimed_at = ? WHERE id = ?",
+            "UPDATE work_items SET status = 'claimed', worker_id = ?, lease_expires_at = ?, claimed_at = ?, lease_epoch = ?, lease_fence = ? WHERE id = ?",
         )
         .bind(worker_id)
         .bind(&lease_expires_at)
         .bind(&claimed_at)
+        .bind(new_epoch)
+        .bind(new_fence)
         .bind(&item_id)
         .execute(&mut *tx)
         .await
@@ -656,6 +673,7 @@ impl StateBackend for TenantScopedSqliteBackend {
 
         let mut claimed = item;
         claimed.worker_id = Some(worker_id.to_string());
+        claimed.lease_fence = new_fence;
         claimed.lease_expires_at = Some(
             DateTime::parse_from_rfc3339(&lease_expires_at)
                 .map(|dt| dt.with_timezone(&Utc))
@@ -736,6 +754,92 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self, terminal_event), fields(tenant = %self.tenant_id, item_id = %item_id))]
+    async fn commit_node_terminal(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        terminal_event: Event,
+    ) -> BackendResult<EventSequence> {
+        let id_str = item_id.to_string();
+        let execution_id = execution_id_str(&terminal_event.execution_id);
+        let event_id = terminal_event.id.to_string();
+        let kind_json = serde_json::to_string(&terminal_event.kind)?;
+        let created_at = terminal_event.created_at.to_rfc3339();
+        let now = Utc::now().to_rfc3339();
+
+        let (status, set_completed_at) = match &terminal_event.kind {
+            EventKind::NodeCompleted { .. } => ("completed", true),
+            EventKind::NodeFailed { .. } => ("failed", false),
+            _ => ("completed", true),
+        };
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // Fenced settle with tenant isolation. Zero rows => stale fence => fail closed.
+        let rows = if set_completed_at {
+            sqlx::query(
+                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL WHERE id = ? AND tenant_id = ? AND lease_fence = ?",
+            )
+            .bind(status)
+            .bind(&now)
+            .bind(&id_str)
+            .bind(&self.tenant_id.0)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected()
+        } else {
+            sqlx::query(
+                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL WHERE id = ? AND tenant_id = ? AND lease_fence = ?",
+            )
+            .bind(status)
+            .bind(&id_str)
+            .bind(&self.tenant_id.0)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected()
+        };
+
+        if rows == 0 {
+            tx.rollback().await.map_err(map_db_err)?;
+            return Err(StateBackendError::FenceLost(id_str));
+        }
+
+        let seq_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&execution_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let sequence: i64 = seq_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&event_id)
+        .bind(&execution_id)
+        .bind(sequence)
+        .bind(&kind_json)
+        .bind(&created_at)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(sequence)
+    }
+
     #[instrument(skip(self), fields(tenant = %self.tenant_id))]
     async fn reclaim_expired_leases(&self) -> BackendResult<ReclaimResult> {
         let now = Utc::now().to_rfc3339();
@@ -793,7 +897,7 @@ impl StateBackend for TenantScopedSqliteBackend {
                     (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
 
                 sqlx::query(
-                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ? WHERE id = ?",
+                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ?, lease_epoch = lease_epoch + 1 WHERE id = ?",
                 )
                 .bind(new_attempt as i64)
                 .bind(&retry_after)

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -4,8 +4,8 @@
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
-    backend::{StateBackend, WorkItem},
-    SqliteBackend,
+    backend::{StateBackend, StateBackendError, WorkItem},
+    Event, EventKind, SqliteBackend,
 };
 use serde_json::json;
 use std::path::PathBuf;
@@ -106,6 +106,76 @@ async fn reclaim_bumps_fence() {
         second.lease_fence,
         first.lease_fence
     );
+
+    std::fs::remove_file(&path).ok();
+}
+
+fn node_completed(node: &str) -> EventKind {
+    EventKind::NodeCompleted {
+        node_id: node.into(),
+        output: json!({ "ok": true }),
+        state_patch: json!({}),
+        duration_ms: 1,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    }
+}
+
+#[tokio::test]
+async fn commit_succeeds_with_correct_fence() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    let item = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let event = Event::new(eid.clone(), 0, node_completed("n1"));
+    let seq = db
+        .commit_node_terminal(item.id, item.lease_fence, event)
+        .await
+        .expect("commit with correct fence");
+    assert!(seq >= 1);
+
+    // Exactly one event was appended.
+    let events = db.get_events(&eid).await.unwrap();
+    assert_eq!(events.len(), 1);
+    // Item is settled — no longer claimable.
+    assert!(db.claim_work_item("worker-B", &["model"]).await.unwrap().is_none());
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[tokio::test]
+async fn commit_fails_closed_with_stale_fence() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    // Worker A claims (fence F1). Backdate the lease so the stale-expiry path
+    // in claim_work_item fires: it bumps lease_epoch+1 and resets to 'pending'.
+    // Worker B then re-claims and receives a strictly greater fence F2.
+    // Worker A is now a zombie holding F1.
+    let zombie = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    db.force_lease_expired_for_test(zombie.id).await.unwrap();
+    let _b = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+
+    let event = Event::new(eid.clone(), 0, node_completed("n1"));
+    let err = db
+        .commit_node_terminal(zombie.id, zombie.lease_fence, event)
+        .await
+        .expect_err("zombie commit must fail closed");
+    assert!(matches!(err, StateBackendError::FenceLost(_)));
+
+    // The zombie's commit emitted NOTHING.
+    assert_eq!(db.get_events(&eid).await.unwrap().len(), 0);
 
     std::fs::remove_file(&path).ok();
 }

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -4,8 +4,7 @@
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
-    backend::{StateBackend, StateBackendError, WorkItem},
-    event::{Event, EventKind},
+    backend::{StateBackend, WorkItem},
     SqliteBackend,
 };
 use serde_json::json;
@@ -67,6 +66,46 @@ async fn claim_mints_nonzero_fence() {
 
     let claimed = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
     assert!(claimed.lease_fence > 0, "claim must mint a non-zero fence");
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// Verify that a re-claim (after a stale/expired lease) mints a strictly
+/// greater fence. This is the anti-double-commit invariant: a zombie worker
+/// holding the old fence value gets 0 rows on renew_lease / commit.
+///
+/// Adaptation from brief: `fail_work_item` sets status='failed' (not
+/// 'pending') in the SQLite backend, so we cannot use it to make the item
+/// re-claimable. Instead we use `force_lease_expired_for_test` to backdate the
+/// lease_expires_at, then call `claim_work_item` which has a built-in
+/// stale-expiry UPDATE that bumps `lease_epoch + 1` and resets to 'pending'
+/// before the second claim.
+#[tokio::test]
+async fn reclaim_bumps_fence() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    // First claim mints fence F1 (term=0, epoch=1 → F1=1).
+    let first = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    assert!(first.lease_fence > 0, "first claim must mint a non-zero fence");
+
+    // Backdate the lease so the stale-expiry path inside claim_work_item fires.
+    // (fail_work_item sets status='failed', not 'pending', so it is not
+    //  directly re-claimable — see adaptation note above.)
+    db.force_lease_expired_for_test(first.id).await.unwrap();
+
+    // Re-claim: claim_work_item's stale-expiry UPDATE bumps lease_epoch+1 and
+    // resets status='pending'; the subsequent INSERT mints a strictly greater fence.
+    let second = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+    assert!(
+        second.lease_fence > first.lease_fence,
+        "re-claim must mint a strictly greater fence ({} !> {})",
+        second.lease_fence,
+        first.lease_fence
+    );
 
     std::fs::remove_file(&path).ok();
 }

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
     backend::{StateBackend, StateBackendError, WorkItem},
-    Event, EventKind, SqliteBackend,
+    Event, EventKind, InMemoryBackend, SqliteBackend, TenantId,
 };
 use serde_json::json;
 use std::path::PathBuf;
@@ -177,5 +177,283 @@ async fn commit_fails_closed_with_stale_fence() {
     // The zombie's commit emitted NOTHING.
     assert_eq!(db.get_events(&eid).await.unwrap().len(), 0);
 
+    std::fs::remove_file(&path).ok();
+}
+
+/// Simulates a lost-tail failover: the primary store drops while a worker
+/// holds a lease. A promoted store (same DB file, bumped term) is opened,
+/// the stale lease is expired and re-claimed under the new term. The original
+/// zombie fence (minted under term 0) is rejected on the promoted store.
+///
+/// Central invariant: a fence minted under term N is rejected after promotion
+/// to term N+1. The fence packs the store term in the high 32 bits, so any
+/// term-0 fence is numerically less than any term-1 fence, and the
+/// `AND lease_fence = ?` WHERE clause in commit_node_terminal will find zero
+/// rows -> FenceLost, zero events written.
+///
+/// Mechanics note: rather than copying a DB file (the brief's two-file sketch),
+/// we drop the `SqliteBackend` handle (simulating the primary going away) and
+/// re-open the same on-disk file as the "promoted" store. The data persists
+/// because SQLite WAL files survive the connection close. This is deterministic
+/// without filesystem copies.
+#[tokio::test]
+async fn fence_survives_lost_tail_failover() {
+    let path = temp_db_path();
+    let eid = ExecutionId::new();
+    let zombie_fence: i64;
+    let zombie_item_id: Uuid;
+
+    // --- Primary store: claim under term 0 ---
+    {
+        let primary = open_db(&path).await;
+        primary.create_execution(sample_execution(&eid)).await.unwrap();
+        zombie_item_id = primary.enqueue_work_item(sample_item(&eid)).await.unwrap();
+        let z = primary
+            .claim_work_item("worker-A", &["model"])
+            .await
+            .unwrap()
+            .unwrap();
+        zombie_fence = z.lease_fence; // term=0, epoch=1 -> value=1
+        assert!(zombie_fence > 0, "zombie fence must be nonzero");
+        // Primary "crashes" here: SqliteBackend dropped, item still in 'claimed'
+        // state on disk (no commit was issued).
+    }
+
+    // --- Promoted store: same file, bump failover generation to term=1 ---
+    let promoted = open_db(&path).await;
+    let new_term = promoted.bump_store_term().await.unwrap();
+    assert_eq!(new_term, 1, "term must be 1 after first promotion");
+
+    // Expire the stale lease (worker-A is gone). The backdated lease_expires_at
+    // causes claim_work_item's built-in stale-expiry UPDATE to reset the item
+    // to 'pending' with a bumped epoch before the fresh claim.
+    promoted
+        .force_lease_expired_for_test(zombie_item_id)
+        .await
+        .unwrap();
+    let fresh = promoted
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    // Fresh fence: term=1 * 4_294_967_296 + epoch=3 >> zombie_fence (term-0).
+    assert!(
+        fresh.lease_fence > zombie_fence,
+        "term-1 fence {} must be > term-0 zombie fence {}",
+        fresh.lease_fence,
+        zombie_fence
+    );
+
+    // Central assertion: the zombie's term-0 fence is rejected on the promoted
+    // store. commit_node_terminal WHERE clause `AND lease_fence = zombie_fence`
+    // finds zero rows (current fence is the term-1 value) -> FenceLost.
+    let ev = Event::new(eid.clone(), 0, node_completed("n1"));
+    let err = promoted
+        .commit_node_terminal(zombie_item_id, zombie_fence, ev)
+        .await
+        .expect_err("term-0 zombie fence must be rejected after promotion to term 1");
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+    // The zombie commit must have written NOTHING.
+    assert_eq!(
+        promoted.get_events(&eid).await.unwrap().len(),
+        0,
+        "zombie must emit zero events"
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// Negative control: proves the fence check catches a bad fence value even
+/// when the store term has NOT changed. A fabricated fence (item.lease_fence + 1)
+/// is one higher than the real fence; commit_node_terminal must reject it with
+/// FenceLost and emit zero events. This demonstrates the test would catch a
+/// regression that removed the fence check.
+#[tokio::test]
+async fn term_pin_reopens_window_negative_control() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    let item = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Fabricate a fence that is one higher than the real value.
+    let wrong_fence = item.lease_fence + 1;
+    let ev = Event::new(eid.clone(), 0, node_completed("n1"));
+    let err = db
+        .commit_node_terminal(item.id, wrong_fence, ev)
+        .await
+        .expect_err("fabricated wrong fence must be rejected");
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+    assert_eq!(
+        db.get_events(&eid).await.unwrap().len(),
+        0,
+        "wrong-fence commit must emit zero events"
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// Crash-injection exactly-once-commit: worker A claims but crashes (the
+/// SqliteBackend is dropped) before committing. The lease is force-expired and
+/// worker B re-claims the same item. B's commit must succeed, and exactly one
+/// NodeCompleted event must exist in the log — no double-write, no ghost event.
+///
+/// Mechanics: the item id is captured at enqueue so it can be threaded into
+/// force_lease_expired_for_test after the re-open (no db_first_item_id helper
+/// needed). The stale-expiry path inside claim_work_item resets the item to
+/// 'pending' with a bumped epoch before the re-claim.
+#[tokio::test]
+async fn crash_before_commit_then_reclaim_yields_exactly_one_terminal() {
+    let path = temp_db_path();
+    let eid = ExecutionId::new();
+    let item_id: Uuid;
+
+    // Worker A claims but "crashes" before commit (SqliteBackend dropped).
+    {
+        let db = open_db(&path).await;
+        db.create_execution(sample_execution(&eid)).await.unwrap();
+        item_id = db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+        let _a = db
+            .claim_work_item("worker-A", &["model"])
+            .await
+            .unwrap()
+            .unwrap();
+        // db dropped here; item remains in 'claimed' state, no events written.
+    }
+
+    // New "process": re-open the same DB, expire worker-A's stale lease,
+    // re-claim as worker B, commit.
+    let db = open_db(&path).await;
+    db.force_lease_expired_for_test(item_id).await.unwrap();
+    let b = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let ev = Event::new(eid.clone(), 0, node_completed("n1"));
+    db.commit_node_terminal(b.id, b.lease_fence, ev)
+        .await
+        .expect("worker-B commit must succeed after re-claim");
+
+    // Exactly one terminal event must exist — the zombie A never committed.
+    let completions = db
+        .get_events(&eid)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+        .count();
+    assert_eq!(
+        completions, 1,
+        "exactly one NodeCompleted must exist after crash-then-reclaim; got {completions}"
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+// ── Cross-backend helpers ─────────────────────────────────────────────────────
+
+/// Generic helper: asserts that `commit_node_terminal` with the CORRECT fence
+/// succeeds and appends exactly one event. Backend-agnostic.
+async fn assert_fence_commit_succeeds(backend: &dyn StateBackend) {
+    let eid = ExecutionId::new();
+    backend
+        .create_execution(sample_execution(&eid))
+        .await
+        .unwrap();
+    backend.enqueue_work_item(sample_item(&eid)).await.unwrap();
+    let item = backend
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let ev = Event::new(eid.clone(), 0, node_completed("n1"));
+    let seq = backend
+        .commit_node_terminal(item.id, item.lease_fence, ev)
+        .await
+        .expect("commit with correct fence must succeed");
+    assert!(seq >= 1, "sequence must be at least 1");
+    assert_eq!(
+        backend.get_events(&eid).await.unwrap().len(),
+        1,
+        "exactly one event must exist after successful commit"
+    );
+}
+
+/// Generic helper: asserts that `commit_node_terminal` with a FABRICATED wrong
+/// fence returns FenceLost and writes zero events. Backend-agnostic.
+async fn assert_fence_commit_fails_stale(backend: &dyn StateBackend) {
+    let eid = ExecutionId::new();
+    backend
+        .create_execution(sample_execution(&eid))
+        .await
+        .unwrap();
+    backend.enqueue_work_item(sample_item(&eid)).await.unwrap();
+    let item = backend
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let wrong_fence = item.lease_fence + 1; // fabricated — one higher than real
+    let ev = Event::new(eid.clone(), 0, node_completed("n1"));
+    let err = backend
+        .commit_node_terminal(item.id, wrong_fence, ev)
+        .await
+        .expect_err("fabricated wrong fence must be rejected");
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+    assert_eq!(
+        backend.get_events(&eid).await.unwrap().len(),
+        0,
+        "stale-fence commit must emit zero events"
+    );
+}
+
+// ── InMemoryBackend cross-backend tests ───────────────────────────────────────
+
+#[tokio::test]
+async fn commit_succeeds_with_correct_fence_inmemory() {
+    let backend = InMemoryBackend::new();
+    assert_fence_commit_succeeds(&backend).await;
+}
+
+#[tokio::test]
+async fn commit_fails_closed_with_stale_fence_inmemory() {
+    let backend = InMemoryBackend::new();
+    assert_fence_commit_fails_stale(&backend).await;
+}
+
+// ── TenantScopedSqliteBackend cross-backend tests ─────────────────────────────
+
+#[tokio::test]
+async fn commit_succeeds_with_correct_fence_tenant_scoped() {
+    let path = temp_db_path();
+    // open_db runs migrations; for_tenant creates a scoped view over the same pool.
+    let base = open_db(&path).await;
+    let backend = base.for_tenant(TenantId::default_tenant());
+    assert_fence_commit_succeeds(&backend).await;
+    std::fs::remove_file(&path).ok();
+}
+
+#[tokio::test]
+async fn commit_fails_closed_with_stale_fence_tenant_scoped() {
+    let path = temp_db_path();
+    let base = open_db(&path).await;
+    let backend = base.for_tenant(TenantId::default_tenant());
+    assert_fence_commit_fails_stale(&backend).await;
     std::fs::remove_file(&path).ok();
 }

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -126,6 +126,15 @@ fn node_completed(node: &str) -> EventKind {
     }
 }
 
+fn node_failed(node: &str) -> EventKind {
+    EventKind::NodeFailed {
+        node_id: node.into(),
+        error: "boom".into(),
+        attempt: 0,
+        retryable: false,
+    }
+}
+
 #[tokio::test]
 async fn commit_succeeds_with_correct_fence() {
     let path = temp_db_path();
@@ -363,6 +372,73 @@ async fn crash_before_commit_then_reclaim_yields_exactly_one_terminal() {
     std::fs::remove_file(&path).ok();
 }
 
+/// `commit_node_terminal` with a `NodeFailed` event and the correct fence must
+/// succeed, settle the item as failed (lease_expires_at=NULL, worker_id=NULL,
+/// completed_at=NULL), and append exactly one NodeFailed event to the log.
+#[tokio::test]
+async fn commit_node_terminal_node_failed_settles_failed() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    let item = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let event = Event::new(eid.clone(), 0, node_failed("n1"));
+    let seq = db
+        .commit_node_terminal(item.id, item.lease_fence, event)
+        .await
+        .expect("commit NodeFailed with correct fence must succeed");
+    assert!(seq >= 1, "sequence must be at least 1");
+
+    // Exactly one event in the log, and it is a NodeFailed.
+    let events = db.get_events(&eid).await.unwrap();
+    assert_eq!(events.len(), 1, "exactly one event must exist after NodeFailed commit");
+    assert!(
+        matches!(events[0].kind, EventKind::NodeFailed { .. }),
+        "the committed event must be NodeFailed, got {:?}",
+        events[0].kind
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// A zombie (stale fence) attempting to commit a `NodeFailed` event must be
+/// rejected with `FenceLost` and must write zero events to the log.
+#[tokio::test]
+async fn commit_node_terminal_node_failed_stale_fence_fails_closed() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    // Worker A claims (fence F1), then has its lease expired and re-claimed by B.
+    let zombie = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    db.force_lease_expired_for_test(zombie.id).await.unwrap();
+    let _b = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+
+    // Zombie tries to commit a NodeFailed with stale fence F1.
+    let event = Event::new(eid.clone(), 0, node_failed("n1"));
+    let err = db
+        .commit_node_terminal(zombie.id, zombie.lease_fence, event)
+        .await
+        .expect_err("zombie NodeFailed commit must fail closed");
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+
+    // Zero events written — the zombie's NodeFailed must not appear.
+    assert_eq!(
+        db.get_events(&eid).await.unwrap().len(),
+        0,
+        "zombie NodeFailed commit must emit zero events"
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
 // ── Cross-backend helpers ─────────────────────────────────────────────────────
 
 /// Generic helper: asserts that `commit_node_terminal` with the CORRECT fence
@@ -455,5 +531,100 @@ async fn commit_fails_closed_with_stale_fence_tenant_scoped() {
     let base = open_db(&path).await;
     let backend = base.for_tenant(TenantId::default_tenant());
     assert_fence_commit_fails_stale(&backend).await;
+    std::fs::remove_file(&path).ok();
+}
+
+// ── NodeFailed cross-backend helpers ─────────────────────────────────────────
+
+/// Generic helper: asserts that `commit_node_terminal` with a `NodeFailed` event
+/// and the CORRECT fence succeeds and appends exactly one NodeFailed event.
+async fn assert_fence_node_failed_succeeds(backend: &dyn StateBackend) {
+    let eid = ExecutionId::new();
+    backend
+        .create_execution(sample_execution(&eid))
+        .await
+        .unwrap();
+    backend.enqueue_work_item(sample_item(&eid)).await.unwrap();
+    let item = backend
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let ev = Event::new(eid.clone(), 0, node_failed("n1"));
+    let seq = backend
+        .commit_node_terminal(item.id, item.lease_fence, ev)
+        .await
+        .expect("NodeFailed commit with correct fence must succeed");
+    assert!(seq >= 1, "sequence must be at least 1");
+    let events = backend.get_events(&eid).await.unwrap();
+    assert_eq!(events.len(), 1, "exactly one event must exist after NodeFailed commit");
+    assert!(
+        matches!(events[0].kind, EventKind::NodeFailed { .. }),
+        "the committed event must be NodeFailed"
+    );
+}
+
+/// Generic helper: asserts that `commit_node_terminal` with a `NodeFailed` event
+/// and a FABRICATED wrong fence returns FenceLost and writes zero events.
+async fn assert_fence_node_failed_stale_fails(backend: &dyn StateBackend) {
+    let eid = ExecutionId::new();
+    backend
+        .create_execution(sample_execution(&eid))
+        .await
+        .unwrap();
+    backend.enqueue_work_item(sample_item(&eid)).await.unwrap();
+    let item = backend
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let wrong_fence = item.lease_fence + 1;
+    let ev = Event::new(eid.clone(), 0, node_failed("n1"));
+    let err = backend
+        .commit_node_terminal(item.id, wrong_fence, ev)
+        .await
+        .expect_err("stale-fence NodeFailed must be rejected");
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+    assert_eq!(
+        backend.get_events(&eid).await.unwrap().len(),
+        0,
+        "stale-fence NodeFailed commit must emit zero events"
+    );
+}
+
+// ── NodeFailed — InMemoryBackend ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn commit_node_failed_succeeds_with_correct_fence_inmemory() {
+    let backend = InMemoryBackend::new();
+    assert_fence_node_failed_succeeds(&backend).await;
+}
+
+#[tokio::test]
+async fn commit_node_failed_stale_fence_fails_closed_inmemory() {
+    let backend = InMemoryBackend::new();
+    assert_fence_node_failed_stale_fails(&backend).await;
+}
+
+// ── NodeFailed — TenantScopedSqliteBackend ────────────────────────────────────
+
+#[tokio::test]
+async fn commit_node_failed_succeeds_with_correct_fence_tenant_scoped() {
+    let path = temp_db_path();
+    let base = open_db(&path).await;
+    let backend = base.for_tenant(TenantId::default_tenant());
+    assert_fence_node_failed_succeeds(&backend).await;
+    std::fs::remove_file(&path).ok();
+}
+
+#[tokio::test]
+async fn commit_node_failed_stale_fence_fails_closed_tenant_scoped() {
+    let path = temp_db_path();
+    let base = open_db(&path).await;
+    let backend = base.for_tenant(TenantId::default_tenant());
+    assert_fence_node_failed_stale_fails(&backend).await;
     std::fs::remove_file(&path).ok();
 }

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -1,0 +1,72 @@
+//! Lease-fencing tests: a zombie worker cannot double-commit; the fence is
+//! monotonic across reclaim and survives a simulated store failover.
+
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::{
+    backend::{StateBackend, StateBackendError, WorkItem},
+    event::{Event, EventKind},
+    SqliteBackend,
+};
+use serde_json::json;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+fn temp_db_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let unique = Uuid::new_v4().to_string().replace('-', "");
+    path.push(format!("jamjet_fence_{unique}.db"));
+    path
+}
+
+async fn open_db(path: &PathBuf) -> SqliteBackend {
+    let url = format!("sqlite://{}", path.display());
+    SqliteBackend::open(&url).await.expect("open test db")
+}
+
+fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "wf-fence".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({}),
+        current_state: json!({}),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+    }
+}
+
+fn sample_item(execution_id: &ExecutionId) -> WorkItem {
+    WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: execution_id.clone(),
+        node_id: "n1".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    }
+}
+
+#[tokio::test]
+async fn claim_mints_nonzero_fence() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+
+    let claimed = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    assert!(claimed.lease_fence > 0, "claim must mint a non-zero fence");
+
+    std::fs::remove_file(&path).ok();
+}

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -64,7 +64,11 @@ async fn claim_mints_nonzero_fence() {
     db.create_execution(sample_execution(&eid)).await.unwrap();
     db.enqueue_work_item(sample_item(&eid)).await.unwrap();
 
-    let claimed = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let claimed = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     assert!(claimed.lease_fence > 0, "claim must mint a non-zero fence");
 
     std::fs::remove_file(&path).ok();
@@ -89,8 +93,15 @@ async fn reclaim_bumps_fence() {
     db.enqueue_work_item(sample_item(&eid)).await.unwrap();
 
     // First claim mints fence F1 (term=0, epoch=1 → F1=1).
-    let first = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
-    assert!(first.lease_fence > 0, "first claim must mint a non-zero fence");
+    let first = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        first.lease_fence > 0,
+        "first claim must mint a non-zero fence"
+    );
 
     // Backdate the lease so the stale-expiry path inside claim_work_item fires.
     // (fail_work_item sets status='failed', not 'pending', so it is not
@@ -99,7 +110,11 @@ async fn reclaim_bumps_fence() {
 
     // Re-claim: claim_work_item's stale-expiry UPDATE bumps lease_epoch+1 and
     // resets status='pending'; the subsequent INSERT mints a strictly greater fence.
-    let second = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+    let second = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     assert!(
         second.lease_fence > first.lease_fence,
         "re-claim must mint a strictly greater fence ({} !> {})",
@@ -143,7 +158,11 @@ async fn commit_succeeds_with_correct_fence() {
     db.create_execution(sample_execution(&eid)).await.unwrap();
     db.enqueue_work_item(sample_item(&eid)).await.unwrap();
 
-    let item = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let item = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let seq = db
         .commit_node_terminal(item.id, item.lease_fence, event)
@@ -155,7 +174,11 @@ async fn commit_succeeds_with_correct_fence() {
     let events = db.get_events(&eid).await.unwrap();
     assert_eq!(events.len(), 1);
     // Item is settled — no longer claimable.
-    assert!(db.claim_work_item("worker-B", &["model"]).await.unwrap().is_none());
+    assert!(db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .is_none());
 
     std::fs::remove_file(&path).ok();
 }
@@ -172,9 +195,17 @@ async fn commit_fails_closed_with_stale_fence() {
     // in claim_work_item fires: it bumps lease_epoch+1 and resets to 'pending'.
     // Worker B then re-claims and receives a strictly greater fence F2.
     // Worker A is now a zombie holding F1.
-    let zombie = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let zombie = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     db.force_lease_expired_for_test(zombie.id).await.unwrap();
-    let _b = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+    let _b = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
 
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = db
@@ -215,7 +246,10 @@ async fn fence_survives_lost_tail_failover() {
     // --- Primary store: claim under term 0 ---
     {
         let primary = open_db(&path).await;
-        primary.create_execution(sample_execution(&eid)).await.unwrap();
+        primary
+            .create_execution(sample_execution(&eid))
+            .await
+            .unwrap();
         zombie_item_id = primary.enqueue_work_item(sample_item(&eid)).await.unwrap();
         let z = primary
             .claim_work_item("worker-A", &["model"])
@@ -383,7 +417,11 @@ async fn commit_node_terminal_node_failed_settles_failed() {
     db.create_execution(sample_execution(&eid)).await.unwrap();
     db.enqueue_work_item(sample_item(&eid)).await.unwrap();
 
-    let item = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let item = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
     let seq = db
         .commit_node_terminal(item.id, item.lease_fence, event)
@@ -393,7 +431,11 @@ async fn commit_node_terminal_node_failed_settles_failed() {
 
     // Exactly one event in the log, and it is a NodeFailed.
     let events = db.get_events(&eid).await.unwrap();
-    assert_eq!(events.len(), 1, "exactly one event must exist after NodeFailed commit");
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one event must exist after NodeFailed commit"
+    );
     assert!(
         matches!(events[0].kind, EventKind::NodeFailed { .. }),
         "the committed event must be NodeFailed, got {:?}",
@@ -414,9 +456,17 @@ async fn commit_node_terminal_node_failed_stale_fence_fails_closed() {
     db.enqueue_work_item(sample_item(&eid)).await.unwrap();
 
     // Worker A claims (fence F1), then has its lease expired and re-claimed by B.
-    let zombie = db.claim_work_item("worker-A", &["model"]).await.unwrap().unwrap();
+    let zombie = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
     db.force_lease_expired_for_test(zombie.id).await.unwrap();
-    let _b = db.claim_work_item("worker-B", &["model"]).await.unwrap().unwrap();
+    let _b = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
 
     // Zombie tries to commit a NodeFailed with stale fence F1.
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
@@ -557,7 +607,11 @@ async fn assert_fence_node_failed_succeeds(backend: &dyn StateBackend) {
         .expect("NodeFailed commit with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
     let events = backend.get_events(&eid).await.unwrap();
-    assert_eq!(events.len(), 1, "exactly one event must exist after NodeFailed commit");
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one event must exist after NodeFailed commit"
+    );
     assert!(
         matches!(events[0].kind, EventKind::NodeFailed { .. }),
         "the committed event must be NodeFailed"

--- a/runtime/state/tests/memory_backend.rs
+++ b/runtime/state/tests/memory_backend.rs
@@ -158,6 +158,7 @@ async fn test_work_queue() {
         created_at: Utc::now(),
         lease_expires_at: None,
         worker_id: None,
+        lease_fence: 0,
         tenant_id: "default".into(),
     };
     let item_id = backend.enqueue_work_item(item).await.unwrap();

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -276,6 +276,7 @@ async fn work_items_are_tenant_isolated() {
         created_at: Utc::now(),
         lease_expires_at: None,
         worker_id: None,
+        lease_fence: 0,
         tenant_id: "alpha".to_string(),
     };
     tenant_a.enqueue_work_item(item).await.unwrap();
@@ -299,6 +300,7 @@ async fn work_items_are_tenant_isolated() {
         created_at: Utc::now(),
         lease_expires_at: None,
         worker_id: None,
+        lease_fence: 0,
         tenant_id: "alpha".to_string(),
     };
     // Create execution first for the foreign key

--- a/runtime/workers/src/executors/agent_tool.rs
+++ b/runtime/workers/src/executors/agent_tool.rs
@@ -883,6 +883,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             lease_expires_at: None,
             worker_id: None,
+            lease_fence: 0,
             tenant_id: "default".into(),
         }
     }

--- a/runtime/workers/src/heartbeat.rs
+++ b/runtime/workers/src/heartbeat.rs
@@ -3,7 +3,7 @@
 use jamjet_state::backend::{StateBackend, WorkItemId};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::warn;
+use tracing::info;
 
 /// Spawns a background task that renews the lease on a work item.
 /// Returns a JoinHandle that can be aborted when the item is completed.
@@ -19,11 +19,14 @@ pub fn spawn_heartbeat(
         loop {
             ticker.tick().await;
             if let Err(e) = backend.renew_lease(item_id, &worker_id, lease_fence).await {
-                warn!(
+                // The lease is gone (stolen, failed over, or item already settled).
+                // Stop renewing; the fenced commit path fails closed on its own.
+                info!(
                     worker_id = %worker_id,
                     item_id = %item_id,
-                    "Failed to renew lease: {e}"
+                    "Heartbeat stopping: lease no longer held ({e})"
                 );
+                break;
             }
         }
     })

--- a/runtime/workers/src/heartbeat.rs
+++ b/runtime/workers/src/heartbeat.rs
@@ -11,13 +11,14 @@ pub fn spawn_heartbeat(
     backend: Arc<dyn StateBackend>,
     item_id: WorkItemId,
     worker_id: String,
+    lease_fence: i64,
     interval: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         loop {
             ticker.tick().await;
-            if let Err(e) = backend.renew_lease(item_id, &worker_id).await {
+            if let Err(e) = backend.renew_lease(item_id, &worker_id, lease_fence).await {
                 warn!(
                     worker_id = %worker_id,
                     item_id = %item_id,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -8,7 +8,7 @@ use jamjet_policy::autonomy::{AutonomyContext, AutonomyDecision, AutonomyEnforce
 use jamjet_policy::engine::node_kind_tag;
 use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
 use jamjet_state::approvals::NodeApprovalStatus;
-use jamjet_state::backend::{StateBackend, WorkItem, WorkItemId};
+use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
 use jamjet_state::event::EventKind;
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
@@ -108,6 +108,7 @@ impl Worker {
         let tenant_id = item.tenant_id.clone();
         let attempt = item.attempt;
         let item_id = item.id;
+        let lease_fence = item.lease_fence;
 
         let node_span = tracing::info_span!(
             "jamjet.node",
@@ -291,47 +292,57 @@ impl Worker {
                     );
                 }
 
-                self.backend.complete_work_item(item_id).await?;
-
-                let seq = self.backend.latest_sequence(&execution_id).await? + 1;
-                self.backend
-                    .append_event(jamjet_state::Event::new(
-                        execution_id.clone(),
-                        seq,
-                        EventKind::NodeCompleted {
-                            node_id: node_id.clone(),
-                            output: exec_result.output,
-                            state_patch: exec_result.state_patch,
-                            duration_ms,
-                            gen_ai_system: exec_result.gen_ai_system,
-                            gen_ai_model: exec_result.gen_ai_model,
-                            input_tokens: exec_result.input_tokens,
-                            output_tokens: exec_result.output_tokens,
-                            finish_reason: exec_result.finish_reason,
-                            cost_usd: None,
-                            provenance: None,
-                        },
-                    ))
-                    .await?;
-
-                info!(execution_id = %execution_id, node_id = %node_id, duration_ms, "Node completed");
+                let terminal = jamjet_state::Event::new(
+                    execution_id.clone(),
+                    0, // sequence assigned atomically inside commit_node_terminal
+                    EventKind::NodeCompleted {
+                        node_id: node_id.clone(),
+                        output: exec_result.output,
+                        state_patch: exec_result.state_patch,
+                        duration_ms,
+                        gen_ai_system: exec_result.gen_ai_system,
+                        gen_ai_model: exec_result.gen_ai_model,
+                        input_tokens: exec_result.input_tokens,
+                        output_tokens: exec_result.output_tokens,
+                        finish_reason: exec_result.finish_reason,
+                        cost_usd: None,
+                        provenance: None,
+                    },
+                );
+                match self.backend.commit_node_terminal(item_id, lease_fence, terminal).await {
+                    Ok(_) => {
+                        info!(execution_id = %execution_id, node_id = %node_id, duration_ms, "Node completed");
+                    }
+                    Err(StateBackendError::FenceLost(_)) => {
+                        // This worker's lease was stolen (stall/failover). Another
+                        // worker owns the item now. Stop quietly; emit nothing.
+                        warn!(execution_id = %execution_id, node_id = %node_id, "Fence lost on commit; abandoning (lease stolen)");
+                        return Ok(());
+                    }
+                    Err(e) => return Err(Box::new(e)),
+                }
             }
             Err(error) => {
-                self.backend.fail_work_item(item_id, &error).await?;
-                let seq = self.backend.latest_sequence(&execution_id).await? + 1;
-                self.backend
-                    .append_event(jamjet_state::Event::new(
-                        execution_id.clone(),
-                        seq,
-                        EventKind::NodeFailed {
-                            node_id: node_id.clone(),
-                            error: error.clone(),
-                            attempt,
-                            retryable: false,
-                        },
-                    ))
-                    .await?;
-                warn!(execution_id = %execution_id, node_id = %node_id, attempt, %error, "Node failed");
+                let terminal = jamjet_state::Event::new(
+                    execution_id.clone(),
+                    0, // sequence assigned atomically inside commit_node_terminal
+                    EventKind::NodeFailed {
+                        node_id: node_id.clone(),
+                        error: error.clone(),
+                        attempt,
+                        retryable: false,
+                    },
+                );
+                match self.backend.commit_node_terminal(item_id, lease_fence, terminal).await {
+                    Ok(_) => {
+                        warn!(execution_id = %execution_id, node_id = %node_id, attempt, %error, "Node failed");
+                    }
+                    Err(StateBackendError::FenceLost(_)) => {
+                        warn!(execution_id = %execution_id, node_id = %node_id, "Fence lost on failure commit; abandoning");
+                        return Ok(());
+                    }
+                    Err(e) => return Err(Box::new(e)),
+                }
             }
         }
         Ok(())
@@ -848,4 +859,194 @@ fn parse_payload(payload: &serde_json::Value) -> (String, String) {
         .unwrap_or("1.0.0")
         .to_string();
     (workflow_id, workflow_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use jamjet_state::{
+        InMemoryBackend,
+        backend::{StateBackend, WorkflowDefinition, WorkItem},
+        event::EventKind,
+    };
+    use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Minimal workflow IR with one tool node (no executor registered →
+    /// worker falls through to the stub path which succeeds instantly).
+    fn minimal_ir_json() -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "test-wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": {
+                "n1": {
+                    "id": "n1",
+                    "kind": {
+                        "type": "tool",
+                        "tool_ref": "stub",
+                        "input_mapping": {},
+                        "output_schema": "{}"
+                    }
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {}
+        })
+    }
+
+    fn sample_execution(eid: &ExecutionId) -> WorkflowExecution {
+        let now = Utc::now();
+        WorkflowExecution {
+            execution_id: eid.clone(),
+            workflow_id: "test-wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        }
+    }
+
+    fn sample_item(eid: &ExecutionId) -> WorkItem {
+        WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: eid.clone(),
+            node_id: "n1".into(),
+            queue_type: "default".into(),
+            payload: serde_json::json!({
+                "workflow_id": "test-wf",
+                "workflow_version": "1.0.0"
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: "default".into(),
+            lease_fence: 0,
+        }
+    }
+
+    async fn setup_backend() -> (Arc<InMemoryBackend>, ExecutionId) {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        backend.create_execution(sample_execution(&eid)).await.unwrap();
+        backend
+            .store_workflow(WorkflowDefinition {
+                workflow_id: "test-wf".into(),
+                version: "1.0.0".into(),
+                ir: minimal_ir_json(),
+                created_at: Utc::now(),
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        backend.enqueue_work_item(sample_item(&eid)).await.unwrap();
+        (backend, eid)
+    }
+
+    fn make_worker(backend: Arc<InMemoryBackend>) -> Worker {
+        Worker::new("test-worker".into(), backend, vec!["default".into()])
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// Happy path: the worker routes completion through `commit_node_terminal`
+    /// (fenced), producing exactly one `NodeCompleted` event.
+    ///
+    /// Before this wiring was added, `execute_item` called `complete_work_item`
+    /// + separate `append_event`; now it calls `commit_node_terminal`. This test
+    /// would fail if we reverted to the unfenced path because the assertion is
+    /// on the event KIND (NodeCompleted), which only appears when the fenced
+    /// primitive succeeds and emits inside the same transaction.
+    #[tokio::test]
+    async fn happy_path_emits_exactly_one_node_completed() {
+        let (backend, eid) = setup_backend().await;
+        let worker = make_worker(Arc::clone(&backend));
+
+        // Claim the item so we have a valid leased item to pass to execute_item.
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        // execute_item is private but accessible from this child module.
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+        let completed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .count();
+        assert_eq!(completed_count, 1, "expected exactly one NodeCompleted event; got {completed_count}");
+    }
+
+    /// Zombie path: a worker holding a stale fence (F1) tries to commit after
+    /// the lease was stolen (the item now carries fence F2). The fenced
+    /// `commit_node_terminal` must reject the zombie's write with FenceLost;
+    /// the worker abandons quietly and emits zero `NodeCompleted` events.
+    ///
+    /// This is the key moat invariant: even if two workers race to complete the
+    /// same work item, only one can commit — the one whose fence matches the
+    /// current lease. The zombie returns `Ok(())` (silent abandon) rather than
+    /// double-writing.
+    #[tokio::test]
+    async fn zombie_commit_is_rejected_emits_no_node_completed() {
+        let (backend, eid) = setup_backend().await;
+        let worker = make_worker(Arc::clone(&backend));
+
+        // Worker A claims the item and gets fence F1.
+        let item_a = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        let f1 = item_a.lease_fence;
+        assert!(f1 > 0, "fence must be non-zero after claim");
+
+        // Steal the lease: fail_work_item resets worker_id + bumps the epoch,
+        // making the item re-claimable.
+        backend
+            .fail_work_item(item_a.id, "lease stolen for test")
+            .await
+            .unwrap();
+
+        // Worker B claims and gets fence F2 > F1.
+        let item_b = backend
+            .claim_work_item("worker-B", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be re-claimable after fail");
+        assert!(item_b.lease_fence > f1, "F2 must be > F1");
+
+        // Drive Worker A's completion with the stale item (fence F1).
+        // The fenced commit must detect the mismatch and return Ok(()) quietly.
+        let result = worker.execute_item(item_a).await;
+        assert!(result.is_ok(), "zombie execute_item must not propagate FenceLost as error");
+
+        // No NodeCompleted event must have been written by the zombie.
+        let events = backend.get_events(&eid).await.unwrap();
+        let completed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .count();
+        assert_eq!(
+            completed_count, 0,
+            "zombie must not emit NodeCompleted; got {completed_count}"
+        );
+    }
 }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -309,7 +309,11 @@ impl Worker {
                         provenance: None,
                     },
                 );
-                match self.backend.commit_node_terminal(item_id, lease_fence, terminal).await {
+                match self
+                    .backend
+                    .commit_node_terminal(item_id, lease_fence, terminal)
+                    .await
+                {
                     Ok(_) => {
                         info!(execution_id = %execution_id, node_id = %node_id, duration_ms, "Node completed");
                     }
@@ -333,7 +337,11 @@ impl Worker {
                         retryable: false,
                     },
                 );
-                match self.backend.commit_node_terminal(item_id, lease_fence, terminal).await {
+                match self
+                    .backend
+                    .commit_node_terminal(item_id, lease_fence, terminal)
+                    .await
+                {
                     Ok(_) => {
                         warn!(execution_id = %execution_id, node_id = %node_id, attempt, %error, "Node failed");
                     }
@@ -866,12 +874,12 @@ mod tests {
     use super::*;
     use crate::executor::{ExecutionResult, NodeExecutor};
     use chrono::Utc;
-    use jamjet_state::{
-        InMemoryBackend,
-        backend::{StateBackend, WorkflowDefinition, WorkItem},
-        event::EventKind,
-    };
     use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+    use jamjet_state::{
+        backend::{StateBackend, WorkItem, WorkflowDefinition},
+        event::EventKind,
+        InMemoryBackend,
+    };
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -944,7 +952,10 @@ mod tests {
     async fn setup_backend() -> (Arc<InMemoryBackend>, ExecutionId) {
         let backend = Arc::new(InMemoryBackend::new());
         let eid = ExecutionId::new();
-        backend.create_execution(sample_execution(&eid)).await.unwrap();
+        backend
+            .create_execution(sample_execution(&eid))
+            .await
+            .unwrap();
         backend
             .store_workflow(WorkflowDefinition {
                 workflow_id: "test-wf".into(),
@@ -994,7 +1005,10 @@ mod tests {
             .iter()
             .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
             .count();
-        assert_eq!(completed_count, 1, "expected exactly one NodeCompleted event; got {completed_count}");
+        assert_eq!(
+            completed_count, 1,
+            "expected exactly one NodeCompleted event; got {completed_count}"
+        );
     }
 
     // ── Failure-path executor stub ────────────────────────────────────────────
@@ -1091,7 +1105,10 @@ mod tests {
         // Drive Worker A's completion with the stale item (fence F1).
         // The fenced commit must detect the mismatch and return Ok(()) quietly.
         let result = worker.execute_item(item_a).await;
-        assert!(result.is_ok(), "zombie execute_item must not propagate FenceLost as error");
+        assert!(
+            result.is_ok(),
+            "zombie execute_item must not propagate FenceLost as error"
+        );
 
         // No NodeCompleted event must have been written by the zombie.
         let events = backend.get_events(&eid).await.unwrap();

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -147,6 +147,7 @@ impl Worker {
             Arc::clone(&self.backend),
             item_id,
             self.worker_id.clone(),
+            item.lease_fence,
             Duration::from_secs(15),
         );
 

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -864,6 +864,7 @@ fn parse_payload(payload: &serde_json::Value) -> (String, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::{ExecutionResult, NodeExecutor};
     use chrono::Utc;
     use jamjet_state::{
         InMemoryBackend,
@@ -967,11 +968,12 @@ mod tests {
     /// Happy path: the worker routes completion through `commit_node_terminal`
     /// (fenced), producing exactly one `NodeCompleted` event.
     ///
-    /// Before this wiring was added, `execute_item` called `complete_work_item`
-    /// + separate `append_event`; now it calls `commit_node_terminal`. This test
-    /// would fail if we reverted to the unfenced path because the assertion is
-    /// on the event KIND (NodeCompleted), which only appears when the fenced
-    /// primitive succeeds and emits inside the same transaction.
+    /// Note: this test checks that a single NodeCompleted is emitted; it is NOT
+    /// the fence-bypass guard. The old unfenced path (`complete_work_item` +
+    /// `append_event`) also emitted exactly one NodeCompleted, so reverting to
+    /// it would not break this assertion. The real fence-bypass guard is
+    /// `zombie_commit_is_rejected_emits_no_node_completed`, which exercises the
+    /// stale-fence rejection path.
     #[tokio::test]
     async fn happy_path_emits_exactly_one_node_completed() {
         let (backend, eid) = setup_backend().await;
@@ -995,13 +997,66 @@ mod tests {
         assert_eq!(completed_count, 1, "expected exactly one NodeCompleted event; got {completed_count}");
     }
 
+    // ── Failure-path executor stub ────────────────────────────────────────────
+
+    /// A stub executor that always returns an error.  Used to drive the
+    /// `Err(error)` arm inside `execute_item`, which must emit exactly one
+    /// `NodeFailed` event via the fenced `commit_node_terminal` path.
+    struct FailingExecutor;
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for FailingExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, String> {
+            Err("boom".into())
+        }
+    }
+
+    /// Failure path: when the executor returns `Err`, `execute_item` must emit
+    /// exactly one `NodeFailed` event through the fenced `commit_node_terminal`
+    /// path and return `Ok(())` (node failure is not a worker error).
+    #[tokio::test]
+    async fn failure_path_emits_exactly_one_node_failed() {
+        let (backend, eid) = setup_backend().await;
+        // Register a failing executor for "tool" — the kind_tag of the node in
+        // minimal_ir_json. This drives the Err(error) arm in execute_item.
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("tool", Arc::new(FailingExecutor));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        // execute_item returns Ok(()) even when the node fails — node failure is
+        // surfaced as a NodeFailed event, not a worker-level error.
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+        let failed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeFailed { .. }))
+            .count();
+        assert_eq!(
+            failed_count, 1,
+            "expected exactly one NodeFailed event; got {failed_count}"
+        );
+    }
+
     /// Zombie path: a worker holding a stale fence (F1) tries to commit after
     /// the lease was stolen (the item now carries fence F2). The fenced
     /// `commit_node_terminal` must reject the zombie's write with FenceLost;
     /// the worker abandons quietly and emits zero `NodeCompleted` events.
     ///
-    /// This is the key moat invariant: even if two workers race to complete the
-    /// same work item, only one can commit — the one whose fence matches the
+    /// This is the key fence-bypass guard: even if two workers race to complete
+    /// the same work item, only one can commit — the one whose fence matches the
     /// current lease. The zombie returns `Ok(())` (silent abandon) rather than
     /// double-writing.
     #[tokio::test]


### PR DESCRIPTION
## What

Sub-plan 2a of the durable-engine work (ADK Track 2): replace the worker's three-disjoint-transaction node-completion path with a single atomic, fenced commit, so a node completion is one fsync, a crash never silently loses a completion, and a zombie worker (whose lease was stolen) cannot double-commit.

Three parts in `jamjet-state` plus the worker:

1. A canonical-JSON + SHA-256 hashing utility (foundation for idempotency keys and receipts in later slices).
2. A monotonic `lease_fence = store_term * 2^32 + per_item_epoch`, minted on every claim and reclaim, gating `renew_lease`. The store term lives above the per-item epoch so a fence minted under an older failover generation is always smaller.
3. `commit_node_terminal(item_id, lease_fence, terminal_event)`: in one `BEGIN IMMEDIATE` transaction it settles the work item gated by `AND lease_fence = ?` and appends the terminal event. A stale fence matches zero rows, rolls back, and returns `FenceLost`, emitting nothing. Implemented across the SQLite, tenant-scoped, and in-memory backends. The worker now routes both the success and failure completion paths through it; `FenceLost` makes the worker abandon the node quietly. A non-terminal event fails loud.

The heartbeat now stops renewing once the lease is lost.

## Why

The old path did `complete_work_item` then a separate `append_event`, so a crash between them left the item settled with no event, and nothing stopped two workers from each completing the same stolen item. The fence makes the settle and the event one atomic, fenced write.

## Tests

Full `jamjet-state` + `jamjet-worker` suite green. A 17-test fencing suite covers zombie rejection, lost-tail failover (a term-0 fence is rejected after promotion to term 1), a negative control, crash-injection exactly-once, the NodeFailed path, and cross-backend coverage on all three backends. Two worker-level integration tests prove the worker routes completion through the fence (a zombie produces zero NodeCompleted events) — the primitive-level tests alone were a false green.

## Reviews

Two independent adversarial passes. The first caught that the fenced commit was correct but not yet wired into the worker (a real gap, now closed with a worker-level test). The final whole-branch pass returned no Critical; its one merge-gating finding (the NodeFailed terminal path was untested) is fixed, with no bug surfaced.

## Follow-ups (tracked, not in this PR)

- **F1:** `bump_store_term` is currently driven only by tests. Until it is wired to the promotion coordinator (LiteFS lease epoch / Postgres timeline), the failover-monotonicity property is mechanically correct and tested but inert in production (the term stays 0). Failover-safety should not be assumed live until F1 lands.
- **F2:** the admin `POST /work-items/:id/complete` endpoint is still an unfenced, non-atomic completion that should route through `commit_node_terminal`. Pre-existing and admin-gated.

## Scope

This is the commit primitive only. The snapshot fold (commit_turn), the idempotency cache, segments, park-on-429, the async projector, and content-addressed artifacts are later sub-plans.
