### PR TITLE
feat(2e): durable model calls go through the governed Python seam via a sidecar

### DIFF
--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -164,7 +164,11 @@ async fn main() -> anyhow::Result<()> {
     // worker processes against the same state backend instead. The base backend
     // claims across all tenants, so workers drain every execution's queue.
     if config.dev_mode || std::env::var("JAMJET_EMBED_WORKERS").is_ok() {
-        let model_registry = Arc::new(jamjet_models::registry::registry_from_env());
+        let model_registry = Arc::new(
+            jamjet_models::registry::registry_from_env_checked()
+                .await
+                .map_err(|e| anyhow::anyhow!("model seam coverage guard failed: {e}"))?,
+        );
         let pool = jamjet_worker::default_pool(state.backend.clone())
             .with_executor(
                 "model",

--- a/runtime/models/Cargo.toml
+++ b/runtime/models/Cargo.toml
@@ -21,3 +21,7 @@ async-trait = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
+
+[dev-dependencies]
+mockito = "1"
+tokio = { workspace = true }

--- a/runtime/models/src/anthropic.rs
+++ b/runtime/models/src/anthropic.rs
@@ -79,7 +79,10 @@ impl AnthropicAdapter {
     }
 
     fn build_request_body(&self, messages: &[ChatMessage], config: &ModelConfig) -> Value {
-        let model = config.model.as_deref().unwrap_or(&self.default_model);
+        let raw_model = config.model.as_deref().unwrap_or(&self.default_model);
+        // Strip "anthropic/" prefix when present — callers may send the fully-qualified
+        // form ("anthropic/claude-sonnet-4-6") but the Anthropic API expects bare names.
+        let model = raw_model.strip_prefix("anthropic/").unwrap_or(raw_model);
         let max_tokens = config.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
 
         // Anthropic separates system prompt from messages.

--- a/runtime/models/src/lib.rs
+++ b/runtime/models/src/lib.rs
@@ -15,9 +15,11 @@ pub mod google;
 pub mod ollama;
 pub mod openai;
 pub mod registry;
+pub mod sidecar;
 
 pub use adapter::{
     ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError, ModelRequest, ModelResponse,
     StructuredRequest,
 };
 pub use registry::ModelRegistry;
+pub use sidecar::SidecarModelAdapter;

--- a/runtime/models/src/registry.rs
+++ b/runtime/models/src/registry.rs
@@ -179,9 +179,10 @@ pub fn registry_from_env() -> ModelRegistry {
         }
     }
 
-    // Sidecar takes highest priority when configured — overrides the native default.
-    // Native adapters remain registered as prefix-routed fallbacks so explicit
-    // provider model strings (e.g. "claude-3-haiku") still route correctly.
+    // Sidecar takes highest priority when configured. In seam mode the registry
+    // is sidecar-only: apply_sidecar discards the native adapters and returns a
+    // fresh registry with no prefix routes and no native fallback. Every model
+    // string routes to the governed Python seam; nothing can bypass it.
     if let Ok(url) = std::env::var("JAMJET_MODEL_SEAM_URL") {
         registry = apply_sidecar(registry, url);
     }

--- a/runtime/models/src/registry.rs
+++ b/runtime/models/src/registry.rs
@@ -96,6 +96,15 @@ impl Default for ModelRegistry {
     }
 }
 
+impl ModelRegistry {
+    /// The system name of the current default adapter, if one is set.
+    ///
+    /// Primarily for tests and introspection — not on the hot path.
+    pub fn default_system(&self) -> Option<&str> {
+        self.default.as_deref()
+    }
+}
+
 /// Build a `ModelRegistry` from environment variables.
 ///
 /// Registers adapters based on available API keys / services:
@@ -104,9 +113,16 @@ impl Default for ModelRegistry {
 /// - Google if `GOOGLE_API_KEY` or `GEMINI_API_KEY` is set
 /// - Ollama if `OLLAMA_HOST` is set or defaults to localhost:11434
 ///
+/// If `JAMJET_MODEL_SEAM_URL` is set, also registers the `SidecarModelAdapter`
+/// and sets it as the default so durable-path calls go through the governed
+/// Python seam.  Native adapters stay registered as prefix-routed fallbacks.
+///
 /// Sets up standard prefix routing:
 ///   claude-* → anthropic, gpt-*/o1-*/o3-* → openai,
 ///   gemini-* → google, ollama model names → ollama.
+///
+/// **Does NOT probe the sidecar health endpoint.** Call
+/// [`registry_from_env_checked`] at startup if you need the fail-loud guard.
 pub fn registry_from_env() -> ModelRegistry {
     use crate::{
         anthropic::AnthropicAdapter, google::GoogleAdapter, ollama::OllamaAdapter,
@@ -158,5 +174,116 @@ pub fn registry_from_env() -> ModelRegistry {
         }
     }
 
+    // Sidecar takes highest priority when configured — overrides the native default.
+    // Native adapters remain registered as prefix-routed fallbacks so explicit
+    // provider model strings (e.g. "claude-3-haiku") still route correctly.
+    if let Ok(url) = std::env::var("JAMJET_MODEL_SEAM_URL") {
+        registry = apply_sidecar(registry, url);
+    }
+
     registry
+}
+
+/// Wire the sidecar into `registry`, setting it as the default adapter.
+///
+/// Extracted so tests can call it directly without touching env vars.
+pub(crate) fn apply_sidecar(registry: ModelRegistry, url: String) -> ModelRegistry {
+    use crate::sidecar::SidecarModelAdapter;
+    registry
+        .register(Arc::new(SidecarModelAdapter::new(url)))
+        .with_default("sidecar")
+}
+
+/// Like [`registry_from_env`] but also probes the sidecar `/health` endpoint.
+///
+/// Returns `Err` if `JAMJET_MODEL_SEAM_URL` is set but the sidecar is
+/// unreachable or responds non-2xx — so a misconfigured deployment fails loud
+/// at startup rather than silently falling through to the native adapters.
+///
+/// Call this at the `main()` call site instead of `registry_from_env()`.
+pub async fn registry_from_env_checked() -> Result<ModelRegistry, ModelError> {
+    let registry = registry_from_env();
+    if let Ok(url) = std::env::var("JAMJET_MODEL_SEAM_URL") {
+        let client = reqwest::Client::new();
+        crate::sidecar::check_sidecar_health(&url, &client).await?;
+    }
+    Ok(registry)
+}
+
+// ── Registry wiring tests ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialise env-var-mutating tests to avoid races between parallel test threads.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn apply_sidecar_sets_sidecar_as_default() {
+        let registry = apply_sidecar(ModelRegistry::new(), "http://127.0.0.1:4280".into());
+        assert_eq!(
+            registry.default_system(),
+            Some("sidecar"),
+            "sidecar must be the default when URL is wired"
+        );
+    }
+
+    #[test]
+    fn apply_sidecar_registers_adapter_by_name() {
+        let registry = apply_sidecar(ModelRegistry::new(), "http://127.0.0.1:4280".into());
+        // The adapter must be reachable (resolve returns Some for empty model name).
+        let adapter = registry.resolve("");
+        assert!(adapter.is_some(), "sidecar adapter must be registered");
+        assert_eq!(adapter.unwrap().system_name(), "sidecar");
+    }
+
+    #[test]
+    fn registry_from_env_sets_sidecar_default_when_url_set() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Safety: guarded by ENV_LOCK; removed immediately after.
+        unsafe {
+            std::env::set_var("JAMJET_MODEL_SEAM_URL", "http://127.0.0.1:4280");
+        }
+        let registry = registry_from_env();
+        unsafe {
+            std::env::remove_var("JAMJET_MODEL_SEAM_URL");
+        }
+        assert_eq!(
+            registry.default_system(),
+            Some("sidecar"),
+            "registry_from_env must make sidecar the default when JAMJET_MODEL_SEAM_URL is set"
+        );
+    }
+
+    #[test]
+    fn registry_from_env_no_sidecar_when_url_unset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var("JAMJET_MODEL_SEAM_URL");
+        }
+        let registry = registry_from_env();
+        assert_ne!(
+            registry.default_system(),
+            Some("sidecar"),
+            "sidecar must not be default when JAMJET_MODEL_SEAM_URL is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_from_env_checked_errors_on_unreachable_sidecar() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            // Port 1 is never open — connection will be refused immediately.
+            std::env::set_var("JAMJET_MODEL_SEAM_URL", "http://127.0.0.1:1");
+        }
+        let result = registry_from_env_checked().await;
+        unsafe {
+            std::env::remove_var("JAMJET_MODEL_SEAM_URL");
+        }
+        assert!(
+            result.is_err(),
+            "registry_from_env_checked must fail when sidecar is unreachable"
+        );
+    }
 }

