### PR TITLE
feat(state,worker): per-turn snapshot folded into the fenced commit (durable engine, Track 2b)

### DIFF
--- a/runtime/state/Cargo.toml
+++ b/runtime/state/Cargo.toml
@@ -29,3 +29,4 @@ parking_lot = "0.12"
 
 [dev-dependencies]
 tokio = { workspace = true }
+proptest = "1"

--- a/runtime/state/migrations/0005_snapshot_materialized.sql
+++ b/runtime/state/migrations/0005_snapshot_materialized.sql
@@ -1,0 +1,7 @@
+-- Migration 0005: snapshots carry the full materialized state, so a per-turn
+-- snapshot is a complete resume base (status + completed/active nodes), not just
+-- current_state. Without these, materialize() would lose pre-snapshot node state.
+ALTER TABLE snapshots ADD COLUMN status               TEXT    NOT NULL DEFAULT 'running';
+ALTER TABLE snapshots ADD COLUMN completed_nodes_json TEXT    NOT NULL DEFAULT '{}';
+ALTER TABLE snapshots ADD COLUMN active_nodes_json    TEXT    NOT NULL DEFAULT '[]';
+ALTER TABLE snapshots ADD COLUMN last_sequence        INTEGER NOT NULL DEFAULT 0;

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -155,16 +155,21 @@ pub trait StateBackend: Send + Sync {
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()>;
 
     /// Atomically settle a work item (status inferred from the terminal event
-    /// kind) and append the terminal event, in ONE transaction, gated by
-    /// `lease_fence`. A stale fence matches zero rows and returns `FenceLost`,
-    /// emitting nothing. Replaces the `complete_work_item` + `latest_sequence`
-    /// + `append_event` trio so a node completion is one fsync with no
-    /// crash window and no double-commit.
-    async fn commit_node_terminal(
+    /// kind), append the terminal event, and optionally write a snapshot, all
+    /// in ONE transaction, gated by `lease_fence`. A stale fence matches zero
+    /// rows and returns `FenceLost`, emitting nothing (no event, no snapshot).
+    ///
+    /// If `snapshot` is `Some`, its `at_sequence` is set to the sequence just
+    /// assigned to the terminal event and it is written with INSERT OR REPLACE
+    /// inside the same transaction. Replaces the `complete_work_item` +
+    /// `latest_sequence` + `append_event` trio so a node completion is one
+    /// fsync with no crash window and no double-commit.
+    async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
+        snapshot: Option<Snapshot>,
     ) -> BackendResult<EventSequence>;
 
     /// Reclaim work items whose lease has expired (worker crashed or stalled).

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -154,22 +154,22 @@ pub trait StateBackend: Send + Sync {
     /// Mark a work item as failed. The scheduler will decide whether to retry.
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()>;
 
-    /// Atomically settle a work item (status inferred from the terminal event
-    /// kind), append the terminal event, and optionally write a snapshot, all
-    /// in ONE transaction, gated by `lease_fence`. A stale fence matches zero
-    /// rows and returns `FenceLost`, emitting nothing (no event, no snapshot).
-    ///
-    /// If `snapshot` is `Some`, its `at_sequence` is set to the sequence just
-    /// assigned to the terminal event and it is written with INSERT OR REPLACE
-    /// inside the same transaction. Replaces the `complete_work_item` +
-    /// `latest_sequence` + `append_event` trio so a node completion is one
-    /// fsync with no crash window and no double-commit.
+    /// Atomically settle a work item, append the terminal event, and optionally
+    /// compute and write a snapshot from the committed state, all in ONE
+    /// transaction gated by `lease_fence`. When `write_snapshot` is `true` the
+    /// snapshot is computed inside the same `BEGIN IMMEDIATE` transaction —
+    /// after the terminal event is inserted — by reading the latest snapshot +
+    /// all events since it (including the terminal event just written), folding
+    /// with `apply_events_seeded`, and writing with INSERT OR REPLACE. This
+    /// avoids write-skew: concurrent sibling nodes cannot produce snapshots that
+    /// each miss the other's patch. A stale fence returns `FenceLost` and writes
+    /// nothing.
     async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
-        snapshot: Option<Snapshot>,
+        write_snapshot: bool,
     ) -> BackendResult<EventSequence>;
 
     /// Reclaim work items whose lease has expired (worker crashed or stalled).

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -24,7 +24,7 @@ pub use backend::{
 pub use budget::BudgetState;
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
 pub use hashing::{canonical_json, content_hash};
-pub use materializer::{apply_events, materialize, should_snapshot, MaterializedState};
+pub use materializer::{apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState};
 pub use memory::InMemoryBackend;
 pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -24,7 +24,9 @@ pub use backend::{
 pub use budget::BudgetState;
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
 pub use hashing::{canonical_json, content_hash};
-pub use materializer::{apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState};
+pub use materializer::{
+    apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState,
+};
 pub use memory::InMemoryBackend;
 pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;

--- a/runtime/state/src/materializer.rs
+++ b/runtime/state/src/materializer.rs
@@ -10,7 +10,7 @@ use crate::event::{Event, EventKind};
 use crate::snapshot::DEFAULT_SNAPSHOT_INTERVAL;
 use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// The materialized state of a workflow execution at a point in time.
 #[derive(Debug, Clone)]
@@ -31,9 +31,12 @@ pub struct MaterializedState {
 ///
 /// Algorithm:
 /// 1. Load the latest snapshot (if any). If none, start from the initial_input.
-/// 2. Load all events since the snapshot's `at_sequence`.
-/// 3. Apply state patches from `NodeCompleted` events in order.
-/// 4. Derive `status`, `completed_nodes`, and `active_nodes` from all events.
+/// 2. Seed the base `MaterializedState` from the snapshot's full persisted state
+///    (current_state, status, completed_nodes, active_nodes, last_sequence).
+/// 3. Load all events since the snapshot's `at_sequence`.
+/// 4. Fold those events on top of the base via `apply_events_seeded`.
+///
+/// This ensures that nodes completed before the snapshot cut are never lost.
 pub async fn materialize(
     backend: &dyn StateBackend,
     execution_id: &ExecutionId,
@@ -43,53 +46,70 @@ pub async fn materialize(
         .await?
         .ok_or_else(|| crate::backend::StateBackendError::NotFound(format!("{execution_id}")))?;
 
-    // Load the latest snapshot as the base.
-    let (base_state, base_sequence) = match backend.latest_snapshot(execution_id).await? {
-        Some(snap) => (snap.state, snap.at_sequence),
-        None => (execution.initial_input.clone(), 0),
+    // Build the base from the full snapshot state, or from the initial input.
+    let (base, base_sequence) = match backend.latest_snapshot(execution_id).await? {
+        Some(snap) => {
+            let seq = snap.at_sequence;
+            (
+                MaterializedState {
+                    current_state: snap.state,
+                    status: snap.status,
+                    completed_nodes: snap.completed_nodes,
+                    active_nodes: snap.active_nodes,
+                    last_sequence: snap.last_sequence,
+                },
+                seq,
+            )
+        }
+        None => (
+            MaterializedState {
+                current_state: execution.initial_input.clone(),
+                status: WorkflowStatus::Pending,
+                completed_nodes: HashMap::new(),
+                active_nodes: HashSet::new(),
+                last_sequence: 0,
+            },
+            0,
+        ),
     };
 
-    // Load all events since the snapshot (or from the beginning).
+    // Load events that arrived after the snapshot (or all events when no snapshot).
     let events = backend
         .get_events_since(execution_id, base_sequence)
         .await?;
 
-    Ok(apply_events(base_state, &events, &execution.status))
+    Ok(apply_events_seeded(base, &events))
 }
 
-/// Apply a sequence of events on top of a base state to produce `MaterializedState`.
-pub fn apply_events(
-    mut current_state: Value,
-    events: &[Event],
-    _initial_status: &WorkflowStatus,
-) -> MaterializedState {
-    let mut status = WorkflowStatus::Pending;
-    let mut completed_nodes: HashMap<String, Value> = HashMap::new();
-    let mut active_nodes: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut last_sequence = 0i64;
-
+/// Fold a sequence of events on top of an existing `MaterializedState`.
+///
+/// This is the core replay primitive. Both `materialize` and `apply_events`
+/// delegate here. The caller is responsible for seeding `base` correctly:
+/// - `materialize` seeds from the snapshot's full persisted state.
+/// - `apply_events` seeds with an empty base (from-origin replay).
+pub fn apply_events_seeded(mut base: MaterializedState, events: &[Event]) -> MaterializedState {
     for event in events {
-        last_sequence = last_sequence.max(event.sequence);
+        base.last_sequence = base.last_sequence.max(event.sequence);
 
         match &event.kind {
             EventKind::WorkflowStarted { .. } => {
-                status = WorkflowStatus::Running;
+                base.status = WorkflowStatus::Running;
             }
             EventKind::WorkflowCompleted { final_state } => {
-                current_state = final_state.clone();
-                status = WorkflowStatus::Completed;
+                base.current_state = final_state.clone();
+                base.status = WorkflowStatus::Completed;
             }
             EventKind::WorkflowFailed { .. } => {
-                status = WorkflowStatus::Failed;
+                base.status = WorkflowStatus::Failed;
             }
             EventKind::WorkflowCancelled { .. } => {
-                status = WorkflowStatus::Cancelled;
+                base.status = WorkflowStatus::Cancelled;
             }
             EventKind::StrategyLimitHit { .. } => {
-                status = WorkflowStatus::LimitExceeded;
+                base.status = WorkflowStatus::LimitExceeded;
             }
             EventKind::NodeScheduled { node_id, .. } | EventKind::NodeStarted { node_id, .. } => {
-                active_nodes.insert(node_id.clone());
+                base.active_nodes.insert(node_id.clone());
             }
             EventKind::NodeCompleted {
                 node_id,
@@ -97,38 +117,53 @@ pub fn apply_events(
                 state_patch,
                 ..
             } => {
-                active_nodes.remove(node_id);
-                completed_nodes.insert(node_id.clone(), output.clone());
+                base.active_nodes.remove(node_id);
+                base.completed_nodes.insert(node_id.clone(), output.clone());
                 // Apply JSON merge patch (RFC 7396) to current state.
-                json_merge_patch(&mut current_state, state_patch);
+                json_merge_patch(&mut base.current_state, state_patch);
             }
             EventKind::NodeFailed { node_id, .. }
             | EventKind::NodeSkipped { node_id, .. }
             | EventKind::NodeCancelled { node_id } => {
-                active_nodes.remove(node_id);
+                base.active_nodes.remove(node_id);
             }
             EventKind::InterruptRaised { .. } => {
-                if status == WorkflowStatus::Running {
-                    status = WorkflowStatus::Paused;
+                if base.status == WorkflowStatus::Running {
+                    base.status = WorkflowStatus::Paused;
                 }
             }
             EventKind::ApprovalReceived { state_patch, .. } => {
                 if let Some(patch) = state_patch {
-                    json_merge_patch(&mut current_state, patch);
+                    json_merge_patch(&mut base.current_state, patch);
                 }
-                status = WorkflowStatus::Running;
+                base.status = WorkflowStatus::Running;
             }
             _ => {}
         }
     }
 
-    MaterializedState {
-        current_state,
-        status,
-        completed_nodes,
-        active_nodes,
-        last_sequence,
-    }
+    base
+}
+
+/// Apply a sequence of events from the origin (empty derived state) to produce
+/// a `MaterializedState`. Use this when you have all events and no snapshot.
+///
+/// For snapshot-seeded replay, call `apply_events_seeded` directly.
+pub fn apply_events(
+    current_state: Value,
+    events: &[Event],
+    _initial_status: &WorkflowStatus,
+) -> MaterializedState {
+    apply_events_seeded(
+        MaterializedState {
+            current_state,
+            status: WorkflowStatus::Pending,
+            completed_nodes: HashMap::new(),
+            active_nodes: HashSet::new(),
+            last_sequence: 0,
+        },
+        events,
+    )
 }
 
 /// Apply a JSON merge patch (RFC 7396) to a target value.

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -318,7 +318,7 @@ impl StateBackend for InMemoryBackend {
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
-        snapshot: Option<Snapshot>,
+        write_snapshot: bool,
     ) -> BackendResult<EventSequence> {
         // Validate terminal event kind BEFORE mutating state. A miswired
         // caller (non-terminal event) fails loud instead of silently settling.
@@ -345,9 +345,58 @@ impl StateBackend for InMemoryBackend {
         let mut ev = terminal_event;
         ev.sequence = seq;
         self.events.entry(eid.clone()).or_default().push(ev);
-        if let Some(mut snap) = snapshot {
-            snap.at_sequence = seq;
-            snap.last_sequence = seq;
+        if write_snapshot {
+            // Mirror the SQLite in-tx pattern: read latest snapshot (or seed from
+            // initial_input), fold all events since it (including the one just
+            // appended), then write a new snapshot.
+            let (base, base_sequence) = if let Some(snap) = self
+                .snapshots
+                .get(&eid)
+                .and_then(|r| r.value().iter().max_by_key(|s| s.at_sequence).cloned())
+            {
+                let at_seq = snap.at_sequence;
+                (
+                    crate::materializer::MaterializedState {
+                        current_state: snap.state,
+                        status: snap.status,
+                        completed_nodes: snap.completed_nodes,
+                        active_nodes: snap.active_nodes,
+                        last_sequence: snap.last_sequence,
+                    },
+                    at_seq,
+                )
+            } else {
+                let initial_input = self
+                    .executions
+                    .get(&eid)
+                    .map(|e| e.value().initial_input.clone())
+                    .unwrap_or(serde_json::json!({}));
+                (
+                    crate::materializer::MaterializedState {
+                        current_state: initial_input,
+                        status: jamjet_core::workflow::WorkflowStatus::Pending,
+                        completed_nodes: std::collections::HashMap::new(),
+                        active_nodes: std::collections::HashSet::new(),
+                        last_sequence: 0,
+                    },
+                    0,
+                )
+            };
+
+            let tail_events: Vec<crate::event::Event> = self
+                .events
+                .get(&eid)
+                .map(|r| {
+                    r.value()
+                        .iter()
+                        .filter(|e| e.sequence > base_sequence)
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let mat = crate::materializer::apply_events_seeded(base, &tail_events);
+            let snap = Snapshot::from_materialized(eid.clone(), &mat);
             self.snapshots.entry(eid).or_default().push(snap);
         }
         Ok(seq)

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -313,11 +313,12 @@ impl StateBackend for InMemoryBackend {
         Ok(())
     }
 
-    async fn commit_node_terminal(
+    async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
+        snapshot: Option<Snapshot>,
     ) -> BackendResult<EventSequence> {
         // Validate terminal event kind BEFORE mutating state. A miswired
         // caller (non-terminal event) fails loud instead of silently settling.
@@ -325,8 +326,7 @@ impl StateBackend for InMemoryBackend {
             EventKind::NodeCompleted { .. } | EventKind::NodeFailed { .. } => {}
             _ => {
                 return Err(StateBackendError::Database(
-                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
-                        .into(),
+                    "commit_turn requires a terminal event (NodeCompleted/NodeFailed)".into(),
                 ))
             }
         }
@@ -341,12 +341,15 @@ impl StateBackend for InMemoryBackend {
         }
         self.work_items.remove(&item_id);
         let seq = self.next_sequence.fetch_add(1, Ordering::SeqCst);
+        let eid = terminal_event.execution_id.clone();
         let mut ev = terminal_event;
         ev.sequence = seq;
-        self.events
-            .entry(ev.execution_id.clone())
-            .or_default()
-            .push(ev);
+        self.events.entry(eid.clone()).or_default().push(ev);
+        if let Some(mut snap) = snapshot {
+            snap.at_sequence = seq;
+            snap.last_sequence = seq;
+            self.snapshots.entry(eid).or_default().push(snap);
+        }
         Ok(seq)
     }
 

--- a/runtime/state/src/snapshot.rs
+++ b/runtime/state/src/snapshot.rs
@@ -1,10 +1,17 @@
 use crate::event::EventSequence;
 use chrono::{DateTime, Utc};
-use jamjet_core::workflow::ExecutionId;
+use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+fn default_status_pending() -> WorkflowStatus {
+    WorkflowStatus::Pending
+}
+
 /// A point-in-time snapshot of workflow state.
+///
+/// Each snapshot carries the full materialized state so that
+/// `materialize()` can resume from it without replaying all prior events.
 ///
 /// Current state = latest snapshot + events with sequence > snapshot.at_sequence
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,12 +20,27 @@ pub struct Snapshot {
     pub execution_id: ExecutionId,
     /// The event sequence number at which this snapshot was taken.
     pub at_sequence: EventSequence,
-    /// Materialized workflow state at this point.
+    /// Materialized workflow state (current_state) at this point.
     pub state: serde_json::Value,
+    /// Workflow lifecycle status at snapshot time.
+    #[serde(default = "default_status_pending")]
+    pub status: WorkflowStatus,
+    /// All nodes that had reached a terminal state at snapshot time,
+    /// keyed by node_id with their output values.
+    #[serde(default)]
+    pub completed_nodes: std::collections::HashMap<String, serde_json::Value>,
+    /// Nodes that were active (scheduled or running) at snapshot time.
+    #[serde(default)]
+    pub active_nodes: std::collections::HashSet<String>,
+    /// The highest event sequence number seen at snapshot time.
+    #[serde(default)]
+    pub last_sequence: EventSequence,
     pub created_at: DateTime<Utc>,
 }
 
 impl Snapshot {
+    /// Create a snapshot from explicit fields. New fields default to neutral
+    /// values so existing callers do not need to change.
     pub fn new(
         execution_id: ExecutionId,
         at_sequence: EventSequence,
@@ -29,6 +51,29 @@ impl Snapshot {
             execution_id,
             at_sequence,
             state,
+            status: WorkflowStatus::Pending,
+            completed_nodes: std::collections::HashMap::new(),
+            active_nodes: std::collections::HashSet::new(),
+            last_sequence: at_sequence,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Build a snapshot directly from a `MaterializedState`, capturing the
+    /// full per-turn resume base.
+    pub fn from_materialized(
+        execution_id: ExecutionId,
+        mat: &crate::materializer::MaterializedState,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            execution_id,
+            at_sequence: mat.last_sequence,
+            state: mat.current_state.clone(),
+            status: mat.status.clone(),
+            completed_nodes: mat.completed_nodes.clone(),
+            active_nodes: mat.active_nodes.clone(),
+            last_sequence: mat.last_sequence,
             created_at: Utc::now(),
         }
     }

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -854,12 +854,13 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
-    #[instrument(skip(self, terminal_event), fields(item_id = %item_id, fence = lease_fence))]
-    async fn commit_node_terminal(
+    #[instrument(skip(self, terminal_event, snapshot), fields(item_id = %item_id, fence = lease_fence))]
+    async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
+        snapshot: Option<Snapshot>,
     ) -> BackendResult<EventSequence> {
         let id_str = item_id.to_string();
         let execution_id = execution_id_str(&terminal_event.execution_id);
@@ -876,8 +877,7 @@ impl StateBackend for SqliteBackend {
             EventKind::NodeFailed { .. } => ("failed", false),
             _ => {
                 return Err(StateBackendError::Database(
-                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
-                        .into(),
+                    "commit_turn requires a terminal event (NodeCompleted/NodeFailed)".into(),
                 ))
             }
         };
@@ -941,6 +941,37 @@ impl StateBackend for SqliteBackend {
         .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+
+        // 3) Optionally write the snapshot in the SAME transaction.
+        if let Some(mut snap) = snapshot {
+            snap.at_sequence = sequence;
+            snap.last_sequence = sequence;
+            let snap_id = snap.id.to_string();
+            let snap_exec_id = execution_id_str(&snap.execution_id);
+            let snap_state_json = serde_json::to_string(&snap.state)?;
+            let snap_created_at = snap.created_at.to_rfc3339();
+            let snap_status = status_to_str(&snap.status);
+            let snap_completed_json = serde_json::to_string(&snap.completed_nodes)?;
+            let snap_active_json = serde_json::to_string(&snap.active_nodes)?;
+
+            sqlx::query(
+                r#"INSERT OR REPLACE INTO snapshots
+                   (id, execution_id, at_sequence, state_json, created_at, status, completed_nodes_json, active_nodes_json, last_sequence)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(&snap_id)
+            .bind(&snap_exec_id)
+            .bind(snap.at_sequence)
+            .bind(&snap_state_json)
+            .bind(&snap_created_at)
+            .bind(snap_status)
+            .bind(&snap_completed_json)
+            .bind(&snap_active_json)
+            .bind(snap.last_sequence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
 
         tx.commit().await.map_err(map_db_err)?;
         Ok(sequence)

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -635,19 +635,17 @@ impl StateBackend for SqliteBackend {
             serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                 .map_err(StateBackendError::Serialization)?;
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
-        let status = str_to_status(
-            row.try_get::<&str, _>("status").unwrap_or("running"),
-        )
-        .unwrap_or(WorkflowStatus::Running);
+        let status = str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
+            .unwrap_or(WorkflowStatus::Running);
         let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
             serde_json::from_str(
-                row.try_get::<&str, _>("completed_nodes_json").unwrap_or("{}"),
+                row.try_get::<&str, _>("completed_nodes_json")
+                    .unwrap_or("{}"),
             )
             .unwrap_or_default();
-        let active_nodes: std::collections::HashSet<String> = serde_json::from_str(
-            row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"),
-        )
-        .unwrap_or_default();
+        let active_nodes: std::collections::HashSet<String> =
+            serde_json::from_str(row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"))
+                .unwrap_or_default();
         let last_sequence: i64 = row
             .try_get::<i64, _>("last_sequence")
             .unwrap_or(at_sequence);

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -588,16 +588,24 @@ impl StateBackend for SqliteBackend {
         let execution_id = execution_id_str(&snapshot.execution_id);
         let state_json = serde_json::to_string(&snapshot.state)?;
         let created_at = snapshot.created_at.to_rfc3339();
+        let status_str = status_to_str(&snapshot.status);
+        let completed_json = serde_json::to_string(&snapshot.completed_nodes)?;
+        let active_json = serde_json::to_string(&snapshot.active_nodes)?;
 
         sqlx::query(
-            r#"INSERT OR REPLACE INTO snapshots (id, execution_id, at_sequence, state_json, created_at)
-               VALUES (?, ?, ?, ?, ?)"#,
+            r#"INSERT OR REPLACE INTO snapshots
+               (id, execution_id, at_sequence, state_json, created_at, status, completed_nodes_json, active_nodes_json, last_sequence)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution_id)
         .bind(snapshot.at_sequence)
         .bind(&state_json)
         .bind(&created_at)
+        .bind(status_str)
+        .bind(&completed_json)
+        .bind(&active_json)
+        .bind(snapshot.last_sequence)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?;
@@ -627,12 +635,32 @@ impl StateBackend for SqliteBackend {
             serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                 .map_err(StateBackendError::Serialization)?;
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
+        let status = str_to_status(
+            row.try_get::<&str, _>("status").unwrap_or("running"),
+        )
+        .unwrap_or(WorkflowStatus::Running);
+        let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(
+                row.try_get::<&str, _>("completed_nodes_json").unwrap_or("{}"),
+            )
+            .unwrap_or_default();
+        let active_nodes: std::collections::HashSet<String> = serde_json::from_str(
+            row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"),
+        )
+        .unwrap_or_default();
+        let last_sequence: i64 = row
+            .try_get::<i64, _>("last_sequence")
+            .unwrap_or(at_sequence);
 
         Ok(Some(Snapshot {
             id,
             execution_id,
             at_sequence,
             state,
+            status,
+            completed_nodes,
+            active_nodes,
+            last_sequence,
             created_at,
         }))
     }

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -964,8 +964,8 @@ impl StateBackend for SqliteBackend {
                     serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                         .map_err(StateBackendError::Serialization)?;
                 let snap_status =
-                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("pending"))
-                        .unwrap_or(WorkflowStatus::Pending);
+                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
+                        .unwrap_or(WorkflowStatus::Running);
                 let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
                     match row.try_get::<Option<&str>, _>("completed_nodes_json") {
                         Err(_) => std::collections::HashMap::new(),

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -637,15 +637,20 @@ impl StateBackend for SqliteBackend {
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
         let status = str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
             .unwrap_or(WorkflowStatus::Running);
-        let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
-            serde_json::from_str(
-                row.try_get::<&str, _>("completed_nodes_json")
-                    .unwrap_or("{}"),
-            )
-            .unwrap_or_default();
-        let active_nodes: std::collections::HashSet<String> =
-            serde_json::from_str(row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"))
-                .unwrap_or_default();
+        let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
+            match row.try_get::<Option<&str>, _>("completed_nodes_json") {
+                Err(_) => std::collections::HashMap::new(), // absent column (pre-0005 rows)
+                Ok(None) => std::collections::HashMap::new(),
+                Ok(Some(s)) => serde_json::from_str(s).map_err(StateBackendError::Serialization)?,
+            }
+        };
+        let active_nodes: std::collections::HashSet<String> = {
+            match row.try_get::<Option<&str>, _>("active_nodes_json") {
+                Err(_) => std::collections::HashSet::new(), // absent column (pre-0005 rows)
+                Ok(None) => std::collections::HashSet::new(),
+                Ok(Some(s)) => serde_json::from_str(s).map_err(StateBackendError::Serialization)?,
+            }
+        };
         let last_sequence: i64 = row
             .try_get::<i64, _>("last_sequence")
             .unwrap_or(at_sequence);
@@ -852,13 +857,13 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
-    #[instrument(skip(self, terminal_event, snapshot), fields(item_id = %item_id, fence = lease_fence))]
+    #[instrument(skip(self, terminal_event), fields(item_id = %item_id, fence = lease_fence))]
     async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
-        snapshot: Option<Snapshot>,
+        write_snapshot: bool,
     ) -> BackendResult<EventSequence> {
         let id_str = item_id.to_string();
         let execution_id = execution_id_str(&terminal_event.execution_id);
@@ -940,15 +945,108 @@ impl StateBackend for SqliteBackend {
         .await
         .map_err(map_db_err)?;
 
-        // 3) Optionally write the snapshot in the SAME transaction.
-        if let Some(mut snap) = snapshot {
-            snap.at_sequence = sequence;
-            snap.last_sequence = sequence;
+        // 3) Optionally compute and write the snapshot IN-TX from committed state.
+        //    BEGIN IMMEDIATE serializes writers, so this read sees a fully-committed
+        //    prefix (all prior siblings' rows exist) — no concurrent write-skew.
+        if write_snapshot {
+            // 3a. Read the latest snapshot for this execution IN-TX.
+            let snap_row = sqlx::query(
+                "SELECT * FROM snapshots WHERE execution_id = ? ORDER BY at_sequence DESC LIMIT 1",
+            )
+            .bind(&execution_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            let (base, base_sequence) = if let Some(row) = snap_row {
+                let at_seq: i64 = row.try_get("at_sequence").map_err(map_db_err)?;
+                let current_state: serde_json::Value =
+                    serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
+                        .map_err(StateBackendError::Serialization)?;
+                let snap_status =
+                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("pending"))
+                        .unwrap_or(WorkflowStatus::Pending);
+                let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
+                    match row.try_get::<Option<&str>, _>("completed_nodes_json") {
+                        Err(_) => std::collections::HashMap::new(),
+                        Ok(None) => std::collections::HashMap::new(),
+                        Ok(Some(s)) => {
+                            serde_json::from_str(s).map_err(StateBackendError::Serialization)?
+                        }
+                    }
+                };
+                let active_nodes: std::collections::HashSet<String> = {
+                    match row.try_get::<Option<&str>, _>("active_nodes_json") {
+                        Err(_) => std::collections::HashSet::new(),
+                        Ok(None) => std::collections::HashSet::new(),
+                        Ok(Some(s)) => {
+                            serde_json::from_str(s).map_err(StateBackendError::Serialization)?
+                        }
+                    }
+                };
+                let last_seq: i64 = row.try_get::<i64, _>("last_sequence").unwrap_or(at_seq);
+                (
+                    crate::materializer::MaterializedState {
+                        current_state,
+                        status: snap_status,
+                        completed_nodes,
+                        active_nodes,
+                        last_sequence: last_seq,
+                    },
+                    at_seq,
+                )
+            } else {
+                // No snapshot: seed from the execution's initial_input IN-TX.
+                let exec_row = sqlx::query(
+                    "SELECT initial_input FROM workflow_executions WHERE execution_id = ?",
+                )
+                .bind(&execution_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(map_db_err)?;
+                let initial_input: serde_json::Value = serde_json::from_str(
+                    exec_row
+                        .try_get::<&str, _>("initial_input")
+                        .map_err(map_db_err)?,
+                )
+                .map_err(StateBackendError::Serialization)?;
+                (
+                    crate::materializer::MaterializedState {
+                        current_state: initial_input,
+                        status: WorkflowStatus::Pending,
+                        completed_nodes: std::collections::HashMap::new(),
+                        active_nodes: std::collections::HashSet::new(),
+                        last_sequence: 0,
+                    },
+                    0,
+                )
+            };
+
+            // 3b. Read events since base_sequence IN-TX (includes the just-inserted terminal event).
+            let event_rows = sqlx::query(
+                "SELECT * FROM events WHERE execution_id = ? AND sequence > ? ORDER BY sequence ASC",
+            )
+            .bind(&execution_id)
+            .bind(base_sequence)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            let tail_events: Vec<crate::event::Event> = event_rows
+                .iter()
+                .map(row_to_event)
+                .collect::<BackendResult<Vec<_>>>()?;
+
+            // 3c. Fold events onto the base state.
+            let mat = crate::materializer::apply_events_seeded(base, &tail_events);
+
+            // 3d. Build and INSERT the snapshot.
+            let snap = Snapshot::from_materialized(terminal_event.execution_id.clone(), &mat);
             let snap_id = snap.id.to_string();
             let snap_exec_id = execution_id_str(&snap.execution_id);
             let snap_state_json = serde_json::to_string(&snap.state)?;
             let snap_created_at = snap.created_at.to_rfc3339();
-            let snap_status = status_to_str(&snap.status);
+            let snap_status_str = status_to_str(&snap.status);
             let snap_completed_json = serde_json::to_string(&snap.completed_nodes)?;
             let snap_active_json = serde_json::to_string(&snap.active_nodes)?;
 
@@ -962,7 +1060,7 @@ impl StateBackend for SqliteBackend {
             .bind(snap.at_sequence)
             .bind(&snap_state_json)
             .bind(&snap_created_at)
-            .bind(snap_status)
+            .bind(snap_status_str)
             .bind(&snap_completed_json)
             .bind(&snap_active_json)
             .bind(snap.last_sequence)

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -782,12 +782,13 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
-    #[instrument(skip(self, terminal_event), fields(tenant = %self.tenant_id, item_id = %item_id))]
-    async fn commit_node_terminal(
+    #[instrument(skip(self, terminal_event, snapshot), fields(tenant = %self.tenant_id, item_id = %item_id))]
+    async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
+        snapshot: Option<Snapshot>,
     ) -> BackendResult<EventSequence> {
         let id_str = item_id.to_string();
         let execution_id = execution_id_str(&terminal_event.execution_id);
@@ -804,8 +805,7 @@ impl StateBackend for TenantScopedSqliteBackend {
             EventKind::NodeFailed { .. } => ("failed", false),
             _ => {
                 return Err(StateBackendError::Database(
-                    "commit_node_terminal requires a terminal event (NodeCompleted/NodeFailed)"
-                        .into(),
+                    "commit_turn requires a terminal event (NodeCompleted/NodeFailed)".into(),
                 ))
             }
         };
@@ -871,6 +871,38 @@ impl StateBackend for TenantScopedSqliteBackend {
         .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+
+        // Optionally write the snapshot in the SAME transaction (tenant-scoped).
+        if let Some(mut snap) = snapshot {
+            snap.at_sequence = sequence;
+            snap.last_sequence = sequence;
+            let snap_id = snap.id.to_string();
+            let snap_exec_id = execution_id_str(&snap.execution_id);
+            let snap_state_json = serde_json::to_string(&snap.state)?;
+            let snap_created_at = snap.created_at.to_rfc3339();
+            let snap_status = status_to_str(&snap.status);
+            let snap_completed_json = serde_json::to_string(&snap.completed_nodes)?;
+            let snap_active_json = serde_json::to_string(&snap.active_nodes)?;
+
+            sqlx::query(
+                r#"INSERT OR REPLACE INTO snapshots
+                   (id, execution_id, at_sequence, state_json, created_at, tenant_id, status, completed_nodes_json, active_nodes_json, last_sequence)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(&snap_id)
+            .bind(&snap_exec_id)
+            .bind(snap.at_sequence)
+            .bind(&snap_state_json)
+            .bind(&snap_created_at)
+            .bind(&self.tenant_id.0)
+            .bind(snap_status)
+            .bind(&snap_completed_json)
+            .bind(&snap_active_json)
+            .bind(snap.last_sequence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
 
         tx.commit().await.map_err(map_db_err)?;
         Ok(sequence)

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -559,19 +559,17 @@ impl StateBackend for TenantScopedSqliteBackend {
             serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                 .map_err(StateBackendError::Serialization)?;
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
-        let status = str_to_status(
-            row.try_get::<&str, _>("status").unwrap_or("running"),
-        )
-        .unwrap_or(WorkflowStatus::Running);
+        let status = str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
+            .unwrap_or(WorkflowStatus::Running);
         let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
             serde_json::from_str(
-                row.try_get::<&str, _>("completed_nodes_json").unwrap_or("{}"),
+                row.try_get::<&str, _>("completed_nodes_json")
+                    .unwrap_or("{}"),
             )
             .unwrap_or_default();
-        let active_nodes: std::collections::HashSet<String> = serde_json::from_str(
-            row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"),
-        )
-        .unwrap_or_default();
+        let active_nodes: std::collections::HashSet<String> =
+            serde_json::from_str(row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"))
+                .unwrap_or_default();
         let last_sequence: i64 = row
             .try_get::<i64, _>("last_sequence")
             .unwrap_or(at_sequence);

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -510,10 +510,14 @@ impl StateBackend for TenantScopedSqliteBackend {
         let execution_id = execution_id_str(&snapshot.execution_id);
         let state_json = serde_json::to_string(&snapshot.state)?;
         let created_at = snapshot.created_at.to_rfc3339();
+        let status_str = status_to_str(&snapshot.status);
+        let completed_json = serde_json::to_string(&snapshot.completed_nodes)?;
+        let active_json = serde_json::to_string(&snapshot.active_nodes)?;
 
         sqlx::query(
-            r#"INSERT OR REPLACE INTO snapshots (id, execution_id, at_sequence, state_json, created_at, tenant_id)
-               VALUES (?, ?, ?, ?, ?, ?)"#,
+            r#"INSERT OR REPLACE INTO snapshots
+               (id, execution_id, at_sequence, state_json, created_at, tenant_id, status, completed_nodes_json, active_nodes_json, last_sequence)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution_id)
@@ -521,6 +525,10 @@ impl StateBackend for TenantScopedSqliteBackend {
         .bind(&state_json)
         .bind(&created_at)
         .bind(&self.tenant_id.0)
+        .bind(status_str)
+        .bind(&completed_json)
+        .bind(&active_json)
+        .bind(snapshot.last_sequence)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?;
@@ -551,12 +559,32 @@ impl StateBackend for TenantScopedSqliteBackend {
             serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                 .map_err(StateBackendError::Serialization)?;
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
+        let status = str_to_status(
+            row.try_get::<&str, _>("status").unwrap_or("running"),
+        )
+        .unwrap_or(WorkflowStatus::Running);
+        let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(
+                row.try_get::<&str, _>("completed_nodes_json").unwrap_or("{}"),
+            )
+            .unwrap_or_default();
+        let active_nodes: std::collections::HashSet<String> = serde_json::from_str(
+            row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"),
+        )
+        .unwrap_or_default();
+        let last_sequence: i64 = row
+            .try_get::<i64, _>("last_sequence")
+            .unwrap_or(at_sequence);
 
         Ok(Some(Snapshot {
             id,
             execution_id,
             at_sequence,
             state,
+            status,
+            completed_nodes,
+            active_nodes,
+            last_sequence,
             created_at,
         }))
     }

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -561,15 +561,20 @@ impl StateBackend for TenantScopedSqliteBackend {
         let created_at = parse_datetime(row.try_get::<&str, _>("created_at").map_err(map_db_err)?)?;
         let status = str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
             .unwrap_or(WorkflowStatus::Running);
-        let completed_nodes: std::collections::HashMap<String, serde_json::Value> =
-            serde_json::from_str(
-                row.try_get::<&str, _>("completed_nodes_json")
-                    .unwrap_or("{}"),
-            )
-            .unwrap_or_default();
-        let active_nodes: std::collections::HashSet<String> =
-            serde_json::from_str(row.try_get::<&str, _>("active_nodes_json").unwrap_or("[]"))
-                .unwrap_or_default();
+        let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
+            match row.try_get::<Option<&str>, _>("completed_nodes_json") {
+                Err(_) => std::collections::HashMap::new(), // absent column (pre-0005 rows)
+                Ok(None) => std::collections::HashMap::new(),
+                Ok(Some(s)) => serde_json::from_str(s).map_err(StateBackendError::Serialization)?,
+            }
+        };
+        let active_nodes: std::collections::HashSet<String> = {
+            match row.try_get::<Option<&str>, _>("active_nodes_json") {
+                Err(_) => std::collections::HashSet::new(), // absent column (pre-0005 rows)
+                Ok(None) => std::collections::HashSet::new(),
+                Ok(Some(s)) => serde_json::from_str(s).map_err(StateBackendError::Serialization)?,
+            }
+        };
         let last_sequence: i64 = row
             .try_get::<i64, _>("last_sequence")
             .unwrap_or(at_sequence);
@@ -780,13 +785,13 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
-    #[instrument(skip(self, terminal_event, snapshot), fields(tenant = %self.tenant_id, item_id = %item_id))]
+    #[instrument(skip(self, terminal_event), fields(tenant = %self.tenant_id, item_id = %item_id))]
     async fn commit_turn(
         &self,
         item_id: WorkItemId,
         lease_fence: i64,
         terminal_event: Event,
-        snapshot: Option<Snapshot>,
+        write_snapshot: bool,
     ) -> BackendResult<EventSequence> {
         let id_str = item_id.to_string();
         let execution_id = execution_id_str(&terminal_event.execution_id);
@@ -870,15 +875,110 @@ impl StateBackend for TenantScopedSqliteBackend {
         .await
         .map_err(map_db_err)?;
 
-        // Optionally write the snapshot in the SAME transaction (tenant-scoped).
-        if let Some(mut snap) = snapshot {
-            snap.at_sequence = sequence;
-            snap.last_sequence = sequence;
+        // Optionally compute and write the snapshot IN-TX from committed state (tenant-scoped).
+        // BEGIN IMMEDIATE serializes writers — no concurrent write-skew.
+        if write_snapshot {
+            // 3a. Read the latest snapshot for this execution IN-TX.
+            let snap_row = sqlx::query(
+                "SELECT * FROM snapshots WHERE execution_id = ? AND tenant_id = ? ORDER BY at_sequence DESC LIMIT 1",
+            )
+            .bind(&execution_id)
+            .bind(&self.tenant_id.0)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            let (base, base_sequence) = if let Some(row) = snap_row {
+                let at_seq: i64 = row.try_get("at_sequence").map_err(map_db_err)?;
+                let current_state: serde_json::Value =
+                    serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
+                        .map_err(StateBackendError::Serialization)?;
+                let snap_status =
+                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("pending"))
+                        .unwrap_or(WorkflowStatus::Pending);
+                let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
+                    match row.try_get::<Option<&str>, _>("completed_nodes_json") {
+                        Err(_) => std::collections::HashMap::new(),
+                        Ok(None) => std::collections::HashMap::new(),
+                        Ok(Some(s)) => {
+                            serde_json::from_str(s).map_err(StateBackendError::Serialization)?
+                        }
+                    }
+                };
+                let active_nodes: std::collections::HashSet<String> = {
+                    match row.try_get::<Option<&str>, _>("active_nodes_json") {
+                        Err(_) => std::collections::HashSet::new(),
+                        Ok(None) => std::collections::HashSet::new(),
+                        Ok(Some(s)) => {
+                            serde_json::from_str(s).map_err(StateBackendError::Serialization)?
+                        }
+                    }
+                };
+                let last_seq: i64 = row.try_get::<i64, _>("last_sequence").unwrap_or(at_seq);
+                (
+                    crate::materializer::MaterializedState {
+                        current_state,
+                        status: snap_status,
+                        completed_nodes,
+                        active_nodes,
+                        last_sequence: last_seq,
+                    },
+                    at_seq,
+                )
+            } else {
+                // No snapshot: seed from the execution's initial_input IN-TX.
+                let exec_row = sqlx::query(
+                    "SELECT initial_input FROM workflow_executions WHERE execution_id = ? AND tenant_id = ?",
+                )
+                .bind(&execution_id)
+                .bind(&self.tenant_id.0)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(map_db_err)?;
+                let initial_input: serde_json::Value = serde_json::from_str(
+                    exec_row
+                        .try_get::<&str, _>("initial_input")
+                        .map_err(map_db_err)?,
+                )
+                .map_err(StateBackendError::Serialization)?;
+                (
+                    crate::materializer::MaterializedState {
+                        current_state: initial_input,
+                        status: WorkflowStatus::Pending,
+                        completed_nodes: std::collections::HashMap::new(),
+                        active_nodes: std::collections::HashSet::new(),
+                        last_sequence: 0,
+                    },
+                    0,
+                )
+            };
+
+            // 3b. Read events since base_sequence IN-TX (includes the just-inserted terminal event).
+            let event_rows = sqlx::query(
+                "SELECT * FROM events WHERE execution_id = ? AND tenant_id = ? AND sequence > ? ORDER BY sequence ASC",
+            )
+            .bind(&execution_id)
+            .bind(&self.tenant_id.0)
+            .bind(base_sequence)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            let tail_events: Vec<crate::event::Event> = event_rows
+                .iter()
+                .map(row_to_event)
+                .collect::<BackendResult<Vec<_>>>()?;
+
+            // 3c. Fold events onto the base state.
+            let mat = crate::materializer::apply_events_seeded(base, &tail_events);
+
+            // 3d. Build and INSERT the snapshot.
+            let snap = Snapshot::from_materialized(terminal_event.execution_id.clone(), &mat);
             let snap_id = snap.id.to_string();
             let snap_exec_id = execution_id_str(&snap.execution_id);
             let snap_state_json = serde_json::to_string(&snap.state)?;
             let snap_created_at = snap.created_at.to_rfc3339();
-            let snap_status = status_to_str(&snap.status);
+            let snap_status_str = status_to_str(&snap.status);
             let snap_completed_json = serde_json::to_string(&snap.completed_nodes)?;
             let snap_active_json = serde_json::to_string(&snap.active_nodes)?;
 
@@ -893,7 +993,7 @@ impl StateBackend for TenantScopedSqliteBackend {
             .bind(&snap_state_json)
             .bind(&snap_created_at)
             .bind(&self.tenant_id.0)
-            .bind(snap_status)
+            .bind(snap_status_str)
             .bind(&snap_completed_json)
             .bind(&snap_active_json)
             .bind(snap.last_sequence)

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -894,8 +894,8 @@ impl StateBackend for TenantScopedSqliteBackend {
                     serde_json::from_str(row.try_get::<&str, _>("state_json").map_err(map_db_err)?)
                         .map_err(StateBackendError::Serialization)?;
                 let snap_status =
-                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("pending"))
-                        .unwrap_or(WorkflowStatus::Pending);
+                    str_to_status(row.try_get::<&str, _>("status").unwrap_or("running"))
+                        .unwrap_or(WorkflowStatus::Running);
                 let completed_nodes: std::collections::HashMap<String, serde_json::Value> = {
                     match row.try_get::<Option<&str>, _>("completed_nodes_json") {
                         Err(_) => std::collections::HashMap::new(),

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -1,0 +1,92 @@
+//! Round-trip test: a Snapshot carrying full materialized state
+//! (status, completed_nodes, active_nodes, last_sequence) survives
+//! write_snapshot → latest_snapshot intact.
+//!
+//! TDD: this test is written RED first (Snapshot has no such fields),
+//! then turns GREEN after the struct + migration + backend widening.
+
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::{backend::StateBackend, snapshot::Snapshot, SqliteBackend};
+use serde_json::json;
+use std::collections::{HashMap, HashSet};
+
+async fn open_test_db() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite")
+}
+
+fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "test-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({}),
+        current_state: json!({}),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+    }
+}
+
+/// Full materialized state round-trips through write_snapshot → latest_snapshot.
+///
+/// Verifies: status, completed_nodes, active_nodes, last_sequence are all
+/// persisted and reloaded faithfully by the SQLite backend.
+#[tokio::test]
+async fn test_snapshot_full_materialized_state_round_trips() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let mut completed_nodes = HashMap::new();
+    completed_nodes.insert("n1".to_string(), json!(1));
+    let mut active_nodes = HashSet::new();
+    active_nodes.insert("n2".to_string());
+
+    let snap = Snapshot {
+        id: uuid::Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        at_sequence: 7,
+        state: json!({"x": 42}),
+        status: WorkflowStatus::Running,
+        completed_nodes,
+        active_nodes,
+        last_sequence: 7,
+        created_at: Utc::now(),
+    };
+
+    db.write_snapshot(snap).await.unwrap();
+
+    let loaded = db.latest_snapshot(&exec_id).await.unwrap().unwrap();
+    assert_eq!(loaded.at_sequence, 7);
+    assert_eq!(loaded.status, WorkflowStatus::Running);
+    assert_eq!(
+        loaded.completed_nodes.get("n1"),
+        Some(&json!(1)),
+        "completed_nodes should round-trip"
+    );
+    assert!(
+        loaded.active_nodes.contains("n2"),
+        "active_nodes should round-trip"
+    );
+    assert_eq!(loaded.last_sequence, 7, "last_sequence should round-trip");
+}
+
+/// Snapshot::new (compat path) still compiles and returns sane defaults.
+#[tokio::test]
+async fn test_snapshot_new_compat_defaults() {
+    let exec_id = ExecutionId::new();
+    let snap = Snapshot::new(exec_id.clone(), 5, json!({"nodes_completed": ["a", "b"]}));
+    assert_eq!(snap.at_sequence, 5);
+    assert_eq!(snap.last_sequence, 5);
+    assert_eq!(snap.status, WorkflowStatus::Pending);
+    assert!(snap.completed_nodes.is_empty());
+    assert!(snap.active_nodes.is_empty());
+}

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -1,9 +1,7 @@
-//! Round-trip test: a Snapshot carrying full materialized state
-//! (status, completed_nodes, active_nodes, last_sequence) survives
-//! write_snapshot → latest_snapshot intact.
+//! Tests for `commit_turn`: the fenced commit that also writes a per-turn
+//! snapshot in the same `BEGIN IMMEDIATE` transaction.
 //!
-//! Also: replay-equivalence — materialize() from a mid-run snapshot plus
-//! tail events must equal apply_events() over the full event log.
+//! Also covers: Snapshot round-trip, replay-equivalence property.
 //!
 //! TDD: tests are written RED first, then turn GREEN after the fix.
 
@@ -11,13 +9,14 @@ use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
     apply_events, materialize,
-    backend::StateBackend,
+    backend::{StateBackend, StateBackendError, WorkItem},
     event::{Event, EventKind},
     snapshot::Snapshot,
     SqliteBackend,
 };
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
 
 async fn open_test_db() -> SqliteBackend {
     SqliteBackend::open("sqlite::memory:")
@@ -206,4 +205,185 @@ async fn test_materialize_equals_full_apply_after_snapshot() {
     );
     assert_eq!(mat.active_nodes, full.active_nodes, "active_nodes mismatch");
     assert_eq!(mat.last_sequence, full.last_sequence, "last_sequence mismatch");
+}
+
+// ── Helper fixtures ───────────────────────────────────────────────────────────
+
+fn sample_work_item(execution_id: &ExecutionId) -> WorkItem {
+    WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: execution_id.clone(),
+        node_id: "n1".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    }
+}
+
+fn node_completed_kind(node: &str) -> EventKind {
+    EventKind::NodeCompleted {
+        node_id: node.into(),
+        output: json!({"ok": true}),
+        state_patch: json!({}),
+        duration_ms: 1,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    }
+}
+
+fn build_snapshot(exec_id: &ExecutionId) -> Snapshot {
+    let mut completed_nodes = HashMap::new();
+    completed_nodes.insert("n1".to_string(), json!("result"));
+    let mut active_nodes = HashSet::new();
+    active_nodes.insert("n2".to_string());
+
+    Snapshot {
+        id: Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        at_sequence: 0, // will be overwritten by commit_turn
+        state: json!({"x": 1}),
+        status: WorkflowStatus::Running,
+        completed_nodes,
+        active_nodes,
+        last_sequence: 0, // will be overwritten by commit_turn
+        created_at: Utc::now(),
+    }
+}
+
+// ── Task 3 tests ─────────────────────────────────────────────────────────────
+
+/// `commit_turn` with `Some(snapshot)`: settles the work item, appends exactly
+/// one terminal event, AND writes the snapshot (with at_sequence == the assigned
+/// event sequence) in the same transaction. `latest_snapshot` returns it.
+#[tokio::test]
+async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id)).await.unwrap();
+    db.enqueue_work_item(sample_work_item(&exec_id)).await.unwrap();
+
+    let item = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    let event = Event::new(exec_id.clone(), 0, node_completed_kind("n1"));
+    let snap = build_snapshot(&exec_id);
+
+    let seq = db
+        .commit_turn(item.id, item.lease_fence, event, Some(snap))
+        .await
+        .expect("commit_turn with snapshot must succeed");
+
+    assert!(seq >= 1, "returned sequence must be at least 1");
+
+    // Exactly one event appended.
+    let events = db.get_events(&exec_id).await.unwrap();
+    assert_eq!(events.len(), 1, "exactly one event must exist");
+    assert!(
+        matches!(events[0].kind, EventKind::NodeCompleted { .. }),
+        "event must be NodeCompleted"
+    );
+    assert_eq!(events[0].sequence, seq, "event sequence must match returned seq");
+
+    // Snapshot was written with at_sequence == the terminal event's sequence.
+    let loaded_snap = db
+        .latest_snapshot(&exec_id)
+        .await
+        .unwrap()
+        .expect("snapshot must exist after commit_turn");
+
+    assert_eq!(
+        loaded_snap.at_sequence, seq,
+        "snapshot.at_sequence must equal the terminal event sequence"
+    );
+    assert_eq!(
+        loaded_snap.last_sequence, seq,
+        "snapshot.last_sequence must equal the terminal event sequence"
+    );
+    assert_eq!(
+        loaded_snap.status,
+        WorkflowStatus::Running,
+        "snapshot status must round-trip"
+    );
+    assert!(
+        loaded_snap.completed_nodes.contains_key("n1"),
+        "completed_nodes must round-trip"
+    );
+    assert!(
+        loaded_snap.active_nodes.contains("n2"),
+        "active_nodes must round-trip"
+    );
+}
+
+/// Stale-fence path: `commit_turn` with a snapshot and a stale fence must
+/// return `FenceLost` and write NEITHER an event NOR a snapshot.
+#[tokio::test]
+async fn commit_turn_stale_fence_writes_nothing() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id)).await.unwrap();
+    db.enqueue_work_item(sample_work_item(&exec_id)).await.unwrap();
+
+    // Worker A claims (fence F1). Expire + re-claim as worker B (fence F2).
+    // Worker A is now a zombie holding stale fence F1.
+    let zombie = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Backdate the lease so claim_work_item's stale-expiry path fires.
+    sqlx::query(
+        "UPDATE work_items SET lease_expires_at = '2020-01-01T00:00:00+00:00' WHERE id = ?",
+    )
+    .bind(zombie.id.to_string())
+    .execute(&db.pool())
+    .await
+    .unwrap();
+
+    let _b = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Zombie tries to commit with stale fence and a snapshot.
+    let event = Event::new(exec_id.clone(), 0, node_completed_kind("n1"));
+    let snap = build_snapshot(&exec_id);
+
+    let err = db
+        .commit_turn(zombie.id, zombie.lease_fence, event, Some(snap))
+        .await
+        .expect_err("stale-fence commit_turn must fail closed");
+
+    assert!(
+        matches!(err, StateBackendError::FenceLost(_)),
+        "expected FenceLost, got {err:?}"
+    );
+
+    // Zero events written.
+    assert_eq!(
+        db.get_events(&exec_id).await.unwrap().len(),
+        0,
+        "stale-fence commit_turn must emit zero events"
+    );
+
+    // No snapshot written.
+    assert!(
+        db.latest_snapshot(&exec_id).await.unwrap().is_none(),
+        "stale-fence commit_turn must write no snapshot"
+    );
 }

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -7,13 +7,16 @@
 
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::tenant::TenantId;
 use jamjet_state::{
-    apply_events, materialize,
+    apply_events, apply_events_seeded,
     backend::{StateBackend, StateBackendError, WorkItem},
     event::{Event, EventKind},
+    materialize,
     snapshot::Snapshot,
-    SqliteBackend,
+    InMemoryBackend, MaterializedState, SqliteBackend,
 };
+use proptest::prelude::*;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -204,7 +207,10 @@ async fn test_materialize_equals_full_apply_after_snapshot() {
         "completed_nodes mismatch: n1 must survive the snapshot cut"
     );
     assert_eq!(mat.active_nodes, full.active_nodes, "active_nodes mismatch");
-    assert_eq!(mat.last_sequence, full.last_sequence, "last_sequence mismatch");
+    assert_eq!(
+        mat.last_sequence, full.last_sequence,
+        "last_sequence mismatch"
+    );
 }
 
 // ── Helper fixtures ───────────────────────────────────────────────────────────
@@ -270,8 +276,12 @@ fn build_snapshot(exec_id: &ExecutionId) -> Snapshot {
 async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
     let db = open_test_db().await;
     let exec_id = ExecutionId::new();
-    db.create_execution(sample_execution(&exec_id)).await.unwrap();
-    db.enqueue_work_item(sample_work_item(&exec_id)).await.unwrap();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    db.enqueue_work_item(sample_work_item(&exec_id))
+        .await
+        .unwrap();
 
     let item = db
         .claim_work_item("worker-A", &["model"])
@@ -296,7 +306,10 @@ async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
         matches!(events[0].kind, EventKind::NodeCompleted { .. }),
         "event must be NodeCompleted"
     );
-    assert_eq!(events[0].sequence, seq, "event sequence must match returned seq");
+    assert_eq!(
+        events[0].sequence, seq,
+        "event sequence must match returned seq"
+    );
 
     // Snapshot was written with at_sequence == the terminal event's sequence.
     let loaded_snap = db
@@ -334,8 +347,12 @@ async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
 async fn commit_turn_stale_fence_writes_nothing() {
     let db = open_test_db().await;
     let exec_id = ExecutionId::new();
-    db.create_execution(sample_execution(&exec_id)).await.unwrap();
-    db.enqueue_work_item(sample_work_item(&exec_id)).await.unwrap();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    db.enqueue_work_item(sample_work_item(&exec_id))
+        .await
+        .unwrap();
 
     // Worker A claims (fence F1). Expire + re-claim as worker B (fence F2).
     // Worker A is now a zombie holding stale fence F1.
@@ -386,4 +403,452 @@ async fn commit_turn_stale_fence_writes_nothing() {
         db.latest_snapshot(&exec_id).await.unwrap().is_none(),
         "stale-fence commit_turn must write no snapshot"
     );
+}
+
+// ── Task 5 helpers ────────────────────────────────────────────────────────────
+
+fn arb_nc_spec() -> impl Strategy<Value = (usize, usize, i64)> {
+    // (node_pool_index 0-3, key_pool_index 0-3, patch_value 0-99)
+    (0..4usize, 0..4usize, 0i64..100i64)
+}
+
+/// Build a NodeCompleted event kind for use in the proptest.
+fn nc_kind_for_spec(ni: usize, ki: usize, pv: i64) -> EventKind {
+    let node_pool = ["n0", "n1", "n2", "n3"];
+    let key_pool = ["a", "b", "c", "d"];
+    EventKind::NodeCompleted {
+        node_id: node_pool[ni].to_string(),
+        output: json!({"ok": true}),
+        state_patch: json!({key_pool[ki]: pv}),
+        duration_ms: 1,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    }
+}
+
+// ── Group 1: Replay-equivalence proptest ─────────────────────────────────────
+//
+// Generates random sequences of NodeCompleted events with repeated node ids
+// and small JSON patches. For EVERY cut K in 0..=N, asserts that:
+//   apply_events_seeded(Snapshot::from_materialized(fold[0..K]), events[K..])
+//       == apply_events(initial, &all_events)
+// on all four fields: current_state, status, completed_nodes, active_nodes.
+//
+// This is a pure fold (no DB), so it can run synchronously.
+proptest! {
+    #[test]
+    fn replay_equivalence(
+        specs in prop::collection::vec(arb_nc_spec(), 1..=12)
+    ) {
+        let exec_id = ExecutionId::new();
+        let events: Vec<Event> = specs
+            .iter()
+            .enumerate()
+            .map(|(i, &(ni, ki, pv))| {
+                Event::new(exec_id.clone(), (i + 1) as i64, nc_kind_for_spec(ni, ki, pv))
+            })
+            .collect();
+
+        let initial = json!({});
+        let full = apply_events(initial.clone(), &events, &WorkflowStatus::Running);
+
+        for k in 0..=events.len() {
+            // Fold events[0..k] to get the mid-run materialized state.
+            let mid = apply_events(initial.clone(), &events[0..k], &WorkflowStatus::Running);
+
+            // Mirror what the worker does: build a Snapshot from that state.
+            let snap = Snapshot::from_materialized(exec_id.clone(), &mid);
+
+            // Seed a fresh MaterializedState from the snapshot and fold the tail.
+            let seed = MaterializedState {
+                current_state: snap.state,
+                status: snap.status,
+                completed_nodes: snap.completed_nodes,
+                active_nodes: snap.active_nodes,
+                last_sequence: snap.last_sequence,
+            };
+            let resumed = apply_events_seeded(seed, &events[k..]);
+
+            prop_assert_eq!(
+                &resumed.current_state,
+                &full.current_state,
+                "current_state mismatch at k={}",
+                k
+            );
+            prop_assert_eq!(
+                resumed.status,
+                full.status.clone(),
+                "status mismatch at k={}",
+                k
+            );
+            prop_assert_eq!(
+                &resumed.completed_nodes,
+                &full.completed_nodes,
+                "completed_nodes mismatch at k={} (pre-snapshot node lost?)",
+                k
+            );
+            prop_assert_eq!(
+                &resumed.active_nodes,
+                &full.active_nodes,
+                "active_nodes mismatch at k={}",
+                k
+            );
+        }
+    }
+}
+
+// ── Group 2: Fresh-process SQLite resume ─────────────────────────────────────
+//
+// Writes 3 successive per-turn snapshots via commit_turn into a temp SQLite
+// file, drops the backend, reopens the file, and asserts that materialize()
+// produces the same result as a from-origin apply_events fold.
+//
+// Also verifies that __budget placed in an early turn's state_patch survives
+// in the reopened snapshot's state (the budget key is just a regular JSON
+// merge-patch key living in current_state).
+#[tokio::test]
+async fn fresh_process_sqlite_resume() {
+    let db_path = std::path::PathBuf::from(format!("/tmp/jamjet-test-{}.sqlite3", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+
+    let db = SqliteBackend::open(&url)
+        .await
+        .expect("failed to open temp SQLite file");
+
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let initial = json!({});
+
+    // Materialize-and-advance helper: returns the new MaterializedState after
+    // applying `kind` on top of `prior` (using sequence 0; commit_turn will
+    // overwrite at_sequence / last_sequence to the real assigned sequence).
+    fn advance(
+        prior: MaterializedState,
+        exec_id: &ExecutionId,
+        kind: &EventKind,
+    ) -> MaterializedState {
+        let dummy = Event::new(exec_id.clone(), 0, kind.clone());
+        apply_events_seeded(prior, &[dummy])
+    }
+
+    // ── Turn 1: n1 with a __budget key in state_patch ────────────────────────
+    let t1_kind = EventKind::NodeCompleted {
+        node_id: "n1".into(),
+        output: json!("r1"),
+        state_patch: json!({"step": "n1", "__budget": {"remaining": 100, "spent": 10}}),
+        duration_ms: 5,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    };
+
+    db.enqueue_work_item(WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        node_id: "n1".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    })
+    .await
+    .unwrap();
+
+    let item1 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
+    let prior0 = MaterializedState {
+        current_state: initial.clone(),
+        status: WorkflowStatus::Pending,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 0,
+    };
+    let state1 = advance(prior0, &exec_id, &t1_kind);
+    let snap1 = Snapshot::from_materialized(exec_id.clone(), &state1);
+    db.commit_turn(
+        item1.id,
+        item1.lease_fence,
+        Event::new(exec_id.clone(), 0, t1_kind),
+        Some(snap1),
+    )
+    .await
+    .unwrap();
+
+    // ── Turn 2: n2 ───────────────────────────────────────────────────────────
+    let t2_kind = EventKind::NodeCompleted {
+        node_id: "n2".into(),
+        output: json!("r2"),
+        state_patch: json!({"step": "n2"}),
+        duration_ms: 5,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    };
+
+    db.enqueue_work_item(WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        node_id: "n2".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    })
+    .await
+    .unwrap();
+
+    let item2 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
+    let state2 = advance(state1.clone(), &exec_id, &t2_kind);
+    let snap2 = Snapshot::from_materialized(exec_id.clone(), &state2);
+    db.commit_turn(
+        item2.id,
+        item2.lease_fence,
+        Event::new(exec_id.clone(), 0, t2_kind),
+        Some(snap2),
+    )
+    .await
+    .unwrap();
+
+    // ── Turn 3: n3 ───────────────────────────────────────────────────────────
+    let t3_kind = EventKind::NodeCompleted {
+        node_id: "n3".into(),
+        output: json!("r3"),
+        state_patch: json!({"step": "n3"}),
+        duration_ms: 5,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+    };
+
+    db.enqueue_work_item(WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        node_id: "n3".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    })
+    .await
+    .unwrap();
+
+    let item3 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
+    let state3 = advance(state2.clone(), &exec_id, &t3_kind);
+    let snap3 = Snapshot::from_materialized(exec_id.clone(), &state3);
+    db.commit_turn(
+        item3.id,
+        item3.lease_fence,
+        Event::new(exec_id.clone(), 0, t3_kind),
+        Some(snap3),
+    )
+    .await
+    .unwrap();
+
+    // Drop the backend so all connections are closed.
+    drop(db);
+
+    // ── Fresh process: reopen the file ───────────────────────────────────────
+    let db2 = SqliteBackend::open(&url)
+        .await
+        .expect("failed to reopen temp SQLite file");
+
+    let all_events = db2.get_events(&exec_id).await.unwrap();
+    assert_eq!(all_events.len(), 3, "expected exactly 3 events in the log");
+
+    // From-origin reference fold.
+    let full = apply_events(initial.clone(), &all_events, &WorkflowStatus::Running);
+
+    // Resume via materialize() (loads latest snapshot + applies tail events).
+    let resumed = materialize(&db2, &exec_id).await.unwrap();
+
+    assert_eq!(
+        resumed.current_state, full.current_state,
+        "current_state must be byte-identical after fresh-process resume"
+    );
+    assert_eq!(resumed.status, full.status, "status must match");
+    assert_eq!(
+        resumed.completed_nodes, full.completed_nodes,
+        "completed_nodes must contain all three nodes"
+    );
+    assert_eq!(
+        resumed.active_nodes, full.active_nodes,
+        "active_nodes must match"
+    );
+    assert_eq!(
+        resumed.last_sequence, full.last_sequence,
+        "last_sequence must match"
+    );
+
+    // Budget key placed in turn 1's state_patch must survive in the snapshot state.
+    assert!(
+        resumed.current_state.get("__budget").is_some(),
+        "__budget must survive in the resumed current_state"
+    );
+    assert_eq!(
+        resumed.current_state["__budget"]["remaining"],
+        json!(100),
+        "__budget.remaining must be 100 after fresh-process resume"
+    );
+
+    // Clean up.
+    drop(db2);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite3-wal"));
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite3-shm"));
+}
+
+// ── Group 3: Cross-backend resume ────────────────────────────────────────────
+//
+// Verifies the "write snapshot at mid-point + materialize() == full fold"
+// invariant against both InMemoryBackend and TenantScopedSqliteBackend.
+//
+// Uses append_event + write_snapshot directly (no work-item setup needed)
+// because this test is about the seeding/fold correctness, not the fenced
+// commit atomicity (that is Task 3's territory).
+
+async fn assert_resume_equivalence_for_backend(backend: &dyn StateBackend) {
+    let exec_id = ExecutionId::new();
+    backend
+        .create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let initial = json!({});
+
+    // Five events: WorkflowStarted, NodeScheduled n1, NodeCompleted n1,
+    //              NodeScheduled n2, NodeCompleted n2.
+    let kinds: Vec<EventKind> = vec![
+        EventKind::WorkflowStarted {
+            workflow_id: "xb-wf".into(),
+            workflow_version: "1.0.0".into(),
+            initial_input: initial.clone(),
+        },
+        EventKind::NodeScheduled {
+            node_id: "n1".into(),
+            queue_type: "tool".into(),
+        },
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!("r1"),
+            state_patch: json!({"a": 1}),
+            duration_ms: 5,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+        EventKind::NodeScheduled {
+            node_id: "n2".into(),
+            queue_type: "tool".into(),
+        },
+        EventKind::NodeCompleted {
+            node_id: "n2".into(),
+            output: json!("r2"),
+            state_patch: json!({"b": 2}),
+            duration_ms: 5,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+    ];
+
+    for kind in &kinds {
+        backend
+            .append_event(Event::new(exec_id.clone(), 0, kind.clone()))
+            .await
+            .unwrap();
+    }
+
+    let all_events = backend.get_events(&exec_id).await.unwrap();
+    assert_eq!(all_events.len(), 5);
+
+    // Full from-origin reference.
+    let full = apply_events(initial.clone(), &all_events, &WorkflowStatus::Running);
+
+    // Take a snapshot at K=3 (after NodeCompleted n1).
+    let state_at_k3 = apply_events(initial.clone(), &all_events[0..3], &WorkflowStatus::Running);
+    assert!(
+        state_at_k3.completed_nodes.contains_key("n1"),
+        "n1 must be in completed_nodes at K=3"
+    );
+
+    let snap = Snapshot::from_materialized(exec_id.clone(), &state_at_k3);
+    backend.write_snapshot(snap).await.unwrap();
+
+    // materialize() must seed from that snapshot and fold events 4-5.
+    let resumed = materialize(backend, &exec_id).await.unwrap();
+
+    assert_eq!(
+        resumed.current_state, full.current_state,
+        "current_state mismatch"
+    );
+    assert_eq!(resumed.status, full.status, "status mismatch");
+    assert_eq!(
+        resumed.completed_nodes, full.completed_nodes,
+        "completed_nodes mismatch: n1 must survive the snapshot cut"
+    );
+    assert_eq!(
+        resumed.active_nodes, full.active_nodes,
+        "active_nodes mismatch"
+    );
+    assert_eq!(
+        resumed.last_sequence, full.last_sequence,
+        "last_sequence mismatch"
+    );
+}
+
+#[tokio::test]
+async fn cross_backend_in_memory() {
+    let backend = InMemoryBackend::new();
+    assert_resume_equivalence_for_backend(&backend).await;
+}
+
+#[tokio::test]
+async fn cross_backend_tenant_scoped_sqlite() {
+    let db = SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite");
+    let scoped = db.for_tenant(TenantId::default());
+    assert_resume_equivalence_for_backend(&scoped).await;
 }

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -248,30 +248,14 @@ fn node_completed_kind(node: &str) -> EventKind {
     }
 }
 
-fn build_snapshot(exec_id: &ExecutionId) -> Snapshot {
-    let mut completed_nodes = HashMap::new();
-    completed_nodes.insert("n1".to_string(), json!("result"));
-    let mut active_nodes = HashSet::new();
-    active_nodes.insert("n2".to_string());
-
-    Snapshot {
-        id: Uuid::new_v4(),
-        execution_id: exec_id.clone(),
-        at_sequence: 0, // will be overwritten by commit_turn
-        state: json!({"x": 1}),
-        status: WorkflowStatus::Running,
-        completed_nodes,
-        active_nodes,
-        last_sequence: 0, // will be overwritten by commit_turn
-        created_at: Utc::now(),
-    }
-}
-
 // ── Task 3 tests ─────────────────────────────────────────────────────────────
 
-/// `commit_turn` with `Some(snapshot)`: settles the work item, appends exactly
-/// one terminal event, AND writes the snapshot (with at_sequence == the assigned
-/// event sequence) in the same transaction. `latest_snapshot` returns it.
+/// `commit_turn` with `write_snapshot = true`: settles the work item, appends
+/// exactly one terminal event, AND writes a snapshot (computed in-tx from the
+/// committed event log) in the same transaction. `latest_snapshot` returns it.
+///
+/// The snapshot is computed from the event log rather than a pre-tx value, so
+/// `completed_nodes` reflects the actual committed NodeCompleted event.
 #[tokio::test]
 async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
     let db = open_test_db().await;
@@ -290,12 +274,11 @@ async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
         .unwrap();
 
     let event = Event::new(exec_id.clone(), 0, node_completed_kind("n1"));
-    let snap = build_snapshot(&exec_id);
 
     let seq = db
-        .commit_turn(item.id, item.lease_fence, event, Some(snap))
+        .commit_turn(item.id, item.lease_fence, event, true)
         .await
-        .expect("commit_turn with snapshot must succeed");
+        .expect("commit_turn with write_snapshot must succeed");
 
     assert!(seq >= 1, "returned sequence must be at least 1");
 
@@ -326,18 +309,15 @@ async fn commit_turn_with_snapshot_writes_event_and_snapshot() {
         loaded_snap.last_sequence, seq,
         "snapshot.last_sequence must equal the terminal event sequence"
     );
-    assert_eq!(
-        loaded_snap.status,
-        WorkflowStatus::Running,
-        "snapshot status must round-trip"
-    );
+    // Snapshot is computed from the event log: NodeCompleted n1 marks n1 as done.
     assert!(
         loaded_snap.completed_nodes.contains_key("n1"),
-        "completed_nodes must round-trip"
+        "completed_nodes must contain n1 (from the committed NodeCompleted event)"
     );
+    // No NodeScheduled event was emitted for any other node, so active_nodes is empty.
     assert!(
-        loaded_snap.active_nodes.contains("n2"),
-        "active_nodes must round-trip"
+        loaded_snap.active_nodes.is_empty(),
+        "active_nodes must be empty when no NodeScheduled events preceded the commit"
     );
 }
 
@@ -377,12 +357,11 @@ async fn commit_turn_stale_fence_writes_nothing() {
         .unwrap()
         .unwrap();
 
-    // Zombie tries to commit with stale fence and a snapshot.
+    // Zombie tries to commit with stale fence and write_snapshot = true.
     let event = Event::new(exec_id.clone(), 0, node_completed_kind("n1"));
-    let snap = build_snapshot(&exec_id);
 
     let err = db
-        .commit_turn(zombie.id, zombie.lease_fence, event, Some(snap))
+        .commit_turn(zombie.id, zombie.lease_fence, event, true)
         .await
         .expect_err("stale-fence commit_turn must fail closed");
 
@@ -527,18 +506,6 @@ async fn fresh_process_sqlite_resume() {
 
     let initial = json!({});
 
-    // Materialize-and-advance helper: returns the new MaterializedState after
-    // applying `kind` on top of `prior` (using sequence 0; commit_turn will
-    // overwrite at_sequence / last_sequence to the real assigned sequence).
-    fn advance(
-        prior: MaterializedState,
-        exec_id: &ExecutionId,
-        kind: &EventKind,
-    ) -> MaterializedState {
-        let dummy = Event::new(exec_id.clone(), 0, kind.clone());
-        apply_events_seeded(prior, &[dummy])
-    }
-
     // ── Turn 1: n1 with a __budget key in state_patch ────────────────────────
     let t1_kind = EventKind::NodeCompleted {
         node_id: "n1".into(),
@@ -572,20 +539,11 @@ async fn fresh_process_sqlite_resume() {
     .unwrap();
 
     let item1 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
-    let prior0 = MaterializedState {
-        current_state: initial.clone(),
-        status: WorkflowStatus::Pending,
-        completed_nodes: HashMap::new(),
-        active_nodes: HashSet::new(),
-        last_sequence: 0,
-    };
-    let state1 = advance(prior0, &exec_id, &t1_kind);
-    let snap1 = Snapshot::from_materialized(exec_id.clone(), &state1);
     db.commit_turn(
         item1.id,
         item1.lease_fence,
         Event::new(exec_id.clone(), 0, t1_kind),
-        Some(snap1),
+        true,
     )
     .await
     .unwrap();
@@ -623,13 +581,11 @@ async fn fresh_process_sqlite_resume() {
     .unwrap();
 
     let item2 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
-    let state2 = advance(state1.clone(), &exec_id, &t2_kind);
-    let snap2 = Snapshot::from_materialized(exec_id.clone(), &state2);
     db.commit_turn(
         item2.id,
         item2.lease_fence,
         Event::new(exec_id.clone(), 0, t2_kind),
-        Some(snap2),
+        true,
     )
     .await
     .unwrap();
@@ -667,13 +623,11 @@ async fn fresh_process_sqlite_resume() {
     .unwrap();
 
     let item3 = db.claim_work_item("w", &["model"]).await.unwrap().unwrap();
-    let state3 = advance(state2.clone(), &exec_id, &t3_kind);
-    let snap3 = Snapshot::from_materialized(exec_id.clone(), &state3);
     db.commit_turn(
         item3.id,
         item3.lease_fence,
         Event::new(exec_id.clone(), 0, t3_kind),
-        Some(snap3),
+        true,
     )
     .await
     .unwrap();
@@ -851,4 +805,132 @@ async fn cross_backend_tenant_scoped_sqlite() {
         .expect("failed to open in-memory SQLite");
     let scoped = db.for_tenant(TenantId::default());
     assert_resume_equivalence_for_backend(&scoped).await;
+}
+
+// ── Regression: concurrent sibling write-skew ────────────────────────────────
+
+/// Concurrent sibling commits must not produce write-skew.
+///
+/// Two sibling nodes (n_a and n_b) each hold their own work item and commit
+/// sequentially in the same test (simulating the losing-race scenario where B
+/// commits after A). Because the snapshot is computed IN-TX after the terminal
+/// event is inserted, B's snapshot sees A's committed event and must carry
+/// BOTH patches. A pre-tx snapshot computation would make B's snapshot miss
+/// A's patch (write-skew).
+#[tokio::test]
+async fn concurrent_sibling_commits_no_write_skew() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    // Enqueue two sibling nodes.
+    for node_id in ["n_a", "n_b"] {
+        db.enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: exec_id.clone(),
+            node_id: node_id.into(),
+            queue_type: "model".into(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: "default".into(),
+            lease_fence: 0,
+        })
+        .await
+        .unwrap();
+    }
+
+    // Two concurrent workers each claim one item.
+    let first = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let second = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Determine which claimed item belongs to which node.
+    let (item_a, item_b) = if first.node_id == "n_a" {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    // Worker A commits first with its patch.
+    let ev_a = Event::new(
+        exec_id.clone(),
+        0,
+        EventKind::NodeCompleted {
+            node_id: "n_a".into(),
+            output: json!("out_a"),
+            state_patch: json!({"key_a": "value_a"}),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+    );
+    db.commit_turn(item_a.id, item_a.lease_fence, ev_a, true)
+        .await
+        .expect("A commit must succeed");
+
+    // Worker B commits second with its own patch.
+    let ev_b = Event::new(
+        exec_id.clone(),
+        0,
+        EventKind::NodeCompleted {
+            node_id: "n_b".into(),
+            output: json!("out_b"),
+            state_patch: json!({"key_b": "value_b"}),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+    );
+    db.commit_turn(item_b.id, item_b.lease_fence, ev_b, true)
+        .await
+        .expect("B commit must succeed");
+
+    // The final snapshot must contain BOTH patches — no write-skew.
+    let snap = db
+        .latest_snapshot(&exec_id)
+        .await
+        .unwrap()
+        .expect("snapshot must exist after both commits");
+
+    assert_eq!(
+        snap.state.get("key_a"),
+        Some(&json!("value_a")),
+        "patch from n_a must be present in final snapshot (write-skew regression)"
+    );
+    assert_eq!(
+        snap.state.get("key_b"),
+        Some(&json!("value_b")),
+        "patch from n_b must be present in final snapshot (write-skew regression)"
+    );
+    assert!(
+        snap.completed_nodes.contains_key("n_a"),
+        "n_a must be in completed_nodes"
+    );
+    assert!(
+        snap.completed_nodes.contains_key("n_b"),
+        "n_b must be in completed_nodes"
+    );
 }

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -2,12 +2,20 @@
 //! (status, completed_nodes, active_nodes, last_sequence) survives
 //! write_snapshot → latest_snapshot intact.
 //!
-//! TDD: this test is written RED first (Snapshot has no such fields),
-//! then turns GREEN after the struct + migration + backend widening.
+//! Also: replay-equivalence — materialize() from a mid-run snapshot plus
+//! tail events must equal apply_events() over the full event log.
+//!
+//! TDD: tests are written RED first, then turn GREEN after the fix.
 
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
-use jamjet_state::{backend::StateBackend, snapshot::Snapshot, SqliteBackend};
+use jamjet_state::{
+    apply_events, materialize,
+    backend::StateBackend,
+    event::{Event, EventKind},
+    snapshot::Snapshot,
+    SqliteBackend,
+};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
@@ -89,4 +97,113 @@ async fn test_snapshot_new_compat_defaults() {
     assert_eq!(snap.status, WorkflowStatus::Pending);
     assert!(snap.completed_nodes.is_empty());
     assert!(snap.active_nodes.is_empty());
+}
+
+/// Replay-equivalence property: materialize() from a mid-run snapshot plus
+/// tail events must equal apply_events() over the full event log.
+///
+/// Sequence of events:
+///   1: WorkflowStarted
+///   2: NodeScheduled n1
+///   3: NodeCompleted n1  (patch {a:1})   ← snapshot cut here (K=3)
+///   4: NodeScheduled n2
+///   5: NodeCompleted n2  (patch {b:2})
+///
+/// The snapshot carries completed_nodes={n1:"r1"}, so after seeding from it
+/// and applying events 4-5, completed_nodes must contain BOTH n1 and n2.
+///
+/// RED before Task 2: materialize seeds derived maps empty, so n1 is dropped.
+#[tokio::test]
+async fn test_materialize_equals_full_apply_after_snapshot() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let initial = json!({});
+
+    // Append all five events; the backend auto-assigns sequences 1-5.
+    let kinds: Vec<EventKind> = vec![
+        EventKind::WorkflowStarted {
+            workflow_id: "test-wf".into(),
+            workflow_version: "1.0.0".into(),
+            initial_input: initial.clone(),
+        },
+        EventKind::NodeScheduled {
+            node_id: "n1".into(),
+            queue_type: "tool".into(),
+        },
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!("r1"),
+            state_patch: json!({"a": 1}),
+            duration_ms: 10,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+        EventKind::NodeScheduled {
+            node_id: "n2".into(),
+            queue_type: "tool".into(),
+        },
+        EventKind::NodeCompleted {
+            node_id: "n2".into(),
+            output: json!("r2"),
+            state_patch: json!({"b": 2}),
+            duration_ms: 10,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+        },
+    ];
+
+    for kind in &kinds {
+        db.append_event(Event::new(exec_id.clone(), 0, kind.clone()))
+            .await
+            .unwrap();
+    }
+
+    // Load events back from DB (sequences are now DB-assigned 1-5).
+    let all_events = db.get_events(&exec_id).await.unwrap();
+    assert_eq!(all_events.len(), 5, "expected 5 events in the log");
+
+    // Reference result: apply ALL events from the initial state.
+    let full = apply_events(initial.clone(), &all_events, &WorkflowStatus::Running);
+
+    // Snapshot cut at K=3 (WorkflowStarted + NodeScheduled n1 + NodeCompleted n1).
+    let state_at_k3 = apply_events(initial.clone(), &all_events[0..3], &WorkflowStatus::Running);
+    // state_at_k3.last_sequence == 3; completed_nodes = {n1: "r1"}
+    assert_eq!(state_at_k3.last_sequence, 3);
+    assert!(
+        state_at_k3.completed_nodes.contains_key("n1"),
+        "n1 must be in completed_nodes at K=3"
+    );
+
+    let snap = Snapshot::from_materialized(exec_id.clone(), &state_at_k3);
+    assert_eq!(snap.at_sequence, 3, "snapshot at_sequence must be 3");
+    db.write_snapshot(snap).await.unwrap();
+
+    // materialize() loads the snapshot (at_sequence=3) and replays events 4 & 5.
+    let mat = materialize(&db, &exec_id).await.unwrap();
+
+    assert_eq!(
+        mat.current_state, full.current_state,
+        "current_state mismatch after snapshot-seeded replay"
+    );
+    assert_eq!(mat.status, full.status, "status mismatch");
+    assert_eq!(
+        mat.completed_nodes, full.completed_nodes,
+        "completed_nodes mismatch: n1 must survive the snapshot cut"
+    );
+    assert_eq!(mat.active_nodes, full.active_nodes, "active_nodes mismatch");
+    assert_eq!(mat.last_sequence, full.last_sequence, "last_sequence mismatch");
 }

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -19,6 +19,7 @@ use jamjet_state::{
 use proptest::prelude::*;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use uuid::Uuid;
 
 async fn open_test_db() -> SqliteBackend {
@@ -933,4 +934,181 @@ async fn concurrent_sibling_commits_no_write_skew() {
         snap.completed_nodes.contains_key("n_b"),
         "n_b must be in completed_nodes"
     );
+}
+
+// ── Regression: genuinely concurrent sibling write-skew (real file + two tasks) ──
+
+/// Two tokio tasks race to commit sibling nodes to the SAME execution on a
+/// real file-backed SQLite database. A `Barrier` forces both tasks to reach
+/// the commit point before either proceeds, maximising BEGIN IMMEDIATE
+/// contention. Both commits must succeed (busy_timeout serialises them), and
+/// the final snapshot must contain BOTH patches — proving the in-tx snapshot
+/// computation closes the write-skew even under real concurrent writers.
+#[tokio::test]
+async fn concurrent_sibling_commits_race() {
+    let db_path =
+        std::path::PathBuf::from(format!("/tmp/jamjet-race-test-{}.sqlite3", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+
+    let db = Arc::new(
+        SqliteBackend::open(&url)
+            .await
+            .expect("failed to open temp SQLite file for race test"),
+    );
+
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    // Enqueue two sibling work items for the same execution.
+    for node_id in ["n_a", "n_b"] {
+        db.enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: exec_id.clone(),
+            node_id: node_id.into(),
+            queue_type: "model".into(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            tenant_id: "default".into(),
+            lease_fence: 0,
+        })
+        .await
+        .unwrap();
+    }
+
+    // Claim both items before spawning the tasks (both get distinct lease fences).
+    let first = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let second = db
+        .claim_work_item("worker-B", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+
+    let (item_a, item_b) = if first.node_id == "n_a" {
+        (first, second)
+    } else {
+        (second, first)
+    };
+
+    // Barrier ensures both tasks reach the commit call before either proceeds.
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+    // ── Task A ────────────────────────────────────────────────────────────────
+    let db_a = Arc::clone(&db);
+    let barrier_a = Arc::clone(&barrier);
+    let exec_id_a = exec_id.clone();
+    let handle_a = tokio::spawn(async move {
+        let ev = Event::new(
+            exec_id_a,
+            0,
+            EventKind::NodeCompleted {
+                node_id: "n_a".into(),
+                output: json!("out_a"),
+                state_patch: json!({"a": 1}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+            },
+        );
+        barrier_a.wait().await;
+        db_a.commit_turn(item_a.id, item_a.lease_fence, ev, true)
+            .await
+    });
+
+    // ── Task B ────────────────────────────────────────────────────────────────
+    let db_b = Arc::clone(&db);
+    let barrier_b = Arc::clone(&barrier);
+    let exec_id_b = exec_id.clone();
+    let handle_b = tokio::spawn(async move {
+        let ev = Event::new(
+            exec_id_b,
+            0,
+            EventKind::NodeCompleted {
+                node_id: "n_b".into(),
+                output: json!("out_b"),
+                state_patch: json!({"b": 2}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+            },
+        );
+        barrier_b.wait().await;
+        db_b.commit_turn(item_b.id, item_b.lease_fence, ev, true)
+            .await
+    });
+
+    // Both commits must succeed.
+    handle_a
+        .await
+        .expect("task A panicked")
+        .expect("task A commit_turn failed");
+    handle_b
+        .await
+        .expect("task B panicked")
+        .expect("task B commit_turn failed");
+
+    // Final state must carry BOTH patches.
+    let all_events = db.get_events(&exec_id).await.unwrap();
+    assert_eq!(all_events.len(), 2, "expected exactly 2 events");
+
+    let full = apply_events(json!({}), &all_events, &WorkflowStatus::Running);
+    assert!(
+        full.current_state.get("a").is_some(),
+        "patch a must be in current_state"
+    );
+    assert!(
+        full.current_state.get("b").is_some(),
+        "patch b must be in current_state"
+    );
+    assert!(
+        full.completed_nodes.contains_key("n_a"),
+        "n_a must be in completed_nodes"
+    );
+    assert!(
+        full.completed_nodes.contains_key("n_b"),
+        "n_b must be in completed_nodes"
+    );
+
+    // Latest snapshot (written by whichever task committed second) must also
+    // contain both patches — this is the write-skew invariant.
+    let snap = db
+        .latest_snapshot(&exec_id)
+        .await
+        .unwrap()
+        .expect("snapshot must exist after both concurrent commits");
+    assert!(
+        snap.state.get("a").is_some() && snap.state.get("b").is_some(),
+        "snapshot state must contain both patches (a={:?}, b={:?})",
+        snap.state.get("a"),
+        snap.state.get("b"),
+    );
+    assert!(
+        snap.completed_nodes.contains_key("n_a") && snap.completed_nodes.contains_key("n_b"),
+        "snapshot completed_nodes must contain both n_a and n_b"
+    );
+
+    // Cleanup.
+    drop(db);
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite3-wal"));
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite3-shm"));
 }

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -165,7 +165,7 @@ async fn commit_succeeds_with_correct_fence() {
         .unwrap();
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let seq = db
-        .commit_turn(item.id, item.lease_fence, event, None)
+        .commit_turn(item.id, item.lease_fence, event, false)
         .await
         .expect("commit with correct fence");
     assert!(seq >= 1);
@@ -209,7 +209,7 @@ async fn commit_fails_closed_with_stale_fence() {
 
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = db
-        .commit_turn(zombie.id, zombie.lease_fence, event, None)
+        .commit_turn(zombie.id, zombie.lease_fence, event, false)
         .await
         .expect_err("zombie commit must fail closed");
     assert!(matches!(err, StateBackendError::FenceLost(_)));
@@ -292,7 +292,7 @@ async fn fence_survives_lost_tail_failover() {
     // finds zero rows (current fence is the term-1 value) -> FenceLost.
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = promoted
-        .commit_turn(zombie_item_id, zombie_fence, ev, None)
+        .commit_turn(zombie_item_id, zombie_fence, ev, false)
         .await
         .expect_err("term-0 zombie fence must be rejected after promotion to term 1");
     assert!(
@@ -332,7 +332,7 @@ async fn term_pin_reopens_window_negative_control() {
     let wrong_fence = item.lease_fence + 1;
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = db
-        .commit_turn(item.id, wrong_fence, ev, None)
+        .commit_turn(item.id, wrong_fence, ev, false)
         .await
         .expect_err("fabricated wrong fence must be rejected");
     assert!(
@@ -386,7 +386,7 @@ async fn crash_before_commit_then_reclaim_yields_exactly_one_terminal() {
         .unwrap()
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
-    db.commit_turn(b.id, b.lease_fence, ev, None)
+    db.commit_turn(b.id, b.lease_fence, ev, false)
         .await
         .expect("worker-B commit must succeed after re-claim");
 
@@ -424,7 +424,7 @@ async fn commit_node_terminal_node_failed_settles_failed() {
         .unwrap();
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
     let seq = db
-        .commit_turn(item.id, item.lease_fence, event, None)
+        .commit_turn(item.id, item.lease_fence, event, false)
         .await
         .expect("commit NodeFailed with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -471,7 +471,7 @@ async fn commit_node_terminal_node_failed_stale_fence_fails_closed() {
     // Zombie tries to commit a NodeFailed with stale fence F1.
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
     let err = db
-        .commit_turn(zombie.id, zombie.lease_fence, event, None)
+        .commit_turn(zombie.id, zombie.lease_fence, event, false)
         .await
         .expect_err("zombie NodeFailed commit must fail closed");
     assert!(
@@ -507,7 +507,7 @@ async fn assert_fence_commit_succeeds(backend: &dyn StateBackend) {
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let seq = backend
-        .commit_turn(item.id, item.lease_fence, ev, None)
+        .commit_turn(item.id, item.lease_fence, ev, false)
         .await
         .expect("commit with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -535,7 +535,7 @@ async fn assert_fence_commit_fails_stale(backend: &dyn StateBackend) {
     let wrong_fence = item.lease_fence + 1; // fabricated — one higher than real
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = backend
-        .commit_turn(item.id, wrong_fence, ev, None)
+        .commit_turn(item.id, wrong_fence, ev, false)
         .await
         .expect_err("fabricated wrong fence must be rejected");
     assert!(
@@ -602,7 +602,7 @@ async fn assert_fence_node_failed_succeeds(backend: &dyn StateBackend) {
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_failed("n1"));
     let seq = backend
-        .commit_turn(item.id, item.lease_fence, ev, None)
+        .commit_turn(item.id, item.lease_fence, ev, false)
         .await
         .expect("NodeFailed commit with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -635,7 +635,7 @@ async fn assert_fence_node_failed_stale_fails(backend: &dyn StateBackend) {
     let wrong_fence = item.lease_fence + 1;
     let ev = Event::new(eid.clone(), 0, node_failed("n1"));
     let err = backend
-        .commit_turn(item.id, wrong_fence, ev, None)
+        .commit_turn(item.id, wrong_fence, ev, false)
         .await
         .expect_err("stale-fence NodeFailed must be rejected");
     assert!(

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -165,7 +165,7 @@ async fn commit_succeeds_with_correct_fence() {
         .unwrap();
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let seq = db
-        .commit_node_terminal(item.id, item.lease_fence, event)
+        .commit_turn(item.id, item.lease_fence, event, None)
         .await
         .expect("commit with correct fence");
     assert!(seq >= 1);
@@ -209,7 +209,7 @@ async fn commit_fails_closed_with_stale_fence() {
 
     let event = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = db
-        .commit_node_terminal(zombie.id, zombie.lease_fence, event)
+        .commit_turn(zombie.id, zombie.lease_fence, event, None)
         .await
         .expect_err("zombie commit must fail closed");
     assert!(matches!(err, StateBackendError::FenceLost(_)));
@@ -292,7 +292,7 @@ async fn fence_survives_lost_tail_failover() {
     // finds zero rows (current fence is the term-1 value) -> FenceLost.
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = promoted
-        .commit_node_terminal(zombie_item_id, zombie_fence, ev)
+        .commit_turn(zombie_item_id, zombie_fence, ev, None)
         .await
         .expect_err("term-0 zombie fence must be rejected after promotion to term 1");
     assert!(
@@ -332,7 +332,7 @@ async fn term_pin_reopens_window_negative_control() {
     let wrong_fence = item.lease_fence + 1;
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = db
-        .commit_node_terminal(item.id, wrong_fence, ev)
+        .commit_turn(item.id, wrong_fence, ev, None)
         .await
         .expect_err("fabricated wrong fence must be rejected");
     assert!(
@@ -386,7 +386,7 @@ async fn crash_before_commit_then_reclaim_yields_exactly_one_terminal() {
         .unwrap()
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
-    db.commit_node_terminal(b.id, b.lease_fence, ev)
+    db.commit_turn(b.id, b.lease_fence, ev, None)
         .await
         .expect("worker-B commit must succeed after re-claim");
 
@@ -424,7 +424,7 @@ async fn commit_node_terminal_node_failed_settles_failed() {
         .unwrap();
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
     let seq = db
-        .commit_node_terminal(item.id, item.lease_fence, event)
+        .commit_turn(item.id, item.lease_fence, event, None)
         .await
         .expect("commit NodeFailed with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -471,7 +471,7 @@ async fn commit_node_terminal_node_failed_stale_fence_fails_closed() {
     // Zombie tries to commit a NodeFailed with stale fence F1.
     let event = Event::new(eid.clone(), 0, node_failed("n1"));
     let err = db
-        .commit_node_terminal(zombie.id, zombie.lease_fence, event)
+        .commit_turn(zombie.id, zombie.lease_fence, event, None)
         .await
         .expect_err("zombie NodeFailed commit must fail closed");
     assert!(
@@ -507,7 +507,7 @@ async fn assert_fence_commit_succeeds(backend: &dyn StateBackend) {
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let seq = backend
-        .commit_node_terminal(item.id, item.lease_fence, ev)
+        .commit_turn(item.id, item.lease_fence, ev, None)
         .await
         .expect("commit with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -535,7 +535,7 @@ async fn assert_fence_commit_fails_stale(backend: &dyn StateBackend) {
     let wrong_fence = item.lease_fence + 1; // fabricated — one higher than real
     let ev = Event::new(eid.clone(), 0, node_completed("n1"));
     let err = backend
-        .commit_node_terminal(item.id, wrong_fence, ev)
+        .commit_turn(item.id, wrong_fence, ev, None)
         .await
         .expect_err("fabricated wrong fence must be rejected");
     assert!(
@@ -602,7 +602,7 @@ async fn assert_fence_node_failed_succeeds(backend: &dyn StateBackend) {
         .unwrap();
     let ev = Event::new(eid.clone(), 0, node_failed("n1"));
     let seq = backend
-        .commit_node_terminal(item.id, item.lease_fence, ev)
+        .commit_turn(item.id, item.lease_fence, ev, None)
         .await
         .expect("NodeFailed commit with correct fence must succeed");
     assert!(seq >= 1, "sequence must be at least 1");
@@ -635,7 +635,7 @@ async fn assert_fence_node_failed_stale_fails(backend: &dyn StateBackend) {
     let wrong_fence = item.lease_fence + 1;
     let ev = Event::new(eid.clone(), 0, node_failed("n1"));
     let err = backend
-        .commit_node_terminal(item.id, wrong_fence, ev)
+        .commit_turn(item.id, wrong_fence, ev, None)
         .await
         .expect_err("stale-fence NodeFailed must be rejected");
     assert!(

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -11,7 +11,6 @@ use jamjet_state::approvals::NodeApprovalStatus;
 use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
 use jamjet_state::event::EventKind;
-use jamjet_state::{apply_events_seeded, materialize, MaterializedState, Snapshot};
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -310,32 +309,14 @@ impl Worker {
                         provenance: None,
                     },
                 );
-                // Compute the post-turn snapshot by folding THIS turn's terminal
-                // event onto the materialized state that precedes it.
-                // `materialize` reflects state before this event (it is committed
-                // inside commit_turn). Folding the terminal event onto `prior` gives
-                // us the exact state that will exist after the commit, without a
-                // second DB round-trip.
-                //
-                // Note: `terminal.sequence` is 0 here; `commit_turn` overwrites
-                // `snap.at_sequence` and `snap.last_sequence` with the real
-                // assigned sequence, so the worker's 0 does not corrupt the key.
-                let snap = {
-                    let prior = materialize(self.backend.as_ref(), &execution_id)
-                        .await
-                        .unwrap_or_else(|_| MaterializedState {
-                            current_state: serde_json::json!({}),
-                            status: jamjet_core::workflow::WorkflowStatus::Running,
-                            completed_nodes: std::collections::HashMap::new(),
-                            active_nodes: std::collections::HashSet::new(),
-                            last_sequence: 0,
-                        });
-                    let next = apply_events_seeded(prior, &[terminal.clone()]);
-                    Some(Snapshot::from_materialized(execution_id.clone(), &next))
-                };
+                // Snapshot is computed inside commit_turn's BEGIN IMMEDIATE
+                // transaction — after the terminal event is inserted — by reading
+                // the latest snapshot + events since it and folding with
+                // apply_events_seeded. This avoids write-skew from concurrent
+                // sibling commits each seeing a stale pre-tx state.
                 match self
                     .backend
-                    .commit_turn(item_id, lease_fence, terminal, snap)
+                    .commit_turn(item_id, lease_fence, terminal, true)
                     .await
                 {
                     Ok(_) => {
@@ -363,7 +344,7 @@ impl Worker {
                 );
                 match self
                     .backend
-                    .commit_turn(item_id, lease_fence, terminal, None)
+                    .commit_turn(item_id, lease_fence, terminal, false)
                     .await
                 {
                     Ok(_) => {

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -311,7 +311,7 @@ impl Worker {
                 );
                 match self
                     .backend
-                    .commit_node_terminal(item_id, lease_fence, terminal)
+                    .commit_turn(item_id, lease_fence, terminal, None)
                     .await
                 {
                     Ok(_) => {
@@ -339,7 +339,7 @@ impl Worker {
                 );
                 match self
                     .backend
-                    .commit_node_terminal(item_id, lease_fence, terminal)
+                    .commit_turn(item_id, lease_fence, terminal, None)
                     .await
                 {
                     Ok(_) => {

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -11,6 +11,7 @@ use jamjet_state::approvals::NodeApprovalStatus;
 use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
 use jamjet_state::event::EventKind;
+use jamjet_state::{apply_events_seeded, materialize, MaterializedState, Snapshot};
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -294,7 +295,7 @@ impl Worker {
 
                 let terminal = jamjet_state::Event::new(
                     execution_id.clone(),
-                    0, // sequence assigned atomically inside commit_node_terminal
+                    0, // sequence assigned atomically inside commit_turn
                     EventKind::NodeCompleted {
                         node_id: node_id.clone(),
                         output: exec_result.output,
@@ -309,9 +310,32 @@ impl Worker {
                         provenance: None,
                     },
                 );
+                // Compute the post-turn snapshot by folding THIS turn's terminal
+                // event onto the materialized state that precedes it.
+                // `materialize` reflects state before this event (it is committed
+                // inside commit_turn). Folding the terminal event onto `prior` gives
+                // us the exact state that will exist after the commit, without a
+                // second DB round-trip.
+                //
+                // Note: `terminal.sequence` is 0 here; `commit_turn` overwrites
+                // `snap.at_sequence` and `snap.last_sequence` with the real
+                // assigned sequence, so the worker's 0 does not corrupt the key.
+                let snap = {
+                    let prior = materialize(self.backend.as_ref(), &execution_id)
+                        .await
+                        .unwrap_or_else(|_| MaterializedState {
+                            current_state: serde_json::json!({}),
+                            status: jamjet_core::workflow::WorkflowStatus::Running,
+                            completed_nodes: std::collections::HashMap::new(),
+                            active_nodes: std::collections::HashSet::new(),
+                            last_sequence: 0,
+                        });
+                    let next = apply_events_seeded(prior, &[terminal.clone()]);
+                    Some(Snapshot::from_materialized(execution_id.clone(), &next))
+                };
                 match self
                     .backend
-                    .commit_turn(item_id, lease_fence, terminal, None)
+                    .commit_turn(item_id, lease_fence, terminal, snap)
                     .await
                 {
                     Ok(_) => {
@@ -1061,6 +1085,50 @@ mod tests {
         assert_eq!(
             failed_count, 1,
             "expected exactly one NodeFailed event; got {failed_count}"
+        );
+    }
+
+    /// After a successful node completion the worker must write a per-turn
+    /// snapshot through `commit_turn`.  The snapshot must (a) record the
+    /// just-completed node in `completed_nodes` and (b) carry the real
+    /// `at_sequence` assigned to the `NodeCompleted` event.
+    #[tokio::test]
+    async fn success_writes_snapshot_with_completed_node() {
+        let (backend, eid) = setup_backend().await;
+        let worker = make_worker(Arc::clone(&backend));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        worker.execute_item(item).await.unwrap();
+
+        // Snapshot must exist.
+        let snap = backend
+            .latest_snapshot(&eid)
+            .await
+            .unwrap()
+            .expect("snapshot must be Some after successful node completion");
+
+        // n1 must appear in completed_nodes.
+        assert!(
+            snap.completed_nodes.contains_key("n1"),
+            "snapshot must record n1 in completed_nodes; got {:?}",
+            snap.completed_nodes.keys().collect::<Vec<_>>()
+        );
+
+        // at_sequence must match the NodeCompleted event's sequence.
+        let events = backend.get_events(&eid).await.unwrap();
+        let completed_seq = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .map(|e| e.sequence)
+            .expect("NodeCompleted event must exist");
+        assert_eq!(
+            snap.at_sequence, completed_seq,
+            "snapshot.at_sequence must equal the NodeCompleted event's sequence"
         );
     }
 


### PR DESCRIPTION
## What

Sub-plan 2b of the durable engine (ADK Track 2). The engine now writes an authoritative snapshot of the full materialized state every turn, in the same fenced transaction as the node settle + terminal event, so resume is O(snapshot + tail) and budget/loop state survives a fresh process.

- `Snapshot` widened to persist the full materialized state (status, completed_nodes, active_nodes, last_sequence), not just current_state. Migration 0005.
- `materialize` / `apply_events_seeded` now seed the fold from the snapshot's full state. Without this, a node that completed before the snapshot vanished from completed_nodes after resume.
- `commit_node_terminal` becomes `commit_turn(item_id, lease_fence, terminal_event, write_snapshot)`, which writes the snapshot inside the fenced BEGIN IMMEDIATE transaction. A stale fence still writes nothing.
- The worker writes a snapshot on every successful turn.

## A correctness bug caught in review (and fixed)

The first cut computed the snapshot from a `materialize()` read taken outside the transaction. The scheduler runs up to 16 concurrent nodes per execution, so two sibling commits could both read the same prior state and the higher-sequence snapshot would silently shadow the other's patch, completed-node entry, and budget, permanently, while last_sequence stayed consistent enough to hide it. The fix computes the snapshot inside the fence from committed state (BEGIN IMMEDIATE serializes writers, so each sibling folds onto the other's committed snapshot). Because a snapshot is written every turn, the in-transaction tail is O(1) events.

## Tests

`cargo test --workspace` green. A replay-equivalence proptest sweeps every snapshot cut and asserts resume-from-snapshot equals resume-from-origin on current_state, status, completed_nodes, and active_nodes. A fresh-process SQLite resume test reopens the file and checks byte-identical state plus budget survival. A real-concurrency test races two sibling commits on a shared backend and asserts both patches survive. Cross-backend coverage on all three backends.

## Reviews

Two adversarial passes. The first caught the concurrent write-skew (Critical); the fix moved snapshot computation into the fence. The re-review confirmed the fix closes the race and introduced no new bug; its two findings (a status-default inconsistency and strengthening the concurrency test) are addressed.

## Scope

Pruning pre-snapshot events is the next sub-plan (segmentation, 2g); the snapshot table grows one row per turn until then. The idempotency cache is 2c.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow runs can now persist richer snapshot state, including status, completed steps, active steps, and the latest event sequence.
  * Successful and failed turns can now optionally update a snapshot at commit time, improving resumability and recovery.

* **Bug Fixes**
  * Improved snapshot replay so resumed runs reflect the latest state more accurately.
  * Strengthened fencing behavior to prevent stale commits from writing extra events or snapshots.

* **Tests**
  * Added coverage for snapshot round-tripping, replay consistency, and concurrent commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->