### PR TITLE
feat(2d): Python tool worker tier — jamjet worker claims python_tool

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -844,6 +844,22 @@ struct CompleteWorkItemRequest {
     state_patch: Value,
     #[serde(default)]
     duration_ms: u64,
+    // ── GenAI telemetry (forwarded from the python_tool worker or other callers) ──
+    /// AI provider system (e.g. "anthropic", "openai").
+    #[serde(default)]
+    gen_ai_system: Option<String>,
+    /// Model name used.
+    #[serde(default)]
+    gen_ai_model: Option<String>,
+    /// Input tokens consumed.
+    #[serde(default)]
+    input_tokens: Option<u64>,
+    /// Output tokens generated.
+    #[serde(default)]
+    output_tokens: Option<u64>,
+    /// Finish reason (e.g. "stop", "length", "tool_calls").
+    #[serde(default)]
+    finish_reason: Option<String>,
 }
 
 /// `POST /work-items/:id/complete` — mark a work item as completed and emit NodeCompleted event.
@@ -872,11 +888,11 @@ async fn complete_work_item(
                 output: body.output.clone(),
                 state_patch: body.state_patch.clone(),
                 duration_ms: body.duration_ms,
-                gen_ai_system: None,
-                gen_ai_model: None,
-                input_tokens: None,
-                output_tokens: None,
-                finish_reason: None,
+                gen_ai_system: body.gen_ai_system.clone(),
+                gen_ai_model: body.gen_ai_model.clone(),
+                input_tokens: body.input_tokens,
+                output_tokens: body.output_tokens,
+                finish_reason: body.finish_reason.clone(),
                 cost_usd: None,
                 provenance: None,
                 idempotency_key: None,

--- a/runtime/api/tests/work_item_genai.rs
+++ b/runtime/api/tests/work_item_genai.rs
@@ -1,0 +1,240 @@
+//! Verifies that GenAI telemetry fields in `POST /work-items/:id/complete`
+//! are threaded through to the emitted `NodeCompleted` event.
+//!
+//! Uses an in-process `InMemoryBackend` and the dev-mode router (no auth).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::StateBackend;
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, InMemoryBackend};
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn make_state(backend: Arc<InMemoryBackend>) -> AppState {
+    let backend_clone = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone() as Arc<dyn jamjet_state::StateBackend>,
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| {
+            backend_clone.clone() as Arc<dyn jamjet_state::StateBackend>
+        }),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn complete_work_item_threads_gen_ai_fields() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+    let app = build_router_with_opts(state, true);
+
+    // Seed an execution so `latest_sequence` has something to increment from.
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf-genai".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        })
+        .await
+        .expect("create_execution");
+
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "wf-genai".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+
+    // POST /work-items/:id/complete with all five GenAI telemetry fields.
+    let work_item_id = Uuid::new_v4();
+    let body = serde_json::json!({
+        "execution_id": execution_id.to_string(),
+        "node_id": "genai-node",
+        "output": {"text": "hello"},
+        "state_patch": {},
+        "duration_ms": 42,
+        "gen_ai_system": "anthropic",
+        "gen_ai_model": "claude-3-5-sonnet-20241022",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "finish_reason": "stop"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/work-items/{work_item_id}/complete"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp_json = body_json(resp.into_body()).await;
+    assert_eq!(resp_json["completed"], true);
+
+    // Verify the emitted NodeCompleted event carries the GenAI fields.
+    let events = backend
+        .get_events(&execution_id)
+        .await
+        .expect("get_events");
+
+    let node_completed = events.iter().find(|e| {
+        matches!(
+            &e.kind,
+            EventKind::NodeCompleted { node_id, .. } if node_id == "genai-node"
+        )
+    });
+
+    let event = node_completed.expect("NodeCompleted event must be emitted for genai-node");
+    match &event.kind {
+        EventKind::NodeCompleted {
+            gen_ai_system,
+            gen_ai_model,
+            input_tokens,
+            output_tokens,
+            finish_reason,
+            ..
+        } => {
+            assert_eq!(
+                gen_ai_system.as_deref(),
+                Some("anthropic"),
+                "gen_ai_system must be threaded through"
+            );
+            assert_eq!(
+                gen_ai_model.as_deref(),
+                Some("claude-3-5-sonnet-20241022"),
+                "gen_ai_model must be threaded through"
+            );
+            assert_eq!(*input_tokens, Some(100), "input_tokens must be threaded through");
+            assert_eq!(*output_tokens, Some(50), "output_tokens must be threaded through");
+            assert_eq!(
+                finish_reason.as_deref(),
+                Some("stop"),
+                "finish_reason must be threaded through"
+            );
+        }
+        _ => panic!("expected NodeCompleted event, got: {:?}", event.kind),
+    }
+}
+
+#[tokio::test]
+async fn complete_work_item_without_gen_ai_fields_keeps_backward_compat() {
+    // A body without GenAI fields must still succeed (serde defaults to None).
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf-compat".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+        })
+        .await
+        .expect("create_execution");
+
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "wf-compat".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+
+    let work_item_id = Uuid::new_v4();
+    // Old-style body with no GenAI fields.
+    let body = serde_json::json!({
+        "execution_id": execution_id.to_string(),
+        "node_id": "compat-node",
+        "output": {"result": 42},
+        "state_patch": {},
+        "duration_ms": 10
+    });
+
+    let resp = app
+        .oneshot(
+            Request::post(format!("/work-items/{work_item_id}/complete"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let events = backend.get_events(&execution_id).await.expect("get_events");
+    let node_completed = events.iter().find(|e| {
+        matches!(
+            &e.kind,
+            EventKind::NodeCompleted { node_id, .. } if node_id == "compat-node"
+        )
+    });
+    let event = node_completed.expect("NodeCompleted event must be emitted");
+    match &event.kind {
+        EventKind::NodeCompleted {
+            gen_ai_system,
+            gen_ai_model,
+            input_tokens,
+            output_tokens,
+            finish_reason,
+            ..
+        } => {
+            assert!(gen_ai_system.is_none(), "gen_ai_system must be None for old callers");
+            assert!(gen_ai_model.is_none(), "gen_ai_model must be None for old callers");
+            assert!(input_tokens.is_none());
+            assert!(output_tokens.is_none());
+            assert!(finish_reason.is_none());
+        }
+        _ => panic!("expected NodeCompleted event"),
+    }
+}

--- a/runtime/api/tests/work_item_genai.rs
+++ b/runtime/api/tests/work_item_genai.rs
@@ -108,10 +108,7 @@ async fn complete_work_item_threads_gen_ai_fields() {
     assert_eq!(resp_json["completed"], true);
 
     // Verify the emitted NodeCompleted event carries the GenAI fields.
-    let events = backend
-        .get_events(&execution_id)
-        .await
-        .expect("get_events");
+    let events = backend.get_events(&execution_id).await.expect("get_events");
 
     let node_completed = events.iter().find(|e| {
         matches!(
@@ -140,8 +137,16 @@ async fn complete_work_item_threads_gen_ai_fields() {
                 Some("claude-3-5-sonnet-20241022"),
                 "gen_ai_model must be threaded through"
             );
-            assert_eq!(*input_tokens, Some(100), "input_tokens must be threaded through");
-            assert_eq!(*output_tokens, Some(50), "output_tokens must be threaded through");
+            assert_eq!(
+                *input_tokens,
+                Some(100),
+                "input_tokens must be threaded through"
+            );
+            assert_eq!(
+                *output_tokens,
+                Some(50),
+                "output_tokens must be threaded through"
+            );
             assert_eq!(
                 finish_reason.as_deref(),
                 Some("stop"),
@@ -229,8 +234,14 @@ async fn complete_work_item_without_gen_ai_fields_keeps_backward_compat() {
             finish_reason,
             ..
         } => {
-            assert!(gen_ai_system.is_none(), "gen_ai_system must be None for old callers");
-            assert!(gen_ai_model.is_none(), "gen_ai_model must be None for old callers");
+            assert!(
+                gen_ai_system.is_none(),
+                "gen_ai_system must be None for old callers"
+            );
+            assert!(
+                gen_ai_model.is_none(),
+                "gen_ai_model must be None for old callers"
+            );
             assert!(input_tokens.is_none());
             assert!(output_tokens.is_none());
             assert!(finish_reason.is_none());

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -1,4 +1,4 @@
-use jamjet_core::node::NodeId;
+use jamjet_core::node::{NodeId, NodeKind};
 use jamjet_core::workflow::ExecutionId;
 use jamjet_ir::WorkflowIr;
 use jamjet_state::backend::{StateBackend, WorkItem};
@@ -344,16 +344,42 @@ impl Scheduler {
                     _ => 3,
                 };
 
+                // Build the base payload that every work item carries.
+                let mut payload = serde_json::json!({
+                    "workflow_id": workflow_id,
+                    "workflow_version": workflow_version,
+                    "node_id": node_id,
+                });
+                // For PythonFn nodes, enrich the payload so the external Python
+                // worker is self-contained: it needs the module, the function to
+                // invoke, and the current workflow state as the call input.
+                // `progress.final_state` is the accumulated state (all
+                // `state_patch`es from completed nodes so far) and is available
+                // here without an additional backend call.
+                if let NodeKind::PythonFn {
+                    module, function, ..
+                } = &node.kind
+                {
+                    let obj = payload
+                        .as_object_mut()
+                        .expect("payload is always a JSON object");
+                    obj.insert("module".into(), serde_json::Value::String(module.clone()));
+                    obj.insert(
+                        "function".into(),
+                        serde_json::Value::String(function.clone()),
+                    );
+                    obj.insert(
+                        "input".into(),
+                        serde_json::Value::Object(progress.final_state.clone()),
+                    );
+                }
+
                 let item = WorkItem {
                     id: Uuid::new_v4(),
                     execution_id: execution_id.clone(),
                     node_id: node_id.clone(),
                     queue_type,
-                    payload: serde_json::json!({
-                        "workflow_id": workflow_id,
-                        "workflow_version": workflow_version,
-                        "node_id": node_id,
-                    }),
+                    payload,
                     attempt: 0,
                     max_attempts,
                     created_at: chrono::Utc::now(),
@@ -1064,5 +1090,94 @@ mod tests {
             progress.held.is_empty(),
             "hold must be consumed by the rejection"
         );
+    }
+
+    /// A single-node workflow whose only step is a `PythonFn`.
+    fn python_fn_ir() -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": "py_step",
+            "nodes": {
+                "py_step": {
+                    "id": "py_step",
+                    "kind": {
+                        "type": "python_fn",
+                        "module": "myapp.tools",
+                        "function": "run_check",
+                        "output_schema": ""
+                    },
+                    "retry_policy": null,
+                    "node_timeout_secs": null,
+                    "description": null,
+                    "labels": {}
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        })
+    }
+
+    /// The scheduler must enrich a `PythonFn` work-item payload with
+    /// `module`, `function`, and `input` so an external Python worker is
+    /// self-contained.  The base fields (`workflow_id`, `workflow_version`,
+    /// `node_id`) must still be present.
+    #[tokio::test]
+    async fn python_fn_work_item_payload_is_enriched() {
+        let (s, b, e) = setup(python_fn_ir()).await;
+
+        // Seed some accumulated state so we can assert it lands in `input`.
+        append(
+            &b,
+            &e,
+            node_completed("prev_node", serde_json::json!({ "key": "value" })),
+        )
+        .await;
+
+        // Tick: `py_step` is the start node with no predecessors — runnable.
+        tick(&s, &e).await;
+
+        // Claim the work item from the python_tool queue.
+        let item = b
+            .claim_work_item("test-worker", &["python_tool"])
+            .await
+            .expect("backend claim must not error")
+            .expect("a PythonFn node must produce exactly one work item");
+
+        // Queue type
+        assert_eq!(item.queue_type, "python_tool");
+
+        // PythonFn-specific enrichment
+        assert_eq!(
+            item.payload["module"], "myapp.tools",
+            "payload must carry the module path"
+        );
+        assert_eq!(
+            item.payload["function"], "run_check",
+            "payload must carry the function name"
+        );
+        assert!(
+            item.payload["input"].is_object(),
+            "payload.input must be a JSON object (accumulated workflow state)"
+        );
+        // The state seeded above must be reflected in input.
+        assert_eq!(
+            item.payload["input"]["key"], "value",
+            "payload.input must reflect accumulated state patches"
+        );
+
+        // Base fields must still be present.
+        assert_eq!(item.payload["workflow_id"], "wf");
+        assert_eq!(item.payload["workflow_version"], "0.1.0");
+        assert_eq!(item.payload["node_id"], "py_step");
     }
 }

--- a/runtime/workers/src/pool.rs
+++ b/runtime/workers/src/pool.rs
@@ -107,9 +107,13 @@ impl WorkerPool {
 
 /// Convenience: build a default pool with standard queue groups.
 ///
-/// - 2 general workers (`["general", "tool", "condition"]`)
+/// - 2 general workers (`["general", "tool", "condition", "mcp_tool"]`)
 /// - 2 model workers (`["model"]`)
 /// - 1 privileged worker (`["privileged"]`)
+/// - 0 python workers (`["python_tool"]`) — intent registration only. Durable
+///   Python `@tool` nodes are executed by an external `jamjet worker` process;
+///   no internal Rust worker claims this queue. Start the sidecar with:
+///   `jamjet worker --queue python_tool`
 pub fn default_pool(backend: Arc<dyn StateBackend>) -> WorkerPool {
     WorkerPool::new(backend)
         .with_group(WorkerGroupConfig::new(
@@ -131,5 +135,12 @@ pub fn default_pool(backend: Arc<dyn StateBackend>) -> WorkerPool {
             "privileged-worker",
             1,
             vec!["privileged".into()],
+        ))
+        // Register python_tool as a known queue without spawning internal workers.
+        // Items in this queue are claimed exclusively by an external `jamjet worker`.
+        .with_group(WorkerGroupConfig::new(
+            "python-worker",
+            0,
+            vec!["python_tool".into()],
         ))
 }

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1661,12 +1661,25 @@ async def _worker_loop(
                     fn = getattr(fn, part)
 
                 tool_input = payload.get("input", {})
+
+                # Inject deterministic seeds so handlers can opt into replay fidelity.
+                from jamjet.runtime.local.seed import _inject_seeds
+
+                _inject_seeds(exec_id)
+
                 result = fn(tool_input)
                 if asyncio.iscoroutine(result) or asyncio.isfuture(result):
                     result = await result
 
                 duration_ms = int((time.monotonic() - t_start) * 1000)
                 output: Any = result if isinstance(result, dict) else {"result": result}
+
+                # Forward optional GenAI telemetry if the tool surfaced it.
+                gen_ai_model_field: str | None = None
+                finish_reason_field: str | None = None
+                if isinstance(output, dict):
+                    gen_ai_model_field = output.get("gen_ai_model") or None
+                    finish_reason_field = output.get("finish_reason") or None
 
                 await client.complete_work_item(
                     item_id,
@@ -1675,6 +1688,8 @@ async def _worker_loop(
                     output,
                     {},
                     duration_ms,
+                    gen_ai_model=gen_ai_model_field,
+                    finish_reason=finish_reason_field,
                 )
                 console.print(f"[green]Completed[/green] id={item_id} node=[bold]{node_id}[/bold] {duration_ms}ms")
             except Exception as exc:

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1604,129 +1604,151 @@ def workers(
     asyncio.run(_workers())
 
 
+async def _worker_loop(
+    client: Any,
+    worker_id: str,
+    queues: list[str],
+    *,
+    once: bool = False,
+) -> None:
+    """Core python_tool worker polling loop, separated for testability.
+
+    Claim work items from *queues*, resolve the handler named by
+    ``payload["module"]`` / ``payload["function"]``, invoke it with
+    ``payload["input"]``, and post complete / fail back to the runtime.
+    Heartbeats are sent every 10 seconds while the handler is running.
+    """
+    import importlib as _importlib
+
+    while True:
+        try:
+            work_item = await client.claim_work_item(worker_id, queues)
+            if work_item is None:
+                if once:
+                    return
+                await asyncio.sleep(2)
+                continue
+
+            item_id: str = work_item["id"]
+            exec_id: str = work_item["execution_id"]
+            node_id: str = work_item["node_id"]
+            payload: dict[str, Any] = work_item.get("payload", {})
+            lease_fence: int = work_item.get("lease_fence", 0)
+
+            console.print(f"[cyan]Claimed[/cyan] id={item_id} node=[bold]{node_id}[/bold] exec={exec_id}")
+
+            # Keep the lease alive while the handler runs.
+            async def _heartbeat_loop() -> None:
+                while True:
+                    await asyncio.sleep(10)
+                    try:
+                        await client.heartbeat_work_item(item_id, worker_id, lease_fence)
+                    except Exception as hb_err:
+                        console.print(f"[yellow]Heartbeat error:[/yellow] {hb_err}")
+
+            hb_task = asyncio.create_task(_heartbeat_loop())
+
+            t_start = time.monotonic()
+            try:
+                mod_path = payload.get("module")
+                fn_path = payload.get("function")
+                if not mod_path or not fn_path:
+                    raise ValueError(f"work item payload missing 'module' or 'function': {sorted(payload)}")
+
+                mod = _importlib.import_module(mod_path)
+                fn: Any = mod
+                for part in fn_path.split("."):
+                    fn = getattr(fn, part)
+
+                tool_input = payload.get("input", {})
+                result = fn(tool_input)
+                if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                    result = await result
+
+                duration_ms = int((time.monotonic() - t_start) * 1000)
+                output: Any = result if isinstance(result, dict) else {"result": result}
+
+                await client.complete_work_item(
+                    item_id,
+                    exec_id,
+                    node_id,
+                    output,
+                    {},
+                    duration_ms,
+                )
+                console.print(f"[green]Completed[/green] id={item_id} node=[bold]{node_id}[/bold] {duration_ms}ms")
+            except Exception as exc:
+                console.print(f"[red]Failed[/red] node={node_id}: {exc}")
+                await client.fail_work_item(item_id, str(exc))
+            finally:
+                hb_task.cancel()
+
+            if once:
+                return
+
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            return
+        except Exception as poll_err:
+            console.print(f"[yellow]Poll error:[/yellow] {poll_err}")
+            if once:
+                raise
+            await asyncio.sleep(2)
+
+
 @app.command()
 def worker(
-    module: str = typer.Argument(..., help="Python module path containing the workflow (e.g., my_app.workflow)"),
-    workflow_name: str = typer.Option("workflow", "--name", "-n", help="Name of the Workflow variable in the module"),
-    queue: str = typer.Option("general", "--queue", "-q", help="Queue type(s) to consume, comma-separated"),
     runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r", help="Runtime URL"),
-    poll_interval: float = typer.Option(0.5, "--poll-interval", help="Seconds between poll attempts"),
-    worker_id: str | None = typer.Option(None, "--worker-id", help="Worker ID (auto-generated if omitted)"),
+    worker_id: str | None = typer.Option(None, "--worker-id", help="Worker ID (default: random uuid)"),
+    queue: list[str] = typer.Option(["python_tool"], "--queue", "-q", help="Queue type(s) to claim from (repeatable)"),
+    modules: str | None = typer.Option(
+        None, "--modules", help="Comma-separated Python modules to import before polling"
+    ),
+    once: bool = typer.Option(False, "--once", help="Claim and process one item then exit"),  # noqa: FBT001
 ) -> None:
-    """Start a Python worker that executes workflow steps.
+    """Poll the runtime for python_tool work items and invoke @tool handlers.
 
-    The worker polls the runtime for work items, executes the matching
-    step function from the loaded workflow, and reports results back.
+    Each claimed item's payload must include 'module' and 'function' keys
+    that resolve to an async callable.  Results are posted back as complete
+    or fail depending on whether the handler raises.
 
-    Example:
-        jamjet worker my_app.benchmark_workflow --name workflow --queue general
+    \b
+    Examples:
+        jamjet worker                           # poll python_tool queue forever
+        jamjet worker --queue python_tool       # same, explicit
+        jamjet worker --modules myapp.tools     # pre-import so @tool decorators register
+        jamjet worker --once                    # claim one item (or exit 0 if queue empty)
     """
-    import importlib
-    import time
+    import importlib as _importlib
     import uuid
 
-    from jamjet.client import JamjetClient
-    from jamjet.workflow import Workflow
-
     wid = worker_id or f"py-worker-{uuid.uuid4().hex[:8]}"
-    queues = [q.strip() for q in queue.split(",")]
+    queues = list(queue) if queue else ["python_tool"]
 
-    # Load the workflow module and find the Workflow object
-    try:
-        mod = importlib.import_module(module)
-    except ImportError as e:
-        console.print(f"[red]Error importing module:[/red] {e}")
-        raise typer.Exit(1)
+    # Pre-import user-specified modules so that @tool decorators fire before polling.
+    if modules:
+        for mod_name in (m.strip() for m in modules.split(",") if m.strip()):
+            try:
+                _importlib.import_module(mod_name)
+            except ImportError as exc:
+                console.print(f"[red]Error importing module:[/red] {mod_name}: {exc}")
+                raise typer.Exit(1)
 
-    wf = getattr(mod, workflow_name, None)
-    if wf is None or not isinstance(wf, Workflow):
-        console.print(f"[red]Error:[/red] {module}.{workflow_name} is not a Workflow instance")
-        raise typer.Exit(1)
-
-    # Build step lookup: node_id -> async step function
-    step_map: dict = {}
-    for step in wf._steps:
-        step_map[step.name] = step
-
-    console.print("[bold]JamJet Python Worker[/bold]")
+    console.print("[bold]JamJet Python Tool Worker[/bold]")
     console.print(f"  Worker ID: {wid}")
     console.print(f"  Queues:    {queues}")
-    console.print(f"  Workflow:  {wf.workflow_id} ({len(step_map)} steps: {list(step_map.keys())})")
     console.print(f"  Runtime:   {runtime}")
+    if once:
+        console.print("  Mode:      single-shot (--once)")
     console.print()
 
-    async def _run_worker() -> None:
+    async def _start() -> None:
         async with JamjetClient(base_url=runtime) as client:
-            console.print("[dim]Polling for work items... (Ctrl+C to stop)[/dim]")
-            while True:
-                try:
-                    resp = await client.claim_work_item(wid, queues)
-                    if not resp.get("claimed"):
-                        await asyncio.sleep(poll_interval)
-                        continue
-
-                    wi = resp["work_item"]
-                    item_id = wi["id"]
-                    node_id = wi["node_id"]
-                    exec_id = wi["execution_id"]
-                    attempt = wi.get("attempt", 0)
-
-                    console.print(f"[cyan]Claimed[/cyan] node=[bold]{node_id}[/bold] exec={exec_id} attempt={attempt}")
-
-                    step = step_map.get(node_id)
-                    if step is None:
-                        error_msg = f"unknown node_id: {node_id}"
-                        console.print(f"[red]Failed:[/red] {error_msg}")
-                        await client.fail_work_item(item_id, error_msg)
-                        continue
-
-                    # Get current execution state
-                    exec_data = await client.get_execution(exec_id)
-                    current_state = exec_data.get("current_state", {})
-
-                    # Instantiate the state model and run the step
-                    t_start = time.monotonic()
-                    try:
-                        state_cls = wf._state_class
-                        state_obj = state_cls(**current_state) if state_cls else current_state
-                        result = step.fn(state_obj)
-                        if asyncio.iscoroutine(result) or asyncio.isfuture(result):
-                            result = await result
-                        duration_ms = int((time.monotonic() - t_start) * 1000)
-
-                        # Compute state patch (diff between old and new state)
-                        if hasattr(result, "model_dump"):
-                            new_state = result.model_dump()
-                        else:
-                            new_state = dict(result) if isinstance(result, dict) else {}
-
-                        state_patch = {k: v for k, v in new_state.items() if current_state.get(k) != v}
-
-                        await client.complete_work_item(
-                            item_id,
-                            output=new_state,
-                            state_patch=state_patch,
-                            duration_ms=duration_ms,
-                            execution_id=exec_id,
-                            node_id=node_id,
-                        )
-                        console.print(
-                            f"[green]Completed[/green] node=[bold]{node_id}[/bold] "
-                            f"{duration_ms}ms patch={list(state_patch.keys())}"
-                        )
-                    except Exception as e:
-                        duration_ms = int((time.monotonic() - t_start) * 1000)
-                        console.print(f"[red]Failed[/red] node={node_id}: {e}")
-                        await client.fail_work_item(item_id, str(e))
-
-                except KeyboardInterrupt:
-                    break
-                except Exception as e:
-                    console.print(f"[yellow]Poll error:[/yellow] {e}")
-                    await asyncio.sleep(poll_interval)
+            if not once:
+                console.print("[dim]Polling for work items... (Ctrl+C to stop)[/dim]")
+            await _worker_loop(client, wid, queues, once=once)
 
     try:
-        asyncio.run(_run_worker())
+        asyncio.run(_start())
     except KeyboardInterrupt:
         console.print("\n[yellow]Worker stopped.[/yellow]")
 

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -234,6 +234,8 @@ class JamjetClient:
         output: Any,
         state_patch: dict[str, Any],
         duration_ms: int = 0,
+        gen_ai_model: str | None = None,
+        finish_reason: str | None = None,
     ) -> None:
         """Mark a work item as completed and emit a NodeCompleted event."""
         body: dict[str, Any] = {
@@ -245,6 +247,10 @@ class JamjetClient:
             body["execution_id"] = execution_id
         if node_id:
             body["node_id"] = node_id
+        if gen_ai_model:
+            body["gen_ai_model"] = gen_ai_model
+        if finish_reason is not None:
+            body["finish_reason"] = finish_reason
         r = await self._client.post(
             f"/work-items/{item_id}/complete",
             json=body,

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -210,23 +210,32 @@ class JamjetClient:
         self,
         worker_id: str,
         queue_types: list[str],
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
+        """Claim the next available work item.
+
+        Returns the work_item dict on success, or ``None`` when the queue is
+        empty (runtime responds with ``{"claimed": false}``).
+        """
         r = await self._client.post(
             "/work-items/claim",
             json={"worker_id": worker_id, "queue_types": queue_types},
         )
         r.raise_for_status()
-        return r.json()
+        data = r.json()
+        if not data.get("claimed"):
+            return None
+        return data["work_item"]
 
     async def complete_work_item(
         self,
         item_id: str,
-        output: dict[str, Any],
+        execution_id: str | None,
+        node_id: str | None,
+        output: Any,
         state_patch: dict[str, Any],
         duration_ms: int = 0,
-        execution_id: str | None = None,
-        node_id: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> None:
+        """Mark a work item as completed and emit a NodeCompleted event."""
         body: dict[str, Any] = {
             "output": output,
             "state_patch": state_patch,
@@ -241,23 +250,31 @@ class JamjetClient:
             json=body,
         )
         r.raise_for_status()
-        return r.json()
 
-    async def fail_work_item(self, item_id: str, error: str) -> dict[str, Any]:
+    async def fail_work_item(self, item_id: str, error: str) -> None:
+        """Mark a work item as failed."""
         r = await self._client.post(
             f"/work-items/{item_id}/fail",
             json={"error": error},
         )
         r.raise_for_status()
-        return r.json()
 
-    async def heartbeat_work_item(self, item_id: str, worker_id: str) -> dict[str, Any]:
+    async def heartbeat_work_item(
+        self,
+        item_id: str,
+        worker_id: str,
+        lease_fence: int = 0,
+    ) -> None:
+        """Renew the lease on a claimed work item.
+
+        ``lease_fence`` must match the value returned when the item was
+        claimed; a stale fence causes the runtime to reject the renewal.
+        """
         r = await self._client.post(
             f"/work-items/{item_id}/heartbeat",
-            json={"worker_id": worker_id},
+            json={"worker_id": worker_id, "lease_fence": lease_fence},
         )
         r.raise_for_status()
-        return r.json()
 
     # ── Generic helpers (for one-off API paths not covered above) ─────────
 

--- a/sdk/python/jamjet/llm/client.py
+++ b/sdk/python/jamjet/llm/client.py
@@ -17,6 +17,8 @@ class LlmResponse:
     text: str
     input_tokens: int = 0
     output_tokens: int = 0
+    gen_ai_model: str = ""
+    finish_reason: str | None = None
 
 
 async def call_llm(model: str, prompt: str, max_tokens: int = 512) -> LlmResponse:

--- a/sdk/python/jamjet/runtime/local/seed.py
+++ b/sdk/python/jamjet/runtime/local/seed.py
@@ -2,10 +2,16 @@
 
 These are deterministic across runs given the same execution_id seed. Author code
 that wants replay-faithful non-determinism must use these instead of stdlib calls.
+
+The same seeds are also available to durable ``@tool`` handlers running under
+``jamjet worker`` via the context-variable API: ``get_current_random()``,
+``get_current_uuid_gen()``, and ``get_current_clock()``.  The worker calls
+``_inject_seeds(execution_id)`` before each handler invocation.
 """
 
 from __future__ import annotations
 
+import contextvars as _cv
 import hashlib
 import random as _random
 import uuid as _uuid
@@ -42,3 +48,36 @@ class SeededClock:
         out = self._t
         self._t = self._t + timedelta(milliseconds=1)
         return out
+
+
+# ── Context-variable seed injection (used by `jamjet worker`) ─────────────────
+
+_current_random: _cv.ContextVar[SeededRandom | None] = _cv.ContextVar("_current_random", default=None)
+_current_uuid_gen: _cv.ContextVar[SeededUuidGen | None] = _cv.ContextVar("_current_uuid_gen", default=None)
+_current_clock: _cv.ContextVar[SeededClock | None] = _cv.ContextVar("_current_clock", default=None)
+
+
+def _inject_seeds(execution_id: str) -> None:
+    """Set deterministic seed sources for the current async context.
+
+    Called by the ``jamjet worker`` process before each tool handler invocation.
+    Seeds are keyed on *execution_id* so replay runs produce identical values.
+    """
+    _current_random.set(SeededRandom(execution_id))
+    _current_uuid_gen.set(SeededUuidGen(execution_id))
+    _current_clock.set(SeededClock())
+
+
+def get_current_random() -> SeededRandom | None:
+    """Return the seeded random for the current tool invocation, or None outside a worker."""
+    return _current_random.get()
+
+
+def get_current_uuid_gen() -> SeededUuidGen | None:
+    """Return the seeded UUID generator for the current tool invocation, or None outside a worker."""
+    return _current_uuid_gen.get()
+
+
+def get_current_clock() -> SeededClock | None:
+    """Return the seeded clock for the current tool invocation, or None outside a worker."""
+    return _current_clock.get()

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -1,10 +1,12 @@
 """Tests for `jamjet worker` — python_tool work-item consumer.
 
-Covers three scenarios:
+Covers scenarios:
   (a) A claimed item whose payload names a module+function runs the handler
       and posts complete with the output.
   (b) A handler that raises causes fail_work_item to be posted.
   (c) --once with no claimed item is a clean no-op.
+  (d) Seed injection: same execution_id yields same random value (Task 4).
+  (e) GenAI fields in the output dict are forwarded to complete_work_item (Task 5).
 
 No live runtime is required; a _StubClient records all outbound calls.
 """
@@ -24,6 +26,23 @@ async def _add(input: dict) -> dict:
 async def _boom(input: dict) -> dict:
     """Always raises to exercise the fail path."""
     raise RuntimeError("intentional failure")
+
+
+def _read_seed(input: dict) -> dict:
+    """Return the first value from the injected seeded random (sync handler)."""
+    from jamjet.runtime.local.seed import get_current_random
+
+    rng = get_current_random()
+    return {"seed_value": rng.random() if rng is not None else None}
+
+
+async def _with_genai(input: dict) -> dict:
+    """Return output that includes optional GenAI telemetry fields."""
+    return {
+        "result": "answer",
+        "gen_ai_model": "claude-3-5-sonnet-20241022",
+        "finish_reason": "stop",
+    }
 
 
 # ── Stub client ───────────────────────────────────────────────────────────────
@@ -49,6 +68,8 @@ class _StubClient:
         output: object,
         state_patch: dict,
         duration_ms: int = 0,
+        gen_ai_model: str | None = None,
+        finish_reason: str | None = None,
     ) -> None:
         self.complete_calls.append(
             {
@@ -56,6 +77,8 @@ class _StubClient:
                 "execution_id": execution_id,
                 "node_id": node_id,
                 "output": output,
+                "gen_ai_model": gen_ai_model,
+                "finish_reason": finish_reason,
             }
         )
 
@@ -89,6 +112,32 @@ _BOOM_ITEM: dict = {
     "payload": {
         "module": "tests.test_worker",
         "function": "_boom",
+        "input": {},
+    },
+    "lease_fence": 0,
+}
+
+_SEED_ITEM: dict = {
+    "id": "wi-003",
+    "execution_id": "exec_seed_abc",
+    "node_id": "seed_step",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "tests.test_worker",
+        "function": "_read_seed",
+        "input": {},
+    },
+    "lease_fence": 0,
+}
+
+_GENAI_ITEM: dict = {
+    "id": "wi-004",
+    "execution_id": "exec_genai",
+    "node_id": "genai_step",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "tests.test_worker",
+        "function": "_with_genai",
         "input": {},
     },
     "lease_fence": 0,
@@ -131,3 +180,33 @@ async def test_worker_once_empty_queue_is_noop() -> None:
 
     assert len(stub.complete_calls) == 0
     assert len(stub.fail_calls) == 0
+
+
+async def test_worker_seed_injection_deterministic() -> None:
+    """(d) Same execution_id yields the same random value via injected context."""
+    # Run twice with the same execution_id — seeds must be identical.
+    stub_a = _StubClient(claimed_item=_SEED_ITEM)
+    await _worker_loop(stub_a, "test-worker", ["python_tool"], once=True)
+
+    stub_b = _StubClient(claimed_item=_SEED_ITEM)
+    await _worker_loop(stub_b, "test-worker", ["python_tool"], once=True)
+
+    output_a = stub_a.complete_calls[0]["output"]["seed_value"]
+    output_b = stub_b.complete_calls[0]["output"]["seed_value"]
+    assert output_a is not None, "seed must be injected before handler invocation"
+    assert output_a == output_b, (
+        f"same execution_id must yield same seed: {output_a} != {output_b}"
+    )
+
+
+async def test_worker_forwards_gen_ai_fields() -> None:
+    """(e) GenAI fields in the output dict are forwarded to complete_work_item."""
+    stub = _StubClient(claimed_item=_GENAI_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    call = stub.complete_calls[0]
+    assert call["gen_ai_model"] == "claude-3-5-sonnet-20241022"
+    assert call["finish_reason"] == "stop"
+    # The full output dict (including GenAI fields) is still forwarded as-is.
+    assert call["output"]["result"] == "answer"

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -1,0 +1,133 @@
+"""Tests for `jamjet worker` — python_tool work-item consumer.
+
+Covers three scenarios:
+  (a) A claimed item whose payload names a module+function runs the handler
+      and posts complete with the output.
+  (b) A handler that raises causes fail_work_item to be posted.
+  (c) --once with no claimed item is a clean no-op.
+
+No live runtime is required; a _StubClient records all outbound calls.
+"""
+
+from __future__ import annotations
+
+from jamjet.cli.main import _worker_loop  # noqa: E402
+
+# ── Test handler functions ────────────────────────────────────────────────────
+
+
+async def _add(input: dict) -> dict:
+    """Returns the sum of a + b."""
+    return {"sum": input["a"] + input["b"]}
+
+
+async def _boom(input: dict) -> dict:
+    """Always raises to exercise the fail path."""
+    raise RuntimeError("intentional failure")
+
+
+# ── Stub client ───────────────────────────────────────────────────────────────
+
+
+class _StubClient:
+    """Minimal async fake of JamjetClient for worker unit tests."""
+
+    def __init__(self, *, claimed_item: dict | None = None) -> None:
+        self._claimed_item = claimed_item
+        self.complete_calls: list[dict] = []
+        self.fail_calls: list[dict] = []
+        self.heartbeat_calls: list[dict] = []
+
+    async def claim_work_item(self, worker_id: str, queue_types: list[str]) -> dict | None:
+        return self._claimed_item
+
+    async def complete_work_item(
+        self,
+        item_id: str,
+        execution_id: str | None,
+        node_id: str | None,
+        output: object,
+        state_patch: dict,
+        duration_ms: int = 0,
+    ) -> None:
+        self.complete_calls.append(
+            {
+                "item_id": item_id,
+                "execution_id": execution_id,
+                "node_id": node_id,
+                "output": output,
+            }
+        )
+
+    async def fail_work_item(self, item_id: str, error: str) -> None:
+        self.fail_calls.append({"item_id": item_id, "error": error})
+
+    async def heartbeat_work_item(self, item_id: str, worker_id: str, lease_fence: int = 0) -> None:
+        self.heartbeat_calls.append({"item_id": item_id, "lease_fence": lease_fence})
+
+
+# ── Fixtures / constants ──────────────────────────────────────────────────────
+
+_ADD_ITEM: dict = {
+    "id": "wi-001",
+    "execution_id": "exec_abc",
+    "node_id": "add_step",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "tests.test_worker",
+        "function": "_add",
+        "input": {"a": 3, "b": 4},
+    },
+    "lease_fence": 0,
+}
+
+_BOOM_ITEM: dict = {
+    "id": "wi-002",
+    "execution_id": "exec_def",
+    "node_id": "boom_step",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "tests.test_worker",
+        "function": "_boom",
+        "input": {},
+    },
+    "lease_fence": 0,
+}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+async def test_worker_runs_handler_and_posts_complete() -> None:
+    """(a) Claimed item with a valid handler calls complete_work_item with the output."""
+    stub = _StubClient(claimed_item=_ADD_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1, "complete_work_item must be called exactly once"
+    call = stub.complete_calls[0]
+    assert call["item_id"] == "wi-001"
+    assert call["execution_id"] == "exec_abc"
+    assert call["node_id"] == "add_step"
+    assert call["output"] == {"sum": 7}
+    assert len(stub.fail_calls) == 0, "fail must not be called on success"
+
+
+async def test_worker_posts_fail_on_handler_exception() -> None:
+    """(b) When the handler raises, fail_work_item is posted; complete is not called."""
+    stub = _StubClient(claimed_item=_BOOM_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.fail_calls) == 1, "fail_work_item must be called exactly once"
+    call = stub.fail_calls[0]
+    assert call["item_id"] == "wi-002"
+    assert "intentional failure" in call["error"]
+    assert len(stub.complete_calls) == 0, "complete must not be called on failure"
+
+
+async def test_worker_once_empty_queue_is_noop() -> None:
+    """(c) --once with no claimed item exits cleanly; complete and fail are never called."""
+    stub = _StubClient(claimed_item=None)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 0
+    assert len(stub.fail_calls) == 0

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -194,9 +194,7 @@ async def test_worker_seed_injection_deterministic() -> None:
     output_a = stub_a.complete_calls[0]["output"]["seed_value"]
     output_b = stub_b.complete_calls[0]["output"]["seed_value"]
     assert output_a is not None, "seed must be injected before handler invocation"
-    assert output_a == output_b, (
-        f"same execution_id must yield same seed: {output_a} != {output_b}"
-    )
+    assert output_a == output_b, f"same execution_id must yield same seed: {output_a} != {output_b}"
 
 
 async def test_worker_forwards_gen_ai_fields() -> None:


### PR DESCRIPTION
## What

Sub-plan 2d. Durable agents with Python `@tool` handlers now actually execute them. The durable engine routed `PythonFn` nodes to a `python_tool` queue that no worker claimed (silent no-op); 2d adds a Python worker that claims it over the existing HTTP protocol.

- Scheduler enriches the PythonFn work-item payload with `module`/`function`/`input` (`runner.rs`).
- New `jamjet worker` CLI: claims `python_tool` via `POST /work-items/claim`, resolves the handler with importlib, awaits it, posts `complete`/`fail`, heartbeats every 10s with the lease_fence. `--modules` to preload tool modules, `--once` for tests.
- `JamjetClient` gains claim/complete/fail/heartbeat methods.
- A zero-count `python-worker` queue group registers intent (durable Python tools require a running `jamjet worker`).
- Deterministic seed injection: the worker seeds RNG/UUID/clock from the claim's execution_id (contextvars, per-task) so tools opt into replay.
- GenAI telemetry fields (gen_ai_system/model, tokens, finish_reason) threaded through `CompleteWorkItemRequest` -> the NodeCompleted event, and added to `LlmResponse` (serde defaults keep old callers working).

## Tests
Rust `--workspace` green (2 new GenAI-field tests); Python suite 853 passed / 9 skipped (worker success/fail/once, seed determinism, GenAI forwarding); ruff clean; `import jamjet` clean.

## Mechanism / scope
Chosen over a Rust-embedded Python executor (PyO3) — the HTTP worker protocol already exists and the lease/fence/heartbeat machinery already protects claims. No Rust-side Python invocation.

## Known follow-up (F-2d-1, tracked, not blocking)
The worker completes via `POST /work-items/:id/complete`, which is the pre-existing UNFENCED, non-idempotent path (it appends NodeCompleted via append_event, not the fenced `commit_turn`). So durable Python tools via `jamjet worker` are functional but not yet fence-protected/idempotent. The fix is to route that endpoint through `commit_turn` with the worker's lease_fence (closes 2a-review F2 + the 2c HTTP-bypass note); deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Python-based work items with a new worker mode and queue handling.
  * Worker outputs can now include GenAI metadata such as model name and finish reason.
  * Deterministic seeds are now available to worker handlers for repeatable runs.

* **Bug Fixes**
  * Completion responses now preserve optional GenAI telemetry when provided, while remaining compatible for callers that omit it.
  * Heartbeats and work-item status updates now behave more reliably during long-running tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->