--- a/runtime/models/src/registry.rs
+++ b/runtime/models/src/registry.rs
@@ -113,9 +113,10 @@ impl ModelRegistry {
 /// - Google if `GOOGLE_API_KEY` or `GEMINI_API_KEY` is set
 /// - Ollama if `OLLAMA_HOST` is set or defaults to localhost:11434
 ///
-/// If `JAMJET_MODEL_SEAM_URL` is set, also registers the `SidecarModelAdapter`
-/// and sets it as the default so durable-path calls go through the governed
-/// Python seam.  Native adapters stay registered as prefix-routed fallbacks.
+/// If `JAMJET_MODEL_SEAM_URL` is set, all native adapters and prefix routes are
+/// DISCARDED and a sidecar-only registry is returned via [`apply_sidecar`].
+/// Every model string — with or without a provider prefix — routes to the
+/// governed Python seam.  No native bypass paths survive in seam mode.
 ///
 /// Sets up standard prefix routing:
 ///   claude-* → anthropic, gpt-*/o1-*/o3-* → openai,
@@ -130,12 +131,16 @@ pub fn registry_from_env() -> ModelRegistry {
     };
 
     let mut registry = ModelRegistry::new()
+        // Fully-qualified provider-prefixed strings (e.g. "anthropic/claude-sonnet-4-6").
+        .route_prefix("anthropic/", "anthropic")
+        .route_prefix("openai/", "openai")
+        .route_prefix("google/", "google")
+        // Bare model-name prefixes for backwards compat.
         .route_prefix("claude-", "anthropic")
         .route_prefix("gpt-", "openai")
         .route_prefix("o1-", "openai")
         .route_prefix("o3-", "openai")
         .route_prefix("gemini-", "google")
-        .route_prefix("google/", "google")
         // Common Ollama model name patterns.
         .route_prefix("llama", "ollama")
         .route_prefix("qwen", "ollama")
@@ -184,12 +189,22 @@ pub fn registry_from_env() -> ModelRegistry {
     registry
 }
 
-/// Wire the sidecar into `registry`, setting it as the default adapter.
+/// Build a sidecar-only `ModelRegistry` for seam mode.
+///
+/// In seam mode ALL model calls — regardless of model name or prefix — must go
+/// through the governed Python sidecar. We therefore return a FRESH registry
+/// containing ONLY the `SidecarModelAdapter`, with no native adapters and no
+/// prefix routes. Any model string (bare `"claude-sonnet-4-6"`, qualified
+/// `"anthropic/claude-3"`, or empty) falls through to the sidecar default.
+///
+/// The incoming `_registry` (which may contain native adapters built from env
+/// vars) is intentionally discarded — registering native adapters alongside the
+/// sidecar would keep the bypass paths alive.
 ///
 /// Extracted so tests can call it directly without touching env vars.
-pub(crate) fn apply_sidecar(registry: ModelRegistry, url: String) -> ModelRegistry {
+pub(crate) fn apply_sidecar(_registry: ModelRegistry, url: String) -> ModelRegistry {
     use crate::sidecar::SidecarModelAdapter;
-    registry
+    ModelRegistry::new()
         .register(Arc::new(SidecarModelAdapter::new(url)))
         .with_default("sidecar")
 }
@@ -285,5 +300,97 @@ mod tests {
             result.is_err(),
             "registry_from_env_checked must fail when sidecar is unreachable"
         );
+    }
+
+    /// C2A: in seam mode ALL model strings must resolve to the sidecar adapter.
+    ///
+    /// This test would FAIL under the old `apply_sidecar` (which kept native
+    /// prefix routes alive — a bare "claude-..." would bypass the sidecar if
+    /// ANTHROPIC_API_KEY was set). It passes after the fix where `apply_sidecar`
+    /// returns a fresh sidecar-only registry.
+    #[test]
+    fn seam_mode_all_model_strings_route_to_sidecar() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("JAMJET_MODEL_SEAM_URL", "http://127.0.0.1:4280");
+        }
+        let registry = registry_from_env();
+        unsafe {
+            std::env::remove_var("JAMJET_MODEL_SEAM_URL");
+        }
+
+        // Every model string — bare, qualified, empty — must route to sidecar.
+        let cases = [
+            "claude-sonnet-4-6",  // bare string: old bug — routed to native anthropic
+            "anthropic/claude-3", // qualified: also bypassed via prefix route
+            "gpt-4",              // would have routed to native openai
+            "",                   // unspecified default
+        ];
+        for model in &cases {
+            let adapter = registry.resolve(model);
+            assert!(
+                adapter.is_some(),
+                "seam mode: adapter must exist for model string {model:?}"
+            );
+            assert_eq!(
+                adapter.unwrap().system_name(),
+                "sidecar",
+                "seam mode: model string {model:?} must route to sidecar, not a native adapter"
+            );
+        }
+    }
+
+    /// C2A non-seam: prefix routing to native adapters still works without sidecar.
+    ///
+    /// Builds a registry manually (no env vars needed) with a stub adapter and
+    /// verifies that prefix routes function correctly in non-seam mode.
+    #[test]
+    fn non_seam_prefix_routes_work() {
+        use crate::adapter::{
+            ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest,
+        };
+
+        struct StubAdapter(&'static str);
+        #[async_trait::async_trait]
+        impl ModelAdapter for StubAdapter {
+            fn system_name(&self) -> &'static str {
+                self.0
+            }
+            fn default_model(&self) -> &str {
+                "stub"
+            }
+            async fn chat(&self, _: ModelRequest) -> Result<ModelResponse, ModelError> {
+                unimplemented!()
+            }
+            async fn structured_output(
+                &self,
+                _: StructuredRequest,
+            ) -> Result<ModelResponse, ModelError> {
+                unimplemented!()
+            }
+        }
+
+        let registry = ModelRegistry::new()
+            .route_prefix("anthropic/", "anthropic")
+            .route_prefix("claude-", "anthropic")
+            .route_prefix("gpt-", "openai")
+            .register(Arc::new(StubAdapter("anthropic")))
+            .register(Arc::new(StubAdapter("openai")))
+            .with_default("anthropic");
+
+        // Qualified prefix routes to the right adapter.
+        let a = registry.resolve("anthropic/claude-sonnet-4-6");
+        assert_eq!(a.unwrap().system_name(), "anthropic");
+
+        // Bare model prefix routes correctly.
+        let b = registry.resolve("claude-3-haiku");
+        assert_eq!(b.unwrap().system_name(), "anthropic");
+
+        let c = registry.resolve("gpt-4");
+        assert_eq!(c.unwrap().system_name(), "openai");
+
+        // Unrecognised string falls to the default.
+        let d = registry.resolve("unknown-model");
+        assert_eq!(d.unwrap().system_name(), "anthropic");
     }
 }

