### PR TITLE
feat(state,worker): exactly-once idempotency cache + replay guard (durable engine, Track 2c)

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -879,6 +879,7 @@ async fn complete_work_item(
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         );
         backend.append_event(event).await?;

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -678,6 +678,7 @@ mod tests {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         }
     }
 

--- a/runtime/state/migrations/0006_tool_effects.sql
+++ b/runtime/state/migrations/0006_tool_effects.sql
@@ -1,6 +1,7 @@
 -- Migration 0006: per-node idempotency cache. A node fire records its result
--- keyed by H(run, segment, step, input_hash); a replay/reclaim reads it back
--- and skips re-firing the side effect.
+-- keyed by content_hash({run, segment, step, node, input_hash}); a replay/reclaim
+-- reads it back and skips re-firing the side effect. Including `node` in the key
+-- prevents cross-node key collisions when sibling nodes share the same step count.
 CREATE TABLE IF NOT EXISTS tool_effects (
     idempotency_key TEXT PRIMARY KEY,
     execution_id    TEXT NOT NULL,

--- a/runtime/state/migrations/0006_tool_effects.sql
+++ b/runtime/state/migrations/0006_tool_effects.sql
@@ -1,0 +1,12 @@
+-- Migration 0006: per-node idempotency cache. A node fire records its result
+-- keyed by H(run, segment, step, input_hash); a replay/reclaim reads it back
+-- and skips re-firing the side effect.
+CREATE TABLE IF NOT EXISTS tool_effects (
+    idempotency_key TEXT PRIMARY KEY,
+    execution_id    TEXT NOT NULL,
+    node_id         TEXT NOT NULL,
+    result_json     TEXT NOT NULL,
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
+    recorded_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tool_effects_execution ON tool_effects(execution_id);

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -126,6 +126,18 @@ pub trait StateBackend: Send + Sync {
     /// Load the latest snapshot for an execution.
     async fn latest_snapshot(&self, execution_id: &ExecutionId) -> BackendResult<Option<Snapshot>>;
 
+    // ── Idempotency cache (tool_effects) ─────────────────────────────────────
+
+    /// Look up a previously recorded node result by its idempotency key.
+    ///
+    /// Returns the `result_json` value — `{output, state_patch, duration_ms,
+    /// gen_ai_system, gen_ai_model, input_tokens, output_tokens, finish_reason}`
+    /// — if the key exists, or `None` if it has not been recorded yet.
+    ///
+    /// Recorded atomically inside `commit_turn` when the terminal event is a
+    /// `NodeCompleted` with `idempotency_key = Some(k)`.
+    async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>>;
+
     // ── Queue (simple Postgres/SQLite backed queue in v1) ────────────────
 
     /// Enqueue a work item for execution.

--- a/runtime/state/src/event.rs
+++ b/runtime/state/src/event.rs
@@ -109,7 +109,11 @@ pub enum EventKind {
         /// Provenance metadata for research traceability.
         #[serde(skip_serializing_if = "Option::is_none")]
         provenance: Option<Box<ProvenanceMetadata>>,
-        /// Deterministic idempotency key for this node fire: H(run,segment,step,input_hash).
+        /// Deterministic idempotency key for this node fire:
+        /// `content_hash({run, segment, step, node, input_hash})`.
+        /// Including `node` in the key prevents cross-node collisions when two
+        /// different nodes share the same `(run, segment, step, input_hash)` —
+        /// e.g. sibling nodes in the same segment at the same step count.
         /// When set, `commit_turn` records the result in `tool_effects` atomically.
         /// The worker reads it back before re-firing a reclaimed node (Task 2).
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/runtime/state/src/event.rs
+++ b/runtime/state/src/event.rs
@@ -109,6 +109,11 @@ pub enum EventKind {
         /// Provenance metadata for research traceability.
         #[serde(skip_serializing_if = "Option::is_none")]
         provenance: Option<Box<ProvenanceMetadata>>,
+        /// Deterministic idempotency key for this node fire: H(run,segment,step,input_hash).
+        /// When set, `commit_turn` records the result in `tool_effects` atomically.
+        /// The worker reads it back before re-firing a reclaimed node (Task 2).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        idempotency_key: Option<String>,
     },
     NodeFailed {
         node_id: NodeId,

--- a/runtime/state/src/materializer.rs
+++ b/runtime/state/src/materializer.rs
@@ -227,6 +227,7 @@ mod tests {
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         )];
         let mat = apply_events(base, &events, &WorkflowStatus::Running);
@@ -252,6 +253,7 @@ mod tests {
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         )];
         let mat = apply_events(base, &events, &WorkflowStatus::Running);
@@ -291,6 +293,7 @@ mod tests {
                     finish_reason: None,
                     cost_usd: None,
                     provenance: None,
+                    idempotency_key: None,
                 },
             ),
             make_event(

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -71,6 +71,13 @@ impl InMemoryBackend {
     pub fn set_store_term_at_least(&self, term: i64) -> i64 {
         self.store_term.fetch_max(term, Ordering::SeqCst).max(term)
     }
+
+    /// Insert a key directly into the idempotency cache.
+    /// Only available on this in-memory (dev/test) backend; SQLite backends
+    /// record effects exclusively via `commit_turn`.
+    pub fn seed_tool_effect_for_test(&self, key: String, value: serde_json::Value) {
+        self.tool_effects.insert(key, value);
+    }
 }
 
 impl Default for InMemoryBackend {

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -38,6 +38,9 @@ pub struct InMemoryBackend {
     lease_epochs: DashMap<WorkItemId, i64>,
     /// Store failover generation (settable to simulate promotion).
     store_term: AtomicI64,
+    /// Idempotency cache: idempotency_key -> result_json.
+    /// Mirrors the `tool_effects` table in the SQLite backends.
+    tool_effects: DashMap<String, serde_json::Value>,
 }
 
 impl InMemoryBackend {
@@ -54,6 +57,7 @@ impl InMemoryBackend {
             next_sequence: AtomicI64::new(1),
             lease_epochs: DashMap::new(),
             store_term: AtomicI64::new(0),
+            tool_effects: DashMap::new(),
         }
     }
 
@@ -251,6 +255,12 @@ impl StateBackend for InMemoryBackend {
             .and_then(|r| r.value().iter().max_by_key(|s| s.at_sequence).cloned()))
     }
 
+    // ── Idempotency cache ─────────────────────────────────────────────────
+
+    async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
+        Ok(self.tool_effects.get(key).map(|r| r.value().clone()))
+    }
+
     // ── Work queue ───────────────────────────────────────────────────
 
     async fn enqueue_work_item(&self, item: WorkItem) -> BackendResult<WorkItemId> {
@@ -342,9 +352,47 @@ impl StateBackend for InMemoryBackend {
         self.work_items.remove(&item_id);
         let seq = self.next_sequence.fetch_add(1, Ordering::SeqCst);
         let eid = terminal_event.execution_id.clone();
+
+        // Extract idempotency info BEFORE moving terminal_event into the event vec.
+        // INSERT OR IGNORE semantics: use `entry(...).or_insert(...)` to keep the
+        // first recorded result if the key is already present.
+        let idem_effect: Option<(String, serde_json::Value)> = if let EventKind::NodeCompleted {
+            ref output,
+            ref state_patch,
+            duration_ms,
+            ref gen_ai_system,
+            ref gen_ai_model,
+            input_tokens,
+            output_tokens,
+            ref finish_reason,
+            idempotency_key: Some(ref key),
+            ..
+        } = terminal_event.kind
+        {
+            let result_json = serde_json::json!({
+                "output": output,
+                "state_patch": state_patch,
+                "duration_ms": duration_ms,
+                "gen_ai_system": gen_ai_system,
+                "gen_ai_model": gen_ai_model,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "finish_reason": finish_reason,
+            });
+            Some((key.clone(), result_json))
+        } else {
+            None
+        };
+
         let mut ev = terminal_event;
         ev.sequence = seq;
         self.events.entry(eid.clone()).or_default().push(ev);
+
+        // Record the idempotency effect if one was extracted above.
+        if let Some((key, result_json)) = idem_effect {
+            self.tool_effects.entry(key).or_insert(result_json);
+        }
+
         if write_snapshot {
             // Mirror the SQLite in-tx pattern: read latest snapshot (or seed from
             // initial_input), fold all events since it (including the one just

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -668,6 +668,23 @@ impl StateBackend for SqliteBackend {
         }))
     }
 
+    // ── Idempotency cache ─────────────────────────────────────────────────
+
+    async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
+        let row = sqlx::query("SELECT result_json FROM tool_effects WHERE idempotency_key = ?")
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+
+        let Some(row) = row else { return Ok(None) };
+
+        let result_json: serde_json::Value =
+            serde_json::from_str(row.try_get::<&str, _>("result_json").map_err(map_db_err)?)
+                .map_err(StateBackendError::Serialization)?;
+        Ok(Some(result_json))
+    }
+
     // ── Work item queue ───────────────────────────────────────────────────
 
     #[instrument(skip(self, item), fields(execution_id = %item.execution_id, node_id = %item.node_id))]
@@ -944,6 +961,49 @@ impl StateBackend for SqliteBackend {
         .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+
+        // 2b) If the terminal event is NodeCompleted with an idempotency key,
+        //     record the result in tool_effects in the SAME transaction.
+        //     INSERT OR IGNORE — a concurrent winner already recorded it.
+        if let EventKind::NodeCompleted {
+            node_id: ref nc_node_id,
+            ref output,
+            ref state_patch,
+            duration_ms,
+            ref gen_ai_system,
+            ref gen_ai_model,
+            input_tokens,
+            output_tokens,
+            ref finish_reason,
+            idempotency_key: Some(ref idem_key),
+            ..
+        } = terminal_event.kind
+        {
+            let result_json = serde_json::json!({
+                "output": output,
+                "state_patch": state_patch,
+                "duration_ms": duration_ms,
+                "gen_ai_system": gen_ai_system,
+                "gen_ai_model": gen_ai_model,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "finish_reason": finish_reason,
+            });
+            let result_json_str = serde_json::to_string(&result_json)?;
+            sqlx::query(
+                r#"INSERT OR IGNORE INTO tool_effects
+                   (idempotency_key, execution_id, node_id, result_json, tenant_id, recorded_at)
+                   VALUES (?, ?, ?, ?, 'default', ?)"#,
+            )
+            .bind(idem_key)
+            .bind(&execution_id)
+            .bind(nc_node_id.as_str())
+            .bind(&result_json_str)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
 
         // 3) Optionally compute and write the snapshot IN-TX from committed state.
         //    BEGIN IMMEDIATE serializes writers, so this read sees a fully-committed

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -592,6 +592,26 @@ impl StateBackend for TenantScopedSqliteBackend {
         }))
     }
 
