### PR TITLE
feat(state,api): production seam for the lease fence's failover generation (F1)

### DIFF
--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -5,6 +5,17 @@ use jamjet_state::{InMemoryBackend, SqliteBackend};
 use std::sync::Arc;
 use tracing::info;
 
+/// The store's failover generation, read from `JAMJET_STORE_TERM`. Orchestrators
+/// (a LiteFS-aware entrypoint, k8s, Fly) set this to the current promotion
+/// generation (LiteFS lease epoch / Postgres timeline ID) on every (re)start, so
+/// the lease fence is failover-safe. Absent or unparseable => `None` (term stays
+/// as-is; on a fresh store that is 0, the pre-F1 behavior).
+fn store_term_from_env() -> Option<i64> {
+    std::env::var("JAMJET_STORE_TERM")
+        .ok()
+        .and_then(|s| s.trim().parse::<i64>().ok())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Load .env if present
@@ -34,6 +45,13 @@ async fn main() -> anyhow::Result<()> {
         info!("Using in-memory storage (ephemeral, no persistence)");
 
         let backend = Arc::new(InMemoryBackend::new());
+        if let Some(term) = store_term_from_env() {
+            let applied = backend.set_store_term_at_least(term);
+            info!(
+                store_term = applied,
+                "Applied failover generation from JAMJET_STORE_TERM"
+            );
+        }
         let backend_clone = backend.clone();
         let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
         let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
@@ -66,6 +84,22 @@ async fn main() -> anyhow::Result<()> {
         let backend = SqliteBackend::open(&database_url)
             .await
             .map_err(|e| anyhow::anyhow!("failed to open state backend: {e}"))?;
+
+        // Failover-safety: raise the store's failover generation to the promotion
+        // generation supplied by the orchestrator, so a lease fence minted under a
+        // previous primary is rejected after a failover (the fence packs term in
+        // its high bits). Without this the term stays 0 and only the per-item epoch
+        // protects, which a lost-tail failover can corrupt.
+        if let Some(term) = store_term_from_env() {
+            let applied = backend
+                .set_store_term_at_least(term)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to set store term: {e}"))?;
+            info!(
+                store_term = applied,
+                "Applied failover generation from JAMJET_STORE_TERM"
+            );
+        }
 
         let agents = SqliteAgentRegistry::connect(&database_url)
             .await

--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -5,15 +5,33 @@ use jamjet_state::{InMemoryBackend, SqliteBackend};
 use std::sync::Arc;
 use tracing::info;
 
-/// The store's failover generation, read from `JAMJET_STORE_TERM`. Orchestrators
-/// (a LiteFS-aware entrypoint, k8s, Fly) set this to the current promotion
-/// generation (LiteFS lease epoch / Postgres timeline ID) on every (re)start, so
-/// the lease fence is failover-safe. Absent or unparseable => `None` (term stays
-/// as-is; on a fresh store that is 0, the pre-F1 behavior).
-fn store_term_from_env() -> Option<i64> {
-    std::env::var("JAMJET_STORE_TERM")
-        .ok()
-        .and_then(|s| s.trim().parse::<i64>().ok())
+/// Parse a `JAMJET_STORE_TERM` value: a non-negative integer (the promotion
+/// generation). A present-but-invalid value is an error, not a silent no-op.
+fn parse_store_term(raw: &str) -> anyhow::Result<i64> {
+    let trimmed = raw.trim();
+    let term = trimmed
+        .parse::<i64>()
+        .map_err(|e| anyhow::anyhow!("invalid JAMJET_STORE_TERM `{trimmed}`: {e}"))?;
+    anyhow::ensure!(
+        term >= 0,
+        "JAMJET_STORE_TERM must be non-negative, got {term}"
+    );
+    Ok(term)
+}
+
+/// The store's failover generation from `JAMJET_STORE_TERM`. Orchestrators (a
+/// LiteFS-aware entrypoint, k8s, Fly) set this to the current promotion generation
+/// (LiteFS lease epoch / Postgres timeline ID) on every (re)start, so the lease
+/// fence is failover-safe. Absent => `Ok(None)` (not configured). Present-but-invalid
+/// => `Err` (fail startup loudly): a typo like `JAMJET_STORE_TERM=abc` must NOT be
+/// silently treated as "not configured", which would leave the term at 0 and re-open
+/// the failover-safety gap the operator believed they had closed.
+fn store_term_from_env() -> anyhow::Result<Option<i64>> {
+    match std::env::var("JAMJET_STORE_TERM") {
+        Ok(raw) => parse_store_term(&raw).map(Some),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(e) => anyhow::bail!("failed to read JAMJET_STORE_TERM: {e}"),
+    }
 }
 
 #[tokio::main]
@@ -28,6 +46,9 @@ async fn main() -> anyhow::Result<()> {
     let otel_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();
     jamjet_telemetry::init(config.dev_mode, otel_endpoint.as_deref());
     let storage_backend = std::env::var("STORAGE_BACKEND").unwrap_or_default();
+    // Parse the failover generation up front so a misconfiguration fails startup
+    // before we open any backend (rather than silently disabling failover-safety).
+    let configured_store_term = store_term_from_env()?;
     let storage_label = if storage_backend == "memory" {
         "memory"
     } else {
@@ -45,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
         info!("Using in-memory storage (ephemeral, no persistence)");
 
         let backend = Arc::new(InMemoryBackend::new());
-        if let Some(term) = store_term_from_env() {
+        if let Some(term) = configured_store_term {
             let applied = backend.set_store_term_at_least(term);
             info!(
                 store_term = applied,
@@ -90,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
         // previous primary is rejected after a failover (the fence packs term in
         // its high bits). Without this the term stays 0 and only the per-item epoch
         // protects, which a lost-tail failover can corrupt.
-        if let Some(term) = store_term_from_env() {
+        if let Some(term) = configured_store_term {
             let applied = backend
                 .set_store_term_at_least(term)
                 .await
@@ -212,4 +233,23 @@ async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to install Ctrl-C handler");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_store_term;
+
+    #[test]
+    fn parses_valid_non_negative() {
+        assert_eq!(parse_store_term("5").unwrap(), 5);
+        assert_eq!(parse_store_term("  0 ").unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_invalid_and_negative() {
+        // A typo must fail loud, not silently disable failover-safety.
+        assert!(parse_store_term("abc").is_err());
+        assert!(parse_store_term("-1").is_err());
+        assert!(parse_store_term("").is_err());
+    }
 }

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -61,6 +61,12 @@ impl InMemoryBackend {
     pub fn bump_store_term(&self) -> i64 {
         self.store_term.fetch_add(1, Ordering::SeqCst) + 1
     }
+
+    /// Raise the in-memory store term to at least `term`, monotonically. Mirrors
+    /// `SqliteBackend::set_store_term_at_least` (the production failover-generation seam).
+    pub fn set_store_term_at_least(&self, term: i64) -> i64 {
+        self.store_term.fetch_max(term, Ordering::SeqCst).max(term)
+    }
 }
 
 impl Default for InMemoryBackend {

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -75,10 +75,26 @@ impl SqliteBackend {
         row.try_get::<i64, _>("term").map_err(map_db_err)
     }
 
-    /// Simulate a store failover by bumping the failover generation. Real
-    /// deployments bump this from the promotion coordinator (LiteFS lease epoch).
+    /// Simulate a store failover by bumping the failover generation. Used by
+    /// tests/simulators; production uses [`Self::set_store_term_at_least`].
     pub async fn bump_store_term(&self) -> BackendResult<i64> {
         sqlx::query("UPDATE store_identity SET term = term + 1 WHERE id = 1")
+            .execute(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        let mut conn = self.pool.acquire().await.map_err(map_db_err)?;
+        self.current_term(&mut conn).await
+    }
+
+    /// Raise the store's failover generation to at least `term`, monotonically
+    /// (it never decreases). Call this at server startup with the promotion
+    /// generation from the coordinator (LiteFS lease epoch / Postgres timeline ID)
+    /// so a `lease_fence` minted under a previous primary is rejected after a
+    /// failover. Returns the resulting term. This is the production path that
+    /// makes the fence's failover-safety live (vs. the term staying 0).
+    pub async fn set_store_term_at_least(&self, term: i64) -> BackendResult<i64> {
+        sqlx::query("UPDATE store_identity SET term = max(term, ?) WHERE id = 1")
+            .bind(term)
             .execute(&self.pool)
             .await
             .map_err(map_db_err)?;

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -682,3 +682,40 @@ async fn commit_node_failed_stale_fence_fails_closed_tenant_scoped() {
     assert_fence_node_failed_stale_fails(&backend).await;
     std::fs::remove_file(&path).ok();
 }
+
+#[tokio::test]
+async fn set_store_term_at_least_is_monotonic_and_lifts_the_fence() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+
+    // Term starts at 0; lift to 5 (e.g. the promotion generation at startup).
+    assert_eq!(db.set_store_term_at_least(5).await.unwrap(), 5);
+    // Monotonic: a lower value is a no-op.
+    assert_eq!(db.set_store_term_at_least(3).await.unwrap(), 5);
+    // Equal is a no-op.
+    assert_eq!(db.set_store_term_at_least(5).await.unwrap(), 5);
+
+    // A fence minted now carries term 5: fence == 5 * 2^32 + epoch (epoch >= 1).
+    db.enqueue_work_item(sample_item(&eid)).await.unwrap();
+    let claimed = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
+    const BAND: i64 = 4_294_967_296; // 2^32
+    assert!(
+        claimed.lease_fence >= 5 * BAND && claimed.lease_fence < 6 * BAND,
+        "fence {} must be in the term-5 band [{}, {})",
+        claimed.lease_fence,
+        5 * BAND,
+        6 * BAND
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[tokio::test]
+async fn set_store_term_at_least_monotonic_in_memory() {
+    use jamjet_state::InMemoryBackend;
+    let db = InMemoryBackend::new();
+    assert_eq!(db.set_store_term_at_least(7), 7);
+    assert_eq!(db.set_store_term_at_least(4), 7); // lower is a no-op
+    assert_eq!(db.set_store_term_at_least(9), 9);
+}


### PR DESCRIPTION
## What

Follow-up F1 to the fenced turn-commit (#90). The lease fence is `store_term * 2^32 + per_item_epoch`, where `store_term` is the failover generation. Until now `store_term` was only bumped by a test helper, so in production it stayed 0 and only the per-item epoch protected the lease, which is exactly what a lost-tail failover (an unreplicated claim write) can corrupt. This wires the production seam:

- `set_store_term_at_least(term)` on both the SQLite and in-memory backends raises the store term monotonically (`UPDATE store_identity SET term = max(term, ?)`).
- The API server reads `JAMJET_STORE_TERM` at startup and applies it.

An orchestrator (a LiteFS-aware container entrypoint, k8s, or Fly) exports the current promotion generation (LiteFS lease epoch / Postgres timeline ID) on every restart, so a lease fence minted under a previous primary is rejected after a failover. This moves the fence's failover-safety from inert (term always 0) to operator-activatable.

## Why

#90's final review flagged that the failover-monotonicity property was mechanically correct and tested but never triggered in production. This closes that gap on the code side.

## Tests

`cargo test --workspace` green (387 passed). New tests: `set_store_term_at_least` is monotonic (a lower or equal value is a no-op) and a fence minted after lifting the term to 5 lands in the term-5 band; plus an in-memory monotonicity test.

## What is NOT in this PR

The LiteFS-aware entrypoint script that reads the lease epoch and exports `JAMJET_STORE_TERM` is deployment infra, not code. Until it exists, an operator activates failover-safety by setting that env var to the promotion generation on each start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup handling so the app can honor an optional store-term setting for both in-memory and SQLite storage.
  * Added stronger protection against outdated state during failover by ensuring the store term never moves backward.

* **Bug Fixes**
  * Prevented lower or duplicate store-term values from overwriting newer ones.
  * Improved consistency of lease/fencing values after failover-related startup adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->