--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -69,8 +69,23 @@ impl SidecarModelAdapter {
             .to_string();
         let model = json["model"].as_str().unwrap_or(DEFAULT_MODEL).to_string();
         let finish_reason = json["finish_reason"].as_str().unwrap_or("stop").to_string();
-        let input_tokens = json["input_tokens"].as_u64().unwrap_or(0);
-        let output_tokens = json["output_tokens"].as_u64().unwrap_or(0);
+
+        // I4: parse token counts strictly — a missing or wrong-type field means the
+        // metering data is corrupt; fail closed rather than silently zeroing the count.
+        // Cost is recorded by the Python MeteringMiddleware after C1; cost_usd is not
+        // threaded to the Rust event here.
+        // F-2e-cost: cost_usd from the Python MeteringMiddleware is not yet threaded to the Rust event.
+        let input_tokens = json["input_tokens"].as_u64().ok_or_else(|| {
+            ModelError::Serialization(
+                "sidecar response missing or invalid 'input_tokens' field".to_string(),
+            )
+        })?;
+        let output_tokens = json["output_tokens"].as_u64().ok_or_else(|| {
+            ModelError::Serialization(
+                "sidecar response missing or invalid 'output_tokens' field".to_string(),
+            )
+        })?;
+
         Ok(ModelResponse {
             content,
             model,
@@ -197,18 +212,43 @@ pub async fn check_sidecar_health(
              Cause: {e}"
         ))
     })?;
-    if !resp.status().is_success() {
-        let status = resp.status().as_u16();
+
+    let status = resp.status();
+    if !status.is_success() {
+        let code = status.as_u16();
         let body = resp.text().await.unwrap_or_default();
         return Err(ModelError::Api {
-            status,
+            status: code,
             body: format!(
-                "JAMJET_MODEL_SEAM_URL set but sidecar /health returned {status} — \
+                "JAMJET_MODEL_SEAM_URL set but sidecar /health returned {code} — \
                  refusing to start so model calls never silently bypass the governed seam. \
                  Body: {body}"
             ),
         });
     }
+
+    // I3: also validate the JSON body — a wrong service returning 200 must not pass.
+    // The sidecar contract guarantees {"ok": true}; anything else is treated as a failure.
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| ModelError::Network(e.to_string()))?;
+    let json: serde_json::Value = serde_json::from_str(&body).map_err(|_| {
+        ModelError::Serialization(format!(
+            "sidecar /health returned a non-JSON body — \
+             refusing to start. Body: {body}"
+        ))
+    })?;
+    if json.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(ModelError::Api {
+            status: status.as_u16(),
+            body: format!(
+                "sidecar /health did not return {{\"ok\":true}} — \
+                 refusing to start. Body: {body}"
+            ),
+        });
+    }
+
     Ok(())
 }
 