+    // ── Idempotency cache ─────────────────────────────────────────────────
+
+    async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
+        let row = sqlx::query(
+            "SELECT result_json FROM tool_effects WHERE idempotency_key = ? AND tenant_id = ?",
+        )
+        .bind(key)
+        .bind(&self.tenant_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        let Some(row) = row else { return Ok(None) };
+
+        let result_json: serde_json::Value =
+            serde_json::from_str(row.try_get::<&str, _>("result_json").map_err(map_db_err)?)
+                .map_err(StateBackendError::Serialization)?;
+        Ok(Some(result_json))
+    }
+
     // ── Work item queue ───────────────────────────────────────────────────
 
     #[instrument(skip(self, item), fields(tenant = %self.tenant_id, execution_id = %item.execution_id))]
@@ -874,6 +894,50 @@ impl StateBackend for TenantScopedSqliteBackend {
         .execute(&mut *tx)
         .await
         .map_err(map_db_err)?;
+
+        // 2b) If the terminal event is NodeCompleted with an idempotency key,
+        //     record the result in tool_effects in the SAME transaction (tenant-scoped).
+        //     INSERT OR IGNORE — a concurrent winner already recorded it.
+        if let EventKind::NodeCompleted {
+            node_id: ref nc_node_id,
+            ref output,
+            ref state_patch,
+            duration_ms,
+            ref gen_ai_system,
+            ref gen_ai_model,
+            input_tokens,
+            output_tokens,
+            ref finish_reason,
+            idempotency_key: Some(ref idem_key),
+            ..
+        } = terminal_event.kind
+        {
+            let result_json = serde_json::json!({
+                "output": output,
+                "state_patch": state_patch,
+                "duration_ms": duration_ms,
+                "gen_ai_system": gen_ai_system,
+                "gen_ai_model": gen_ai_model,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "finish_reason": finish_reason,
+            });
+            let result_json_str = serde_json::to_string(&result_json)?;
+            sqlx::query(
+                r#"INSERT OR IGNORE INTO tool_effects
+                   (idempotency_key, execution_id, node_id, result_json, tenant_id, recorded_at)
+                   VALUES (?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(idem_key)
+            .bind(&execution_id)
+            .bind(nc_node_id.as_str())
+            .bind(&result_json_str)
+            .bind(&self.tenant_id.0)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
 
         // Optionally compute and write the snapshot IN-TX from committed state (tenant-scoped).
         // BEGIN IMMEDIATE serializes writers — no concurrent write-skew.

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -149,6 +149,7 @@ async fn test_materialize_equals_full_apply_after_snapshot() {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
         EventKind::NodeScheduled {
             node_id: "n2".into(),
@@ -166,6 +167,7 @@ async fn test_materialize_equals_full_apply_after_snapshot() {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
     ];
 
@@ -246,6 +248,7 @@ fn node_completed_kind(node: &str) -> EventKind {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     }
 }
 
@@ -408,6 +411,7 @@ fn nc_kind_for_spec(ni: usize, ki: usize, pv: i64) -> EventKind {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     }
 }
 
@@ -520,6 +524,7 @@ async fn fresh_process_sqlite_resume() {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     };
 
     db.enqueue_work_item(WorkItem {
@@ -562,6 +567,7 @@ async fn fresh_process_sqlite_resume() {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     };
 
     db.enqueue_work_item(WorkItem {
@@ -604,6 +610,7 @@ async fn fresh_process_sqlite_resume() {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     };
 
     db.enqueue_work_item(WorkItem {
@@ -728,6 +735,7 @@ async fn assert_resume_equivalence_for_backend(backend: &dyn StateBackend) {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
         EventKind::NodeScheduled {
             node_id: "n2".into(),
@@ -745,6 +753,7 @@ async fn assert_resume_equivalence_for_backend(backend: &dyn StateBackend) {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
     ];
 
@@ -881,6 +890,7 @@ async fn concurrent_sibling_commits_no_write_skew() {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
     );
     db.commit_turn(item_a.id, item_a.lease_fence, ev_a, true)
@@ -903,6 +913,7 @@ async fn concurrent_sibling_commits_no_write_skew() {
             finish_reason: None,
             cost_usd: None,
             provenance: None,
+            idempotency_key: None,
         },
     );
     db.commit_turn(item_b.id, item_b.lease_fence, ev_b, true)
@@ -1022,6 +1033,7 @@ async fn concurrent_sibling_commits_race() {
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         );
         barrier_a.wait().await;
@@ -1049,6 +1061,7 @@ async fn concurrent_sibling_commits_race() {
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         );
         barrier_b.wait().await;

--- a/runtime/state/tests/durability.rs
+++ b/runtime/state/tests/durability.rs
@@ -139,6 +139,7 @@ async fn test_crash_recovery_from_event_log() {
                     finish_reason: None,
                     cost_usd: None,
                     provenance: None,
+                    idempotency_key: None,
                 },
             ),
             Event::new(
@@ -213,6 +214,7 @@ async fn test_recovery_with_snapshot() {
                     finish_reason: None,
                     cost_usd: None,
                     provenance: None,
+                    idempotency_key: None,
                 },
             );
             db.append_event(event).await.unwrap();
@@ -242,6 +244,7 @@ async fn test_recovery_with_snapshot() {
                 finish_reason: None,
                 cost_usd: None,
                 provenance: None,
+                idempotency_key: None,
             },
         ))
         .await

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -138,6 +138,7 @@ fn node_completed(node: &str) -> EventKind {
         finish_reason: None,
         cost_usd: None,
         provenance: None,
+        idempotency_key: None,
     }
 }
 

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -1,0 +1,436 @@
+//! Tests for the `tool_effects` idempotency cache.
+//!
+//! `commit_turn` records a `tool_effects` row atomically when the terminal
+//! event is `NodeCompleted` with `idempotency_key = Some(_)`.
+//! `get_tool_effect(key)` returns the recorded result JSON or `None`.
+//!
+//! TDD: test was written RED (before the field and trait method existed),
+//! turned GREEN after adding `idempotency_key` to `NodeCompleted` and
+//! implementing `get_tool_effect` + the commit_turn recording.
+
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::tenant::{Tenant, TenantStatus};
+use jamjet_state::{
+    backend::{StateBackend, WorkItem},
+    Event, EventKind, InMemoryBackend, SqliteBackend, TenantId,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+async fn open_test_db() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite")
+}
+
+/// Register a tenant so FK constraints in workflow_executions are satisfied.
+async fn register_tenant(db: &SqliteBackend, id: &str) {
+    let now = Utc::now();
+    // The "default" tenant is pre-seeded by migrations; only register non-default ones.
+    if id == "default" {
+        return;
+    }
+    db.for_tenant(TenantId::default())
+        .create_tenant(Tenant {
+            id: TenantId::from(id),
+            name: id.to_string(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("failed to register tenant");
+}
+
+fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "test-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({}),
+        current_state: json!({}),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+    }
+}
+
+fn sample_item(execution_id: &ExecutionId, node_id: &str) -> WorkItem {
+    WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: execution_id.clone(),
+        node_id: node_id.into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    }
+}
+
+// ── SQLite backend tests ─────────────────────────────────────────────────────
+
+/// `commit_turn` with `NodeCompleted { idempotency_key: Some("k1") }` records
+/// a tool_effect; `get_tool_effect("k1")` returns the result JSON with the
+/// expected output and state_patch; `get_tool_effect("nope")` returns None.
+#[tokio::test]
+async fn sqlite_tool_effect_round_trip() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    db.enqueue_work_item(sample_item(&exec_id, "n1"))
+        .await
+        .unwrap();
+
+    let item = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimed");
+
+    let event = Event::new(
+        exec_id.clone(),
+        0, // sequence assigned inside commit_turn
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!({"result": "hello"}),
+            state_patch: json!({"key": "val"}),
+            duration_ms: 42,
+            gen_ai_system: Some("anthropic".into()),
+            gen_ai_model: Some("claude-3".into()),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+            finish_reason: Some("stop".into()),
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: Some("k1".into()),
+        },
+    );
+
+    db.commit_turn(item.id, item.lease_fence, event, false)
+        .await
+        .expect("commit_turn must succeed");
+
+    // k1 must be recorded with the correct result JSON fields.
+    let recorded = db
+        .get_tool_effect("k1")
+        .await
+        .expect("get_tool_effect must not error");
+    assert!(recorded.is_some(), "expected Some for key k1");
+    let val = recorded.unwrap();
+    assert_eq!(val["output"], json!({"result": "hello"}), "output mismatch");
+    assert_eq!(
+        val["state_patch"],
+        json!({"key": "val"}),
+        "state_patch mismatch"
+    );
+    assert_eq!(val["duration_ms"], json!(42u64), "duration_ms mismatch");
+    assert_eq!(
+        val["gen_ai_system"],
+        json!("anthropic"),
+        "gen_ai_system mismatch"
+    );
+    assert_eq!(
+        val["gen_ai_model"],
+        json!("claude-3"),
+        "gen_ai_model mismatch"
+    );
+    assert_eq!(val["input_tokens"], json!(10u64), "input_tokens mismatch");
+    assert_eq!(val["output_tokens"], json!(20u64), "output_tokens mismatch");
+    assert_eq!(
+        val["finish_reason"],
+        json!("stop"),
+        "finish_reason mismatch"
+    );
+
+    // Unknown key must return None.
+    let none_val = db
+        .get_tool_effect("nope")
+        .await
+        .expect("get_tool_effect must not error for unknown key");
+    assert!(none_val.is_none(), "expected None for unknown key");
+}
+
+/// A NodeCompleted WITHOUT an idempotency_key records NO tool_effect row.
+#[tokio::test]
+async fn sqlite_no_key_no_effect_recorded() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    db.enqueue_work_item(sample_item(&exec_id, "n1"))
+        .await
+        .unwrap();
+
+    let item = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimed");
+
+    let event = Event::new(
+        exec_id.clone(),
+        0,
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!("out"),
+            state_patch: json!({}),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: None, // no key
+        },
+    );
+
+    db.commit_turn(item.id, item.lease_fence, event, false)
+        .await
+        .expect("commit_turn must succeed without idempotency key");
+
+    // Nothing recorded for any key.
+    let none_val = db.get_tool_effect("anything").await.unwrap();
+    assert!(
+        none_val.is_none(),
+        "no tool_effect should be recorded when idempotency_key is None"
+    );
+}
+
+/// Concurrent winner: INSERT OR IGNORE means a second commit with the SAME key
+/// keeps the first result intact (the second insert is silently dropped).
+#[tokio::test]
+async fn sqlite_concurrent_winner_insert_or_ignore() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    // Enqueue two items for the same key.
+    for node in ["n1", "n2"] {
+        db.enqueue_work_item(sample_item(&exec_id, node))
+            .await
+            .unwrap();
+    }
+
+    let item1 = db
+        .claim_work_item("w1", &["model"])
+        .await
+        .unwrap()
+        .expect("item1 must be claimed");
+    let item2 = db
+        .claim_work_item("w2", &["model"])
+        .await
+        .unwrap()
+        .expect("item2 must be claimed");
+
+    // First commit records output "first".
+    db.commit_turn(
+        item1.id,
+        item1.lease_fence,
+        Event::new(
+            exec_id.clone(),
+            0,
+            EventKind::NodeCompleted {
+                node_id: item1.node_id.clone(),
+                output: json!("first"),
+                state_patch: json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+                idempotency_key: Some("shared-key".into()),
+            },
+        ),
+        false,
+    )
+    .await
+    .expect("first commit must succeed");
+
+    // Second commit with same key: INSERT OR IGNORE keeps "first".
+    db.commit_turn(
+        item2.id,
+        item2.lease_fence,
+        Event::new(
+            exec_id.clone(),
+            0,
+            EventKind::NodeCompleted {
+                node_id: item2.node_id.clone(),
+                output: json!("second"),
+                state_patch: json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+                idempotency_key: Some("shared-key".into()),
+            },
+        ),
+        false,
+    )
+    .await
+    .expect("second commit with duplicate key must not error (INSERT OR IGNORE)");
+
+    // The first result must be the one that survives.
+    let val = db.get_tool_effect("shared-key").await.unwrap().unwrap();
+    assert_eq!(
+        val["output"],
+        json!("first"),
+        "INSERT OR IGNORE must keep the first result"
+    );
+}
+
+// ── In-memory backend tests ──────────────────────────────────────────────────
+
+/// Same round-trip test against the InMemoryBackend.
+#[tokio::test]
+async fn memory_tool_effect_round_trip() {
+    let db = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    db.enqueue_work_item(sample_item(&exec_id, "n1"))
+        .await
+        .unwrap();
+
+    let item = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimed");
+
+    let event = Event::new(
+        exec_id.clone(),
+        0,
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!({"result": "mem-hello"}),
+            state_patch: json!({"mk": "mv"}),
+            duration_ms: 7,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: Some("mem-k1".into()),
+        },
+    );
+
+    db.commit_turn(item.id, item.lease_fence, event, false)
+        .await
+        .expect("commit_turn must succeed");
+
+    let recorded = db.get_tool_effect("mem-k1").await.unwrap();
+    assert!(recorded.is_some(), "expected Some for key mem-k1");
+    let val = recorded.unwrap();
+    assert_eq!(val["output"], json!({"result": "mem-hello"}));
+    assert_eq!(val["duration_ms"], json!(7u64));
+
+    let none_val = db.get_tool_effect("no-such-key").await.unwrap();
+    assert!(
+        none_val.is_none(),
+        "expected None for unknown key in InMemoryBackend"
+    );
+}
+
+// ── Tenant-scoped SQLite tests ───────────────────────────────────────────────
+
+/// TenantScopedSqliteBackend: tool_effect is scoped by tenant_id.
+/// A lookup from a different tenant must return None.
+#[tokio::test]
+async fn tenant_scoped_tool_effect_round_trip() {
+    let db = SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite");
+
+    // Register both tenants so FK constraints in workflow_executions are satisfied.
+    register_tenant(&db, "tenant-a").await;
+    register_tenant(&db, "tenant-b").await;
+
+    let tenant_a = TenantId("tenant-a".into());
+    let tenant_b = TenantId("tenant-b".into());
+
+    let backend_a = db.for_tenant(tenant_a.clone());
+    let backend_b = db.for_tenant(tenant_b);
+
+    let exec_id = ExecutionId::new();
+    // Create execution as tenant-a (uses shared executions table with tenant_id).
+    backend_a
+        .create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+    backend_a
+        .enqueue_work_item(sample_item(&exec_id, "n1"))
+        .await
+        .unwrap();
+
+    let item = backend_a
+        .claim_work_item("w", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimed by tenant-a");
+
+    let event = Event::new(
+        exec_id.clone(),
+        0,
+        EventKind::NodeCompleted {
+            node_id: "n1".into(),
+            output: json!("tenant-out"),
+            state_patch: json!({}),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: Some("tenant-key".into()),
+        },
+    );
+
+    backend_a
+        .commit_turn(item.id, item.lease_fence, event, false)
+        .await
+        .expect("commit_turn must succeed for tenant-a");
+
+    // tenant-a can read it.
+    let recorded = backend_a.get_tool_effect("tenant-key").await.unwrap();
+    assert!(recorded.is_some(), "tenant-a must see its own tool_effect");
+    assert_eq!(recorded.unwrap()["output"], json!("tenant-out"));
+
+    // tenant-b must NOT see tenant-a's tool_effect.
+    let other = backend_b.get_tool_effect("tenant-key").await.unwrap();
+    assert!(
+        other.is_none(),
+        "tenant-b must not see tenant-a's tool_effect"
+    );
+}

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -305,6 +305,154 @@ async fn sqlite_concurrent_winner_insert_or_ignore() {
     );
 }
 
+// ── Key-stability unit tests ─────────────────────────────────────────────────
+
+/// The key formula is deterministic: the same (execution_id, node_id, step,
+/// current_state) inputs produce the same key regardless of when or how many
+/// times it is computed.
+#[test]
+fn key_stability_same_inputs_yields_same_key() {
+    let exec_id = "exec-stable-abc";
+    let node_id = "n1";
+    let step: u64 = 0;
+    let state = json!({});
+
+    let input_hash = jamjet_state::content_hash(&state);
+    let key_a = jamjet_state::content_hash(&json!({
+        "run": exec_id,
+        "segment": 0,
+        "step": step,
+        "node": node_id,
+        "input": input_hash,
+    }));
+    let key_b = jamjet_state::content_hash(&json!({
+        "run": exec_id,
+        "segment": 0,
+        "step": step,
+        "node": node_id,
+        "input": input_hash,
+    }));
+
+    assert_eq!(key_a, key_b, "same inputs must produce the same key");
+    assert_eq!(key_a.len(), 64, "key must be a 64-char hex sha256");
+    assert!(
+        key_a.chars().all(|c| c.is_ascii_hexdigit()),
+        "key must be lowercase hex"
+    );
+}
+
+/// A second loop occurrence (step advances once per NodeCompleted) produces a
+/// different key from the first occurrence. This ensures the cache cannot
+/// collide across loop passes.
+#[test]
+fn key_differs_when_step_advances() {
+    let exec_id = "exec-stable-abc";
+    let node_id = "n1";
+    let state = json!({});
+    let input_hash = jamjet_state::content_hash(&state);
+
+    let key_step0 = jamjet_state::content_hash(&json!({
+        "run": exec_id,
+        "segment": 0,
+        "step": 0u64,
+        "node": node_id,
+        "input": input_hash,
+    }));
+    let key_step1 = jamjet_state::content_hash(&json!({
+        "run": exec_id,
+        "segment": 0,
+        "step": 1u64,
+        "node": node_id,
+        "input": input_hash,
+    }));
+
+    assert_ne!(
+        key_step0, key_step1,
+        "step=0 and step=1 must yield different keys (second loop occurrence)"
+    );
+}
+
+// ── Restart-survival test ─────────────────────────────────────────────────────
+
+/// A tool_effect written to a file-backed SQLite database is readable after
+/// the connection is closed and reopened — simulating a process restart.
+#[tokio::test]
+async fn sqlite_tool_effect_survives_reopen() {
+    let mut path = std::env::temp_dir();
+    let unique = uuid::Uuid::new_v4().to_string().replace('-', "");
+    path.push(format!("jamjet_idem_test_{unique}.db"));
+    let url = format!("sqlite://{}", path.display());
+
+    // First "process": commit a NodeCompleted with an idempotency key.
+    {
+        let db = SqliteBackend::open(&url)
+            .await
+            .expect("failed to open db for write");
+
+        let exec_id = ExecutionId::new();
+        db.create_execution(sample_execution(&exec_id))
+            .await
+            .unwrap();
+        db.enqueue_work_item(sample_item(&exec_id, "n1"))
+            .await
+            .unwrap();
+
+        let item = db
+            .claim_work_item("worker-1", &["model"])
+            .await
+            .unwrap()
+            .expect("item must be claimed");
+
+        let event = Event::new(
+            exec_id.clone(),
+            0,
+            EventKind::NodeCompleted {
+                node_id: "n1".into(),
+                output: json!({"answer": 99}),
+                state_patch: json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+                idempotency_key: Some("restart-key".into()),
+            },
+        );
+
+        db.commit_turn(item.id, item.lease_fence, event, false)
+            .await
+            .expect("commit_turn must succeed");
+        // db dropped here — connection closed.
+    }
+
+    // Second "process": reopen the same file and verify the effect survived.
+    {
+        let db2 = SqliteBackend::open(&url)
+            .await
+            .expect("failed to reopen db");
+
+        let recorded = db2
+            .get_tool_effect("restart-key")
+            .await
+            .expect("get_tool_effect must not error after reopen");
+        assert!(
+            recorded.is_some(),
+            "tool_effect must survive process restart (db reopen)"
+        );
+        let val = recorded.unwrap();
+        assert_eq!(
+            val["output"],
+            json!({"answer": 99}),
+            "output must survive db reopen"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
 // ── In-memory backend tests ──────────────────────────────────────────────────
 
 /// Same round-trip test against the InMemoryBackend.

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -10,6 +10,7 @@ use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
 use jamjet_state::approvals::NodeApprovalStatus;
 use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
+use jamjet_state::content_hash;
 use jamjet_state::event::EventKind;
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
@@ -160,6 +161,9 @@ impl Worker {
             workflow_version.as_str(),
         );
 
+        // Idempotency key computed inside the node branch; used on NodeCompleted.
+        let mut computed_key: Option<String> = None;
+
         let result: Result<ExecutionResult, String> = match self
             .load_ir(&workflow_id, &workflow_version)
             .await
@@ -201,41 +205,124 @@ impl Worker {
                         return r;
                     }
 
-                    // Execute.
-                    let exec_result = match self.executors.get(&kind_tag) {
-                        Some(executor) if kind_tag == "agent_tool" => {
-                            let (tx, mut rx) = tokio::sync::mpsc::channel::<serde_json::Value>(64);
-                            let backend = Arc::clone(&self.backend);
-                            let eid = execution_id.clone();
-                            let receiver_handle = tokio::spawn(async move {
-                                while let Some(event) = rx.recv().await {
-                                    backend
-                                        .patch_append_array(&eid, "agent_tool_events", event)
-                                        .await
-                                        .map_err(|e| format!("patch_append_array failed: {e}"))?;
-                                }
-                                Ok::<(), String>(())
-                            });
-                            let result = executor.execute_streaming(&item, tx).await;
-                            match receiver_handle.await {
-                                Ok(Err(e)) => Err(e),
-                                Err(e) => Err(format!("Receiver task panicked: {e}")),
-                                Ok(Ok(())) => result,
-                            }
-                        }
-                        Some(executor) => executor.execute(&item).await,
-                        None => {
-                            info!(node_id = %node_id, kind = %kind_tag, "No executor; using stub");
+                    // Compute deterministic idempotency key: H(run, segment, step, node, input_hash).
+                    // step = count of NodeStarted events for this node already in the log minus 1
+                    // (the current NodeStarted was just appended above).
+                    let events_for_key = self.backend.get_events(&execution_id).await?;
+                    let step = events_for_key
+                        .iter()
+                        .filter(|e| {
+                            matches!(
+                                &e.kind,
+                                EventKind::NodeStarted { node_id: nid, .. } if nid == &node_id
+                            )
+                        })
+                        .count()
+                        .saturating_sub(1) as u64;
+                    let current_state = self
+                        .backend
+                        .get_execution(&execution_id)
+                        .await?
+                        .map(|e| e.current_state)
+                        .unwrap_or_else(|| serde_json::json!({}));
+                    let input_hash = content_hash(&current_state);
+                    let key = content_hash(&serde_json::json!({
+                        "run": execution_id.to_string(),
+                        "segment": 0,
+                        "step": step,
+                        "node": node_id,
+                        "input": input_hash,
+                    }));
+                    computed_key = Some(key.clone());
+
+                    // Replay-or-fire: if a result was already committed for this key,
+                    // reconstruct ExecutionResult from it and skip the executor entirely.
+                    let exec_result = match self.backend.get_tool_effect(&key).await? {
+                        Some(rec) => {
+                            info!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                %key,
+                                "Replaying recorded result; executor skipped"
+                            );
                             Ok(ExecutionResult {
-                                output: serde_json::json!({}),
-                                state_patch: serde_json::json!({}),
-                                duration_ms: start.elapsed().as_millis() as u64,
-                                gen_ai_system: None,
-                                gen_ai_model: None,
-                                input_tokens: None,
-                                output_tokens: None,
-                                finish_reason: None,
+                                output: rec
+                                    .get("output")
+                                    .cloned()
+                                    .unwrap_or_else(|| serde_json::json!({})),
+                                state_patch: rec
+                                    .get("state_patch")
+                                    .cloned()
+                                    .unwrap_or_else(|| serde_json::json!({})),
+                                duration_ms: rec
+                                    .get("duration_ms")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0),
+                                gen_ai_system: rec
+                                    .get("gen_ai_system")
+                                    .and_then(|v| v.as_str())
+                                    .map(str::to_string),
+                                gen_ai_model: rec
+                                    .get("gen_ai_model")
+                                    .and_then(|v| v.as_str())
+                                    .map(str::to_string),
+                                input_tokens: rec.get("input_tokens").and_then(|v| v.as_u64()),
+                                output_tokens: rec.get("output_tokens").and_then(|v| v.as_u64()),
+                                finish_reason: rec
+                                    .get("finish_reason")
+                                    .and_then(|v| v.as_str())
+                                    .map(str::to_string),
                             })
+                        }
+                        None => {
+                            // No recorded result — fire the executor.
+                            match self.executors.get(&kind_tag) {
+                                Some(executor) if kind_tag == "agent_tool" => {
+                                    let (tx, mut rx) =
+                                        tokio::sync::mpsc::channel::<serde_json::Value>(64);
+                                    let backend = Arc::clone(&self.backend);
+                                    let eid = execution_id.clone();
+                                    let receiver_handle = tokio::spawn(async move {
+                                        while let Some(event) = rx.recv().await {
+                                            backend
+                                                .patch_append_array(
+                                                    &eid,
+                                                    "agent_tool_events",
+                                                    event,
+                                                )
+                                                .await
+                                                .map_err(|e| {
+                                                    format!("patch_append_array failed: {e}")
+                                                })?;
+                                        }
+                                        Ok::<(), String>(())
+                                    });
+                                    let result = executor.execute_streaming(&item, tx).await;
+                                    match receiver_handle.await {
+                                        Ok(Err(e)) => Err(e),
+                                        Err(e) => Err(format!("Receiver task panicked: {e}")),
+                                        Ok(Ok(())) => result,
+                                    }
+                                }
+                                Some(executor) => executor.execute(&item).await,
+                                None => {
+                                    info!(
+                                        node_id = %node_id,
+                                        kind = %kind_tag,
+                                        "No executor; using stub"
+                                    );
+                                    Ok(ExecutionResult {
+                                        output: serde_json::json!({}),
+                                        state_patch: serde_json::json!({}),
+                                        duration_ms: start.elapsed().as_millis() as u64,
+                                        gen_ai_system: None,
+                                        gen_ai_model: None,
+                                        input_tokens: None,
+                                        output_tokens: None,
+                                        finish_reason: None,
+                                    })
+                                }
+                            }
                         }
                     };
 
@@ -307,7 +394,7 @@ impl Worker {
                         finish_reason: exec_result.finish_reason,
                         cost_usd: None,
                         provenance: None,
-                        idempotency_key: None, // Task 2 sets this
+                        idempotency_key: computed_key,
                     },
                 );
                 // Snapshot is computed inside commit_turn's BEGIN IMMEDIATE
@@ -1170,5 +1257,113 @@ mod tests {
             completed_count, 0,
             "zombie must not emit NodeCompleted; got {completed_count}"
         );
+    }
+
+    // ── Replay executor ───────────────────────────────────────────────────────
+
+    /// Executor that records whether it was called. Used to assert the replay
+    /// path skips executor invocation entirely.
+    struct TrackingExecutor {
+        was_called: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for TrackingExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, String> {
+            self.was_called
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Err("TrackingExecutor fired — replay must prevent this".into())
+        }
+    }
+
+    /// Replay path: when a tool_effect is already recorded for the computed
+    /// idempotency key, the worker must skip the executor, reconstruct the
+    /// ExecutionResult from the cached record, and emit NodeCompleted with the
+    /// replayed output.
+    ///
+    /// Construction: we pre-seed the backend's idempotency cache with the key
+    /// that the worker will compute for this execution+node at step=0 (one
+    /// NodeStarted event in the log after the worker emits it → count=1 →
+    /// step=0). A TrackingExecutor registered for "tool" asserts it is never
+    /// invoked.
+    #[tokio::test]
+    async fn replay_skips_executor_when_result_recorded() {
+        use jamjet_state::content_hash;
+
+        let (backend, eid) = setup_backend().await;
+
+        // Compute the key that the worker will derive at step=0.
+        // At key-computation time the worker has just emitted NodeStarted{n1},
+        // so NodeStarted count = 1 → step = 1 - 1 = 0.
+        // The execution was seeded with current_state = {} in setup_backend.
+        let input_hash = content_hash(&serde_json::json!({}));
+        let expected_key = content_hash(&serde_json::json!({
+            "run": eid.to_string(),
+            "segment": 0,
+            "step": 0u64,
+            "node": "n1",
+            "input": input_hash,
+        }));
+
+        // Pre-seed the idempotency cache with a known output for that key.
+        let seeded_output = serde_json::json!({"answer": 42});
+        backend.seed_tool_effect_for_test(
+            expected_key.clone(),
+            serde_json::json!({
+                "output": seeded_output,
+                "state_patch": serde_json::json!({}),
+                "duration_ms": 7u64,
+                "gen_ai_system": serde_json::Value::Null,
+                "gen_ai_model": serde_json::Value::Null,
+                "input_tokens": serde_json::Value::Null,
+                "output_tokens": serde_json::Value::Null,
+                "finish_reason": serde_json::Value::Null,
+            }),
+        );
+
+        // Register a tracking executor for the "tool" kind. If the replay path
+        // is missing, execute() will be called and set was_called=true.
+        let was_called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(TrackingExecutor {
+                was_called: Arc::clone(&was_called),
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        // Run: replay path must take over; executor must not be called.
+        worker.execute_item(item).await.unwrap();
+
+        assert!(
+            !was_called.load(std::sync::atomic::Ordering::SeqCst),
+            "executor must not be called when a recorded result exists"
+        );
+
+        // The replayed output must appear in the NodeCompleted event.
+        let events = backend.get_events(&eid).await.unwrap();
+        let completed = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .expect("NodeCompleted must be emitted even on replay");
+        if let EventKind::NodeCompleted { output, .. } = &completed.kind {
+            assert_eq!(
+                output, &seeded_output,
+                "replayed output must match the seeded record"
+            );
+        }
     }
 }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -205,10 +205,23 @@ impl Worker {
                         return r;
                     }
 
-                    // Compute deterministic idempotency key: H(run, segment, step, node, input_hash).
+                    // Compute deterministic idempotency key: content_hash({run, segment, step, node, input_hash}).
                     // step = count of NodeCompleted events for this node_id in the event log.
                     // Retries do not complete, so the count is stable across retries and advances
                     // exactly once per successful loop occurrence — making recorded results replay-stable.
+                    //
+                    // Exactly-once-COMMIT is delivered by the lease fence (a committed node settles
+                    // and the scheduler never re-dispatches it; a zombie's commit is fence-rejected).
+                    // This replay cache activates on (a) replaying a recorded run and (b) loop
+                    // re-entry / manual or API re-enqueue, where it returns the recorded result
+                    // instead of re-firing. A node that fired but crashed BEFORE commit has no
+                    // recorded result, so a reclaim re-fires (at-least-once-fire, the documented
+                    // v1 limit). [I1]
+                    //
+                    // input_hash is content_hash(current_state) at fire time; for concurrent sibling
+                    // nodes a sibling's state_patch landing between fire and replay changes
+                    // current_state and thus the key, so zero-outbound replay is exact for linear
+                    // runs in v1 (parallel-sibling replay exactness is a follow-up, see F-2c-3). [I2]
                     let events_for_key = self.backend.get_events(&execution_id).await?;
                     let step = events_for_key
                         .iter()

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -206,19 +206,19 @@ impl Worker {
                     }
 
                     // Compute deterministic idempotency key: H(run, segment, step, node, input_hash).
-                    // step = count of NodeStarted events for this node already in the log minus 1
-                    // (the current NodeStarted was just appended above).
+                    // step = count of NodeCompleted events for this node_id in the event log.
+                    // Retries do not complete, so the count is stable across retries and advances
+                    // exactly once per successful loop occurrence — making recorded results replay-stable.
                     let events_for_key = self.backend.get_events(&execution_id).await?;
                     let step = events_for_key
                         .iter()
                         .filter(|e| {
                             matches!(
                                 &e.kind,
-                                EventKind::NodeStarted { node_id: nid, .. } if nid == &node_id
+                                EventKind::NodeCompleted { node_id: nid, .. } if nid == &node_id
                             )
                         })
-                        .count()
-                        .saturating_sub(1) as u64;
+                        .count() as u64;
                     let current_state = self
                         .backend
                         .get_execution(&execution_id)
@@ -1296,8 +1296,8 @@ mod tests {
         let (backend, eid) = setup_backend().await;
 
         // Compute the key that the worker will derive at step=0.
-        // At key-computation time the worker has just emitted NodeStarted{n1},
-        // so NodeStarted count = 1 → step = 1 - 1 = 0.
+        // At key-computation time no NodeCompleted for n1 exists in the log,
+        // so NodeCompleted count = 0 → step = 0.
         // The execution was seeded with current_state = {} in setup_backend.
         let input_hash = content_hash(&serde_json::json!({}));
         let expected_key = content_hash(&serde_json::json!({
@@ -1363,6 +1363,113 @@ mod tests {
             assert_eq!(
                 output, &seeded_output,
                 "replayed output must match the seeded record"
+            );
+        }
+    }
+
+    /// Record-replay exactly-once: pre-seed the idempotency cache for the step=0
+    /// key (simulating a crash after the effect was recorded but before
+    /// NodeCompleted was committed). Re-run the node with a counting executor.
+    /// The counter must stay at 0 (replay path — zero outbound calls).
+    /// The output emitted in NodeCompleted must match the cached record, not
+    /// what the executor would have returned.
+    #[tokio::test]
+    async fn record_replay_zero_outbound_calls() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct CountingExecutor {
+            count: Arc<AtomicU32>,
+        }
+
+        #[async_trait::async_trait]
+        impl NodeExecutor for CountingExecutor {
+            async fn execute(
+                &self,
+                _item: &jamjet_state::backend::WorkItem,
+            ) -> Result<ExecutionResult, String> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                Ok(ExecutionResult {
+                    output: serde_json::json!({"fresh": true}),
+                    state_patch: serde_json::json!({}),
+                    duration_ms: 1,
+                    gen_ai_system: None,
+                    gen_ai_model: None,
+                    input_tokens: None,
+                    output_tokens: None,
+                    finish_reason: None,
+                })
+            }
+        }
+
+        use jamjet_state::content_hash;
+
+        let (backend, eid) = setup_backend().await;
+
+        // Compute the idempotency key for step=0: no NodeCompleted events exist yet.
+        // current_state = {} as seeded in setup_backend.
+        let input_hash = content_hash(&serde_json::json!({}));
+        let expected_key = content_hash(&serde_json::json!({
+            "run": eid.to_string(),
+            "segment": 0,
+            "step": 0u64,
+            "node": "n1",
+            "input": input_hash,
+        }));
+
+        // Simulate: executor ran and its result was recorded in the idempotency
+        // cache, but NodeCompleted was never committed (crash before commit_turn).
+        let recorded_output = serde_json::json!({"cached": true});
+        backend.seed_tool_effect_for_test(
+            expected_key,
+            serde_json::json!({
+                "output": recorded_output,
+                "state_patch": serde_json::json!({}),
+                "duration_ms": 5u64,
+                "gen_ai_system": serde_json::Value::Null,
+                "gen_ai_model": serde_json::Value::Null,
+                "input_tokens": serde_json::Value::Null,
+                "output_tokens": serde_json::Value::Null,
+                "finish_reason": serde_json::Value::Null,
+            }),
+        );
+
+        let call_count = Arc::new(AtomicU32::new(0));
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(CountingExecutor {
+                count: Arc::clone(&call_count),
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        worker.execute_item(item).await.unwrap();
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "executor must not be called when a cached result exists (exactly-once replay)"
+        );
+
+        // NodeCompleted must carry the cached output, not the executor's output.
+        let events = backend.get_events(&eid).await.unwrap();
+        let completed = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .expect("NodeCompleted must be emitted even on replay");
+        if let EventKind::NodeCompleted { output, .. } = &completed.kind {
+            assert_eq!(
+                output, &recorded_output,
+                "replayed output must match the cached record"
             );
         }
     }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -307,6 +307,7 @@ impl Worker {
                         finish_reason: exec_result.finish_reason,
                         cost_usd: None,
                         provenance: None,
+                        idempotency_key: None, // Task 2 sets this
                     },
                 );
                 // Snapshot is computed inside commit_turn's BEGIN IMMEDIATE


### PR DESCRIPTION
## What

Sub-plan 2c of the durable engine (ADK Track 2). Each node fire gets a deterministic idempotency key, its result is recorded atomically in the fenced commit, and a recorded result is replayed instead of re-fired.

- A `tool_effects(idempotency_key PK, ...)` table (migration 0006). The result is recorded via `INSERT OR IGNORE` inside `commit_turn`'s fenced `BEGIN IMMEDIATE` transaction, keyed by the `idempotency_key` now carried on `NodeCompleted`.
- The worker computes `key = content_hash({run, segment:0, step, node, input_hash})` where `step` = the node's NodeCompleted count (retry-stable: retries emit NodeFailed, not NodeCompleted) and `input_hash` = content_hash of current_state. Before firing it checks `get_tool_effect(key)`; on a hit it reconstructs the ExecutionResult and skips the executor.

## Semantics (documented honestly)

Exactly-once-commit is delivered by the lease fence (a committed node settles and is never re-dispatched; a zombie's commit is fence-rejected). This cache adds replay-dedup for replaying a recorded run and for loop re-entry / manual re-enqueue. A node that fired but crashed before commit re-fires on reclaim (at-least-once-fire, the documented v1 limit). `node` is in the key, which prevents cross-node collisions under Parallel fan-out.

## Tests

`cargo test --workspace` green: record-replay (zero outbound calls), key-stability (same inputs same key, step advance differs), restart-survival (effect readable after a SQLite reopen), cross-backend.

## Reviews

An opus adversarial pass confirmed no wrong-result bug (the Parallel-collision suspect is unreachable because node_id is in the key + the fence shadows zombies). Its findings (the cache is fence-delivered/forward-looking today; per-fire event-scan perf; sibling input_hash exactness) are documented inline and tracked as follow-ups F-2c-1..4 in the plan.

## Scope

Loop-occurrence support, the scheduler-driven replay test, and the perf fix land in 2g; the Python tool tier is 2d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotent node execution, allowing previously recorded results to be reused instead of re-running the same work.
  * Improved replay and recovery so completed work can be restored more consistently after restarts or retries.

* **Bug Fixes**
  * Reduced duplicate side effects from repeated executions.
  * Preserved the first recorded result when multiple runs race on the same work item.
  * Kept cached results isolated by tenant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->