@@ -370,6 +410,109 @@ mod tests {
         assert!(
             matches!(result, Err(ModelError::Network(_))),
             "expected Network error, got {result:?}"
+        );
+    }
+
+    // I3: health guard must reject ok=false and non-JSON 200 bodies.
+
+    #[tokio::test]
+    async fn health_check_errors_on_ok_false() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":false}"#)
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+        let result = check_sidecar_health(&server.url(), &client).await;
+        assert!(
+            matches!(result, Err(ModelError::Api { .. })),
+            "health guard must reject {{\"ok\":false}}, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_errors_on_non_json_200() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("OK")
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+        let result = check_sidecar_health(&server.url(), &client).await;
+        assert!(
+            matches!(result, Err(ModelError::Serialization(_))),
+            "health guard must reject a non-JSON 200 body, got {result:?}"
+        );
+    }
+
+    // I4: missing output_tokens must cause chat() to return Err, not a zero-metered response.
+
+    #[tokio::test]
+    async fn chat_errors_when_output_tokens_missing() {
+        let mut server = mockito::Server::new_async().await;
+
+        // Response omits output_tokens — the old unwrap_or(0) would silently zero it.
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": "hi", "role": "assistant"},
+                "input_tokens": 5,
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": "stop"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::Serialization(_))),
+            "missing output_tokens must produce Serialization error, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_errors_when_input_tokens_missing() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": "hi", "role": "assistant"},
+                "output_tokens": 3,
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": "stop"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::Serialization(_))),
+            "missing input_tokens must produce Serialization error, got {result:?}"
         );
     }
 }

--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -1,0 +1,375 @@
+//! Sidecar model adapter — POSTs to the Python model-seam sidecar.
+//!
+//! Set `JAMJET_MODEL_SEAM_URL` (e.g. `http://127.0.0.1:4280`) to route
+//! durable-path model calls through the governed Python seam (provider
+//! allow-list, PII redaction, cost metering, middleware).
+//!
+//! Sidecar contract:
+//! - `POST /v1/complete` — `{model, messages, temperature?, max_tokens?}`
+//!   → `{message:{content,role}, input_tokens, output_tokens, cost_usd, model, finish_reason}`
+//! - `GET /health` → `{ok:true}`
+
+use crate::adapter::{
+    ChatRole, ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest,
+};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-6";
+
+/// Routes durable-path model calls to the Python model-seam sidecar via HTTP.
+///
+/// The sidecar wraps `jamjet.model.Model` (Track-1 seam), so every call
+/// inherits the same governed middleware as in-process `Agent.run()`.
+pub struct SidecarModelAdapter {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl SidecarModelAdapter {
+    /// Create an adapter that POSTs to `base_url` (e.g. `http://127.0.0.1:4280`).
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+        }
+    }
+
+    async fn call_complete(&self, body: Value) -> Result<Value, ModelError> {
+        let url = format!("{}/v1/complete", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ModelError::Network(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ModelError::Network(e.to_string()))?;
+
+        if status == 429 {
+            return Err(ModelError::RateLimited {
+                retry_after_secs: 60,
+            });
+        }
+        if status != 200 {
+            return Err(ModelError::Api { status, body: text });
+        }
+        serde_json::from_str(&text).map_err(|e| ModelError::Serialization(e.to_string()))
+    }
+
+    fn parse_response(&self, json: Value) -> Result<ModelResponse, ModelError> {
+        let content = json["message"]["content"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        let model = json["model"].as_str().unwrap_or(DEFAULT_MODEL).to_string();
+        let finish_reason = json["finish_reason"].as_str().unwrap_or("stop").to_string();
+        let input_tokens = json["input_tokens"].as_u64().unwrap_or(0);
+        let output_tokens = json["output_tokens"].as_u64().unwrap_or(0);
+        Ok(ModelResponse {
+            content,
+            model,
+            finish_reason,
+            input_tokens,
+            output_tokens,
+            structured: None,
+        })
+    }
+
+    fn build_messages(
+        messages: &[crate::adapter::ChatMessage],
+        system_prompt: Option<&str>,
+    ) -> Vec<Value> {
+        let mut out: Vec<Value> = Vec::new();
+        // Inject system prompt as leading system message if configured.
+        if let Some(sys) = system_prompt {
+            if !sys.is_empty() {
+                out.push(json!({ "role": "system", "content": sys }));
+            }
+        }
+        for m in messages {
+            let role = match m.role {
+                ChatRole::System => "system",
+                ChatRole::User | ChatRole::Tool => "user",
+                ChatRole::Assistant => "assistant",
+            };
+            out.push(json!({ "role": role, "content": m.content }));
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl ModelAdapter for SidecarModelAdapter {
+    fn system_name(&self) -> &'static str {
+        "sidecar"
+    }
+
+    fn default_model(&self) -> &str {
+        DEFAULT_MODEL
+    }
+
+    async fn chat(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        let model = request
+            .config
+            .model
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MODEL.into());
+
+        let messages =
+            Self::build_messages(&request.messages, request.config.system_prompt.as_deref());
+
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+        });
+        if let Some(temp) = request.config.temperature {
+            body["temperature"] = json!(temp);
+        }
+        if let Some(max) = request.config.max_tokens {
+            body["max_tokens"] = json!(max);
+        }
+
+        let resp_json = self.call_complete(body).await?;
+        self.parse_response(resp_json)
+    }
+
+    async fn structured_output(
+        &self,
+        request: StructuredRequest,
+    ) -> Result<ModelResponse, ModelError> {
+        // Append schema instruction to system prompt (mirrors AnthropicAdapter).
+        let schema_str = serde_json::to_string_pretty(&request.output_schema)
+            .map_err(|e| ModelError::Serialization(e.to_string()))?;
+        let mut config = request.config.clone();
+        let system = config.system_prompt.get_or_insert_with(String::new);
+        system.push_str(&format!(
+            "\n\nRespond ONLY with a valid JSON object matching this schema:\n{schema_str}\nDo not include any other text."
+        ));
+
+        let chat_req = ModelRequest {
+            messages: request.messages,
+            config,
+        };
+        let mut response = self.chat(chat_req).await?;
+
+        // Parse structured output from the response content.
+        let structured = serde_json::from_str::<Value>(&response.content)
+            .or_else(|_| {
+                let trimmed = response.content.trim();
+                let inner = trimmed
+                    .trim_start_matches("```json")
+                    .trim_start_matches("```")
+                    .trim_end_matches("```")
+                    .trim();
+                serde_json::from_str::<Value>(inner)
+            })
+            .map_err(|e| {
+                ModelError::Serialization(format!("failed to parse structured output: {e}"))
+            })?;
+
+        response.structured = Some(structured);
+        Ok(response)
+    }
+}
+
+// ── Coverage guard ────────────────────────────────────────────────────────────
+
+/// Probe the sidecar `/health` endpoint at startup.
+///
+/// Returns `Err` with a descriptive message if the sidecar is unreachable or
+/// responds with a non-2xx status — so a misconfigured deployment fails loud
+/// rather than silently falling through to the native (ungoverned) adapters.
+pub async fn check_sidecar_health(
+    base_url: &str,
+    client: &reqwest::Client,
+) -> Result<(), ModelError> {
+    let url = format!("{base_url}/health");
+    let resp = client.get(&url).send().await.map_err(|e| {
+        ModelError::Network(format!(
+            "JAMJET_MODEL_SEAM_URL set but sidecar unreachable at {url} — \
+             refusing to start so model calls never silently bypass the governed seam. \
+             Cause: {e}"
+        ))
+    })?;
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ModelError::Api {
+            status,
+            body: format!(
+                "JAMJET_MODEL_SEAM_URL set but sidecar /health returned {status} — \
+                 refusing to start so model calls never silently bypass the governed seam. \
+                 Body: {body}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::ChatMessage;
+
+    #[tokio::test]
+    async fn chat_maps_response_fields() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": "Hello, world!", "role": "assistant"},
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cost_usd": 0.001,
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": "stop"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let resp = adapter.chat(req).await.expect("chat should succeed");
+
+        assert_eq!(resp.content, "Hello, world!");
+        assert_eq!(resp.input_tokens, 10);
+        assert_eq!(resp.output_tokens, 5);
+        assert_eq!(resp.model, "anthropic/claude-sonnet-4-6");
+        assert_eq!(resp.finish_reason, "stop");
+        assert!(resp.structured.is_none());
+    }
+
+    #[tokio::test]
+    async fn chat_sends_temperature_and_max_tokens() {
+        use crate::adapter::ModelConfig;
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"temperature":0.5,"max_tokens":256}"#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message":{"content":"ok","role":"assistant"},
+                "input_tokens":1,"output_tokens":1,
+                "model":"anthropic/claude-sonnet-4-6","finish_reason":"stop"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]).with_config(ModelConfig {
+            temperature: Some(0.5),
+            max_tokens: Some(256),
+            ..Default::default()
+        });
+        adapter.chat(req).await.expect("should succeed");
+    }
+
+    #[tokio::test]
+    async fn chat_errors_on_non_200() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(500)
+            .with_body("internal server error")
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::Api { status: 500, .. })),
+            "expected Api error with status 500, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_errors_on_rate_limit() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(429)
+            .with_body("rate limited")
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::RateLimited { .. })),
+            "expected RateLimited, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_passes_on_200() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true}"#)
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+        check_sidecar_health(&server.url(), &client)
+            .await
+            .expect("health check should pass");
+    }
+
+    #[tokio::test]
+    async fn health_check_errors_on_non_200() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("GET", "/health")
+            .with_status(503)
+            .with_body("unavailable")
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+        let result = check_sidecar_health(&server.url(), &client).await;
+        assert!(
+            matches!(result, Err(ModelError::Api { status: 503, .. })),
+            "expected Api error with status 503, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_check_errors_on_unreachable() {
+        // Port 1 is never listening.
+        let client = reqwest::Client::new();
+        let result = check_sidecar_health("http://127.0.0.1:1", &client).await;
+        assert!(
+            matches!(result, Err(ModelError::Network(_))),
+            "expected Network error, got {result:?}"
+        );
+    }
+}

--- a/runtime/workers/src/executors/model_node.rs
+++ b/runtime/workers/src/executors/model_node.rs
@@ -30,11 +30,15 @@ impl NodeExecutor for ModelNodeExecutor {
 
         // Extract model config from the work item payload.
         // The payload is populated by the scheduler from the IR node definition.
+        // Default to the fully-qualified provider-prefixed string so that:
+        //  • the Python sidecar's parse_model_ref maps it to provider=anthropic
+        //    (a bare "claude-sonnet-4-6" mis-maps to provider=openai — C2 fix).
+        //  • the non-seam registry routes it via the "anthropic/" prefix route.
         let model = item
             .payload
             .get("model")
             .and_then(|v| v.as_str())
-            .unwrap_or("claude-sonnet-4-6")
+            .unwrap_or("anthropic/claude-sonnet-4-6")
             .to_string();
 
         let system_prompt = item

--- a/runtime/workers/src/executors/model_node.rs
+++ b/runtime/workers/src/executors/model_node.rs
@@ -130,13 +130,25 @@ impl NodeExecutor for ModelNodeExecutor {
             state_patch,
             duration_ms,
             gen_ai_system: Some(
-                // Infer system from model name prefix.
-                if response.model.starts_with("claude") {
-                    "anthropic"
-                } else if response.model.starts_with("gpt") || response.model.starts_with("o1") {
-                    "openai"
-                } else {
-                    "unknown"
+                {
+                    // Infer the provider from the model name, tolerating an optional
+                    // "provider/" prefix (e.g. "anthropic/claude-sonnet-4-6" or bare
+                    // "claude-sonnet-4-6" both classify as "anthropic").
+                    let bare = response
+                        .model
+                        .split_once('/')
+                        .map(|(_, m)| m)
+                        .unwrap_or(response.model.as_str());
+                    if response.model.starts_with("anthropic/") || bare.starts_with("claude") {
+                        "anthropic"
+                    } else if response.model.starts_with("openai/")
+                        || bare.starts_with("gpt")
+                        || bare.starts_with("o1")
+                    {
+                        "openai"
+                    } else {
+                        "unknown"
+                    }
                 }
                 .to_string(),
             ),

--- a/runtime/workers/tests/sidecar_e2e.rs
+++ b/runtime/workers/tests/sidecar_e2e.rs
@@ -103,4 +103,11 @@ async fn model_node_routes_through_sidecar_seam() {
         Some("anthropic/claude-sonnet-4-6"),
         "model name must propagate to telemetry"
     );
+    // Regression guard for the prefix-tolerant gen_ai_system fix:
+    // "anthropic/claude-sonnet-4-6" must classify as "anthropic", not "unknown".
+    assert_eq!(
+        result.gen_ai_system,
+        Some("anthropic".to_string()),
+        "gen_ai_system must classify provider-prefixed model names correctly"
+    );
 }

--- a/runtime/workers/tests/sidecar_e2e.rs
+++ b/runtime/workers/tests/sidecar_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end test: the durable Model node routes through the sidecar seam.
+//!
+//! Proves that when `ModelRegistry` is configured with a `SidecarModelAdapter`,
+//! `ModelNodeExecutor` routes calls through it and surfaces the sidecar's token
+//! metering in `ExecutionResult`. This is a node-level test (not registry-level)
+//! — the full `execute()` path runs, identical to the durable worker call path.
+
+use jamjet_core::workflow::ExecutionId;
+use jamjet_models::{ModelRegistry, SidecarModelAdapter};
+use jamjet_state::backend::WorkItem;
+use jamjet_worker::{ModelNodeExecutor, NodeExecutor};
+use std::sync::Arc;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Minimal work item that drives a Model node with a plain text prompt.
+fn make_model_item() -> WorkItem {
+    WorkItem {
+        id: uuid::Uuid::new_v4(),
+        execution_id: ExecutionId::new(),
+        node_id: "model-1".into(),
+        queue_type: "model".into(),
+        payload: serde_json::json!({
+            "model": "anthropic/claude-sonnet-4-6",
+            "prompt": "say hi",
+        }),
+        attempt: 1,
+        max_attempts: 3,
+        created_at: chrono::Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: "default".into(),
+    }
+}
+
+/// The durable Model node routes through the sidecar and carries its metering.
+///
+/// Wires `SidecarModelAdapter` as the registry default, drives
+/// `ModelNodeExecutor::execute()`, and asserts that token counts and content
+/// from the canned sidecar response appear unchanged in the `ExecutionResult`.
+#[tokio::test]
+async fn model_node_routes_through_sidecar_seam() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/complete"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{
+                "message": {"content": "hi from seam", "role": "assistant"},
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "cost_usd": 0.002,
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": "stop"
+            }"#,
+        ))
+        .mount(&server)
+        .await;
+
+    // Wire the registry so every call goes to the sidecar.
+    let registry = Arc::new(
+        ModelRegistry::new()
+            .register(Arc::new(SidecarModelAdapter::new(server.uri())))
+            .with_default("sidecar"),
+    );
+
+    let executor = ModelNodeExecutor::new(registry);
+    let item = make_model_item();
+
+    let result = executor
+        .execute(&item)
+        .await
+        .expect("ModelNodeExecutor must succeed against the mock sidecar");
+
+    // Token metering from the sidecar must flow through unmodified.
+    assert_eq!(
+        result.input_tokens,
+        Some(11),
+        "input_tokens must match the sidecar response"
+    );
+    assert_eq!(
+        result.output_tokens,
+        Some(7),
+        "output_tokens must match the sidecar response"
+    );
+    assert_eq!(
+        result.finish_reason.as_deref(),
+        Some("stop"),
+        "finish_reason must propagate"
+    );
+
+    // Content surfaces in the ExecutionResult output object.
+    assert_eq!(
+        result.output["content"].as_str(),
+        Some("hi from seam"),
+        "content must be the sidecar's response verbatim"
+    );
+
+    // Telemetry fields must be populated.
+    assert_eq!(
+        result.gen_ai_model.as_deref(),
+        Some("anthropic/claude-sonnet-4-6"),
+        "model name must propagate to telemetry"
+    );
+}

--- a/sdk/python/jamjet/model/README-sidecar.md
+++ b/sdk/python/jamjet/model/README-sidecar.md
@@ -1,0 +1,27 @@
+# Running the model seam sidecar
+
+The JamJet runtime routes durable-path model calls through a local Python process that wraps `jamjet.model.Model`. This gives the Rust engine the same governed seam as in-process `Agent.run()`: provider allowlist, PII redaction, cost metering, and any middleware you register.
+
+## Install
+
+```
+pip install "jamjet[sidecar]"
+```
+
+This pulls in `starlette` and `uvicorn` alongside the core model dependencies.
+
+## Start
+
+```
+uvicorn jamjet.model.sidecar_server:app --host 127.0.0.1 --port 4280
+```
+
+## Configure the runtime
+
+Set this environment variable before starting the runtime process:
+
+```
+JAMJET_MODEL_SEAM_URL=http://127.0.0.1:4280
+```
+
+The runtime probes `GET /health` at startup. If the sidecar is unreachable or returns a non-200 status, the runtime refuses to start with a clear error message. This fail-loud guard ensures model calls never silently bypass the governed seam. If the variable is absent, the runtime falls back to native Rust adapters, which is the default for development.

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -57,8 +57,8 @@ async def _complete(body: dict[str, Any], model: Model) -> dict[str, Any]:
 
 
 async def _handle_complete(request: Request) -> JSONResponse:
-    body = await request.json()
     try:
+        body = await request.json()
         result = await _complete(body, _get_model())
         return JSONResponse(result)
     except (KeyError, ValueError) as exc:

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -17,6 +17,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from jamjet.model.defaults import default_model_middleware
 from jamjet.model.seam import Model
 from jamjet.model.types import ModelRequest, parse_model_ref
 
@@ -28,7 +29,7 @@ _model: Model | None = None
 def _get_model() -> Model:
     global _model  # noqa: PLW0603 -- intentional singleton
     if _model is None:
-        _model = Model()
+        _model = Model(middleware=default_model_middleware())
     return _model
 
 

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -1,0 +1,76 @@
+"""Starlette sidecar that wraps the governed Model seam.
+
+Exposes two routes consumed by the durable Rust engine:
+  POST /v1/complete  -- runs the full middleware chain (allowlist, PII, metering)
+  GET  /health       -- liveness probe used by the Rust startup guard
+
+Run with:
+  uvicorn jamjet.model.sidecar_server:app --host 127.0.0.1 --port 4280
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from jamjet.model.seam import Model
+from jamjet.model.types import ModelRequest, parse_model_ref
+
+# Module-level singleton -- created lazily on first call so tests can inject
+# a fake model by monkeypatching _get_model.
+_model: Model | None = None
+
+
+def _get_model() -> Model:
+    global _model  # noqa: PLW0603 -- intentional singleton
+    if _model is None:
+        _model = Model()
+    return _model
+
+
+async def _complete(body: dict[str, Any], model: Model) -> dict[str, Any]:
+    """Core completion handler; injectable for testing without Starlette."""
+    ref = parse_model_ref(body["model"])
+    req = ModelRequest(
+        ref=ref,
+        messages=body["messages"],
+        temperature=body.get("temperature"),
+        max_tokens=body.get("max_tokens"),
+    )
+    resp = await model.complete(req)
+    return {
+        "message": {
+            "content": resp.message.content,
+            "role": "assistant",
+        },
+        "input_tokens": resp.input_tokens,
+        "output_tokens": resp.output_tokens,
+        "cost_usd": resp.cost_usd,
+        "model": ref.litellm_model,
+        "finish_reason": getattr(resp.message, "finish_reason", None) or "stop",
+    }
+
+
+async def _handle_complete(request: Request) -> JSONResponse:
+    body = await request.json()
+    try:
+        result = await _complete(body, _get_model())
+        return JSONResponse(result)
+    except (KeyError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+
+async def _handle_health(request: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+app = Starlette(
+    routes=[
+        Route("/v1/complete", _handle_complete, methods=["POST"]),
+        Route("/health", _handle_health, methods=["GET"]),
+    ]
+)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -70,6 +70,7 @@ openai = ["openai>=2"]
 anthropic = ["anthropic>=0.40"]
 cloud-all = ["openai>=2", "anthropic>=0.40"]
 model = ["litellm>=1.50"]
+sidecar = ["starlette>=0.40", "uvicorn>=0.30"]
 # Optional extras for the `jamjet.durable` framework shims (introduced in 0.7.0).
 # Each enables a thin durable_run() context manager that bridges the framework's
 # native run identity to JamJet's @durable idempotency cache.

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -144,6 +144,27 @@ async def test_complete_route(monkeypatch: pytest.MonkeyPatch) -> None:
     assert data["model"] == "anthropic/claude-sonnet-4-6"
 
 
+async def test_complete_route_malformed_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /v1/complete with a non-JSON body returns 400, not 500.
+
+    Regression guard for the json.JSONDecodeError (a ValueError subclass) fix:
+    request.json() is now inside the try so a malformed body returns the intended
+    400 rather than an unhandled 500.
+    """
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeModel())
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            content=b"not json at all",
+            headers={"content-type": "application/json"},
+        )
+
+    assert resp.status_code == 400
+    assert "error" in resp.json()
+
+
 async def test_complete_route_missing_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """POST /v1/complete with missing 'model' key returns 400."""
     monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeModel())

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -157,3 +157,34 @@ async def test_complete_route_missing_model_key(monkeypatch: pytest.MonkeyPatch)
 
     assert resp.status_code == 400
     assert "error" in resp.json()
+
+
+# --------------------------------------------------------------------------- #
+# C1: sidecar Model must be governed (non-empty middleware chain)
+# --------------------------------------------------------------------------- #
+
+
+def test_get_model_has_governed_middleware() -> None:
+    """The real _get_model() constructs a Model with the default middleware chain.
+
+    This test would FAIL against the old bare ``Model()`` construction (no middleware)
+    and PASSES once ``default_model_middleware()`` is wired in.
+    """
+    from jamjet.model.metering import MeteringMiddleware
+    from jamjet.model.middleware import ModelAllowlistMiddleware
+
+    # Force a fresh singleton so monkeypatching in other tests doesn't affect us.
+    sidecar_module._model = None
+    model = sidecar_module._get_model()
+
+    assert len(model._middleware) > 0, (
+        "_get_model() returned a bare Model() with no middleware — the sidecar is ungoverned"
+    )
+    mw_types = [type(mw) for mw in model._middleware]
+    assert ModelAllowlistMiddleware in mw_types, (
+        "ModelAllowlistMiddleware must be in the sidecar Model's middleware chain"
+    )
+    assert MeteringMiddleware in mw_types, "MeteringMiddleware must be in the sidecar Model's middleware chain"
+
+    # Restore singleton state so subsequent tests get a fresh instance.
+    sidecar_module._model = None

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -1,0 +1,159 @@
+"""Tests for the Model-seam sidecar server (Task 2e-1).
+
+Tests the core _complete handler directly (no Starlette required) and also
+exercises the HTTP routes via httpx ASGITransport (starlette is installed).
+No real model calls are made; a FakeModel stub is injected throughout.
+"""
+
+import httpx
+import pytest
+
+import jamjet.model.sidecar_server as sidecar_module
+from jamjet.model.sidecar_server import _complete, app
+from jamjet.model.types import ModelResponse
+
+
+class FakeMessage:
+    """Minimal OpenAI-shaped message object returned by the fake backend."""
+
+    def __init__(self, content: str = "hi", finish_reason: str | None = None) -> None:
+        self.content = content
+        self.finish_reason = finish_reason
+
+
+class FakeModel:
+    """Stub that satisfies the Model.complete() contract without a real provider."""
+
+    async def complete(self, request):  # noqa: ANN001, ANN201
+        return ModelResponse(
+            message=FakeMessage(content="hi"),
+            input_tokens=3,
+            output_tokens=4,
+            cost_usd=0.001,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Core handler tests (no Starlette / HTTP)
+# --------------------------------------------------------------------------- #
+
+
+async def test_complete_core_returns_wrapped_shape() -> None:
+    """_complete() maps ModelResponse into the sidecar wire format."""
+    result = await _complete(
+        {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        FakeModel(),  # type: ignore[arg-type]
+    )
+
+    assert result["message"]["content"] == "hi"
+    assert result["message"]["role"] == "assistant"
+    assert result["input_tokens"] == 3
+    assert result["output_tokens"] == 4
+    assert result["cost_usd"] == pytest.approx(0.001)
+    assert result["model"] == "anthropic/claude-sonnet-4-6"
+    assert result["finish_reason"] == "stop"  # None -> "stop"
+
+
+async def test_complete_core_finish_reason_passthrough() -> None:
+    """finish_reason is forwarded when the message carries one."""
+
+    class FakeModelWithReason:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            return ModelResponse(
+                message=FakeMessage(content="done", finish_reason="length"),
+                input_tokens=1,
+                output_tokens=1,
+                cost_usd=0.0,
+            )
+
+    result = await _complete(
+        {"model": "openai/gpt-4o", "messages": []},
+        FakeModelWithReason(),  # type: ignore[arg-type]
+    )
+    assert result["finish_reason"] == "length"
+
+
+async def test_complete_core_optional_params_forwarded() -> None:
+    """temperature and max_tokens are forwarded to the ModelRequest."""
+    received_reqs = []
+
+    class CapturingModel:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            received_reqs.append(request)
+            return ModelResponse(
+                message=FakeMessage(content="ok"),
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+            )
+
+    await _complete(
+        {
+            "model": "anthropic/claude-opus-4-8",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.7,
+            "max_tokens": 512,
+        },
+        CapturingModel(),  # type: ignore[arg-type]
+    )
+
+    assert len(received_reqs) == 1
+    req = received_reqs[0]
+    assert req.temperature == pytest.approx(0.7)
+    assert req.max_tokens == 512
+
+
+# --------------------------------------------------------------------------- #
+# HTTP route tests (via httpx ASGITransport)
+# --------------------------------------------------------------------------- #
+
+
+async def test_health_route() -> None:
+    """GET /health returns {"ok": true}."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+async def test_complete_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /v1/complete returns the wire format via the Starlette route."""
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeModel())
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            json={
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["message"]["content"] == "hi"
+    assert data["message"]["role"] == "assistant"
+    assert data["input_tokens"] == 3
+    assert data["output_tokens"] == 4
+    assert data["model"] == "anthropic/claude-sonnet-4-6"
+
+
+async def test_complete_route_missing_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /v1/complete with missing 'model' key returns 400."""
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeModel())
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert resp.status_code == 400
+    assert "error" in resp.json()

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1938,6 +1938,10 @@ openai-agents = [
 pii = [
     { name = "presidio-analyzer" },
 ]
+sidecar = [
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1969,11 +1973,13 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "scipy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "starlette", marker = "extra == 'sidecar'", specifier = ">=0.40" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "typer", specifier = ">=0.12" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "uvicorn", marker = "extra == 'sidecar'", specifier = ">=0.30" },
 ]
-provides-extras = ["dev", "openai", "anthropic", "cloud-all", "model", "langchain", "crewai", "adk", "anthropic-agent", "openai-agents", "pii", "memory"]
+provides-extras = ["dev", "openai", "anthropic", "cloud-all", "model", "sidecar", "langchain", "crewai", "adk", "anthropic-agent", "openai-agents", "pii", "memory"]
 
 [[package]]
 name = "jamjet-engram"


### PR DESCRIPTION
## What

Track 2e of the ADK build. The durable Rust engine's Model node now calls a localhost Python sidecar that wraps the governed `jamjet.model.Model` seam, so durable model calls get the same provider allowlist, PII redaction, and cost metering as in-process `Agent.run()`. Behind `JAMJET_MODEL_SEAM_URL`; native Rust adapters stay the dev/fallback default when the flag is unset.

## Changes

- **Python sidecar** (`sdk/python/jamjet/model/sidecar_server.py`): Starlette app, `POST /v1/complete` runs the governed Model chain, `GET /health` for the startup probe. New `[sidecar]` extra (`starlette`, `uvicorn`).
- **Rust adapter** (`runtime/models/src/sidecar.rs`): `SidecarModelAdapter` posts to the sidecar and maps the response (tokens, finish_reason). 429/non-200 become a hard `ModelError`.
- **Registry wiring** (`runtime/models/src/registry.rs`): when the seam URL is set, the registry routes every model call to the sidecar (sidecar-only, so nothing prefix-routes around it). `registry_from_env_checked()` probes `/health` at startup and refuses to start if the sidecar is unreachable, so a misconfigured prod can never silently bypass the seam.
- **e2e** (`runtime/workers/tests/sidecar_e2e.rs`): a Model node driven through a mock sidecar carries the sidecar's token metering into the ExecutionResult.

## Review

Implemented subagent-driven with an adversarial review on the enforcement path. The review caught two fail-open bugs before merge (an ungoverned `Model()` in the sidecar, and a default-model prefix route that bypassed the sidecar); both fixed in the last commit, plus strict health-body and token parsing. Re-review confirmed all closed. Full workspace tests + the Python suite are green.

## Follow-ups (tracked, non-blocking)

- F-2e-cost: thread `cost_usd` to the Rust NodeCompleted event + give MeteringMiddleware a sink (durable-path cost is not exported end-to-end yet; tokens are).
- F-2e-timeout: add a request timeout to the sidecar reqwest client.

## Ops

`pip install jamjet[sidecar]`, run `uvicorn jamjet.model.sidecar_server:app --host 127.0.0.1 --port 4280`, set `JAMJET_MODEL_SEAM_URL=http://127.0.0.1:4280`. See `sdk/python/jamjet/model/README-sidecar.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing model requests through a sidecar service, including health checks at startup.
  * Enabled provider-prefixed model selection so requests resolve to the intended model more reliably.

* **Bug Fixes**
  * Improved handling of sidecar failures, rate limits, and malformed responses.
  * Standardized model naming for Anthropic requests to avoid routing mismatches.

* **Documentation**
  * Added setup and configuration guidance for running the sidecar service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->