### PR TITLE
feat(2f): durable agents survive provider rate limits (park-on-429)

### DIFF
--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -52,9 +52,15 @@ impl SidecarModelAdapter {
             .map_err(|e| ModelError::Network(e.to_string()))?;
 
         if status == 429 {
-            return Err(ModelError::RateLimited {
-                retry_after_secs: 60,
-            });
+            // Prefer the retry_after the sidecar extracts from the provider response
+            // (passed back as `{"retry_after": <secs>}` in the body).  Fall back to
+            // 60 s when the body is absent or unparseable — keeps the existing safe
+            // default for responses that predate this contract.
+            let retry_after_secs = serde_json::from_str::<Value>(&text)
+                .ok()
+                .and_then(|v| v["retry_after"].as_u64())
+                .unwrap_or(60);
+            return Err(ModelError::RateLimited { retry_after_secs });
         }
         if status != 200 {
             return Err(ModelError::Api { status, body: text });
@@ -362,6 +368,61 @@ mod tests {
         assert!(
             matches!(result, Err(ModelError::RateLimited { .. })),
             "expected RateLimited, got {result:?}"
+        );
+    }
+
+    // 2f-5: 429 body with retry_after must be propagated into ModelError::RateLimited.
+    #[tokio::test]
+    async fn chat_rate_limit_uses_body_retry_after() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(429)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"rate limit","retry_after":12}"#)
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(ModelError::RateLimited {
+                    retry_after_secs: 12
+                })
+            ),
+            "expected RateLimited{{retry_after_secs:12}}, got {result:?}"
+        );
+    }
+
+    // 2f-5: 429 with no parseable body falls back to 60 s default.
+    #[tokio::test]
+    async fn chat_rate_limit_falls_back_when_no_retry_after() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(429)
+            .with_body("too many requests")
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(ModelError::RateLimited {
+                    retry_after_secs: 60
+                })
+            ),
+            "expected RateLimited{{retry_after_secs:60}}, got {result:?}"
         );
     }
 

--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -17,6 +17,10 @@ use serde_json::{json, Value};
 
 const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-6";
 
+/// Cap a provider-supplied Retry-After so an untrusted/huge value can't overflow
+/// the timestamp math or push the backoff into the past. One hour is plenty.
+const MAX_RETRY_AFTER_SECS: u64 = 3_600;
+
 /// Routes durable-path model calls to the Python model-seam sidecar via HTTP.
 ///
 /// The sidecar wraps `jamjet.model.Model` (Track-1 seam), so every call
@@ -59,7 +63,8 @@ impl SidecarModelAdapter {
             let retry_after_secs = serde_json::from_str::<Value>(&text)
                 .ok()
                 .and_then(|v| v["retry_after"].as_u64())
-                .unwrap_or(60);
+                .unwrap_or(60)
+                .min(MAX_RETRY_AFTER_SECS);
             return Err(ModelError::RateLimited { retry_after_secs });
         }
         if status != 200 {
@@ -546,6 +551,35 @@ mod tests {
             matches!(result, Err(ModelError::Serialization(_))),
             "missing output_tokens must produce Serialization error, got {result:?}"
         );
+    }
+
+    // 2f-security: a huge (malicious or buggy) provider Retry-After must be clamped
+    // to MAX_RETRY_AFTER_SECS so it cannot overflow the timestamp math in the worker.
+    #[tokio::test]
+    async fn chat_rate_limit_clamps_huge_retry_after() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(429)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"rate limit","retry_after":99999999999999}"#)
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        match result {
+            Err(ModelError::RateLimited { retry_after_secs }) => {
+                assert!(
+                    retry_after_secs <= MAX_RETRY_AFTER_SECS,
+                    "retry_after_secs {retry_after_secs} must be <= MAX_RETRY_AFTER_SECS ({MAX_RETRY_AFTER_SECS})"
+                );
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -536,6 +536,13 @@ impl ExecProgress {
             EventKind::RetryScheduled { node_id, .. } => {
                 self.scheduled.insert(node_id.clone());
             }
+            EventKind::NodeParked { .. } => {
+                // NodeParked is an audit/observability event. The node is
+                // already in `self.scheduled` (put there by NodeScheduled) and
+                // stays there — the work item is back in `pending` with a
+                // future `retry_after`; a worker picks it up when ready.
+                // No change to self.scheduled here.
+            }
             EventKind::ToolApprovalRequired { node_id, .. } => {
                 self.held.insert(node_id.clone());
             }

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -184,6 +184,22 @@ pub trait StateBackend: Send + Sync {
         write_snapshot: bool,
     ) -> BackendResult<EventSequence>;
 
+    /// Atomically return a leased work item to `pending`, visible again at
+    /// `retry_after`, with the attempt count set to `next_attempt` and a fresh
+    /// lease epoch (so the next claim mints a strictly-greater fence).
+    ///
+    /// Fence-guarded: if `lease_fence` no longer matches the stored value (stale
+    /// worker, race, or already parked by another path) the update matches zero
+    /// rows and `Ok(false)` is returned — a no-op, consistent with the
+    /// `FenceLost` zombie path in `commit_turn`.
+    async fn park_work_item(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        retry_after: &str,
+        next_attempt: u32,
+    ) -> BackendResult<bool>;
+
     /// Reclaim work items whose lease has expired (worker crashed or stalled).
     ///
     /// For each expired item:

--- a/runtime/state/src/event.rs
+++ b/runtime/state/src/event.rs
@@ -125,6 +125,18 @@ pub enum EventKind {
         attempt: u32,
         retryable: bool,
     },
+    /// Emitted when a work item is parked on a provider rate-limit (429).
+    /// The item is reset to `pending` with `retry_after` set; the node stays
+    /// in `scheduled` and is re-picked up by a worker when the not-before
+    /// time passes. This is an audit/observability event — it does not mutate
+    /// the ExecProgress state (the node is already in `scheduled`).
+    NodeParked {
+        node_id: NodeId,
+        attempt: u32,
+        /// RFC3339 timestamp (now + retry_after_secs) stored as TEXT, matching
+        /// the `retry_after` column type in `work_items`.
+        retry_after: String,
+    },
     NodeSkipped {
         node_id: NodeId,
         reason: String,
@@ -377,6 +389,7 @@ impl EventKind {
             | Self::NodeStarted { node_id, .. }
             | Self::NodeCompleted { node_id, .. }
             | Self::NodeFailed { node_id, .. }
+            | Self::NodeParked { node_id, .. }
             | Self::NodeSkipped { node_id, .. }
             | Self::NodeCancelled { node_id }
             | Self::RetryScheduled { node_id, .. }

--- a/runtime/state/src/materializer.rs
+++ b/runtime/state/src/materializer.rs
@@ -127,6 +127,11 @@ pub fn apply_events_seeded(mut base: MaterializedState, events: &[Event]) -> Mat
             | EventKind::NodeCancelled { node_id } => {
                 base.active_nodes.remove(node_id);
             }
+            // NodeParked is an audit/observability event. The node stays in
+            // `active_nodes` (it remains scheduled; the work item is back in
+            // `pending` and will be re-picked up after `retry_after` passes).
+            // No state mutation here.
+            EventKind::NodeParked { .. } => {}
             EventKind::InterruptRaised { .. } => {
                 if base.status == WorkflowStatus::Running {
                     base.status = WorkflowStatus::Paused;

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -484,6 +484,44 @@ impl StateBackend for InMemoryBackend {
         }
     }
 
+    async fn park_work_item(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        retry_after: &str,
+        next_attempt: u32,
+    ) -> BackendResult<bool> {
+        // Suppress unused-variable warning; retry_after is only meaningful in
+        // SQL backends (the claim query filters `retry_after <= now`). The
+        // in-memory backend does not enforce the not-before window — it is a
+        // dev/test backend. The WorkItem struct has no retry_after field.
+        let _ = retry_after;
+        match self.work_items.get_mut(&item_id) {
+            Some(mut entry) => {
+                // Fence guard: a stale worker (mismatched lease_fence) is a no-op.
+                if entry.lease_fence != lease_fence {
+                    return Ok(false);
+                }
+                // Reset to pending state, mirror the SQL SET columns.
+                entry.attempt = next_attempt;
+                entry.worker_id = None;
+                entry.lease_expires_at = None;
+                // Bump epoch so the next claim mints a strictly-greater fence.
+                let next_epoch = self
+                    .lease_epochs
+                    .get(&item_id)
+                    .map(|e| *e.value())
+                    .unwrap_or(0)
+                    + 1;
+                self.lease_epochs.insert(item_id, next_epoch);
+                // Clear the fence; next claim will mint a fresh one via term*2^32+epoch.
+                entry.lease_fence = 0;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
     async fn reclaim_expired_leases(&self) -> BackendResult<ReclaimResult> {
         let now = Utc::now();
         let mut result = ReclaimResult::default();

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -874,6 +874,36 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self), fields(item_id = %item_id, fence = lease_fence))]
+    async fn park_work_item(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        retry_after: &str,
+        next_attempt: u32,
+    ) -> BackendResult<bool> {
+        let id_str = item_id.to_string();
+        // Atomically reset the work item to pending with a future not-before time.
+        // The fence guard (WHERE id=? AND lease_fence=?) ensures a stale worker
+        // cannot park over a newer attempt. Bumping lease_epoch ensures the next
+        // claim mints a strictly-greater fence than any fence the parking worker held.
+        let rows_affected = sqlx::query(
+            "UPDATE work_items \
+             SET status = 'pending', retry_after = ?, attempt = ?, worker_id = NULL, \
+                 lease_expires_at = NULL, lease_epoch = lease_epoch + 1, lease_fence = 0 \
+             WHERE id = ? AND lease_fence = ?",
+        )
+        .bind(retry_after)
+        .bind(next_attempt as i64)
+        .bind(&id_str)
+        .bind(lease_fence)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        Ok(rows_affected > 0)
+    }
+
     #[instrument(skip(self, terminal_event), fields(item_id = %item_id, fence = lease_fence))]
     async fn commit_turn(
         &self,

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -805,6 +805,34 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self), fields(tenant = %self.tenant_id, item_id = %item_id, fence = lease_fence))]
+    async fn park_work_item(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        retry_after: &str,
+        next_attempt: u32,
+    ) -> BackendResult<bool> {
+        let id_str = item_id.to_string();
+        // Same as SqliteBackend::park_work_item but scoped to tenant_id.
+        let rows_affected = sqlx::query(
+            "UPDATE work_items \
+             SET status = 'pending', retry_after = ?, attempt = ?, worker_id = NULL, \
+                 lease_expires_at = NULL, lease_epoch = lease_epoch + 1, lease_fence = 0 \
+             WHERE id = ? AND lease_fence = ? AND tenant_id = ?",
+        )
+        .bind(retry_after)
+        .bind(next_attempt as i64)
+        .bind(&id_str)
+        .bind(lease_fence)
+        .bind(&self.tenant_id.0)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        Ok(rows_affected > 0)
+    }
+
     #[instrument(skip(self, terminal_event), fields(tenant = %self.tenant_id, item_id = %item_id))]
     async fn commit_turn(
         &self,

--- a/runtime/state/tests/park.rs
+++ b/runtime/state/tests/park.rs
@@ -1,0 +1,433 @@
+//! TDD tests for `park_work_item` — fence-guarded rate-limit parking.
+//!
+//! A parked work item is reset to `pending` with a not-before `retry_after`
+//! timestamp (now + provider backoff). The fence guard ensures a stale worker
+//! cannot overwrite a newer attempt's state. Bumping `lease_epoch` means the
+//! next claim mints a strictly-greater fence.
+//!
+//! Written RED before `park_work_item` existed; turned GREEN after implementing
+//! the method in all three backends (sqlite.rs, tenant_scoped.rs, memory.rs).
+
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::{
+    backend::{StateBackend, WorkItem},
+    InMemoryBackend, SqliteBackend, TenantId,
+};
+use serde_json::json;
+use sqlx::Row;
+use uuid::Uuid;
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+async fn open_test_db() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite for park tests")
+}
+
+fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "park-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({}),
+        current_state: json!({}),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+    }
+}
+
+fn sample_item(execution_id: &ExecutionId) -> WorkItem {
+    WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: execution_id.clone(),
+        node_id: "llm-node".into(),
+        queue_type: "model".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 5,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        tenant_id: "default".into(),
+        lease_fence: 0,
+    }
+}
+
+/// Returns a retry_after timestamp 60 seconds in the future (RFC3339).
+fn future_retry_after() -> String {
+    (Utc::now() + chrono::Duration::seconds(60)).to_rfc3339()
+}
+
+// ── SQLite backend tests ─────────────────────────────────────────────────────
+
+/// Correct fence: park returns Ok(true) and the row is reset to pending
+/// with the expected attempt, NULL worker_id, future retry_after, and a
+/// bumped lease_epoch.
+#[tokio::test]
+async fn sqlite_park_correct_fence_returns_true_and_resets_row() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    // Claim the item to get a valid lease_fence.
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+
+    let original_fence = claimed.lease_fence;
+    assert!(original_fence > 0, "claim must mint a non-zero fence");
+
+    // Read the lease_epoch before parking to verify it is bumped.
+    let epoch_before: i64 = sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("lease_epoch")
+        .unwrap();
+
+    let retry_after = future_retry_after();
+    let parked = db
+        .park_work_item(item_id, original_fence, &retry_after, 1)
+        .await
+        .expect("park_work_item must not error");
+    assert!(parked, "correct fence must return true");
+
+    // Read the row back directly to verify all SET columns.
+    let row = sqlx::query(
+        "SELECT status, attempt, worker_id, retry_after, lease_epoch FROM work_items WHERE id = ?",
+    )
+    .bind(item_id.to_string())
+    .fetch_one(&db.pool())
+    .await
+    .unwrap();
+
+    let status: &str = row.try_get("status").unwrap();
+    assert_eq!(status, "pending", "parked item must be 'pending'");
+
+    let attempt: i64 = row.try_get("attempt").unwrap();
+    assert_eq!(attempt, 1, "attempt must be set to next_attempt (1)");
+
+    let worker_id: Option<String> = row.try_get("worker_id").unwrap();
+    assert!(worker_id.is_none(), "worker_id must be NULL after park");
+
+    let stored_retry_after: &str = row.try_get("retry_after").unwrap();
+    assert_eq!(
+        stored_retry_after, retry_after,
+        "retry_after must match what was passed"
+    );
+
+    let epoch_after: i64 = row.try_get("lease_epoch").unwrap();
+    assert_eq!(
+        epoch_after,
+        epoch_before + 1,
+        "lease_epoch must be bumped by 1"
+    );
+
+    // A parked item with future retry_after is NOT claimable yet.
+    let not_claimable = db.claim_work_item("worker-2", &["model"]).await.unwrap();
+    assert!(
+        not_claimable.is_none(),
+        "parked item with future retry_after must not be claimable"
+    );
+}
+
+/// Stale fence: park returns Ok(false) and the row is unchanged.
+#[tokio::test]
+async fn sqlite_park_stale_fence_returns_false_row_unchanged() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let real_fence = claimed.lease_fence;
+    let _stale_fence = real_fence + 1; // fabricated — documented for clarity, not used directly
+
+    // First: park with the correct fence so the item is back in 'pending'.
+    let retry_after = future_retry_after();
+    let first = db
+        .park_work_item(item_id, real_fence, &retry_after, 1)
+        .await
+        .unwrap();
+    assert!(first, "first park with correct fence must return true");
+
+    // Now the item is pending with lease_fence effectively gone (bumped).
+    // A second park with the original (now stale) fence must be a no-op.
+    let later_retry = future_retry_after();
+    let second = db
+        .park_work_item(item_id, real_fence, &later_retry, 2)
+        .await
+        .unwrap();
+    assert!(
+        !second,
+        "stale fence park must return false (fence was bumped by first park)"
+    );
+
+    // Row must be unchanged from the FIRST park (attempt=1, retry_after from first).
+    let row =
+        sqlx::query("SELECT status, attempt, worker_id, retry_after FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap();
+
+    let status: &str = row.try_get("status").unwrap();
+    assert_eq!(status, "pending", "status must still be 'pending'");
+
+    let attempt: i64 = row.try_get("attempt").unwrap();
+    assert_eq!(
+        attempt, 1,
+        "attempt must still be 1 (not 2 from stale park)"
+    );
+
+    let stored_retry_after: &str = row.try_get("retry_after").unwrap();
+    assert_eq!(
+        stored_retry_after, retry_after,
+        "retry_after must be the one set by the first (valid) park"
+    );
+}
+
+/// A completely wrong (fabricated) fence on a claimed item returns false
+/// and leaves the item in 'claimed' state.
+#[tokio::test]
+async fn sqlite_park_wrong_fence_on_claimed_item_is_noop() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .unwrap();
+    let wrong_fence = claimed.lease_fence + 999;
+
+    let result = db
+        .park_work_item(item_id, wrong_fence, &future_retry_after(), 1)
+        .await
+        .unwrap();
+    assert!(!result, "wrong fence must return false");
+
+    // Item is still 'claimed', not 'pending'.
+    let status: String = sqlx::query("SELECT status FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("status")
+        .unwrap();
+    assert_eq!(
+        status, "claimed",
+        "item must remain 'claimed' after stale-fence park"
+    );
+}
+
+// ── In-memory backend tests ──────────────────────────────────────────────────
+
+/// Correct fence on in-memory backend returns Ok(true); attempt and fence are updated.
+/// Note: InMemoryBackend does not enforce the retry_after not-before window in
+/// claim_work_item (no SQL filter). The fence guard and state mutation are tested here.
+#[tokio::test]
+async fn memory_park_correct_fence_returns_true_and_resets_item() {
+    let db = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let fence = claimed.lease_fence;
+    assert!(fence > 0);
+
+    let parked = db
+        .park_work_item(item_id, fence, &future_retry_after(), 1)
+        .await
+        .unwrap();
+    assert!(parked, "correct fence must return true");
+
+    // After park: item is back in pending (worker_id=None, fence reset).
+    // In-memory claim picks it up immediately (no retry_after filter).
+    let reclaimed = db
+        .claim_work_item("worker-2", &["model"])
+        .await
+        .unwrap()
+        .expect("in-memory item must be re-claimable after park");
+
+    assert_eq!(
+        reclaimed.attempt, 1,
+        "attempt must be set to next_attempt after park"
+    );
+    assert!(
+        reclaimed.lease_fence > 0,
+        "re-claim must mint a fresh non-zero fence"
+    );
+    // The new fence must be different from (and ideally greater than) the old one.
+    assert_ne!(
+        reclaimed.lease_fence, fence,
+        "re-claim fence must differ from the parked fence"
+    );
+}
+
+/// Stale fence on in-memory backend returns Ok(false) and item is unchanged.
+#[tokio::test]
+async fn memory_park_stale_fence_returns_false_item_unchanged() {
+    let db = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let real_fence = claimed.lease_fence;
+
+    // Park with correct fence first.
+    let first = db
+        .park_work_item(item_id, real_fence, &future_retry_after(), 1)
+        .await
+        .unwrap();
+    assert!(first, "first park must succeed");
+
+    // Park with the now-stale fence → no-op.
+    let second = db
+        .park_work_item(item_id, real_fence, &future_retry_after(), 2)
+        .await
+        .unwrap();
+    assert!(!second, "stale fence must return false");
+
+    // Item's attempt must still be 1 (from the first valid park), not 2.
+    let reclaimed = db
+        .claim_work_item("worker-2", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    assert_eq!(
+        reclaimed.attempt, 1,
+        "attempt must be 1 from first park; stale park must not update it"
+    );
+}
+
+// ── Tenant-scoped backend tests ──────────────────────────────────────────────
+
+/// TenantScopedSqliteBackend: park is scoped to tenant — a stale fence from a
+/// different worker is rejected; the lease_epoch is bumped for re-claim.
+#[tokio::test]
+async fn tenant_scoped_park_fence_guard_and_epoch_bump() {
+    let db = open_test_db().await;
+    let tenant = db.for_tenant(TenantId::default_tenant());
+
+    let exec_id = ExecutionId::new();
+    tenant
+        .create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    tenant.enqueue_work_item(item).await.unwrap();
+
+    let claimed = tenant
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("tenant item must be claimable");
+    let fence = claimed.lease_fence;
+
+    // Read epoch before parking.
+    let epoch_before: i64 =
+        sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ? AND tenant_id = 'default'")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap()
+            .try_get("lease_epoch")
+            .unwrap();
+
+    // Correct fence → parked.
+    let retry_after = future_retry_after();
+    let ok = tenant
+        .park_work_item(item_id, fence, &retry_after, 1)
+        .await
+        .unwrap();
+    assert!(ok, "tenant-scoped park with correct fence must return true");
+
+    // Verify epoch bumped.
+    let epoch_after: i64 =
+        sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ? AND tenant_id = 'default'")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap()
+            .try_get("lease_epoch")
+            .unwrap();
+    assert_eq!(
+        epoch_after,
+        epoch_before + 1,
+        "tenant-scoped park must bump lease_epoch"
+    );
+
+    // Stale fence → no-op.
+    let noop = tenant
+        .park_work_item(item_id, fence, &future_retry_after(), 2)
+        .await
+        .unwrap();
+    assert!(!noop, "stale fence must be no-op for tenant-scoped backend");
+
+    // Attempt must still be 1.
+    let attempt: i64 = sqlx::query("SELECT attempt FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("attempt")
+        .unwrap();
+    assert_eq!(
+        attempt, 1,
+        "attempt must be unchanged after stale-fence park"
+    );
+}

--- a/runtime/state/tests/park.rs
+++ b/runtime/state/tests/park.rs
@@ -64,6 +64,14 @@ fn future_retry_after() -> String {
     (Utc::now() + chrono::Duration::seconds(60)).to_rfc3339()
 }
 
+/// Returns a retry_after timestamp 5 seconds in the past (RFC3339).
+/// Used to verify that a parked item becomes immediately claimable once its
+/// not-before window has elapsed.  No real sleep needed: the SQL filter is
+/// `retry_after <= now`, so a past timestamp is always visible on the next claim.
+fn past_retry_after() -> String {
+    (Utc::now() - chrono::Duration::seconds(5)).to_rfc3339()
+}
+
 // ── SQLite backend tests ─────────────────────────────────────────────────────
 
 /// Correct fence: park returns Ok(true) and the row is reset to pending
@@ -430,4 +438,461 @@ async fn tenant_scoped_park_fence_guard_and_epoch_bump() {
         attempt, 1,
         "attempt must be unchanged after stale-fence park"
     );
+}
+
+// ── Task 2f-4: park/reclaim visibility (not-before filter) ───────────────────
+
+/// SQLite: park with a PAST retry_after makes the item immediately claimable.
+///
+/// This is the complement of the "future = not claimable" assertion that already
+/// lives in `sqlite_park_correct_fence_returns_true_and_resets_row` (2f-1).
+/// Together, the two tests prove the retry_after filter in both directions without
+/// any real sleep.  The SQLite claim SQL is:
+///   AND (retry_after IS NULL OR retry_after <= ?)
+/// so a past timestamp passes immediately on the next claim call.
+///
+/// The reclaimed item must carry the bumped attempt and a fresh non-zero fence
+/// that differs from the fence the parking worker held.
+#[tokio::test]
+async fn sqlite_park_past_retry_after_is_immediately_claimable() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let fence = claimed.lease_fence;
+
+    // Park with a timestamp in the PAST — item should be visible on the next claim.
+    let past_ts = past_retry_after();
+    let parked = db
+        .park_work_item(item_id, fence, &past_ts, 1)
+        .await
+        .unwrap();
+    assert!(parked, "park with correct fence must return true");
+
+    // Immediately claimable because retry_after <= now.
+    let reclaimed = db
+        .claim_work_item("worker-2", &["model"])
+        .await
+        .unwrap()
+        .expect("item parked with past retry_after must be immediately claimable");
+
+    assert_eq!(
+        reclaimed.attempt, 1,
+        "re-claimed item must have attempt=1 (set by park)"
+    );
+    assert!(
+        reclaimed.lease_fence > 0,
+        "re-claim must mint a fresh non-zero fence"
+    );
+    assert_ne!(
+        reclaimed.lease_fence, fence,
+        "re-claim fence must differ from the park-time fence"
+    );
+}
+
+/// Tenant-scoped: park with a PAST retry_after is immediately claimable.
+///
+/// Verifies the same not-before filter (`retry_after <= ?`) on the
+/// tenant-scoped claim SQL which adds `AND tenant_id = ?`.
+#[tokio::test]
+async fn tenant_scoped_park_past_retry_after_is_immediately_claimable() {
+    let db = open_test_db().await;
+    let tenant = db.for_tenant(TenantId::default_tenant());
+
+    let exec_id = ExecutionId::new();
+    tenant
+        .create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    tenant.enqueue_work_item(item).await.unwrap();
+
+    let claimed = tenant
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let fence = claimed.lease_fence;
+
+    // Park with a past timestamp.
+    let parked = tenant
+        .park_work_item(item_id, fence, &past_retry_after(), 1)
+        .await
+        .unwrap();
+    assert!(
+        parked,
+        "tenant-scoped park with correct fence must return true"
+    );
+
+    // Immediately claimable (past retry_after passes the <= now filter).
+    let reclaimed = tenant
+        .claim_work_item("worker-2", &["model"])
+        .await
+        .unwrap()
+        .expect("tenant item parked with past retry_after must be immediately claimable");
+
+    assert_eq!(reclaimed.attempt, 1, "reclaimed attempt must be 1");
+    assert_ne!(
+        reclaimed.lease_fence, fence,
+        "reclaimed fence must differ from park-time fence"
+    );
+}
+
+// ── Task 2f-4: fence-safety end-to-end ───────────────────────────────────────
+
+/// SQLite: full end-to-end fence-safety sequence —
+///   claim(F1) → park(F1, past_ts, 1) → reclaim(F2) → stale-park(F1, .., 2) = false.
+///
+/// The 2f-1 unit test (`sqlite_park_stale_fence_returns_false_row_unchanged`)
+/// exercises claim→park→stale-park. This test adds the RECLAIM step in between,
+/// proving that F1 is truly stale after the item has been reclaimed by a new
+/// worker holding F2, and that the newer attempt's state (attempt=1) survives the
+/// rejected stale park.
+#[tokio::test]
+async fn sqlite_fence_safety_claim_park_reclaim_stale_park() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let item = sample_item(&exec_id);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    // Step 1: claim → get fence F1.
+    let claimed = db
+        .claim_work_item("worker-1", &["model"])
+        .await
+        .unwrap()
+        .expect("item must be claimable");
+    let f1 = claimed.lease_fence;
+    assert!(f1 > 0);
+
+    // Step 2: park with F1 (past ts so re-claimable immediately).
+    let parked = db
+        .park_work_item(item_id, f1, &past_retry_after(), 1)
+        .await
+        .unwrap();
+    assert!(parked, "park with F1 must succeed");
+
+    // Step 3: a second worker reclaims → gets fence F2 > F1.
+    let reclaimed = db
+        .claim_work_item("worker-2", &["model"])
+        .await
+        .unwrap()
+        .expect("re-claim after past-ts park must succeed");
+    let f2 = reclaimed.lease_fence;
+    assert_ne!(f2, f1, "F2 must differ from F1");
+    assert_eq!(reclaimed.attempt, 1, "reclaimed item must be at attempt=1");
+
+    // Step 4: stale worker (holding F1) tries to park again → must be no-op.
+    let stale = db
+        .park_work_item(item_id, f1, &future_retry_after(), 2)
+        .await
+        .unwrap();
+    assert!(!stale, "stale-fence park after reclaim must return false");
+
+    // The row must still be at attempt=1 (not 2 from the stale park).
+    // Status is 'claimed' because worker-2 holds it.
+    let row = sqlx::query("SELECT status, attempt FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap();
+    let status: &str = row.try_get("status").unwrap();
+    assert_eq!(
+        status, "claimed",
+        "item must still be 'claimed' by worker-2"
+    );
+    let attempt: i64 = row.try_get("attempt").unwrap();
+    assert_eq!(
+        attempt, 1,
+        "attempt must be 1; stale park must not advance it"
+    );
+}
+
+// ── Task 2f-4: attempt monotonicity + epoch freshness (cross-backend) ────────
+
+/// SQLite: each successful park increments attempt by exactly 1 and bumps
+/// lease_epoch, so the next claim mints a strictly different fence.
+///
+/// Sequence: claim → park(1) → reclaim(F2) → park(2) → reclaim(F3).
+/// After each park, attempt increases by 1 and lease_epoch increases by 1.
+/// Past timestamps are used so both reclaims succeed without sleeping.
+///
+/// Note: `claim_work_item` also bumps `lease_epoch` (so the fence is strictly
+/// increasing). The epoch is read AFTER each claim so the assertion only checks
+/// the delta contributed by `park_work_item` itself (+1 per park).
+#[tokio::test]
+async fn sqlite_attempt_monotonicity_and_epoch_freshness() {
+    let db = open_test_db().await;
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let mut item = sample_item(&exec_id);
+    item.max_attempts = 10; // headroom for two parks
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    // ── Park 1: attempt 0 → 1 ────────────────────────────────────────────────
+    let c1 = db
+        .claim_work_item("w1", &["model"])
+        .await
+        .unwrap()
+        .expect("first claim must succeed");
+    let f1 = c1.lease_fence;
+    assert!(f1 > 0, "fence must be non-zero after claim");
+
+    // Read epoch AFTER claim so we measure the park delta (+1) cleanly.
+    let epoch_after_claim1: i64 = sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("lease_epoch")
+        .unwrap();
+
+    db.park_work_item(item_id, f1, &past_retry_after(), 1)
+        .await
+        .unwrap();
+
+    let epoch_after_park1: i64 = sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("lease_epoch")
+        .unwrap();
+    assert_eq!(
+        epoch_after_park1,
+        epoch_after_claim1 + 1,
+        "first park must bump lease_epoch by exactly 1"
+    );
+
+    // ── Park 2: attempt 1 → 2 ────────────────────────────────────────────────
+    let c2 = db
+        .claim_work_item("w2", &["model"])
+        .await
+        .unwrap()
+        .expect("second claim must succeed after past-ts park");
+    let f2 = c2.lease_fence;
+    assert_ne!(f2, f1, "second claim must mint a different fence");
+    assert_eq!(
+        c2.attempt, 1,
+        "item must be at attempt=1 before second park"
+    );
+
+    // Read epoch after second claim.
+    let epoch_after_claim2: i64 = sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap()
+        .try_get("lease_epoch")
+        .unwrap();
+
+    db.park_work_item(item_id, f2, &past_retry_after(), 2)
+        .await
+        .unwrap();
+
+    let row = sqlx::query("SELECT lease_epoch, attempt FROM work_items WHERE id = ?")
+        .bind(item_id.to_string())
+        .fetch_one(&db.pool())
+        .await
+        .unwrap();
+    let epoch_after_park2: i64 = row.try_get("lease_epoch").unwrap();
+    let attempt2: i64 = row.try_get("attempt").unwrap();
+    assert_eq!(
+        epoch_after_park2,
+        epoch_after_claim2 + 1,
+        "second park must bump lease_epoch by exactly 1"
+    );
+    assert_eq!(attempt2, 2, "attempt must be 2 after second park");
+
+    // ── Third claim: fence differs from both F1 and F2 ───────────────────────
+    let c3 = db
+        .claim_work_item("w3", &["model"])
+        .await
+        .unwrap()
+        .expect("third claim must succeed");
+    let f3 = c3.lease_fence;
+    assert_ne!(f3, f1, "third fence must differ from F1");
+    assert_ne!(f3, f2, "third fence must differ from F2");
+    assert_eq!(c3.attempt, 2, "item must be at attempt=2 on third claim");
+}
+
+/// In-memory: each successful park increments attempt by exactly 1 and the next
+/// claim mints a fresh fence.
+///
+/// The in-memory backend does not enforce the retry_after not-before window, so
+/// future timestamps are used (no real sleep needed — claim ignores retry_after).
+/// Epoch is not readable directly; monotonicity is asserted via the fence values
+/// from successive claims.
+#[tokio::test]
+async fn memory_attempt_monotonicity_and_epoch_freshness() {
+    let db = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    db.create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let mut item = sample_item(&exec_id);
+    item.max_attempts = 10;
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    // ── Park 1: attempt 0 → 1 ────────────────────────────────────────────────
+    let c1 = db
+        .claim_work_item("w1", &["model"])
+        .await
+        .unwrap()
+        .expect("first claim must succeed");
+    let f1 = c1.lease_fence;
+
+    db.park_work_item(item_id, f1, &future_retry_after(), 1)
+        .await
+        .unwrap();
+
+    let c2 = db
+        .claim_work_item("w2", &["model"])
+        .await
+        .unwrap()
+        .expect("in-memory re-claim must succeed immediately after park");
+    let f2 = c2.lease_fence;
+    assert_eq!(c2.attempt, 1, "attempt must be 1 after first park");
+    assert_ne!(f2, f1, "second fence must differ from first");
+    assert_ne!(f2, 0, "fence must be non-zero after re-claim");
+
+    // ── Park 2: attempt 1 → 2 ────────────────────────────────────────────────
+    db.park_work_item(item_id, f2, &future_retry_after(), 2)
+        .await
+        .unwrap();
+
+    let c3 = db
+        .claim_work_item("w3", &["model"])
+        .await
+        .unwrap()
+        .expect("third claim must succeed");
+    let f3 = c3.lease_fence;
+    assert_eq!(c3.attempt, 2, "attempt must be 2 after second park");
+    assert_ne!(f3, f2, "third fence must differ from second");
+    assert_ne!(f3, f1, "third fence must differ from first");
+}
+
+/// Tenant-scoped: each successful park increments attempt by exactly 1 and
+/// bumps lease_epoch.
+///
+/// Uses past timestamps so re-claims succeed without sleeping. Epoch is
+/// verified via direct SQL (pool from the parent SqliteBackend).
+/// Note: `claim_work_item` also bumps `lease_epoch`, so epochs are read
+/// AFTER each claim to isolate the park-only delta (+1 per park).
+#[tokio::test]
+async fn tenant_scoped_attempt_monotonicity_and_epoch_freshness() {
+    let db = open_test_db().await;
+    let tenant = db.for_tenant(TenantId::default_tenant());
+
+    let exec_id = ExecutionId::new();
+    tenant
+        .create_execution(sample_execution(&exec_id))
+        .await
+        .unwrap();
+
+    let mut item = sample_item(&exec_id);
+    item.max_attempts = 10;
+    let item_id = item.id;
+    tenant.enqueue_work_item(item).await.unwrap();
+
+    // ── Park 1: attempt 0 → 1 ────────────────────────────────────────────────
+    let c1 = tenant
+        .claim_work_item("w1", &["model"])
+        .await
+        .unwrap()
+        .expect("first claim");
+    let f1 = c1.lease_fence;
+
+    // Read epoch AFTER claim to measure only the park delta (+1).
+    let epoch_after_claim1: i64 =
+        sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ? AND tenant_id = 'default'")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap()
+            .try_get("lease_epoch")
+            .unwrap();
+
+    tenant
+        .park_work_item(item_id, f1, &past_retry_after(), 1)
+        .await
+        .unwrap();
+
+    let epoch_after_park1: i64 =
+        sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ? AND tenant_id = 'default'")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap()
+            .try_get("lease_epoch")
+            .unwrap();
+    assert_eq!(
+        epoch_after_park1,
+        epoch_after_claim1 + 1,
+        "first park must bump epoch by exactly 1"
+    );
+
+    // ── Park 2: attempt 1 → 2 ────────────────────────────────────────────────
+    let c2 = tenant
+        .claim_work_item("w2", &["model"])
+        .await
+        .unwrap()
+        .expect("second claim");
+    let f2 = c2.lease_fence;
+    assert_ne!(f2, f1, "second fence must differ");
+    assert_eq!(c2.attempt, 1, "attempt must be 1 before second park");
+
+    // Read epoch after second claim.
+    let epoch_after_claim2: i64 =
+        sqlx::query("SELECT lease_epoch FROM work_items WHERE id = ? AND tenant_id = 'default'")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap()
+            .try_get("lease_epoch")
+            .unwrap();
+
+    tenant
+        .park_work_item(item_id, f2, &past_retry_after(), 2)
+        .await
+        .unwrap();
+
+    let row = sqlx::query(
+        "SELECT lease_epoch, attempt FROM work_items WHERE id = ? AND tenant_id = 'default'",
+    )
+    .bind(item_id.to_string())
+    .fetch_one(&db.pool())
+    .await
+    .unwrap();
+    let epoch_after_park2: i64 = row.try_get("lease_epoch").unwrap();
+    let attempt2: i64 = row.try_get("attempt").unwrap();
+    assert_eq!(
+        epoch_after_park2,
+        epoch_after_claim2 + 1,
+        "second park must bump epoch by exactly 1"
+    );
+    assert_eq!(attempt2, 2, "attempt must be 2 after second park");
 }

--- a/runtime/workers/src/executor.rs
+++ b/runtime/workers/src/executor.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 /// Channel sender for real-time streaming events from executors.
 pub type StreamEventSender = tokio::sync::mpsc::Sender<Value>;
 
+#[derive(Debug)]
 pub struct ExecutionResult {
     pub output: Value,
     pub state_patch: Value,
@@ -23,17 +24,59 @@ pub struct ExecutionResult {
     pub finish_reason: Option<String>,
 }
 
+/// Structured error returned by node executors.
+///
+/// The variant tells the worker whether to park the work item for a later retry
+/// (rate-limit) or to terminate it immediately (fatal). ONLY `ModelError::RateLimited`
+/// maps to `RateLimited`; every other error from every executor maps to `Fatal`.
+#[derive(Debug)]
+pub enum ExecutorError {
+    /// Provider rate limit. The worker should park the work item and retry after
+    /// `retry_after_secs` seconds. Only `ModelError::RateLimited` produces this
+    /// variant; all other errors produce `Fatal`.
+    RateLimited { retry_after_secs: u64 },
+    /// Non-retryable failure. Equivalent to the previous `String` error type.
+    Fatal(String),
+}
+
+impl std::fmt::Display for ExecutorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutorError::RateLimited { retry_after_secs } => {
+                write!(f, "rate limited, retry after {retry_after_secs}s")
+            }
+            ExecutorError::Fatal(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for ExecutorError {}
+
+/// `Err("message".to_string())` and `Err(format!(...))` callers compile unchanged.
+impl From<String> for ExecutorError {
+    fn from(s: String) -> Self {
+        ExecutorError::Fatal(s)
+    }
+}
+
+/// `Err("literal".into())` and `ok_or("literal")?` callers compile unchanged.
+impl From<&str> for ExecutorError {
+    fn from(s: &str) -> Self {
+        ExecutorError::Fatal(s.to_string())
+    }
+}
+
 /// Trait implemented by each node kind executor.
 #[async_trait::async_trait]
 pub trait NodeExecutor: Send + Sync {
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String>;
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError>;
 
     /// Execute with streaming event emission. Default delegates to `execute()`.
     async fn execute_streaming(
         &self,
         item: &WorkItem,
         _tx: StreamEventSender,
-    ) -> Result<ExecutionResult, String> {
+    ) -> Result<ExecutionResult, ExecutorError> {
         self.execute(item).await
     }
 }

--- a/runtime/workers/src/executors/a2a_task.rs
+++ b/runtime/workers/src/executors/a2a_task.rs
@@ -9,7 +9,7 @@
 //! The executor is crash-resumable: if the worker dies mid-poll, the scheduler
 //! will reclaim the lease and re-submit the task on the next attempt.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
 use jamjet_a2a_proto::A2aMessage as Message;
 use jamjet_a2a_proto::A2aPart as Part;
@@ -54,7 +54,7 @@ impl Default for A2aTaskExecutor {
 #[async_trait]
 impl NodeExecutor for A2aTaskExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
         // Extract agent URI and skill from the work item payload.
@@ -180,7 +180,7 @@ impl NodeExecutor for A2aTaskExecutor {
                         })
                     })
                     .unwrap_or_else(|| "A2A task failed".into());
-                Err(error)
+                Err(error.into())
             }
             A2aTaskState::InputRequired => {
                 // The workflow should be paused for user input — return error
@@ -188,7 +188,7 @@ impl NodeExecutor for A2aTaskExecutor {
                 warn!(task_id = %response_task_id, "A2A task requires input — not yet handled");
                 Err("A2A task requires input — multi-turn not yet supported in this node".into())
             }
-            other => Err(format!("A2A task ended in unexpected state: {other:?}")),
+            other => Err(format!("A2A task ended in unexpected state: {other:?}").into()),
         }
     }
 }

--- a/runtime/workers/src/executors/agent_discovery.rs
+++ b/runtime/workers/src/executors/agent_discovery.rs
@@ -4,7 +4,7 @@
 //! the discovered capabilities as the node output so the workflow can select
 //! an agent and delegate to it dynamically.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
 use jamjet_state::backend::WorkItem;
 use serde_json::{json, Value};
@@ -15,7 +15,7 @@ pub struct AgentDiscoveryExecutor;
 #[async_trait]
 impl NodeExecutor for AgentDiscoveryExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
         let agent_url = item

--- a/runtime/workers/src/executors/agent_tool.rs
+++ b/runtime/workers/src/executors/agent_tool.rs
@@ -7,7 +7,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::executor::{ExecutionResult, NodeExecutor, StreamEventSender};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor, StreamEventSender};
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures::StreamExt;
@@ -399,7 +399,7 @@ impl AgentToolExecutor {
 #[async_trait]
 impl NodeExecutor for AgentToolExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
         let p = &item.payload;
 
@@ -470,8 +470,8 @@ impl NodeExecutor for AgentToolExecutor {
         debug!(agent_uri = %agent_uri, mode = %mode, protocol = %protocol, "AgentTool: invoking");
 
         match mode.as_str() {
-            "sync" => {
-                self.execute_sync(
+            "sync" => self
+                .execute_sync(
                     item,
                     agent_uri,
                     protocol,
@@ -482,9 +482,9 @@ impl NodeExecutor for AgentToolExecutor {
                     start,
                 )
                 .await
-            }
-            "streaming" => {
-                self.stream_ndjson(
+                .map_err(ExecutorError::Fatal),
+            "streaming" => self
+                .stream_ndjson(
                     item,
                     agent_uri,
                     protocol,
@@ -496,9 +496,9 @@ impl NodeExecutor for AgentToolExecutor {
                     start,
                 )
                 .await
-            }
-            "conversational" => {
-                self.execute_conversational(
+                .map_err(ExecutorError::Fatal),
+            "conversational" => self
+                .execute_conversational(
                     item,
                     agent_uri,
                     protocol,
@@ -509,8 +509,10 @@ impl NodeExecutor for AgentToolExecutor {
                     start,
                 )
                 .await
-            }
-            other => Err(format!("Unknown agent_tool mode: '{other}'")),
+                .map_err(ExecutorError::Fatal),
+            other => Err(ExecutorError::Fatal(format!(
+                "Unknown agent_tool mode: '{other}'"
+            ))),
         }
     }
 
@@ -521,7 +523,7 @@ impl NodeExecutor for AgentToolExecutor {
         &self,
         item: &WorkItem,
         tx: StreamEventSender,
-    ) -> Result<ExecutionResult, String> {
+    ) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
         let p = &item.payload;
 
@@ -623,7 +625,7 @@ impl NodeExecutor for AgentToolExecutor {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(format!("Agent returned error {status}: {body}"));
+            return Err(format!("Agent returned error {status}: {body}").into());
         }
 
         // ── Incremental NDJSON read loop ────────────────────────────────
@@ -813,7 +815,7 @@ impl NodeExecutor for AgentToolExecutor {
 
         // ── Return error for hard failures ───────────────────────────────
         if let Some(error) = terminal_error {
-            return Err(error);
+            return Err(error.into());
         }
 
         // ── Emit completed (if not terminated early) ────────────────────

--- a/runtime/workers/src/executors/coordinator.rs
+++ b/runtime/workers/src/executors/coordinator.rs
@@ -3,7 +3,7 @@
 //! Runs the three-phase coordinator pipeline: discovery → scoring → decision,
 //! delegating each phase to the Python strategy bridge via REST.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
 use jamjet_scheduler::strategy_bridge::{
     DecideRequest, DiscoverRequest, ScoreRequest, StrategyBridge,
@@ -27,7 +27,7 @@ impl CoordinatorExecutor {
 #[async_trait]
 impl NodeExecutor for CoordinatorExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
         let p = &item.payload;
 

--- a/runtime/workers/src/executors/eval.rs
+++ b/runtime/workers/src/executors/eval.rs
@@ -10,7 +10,7 @@
 //! On failure, the configured `on_fail` action determines the next step:
 //! `retry_with_feedback`, `escalate`, `halt`, or `log_and_continue`.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
 use jamjet_core::node::{EvalOnFail, EvalScorer};
 use jamjet_models::{ChatMessage, ModelConfig, ModelRegistry, ModelRequest};
@@ -173,7 +173,7 @@ impl EvalExecutor {
 #[async_trait]
 impl NodeExecutor for EvalExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
         // Deserialize scorer configs from payload.
@@ -291,7 +291,8 @@ impl NodeExecutor for EvalExecutor {
                     .map(|r| r.message.as_str())
                     .collect::<Vec<_>>()
                     .join("; ")
-            ));
+            )
+            .into());
         }
 
         Ok(ExecutionResult {

--- a/runtime/workers/src/executors/mcp_tool.rs
+++ b/runtime/workers/src/executors/mcp_tool.rs
@@ -10,7 +10,7 @@
 //! Each invocation opens a fresh connection. For Phase 2, connection pooling
 //! and persistent stdio processes can be added.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
 use jamjet_ir::workflow::{McpServerConfig, McpTransport as IrMcpTransport};
 use jamjet_mcp::{HttpSseTransport, McpClient, StdioTransport};
@@ -33,7 +33,7 @@ impl McpToolExecutor {
 #[async_trait]
 impl NodeExecutor for McpToolExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
         // Extract server alias and tool name from the payload.

--- a/runtime/workers/src/executors/model_node.rs
+++ b/runtime/workers/src/executors/model_node.rs
@@ -3,9 +3,9 @@
 //! Resolves the model configuration from the workflow IR, calls the appropriate
 //! `ModelAdapter` via `ModelRegistry`, and records GenAI telemetry.
 
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use async_trait::async_trait;
-use jamjet_models::{ChatMessage, ModelConfig, ModelRegistry, ModelRequest};
+use jamjet_models::{ChatMessage, ModelConfig, ModelError, ModelRegistry, ModelRequest};
 use jamjet_state::backend::WorkItem;
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -25,7 +25,7 @@ impl ModelNodeExecutor {
 #[async_trait]
 impl NodeExecutor for ModelNodeExecutor {
     #[instrument(skip(self, item), fields(node_id = %item.node_id))]
-    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, String> {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
         // Extract model config from the work item payload.
@@ -105,11 +105,15 @@ impl NodeExecutor for ModelNodeExecutor {
         debug!(model = %model, messages = messages.len(), "Calling model");
 
         let request = ModelRequest::new(messages).with_config(config);
-        let response = self
-            .registry
-            .chat(request)
-            .await
-            .map_err(|e| format!("Model call failed: {e}"))?;
+        // Intercept RateLimited before erasing the type. ONLY RateLimited becomes
+        // ExecutorError::RateLimited; every other ModelError variant becomes Fatal.
+        let response = match self.registry.chat(request).await {
+            Ok(r) => r,
+            Err(ModelError::RateLimited { retry_after_secs }) => {
+                return Err(ExecutorError::RateLimited { retry_after_secs });
+            }
+            Err(e) => return Err(ExecutorError::Fatal(format!("Model call failed: {e}"))),
+        };
 
         let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -157,5 +161,116 @@ impl NodeExecutor for ModelNodeExecutor {
             output_tokens: Some(response.output_tokens),
             finish_reason: Some(response.finish_reason),
         })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::ExecutorError;
+    use jamjet_models::{ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest};
+    use jamjet_state::backend::WorkItem;
+    use std::sync::Arc;
+
+    // ── Fake adapter ──────────────────────────────────────────────────────────
+
+    enum FakeKind {
+        RateLimited { retry_after_secs: u64 },
+        ApiError,
+    }
+
+    struct FakeAdapter {
+        kind: FakeKind,
+    }
+
+    #[async_trait::async_trait]
+    impl ModelAdapter for FakeAdapter {
+        fn system_name(&self) -> &'static str {
+            "fake"
+        }
+        fn default_model(&self) -> &str {
+            "fake-model"
+        }
+        async fn chat(&self, _req: ModelRequest) -> Result<ModelResponse, ModelError> {
+            match &self.kind {
+                FakeKind::RateLimited { retry_after_secs } => Err(ModelError::RateLimited {
+                    retry_after_secs: *retry_after_secs,
+                }),
+                FakeKind::ApiError => Err(ModelError::Api {
+                    status: 500,
+                    body: "internal server error".into(),
+                }),
+            }
+        }
+        async fn structured_output(
+            &self,
+            _req: StructuredRequest,
+        ) -> Result<ModelResponse, ModelError> {
+            unimplemented!()
+        }
+    }
+
+    fn make_item() -> WorkItem {
+        WorkItem {
+            id: uuid::Uuid::new_v4(),
+            execution_id: jamjet_core::workflow::ExecutionId::new(),
+            node_id: "test-node".into(),
+            queue_type: "model".into(),
+            payload: serde_json::json!({
+                "model": "fake-model",
+                "prompt": "hello",
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        }
+    }
+
+    fn make_executor(kind: FakeKind) -> ModelNodeExecutor {
+        let registry = Arc::new(
+            ModelRegistry::new()
+                .register(Arc::new(FakeAdapter { kind }))
+                .with_default("fake"),
+        );
+        ModelNodeExecutor::new(registry)
+    }
+
+    /// ONLY ModelError::RateLimited maps to ExecutorError::RateLimited, with the
+    /// correct retry_after_secs forwarded.
+    #[tokio::test]
+    async fn rate_limited_maps_to_executor_rate_limited() {
+        let executor = make_executor(FakeKind::RateLimited {
+            retry_after_secs: 7,
+        });
+        let result = executor.execute(&make_item()).await;
+        assert!(
+            matches!(
+                result,
+                Err(ExecutorError::RateLimited {
+                    retry_after_secs: 7
+                })
+            ),
+            "expected RateLimited(7), got: {:?}",
+            result
+        );
+    }
+
+    /// Non-rate-limit ModelErrors (Api, Network, Timeout, etc.) must map to
+    /// ExecutorError::Fatal, never to RateLimited.
+    #[tokio::test]
+    async fn non_rate_limit_error_maps_to_fatal() {
+        let executor = make_executor(FakeKind::ApiError);
+        let result = executor.execute(&make_item()).await;
+        assert!(
+            matches!(result, Err(ExecutorError::Fatal(_))),
+            "expected Fatal, got: {:?}",
+            result
+        );
     }
 }

--- a/runtime/workers/src/lib.rs
+++ b/runtime/workers/src/lib.rs
@@ -13,7 +13,7 @@ pub mod heartbeat;
 pub mod pool;
 pub mod worker;
 
-pub use executor::{ExecutionResult, NodeExecutor};
+pub use executor::{ExecutionResult, ExecutorError, NodeExecutor};
 pub use executors::{
     A2aTaskExecutor, AgentDiscoveryExecutor, EvalExecutor, McpToolExecutor, ModelNodeExecutor,
 };

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1,4 +1,4 @@
-use crate::executor::{ExecutionResult, NodeExecutor};
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use crate::heartbeat::spawn_heartbeat;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
@@ -164,13 +164,15 @@ impl Worker {
         // Idempotency key computed inside the node branch; used on NodeCompleted.
         let mut computed_key: Option<String> = None;
 
-        let result: Result<ExecutionResult, String> = match self
+        let result: Result<ExecutionResult, ExecutorError> = match self
             .load_ir(&workflow_id, &workflow_version)
             .await
         {
-            Err(e) => Err(format!("failed to load IR: {e}")),
+            Err(e) => Err(ExecutorError::Fatal(format!("failed to load IR: {e}"))),
             Ok(ir) => match ir.node(&node_id) {
-                None => Err(format!("node {node_id} not found in IR")),
+                None => Err(ExecutorError::Fatal(format!(
+                    "node {node_id} not found in IR"
+                ))),
                 Some(node_def) => {
                     let kind = &node_def.kind;
                     let kind_tag = node_kind_tag(kind);
@@ -312,8 +314,10 @@ impl Worker {
                                     });
                                     let result = executor.execute_streaming(&item, tx).await;
                                     match receiver_handle.await {
-                                        Ok(Err(e)) => Err(e),
-                                        Err(e) => Err(format!("Receiver task panicked: {e}")),
+                                        Ok(Err(e)) => Err(ExecutorError::Fatal(e)),
+                                        Err(e) => Err(ExecutorError::Fatal(format!(
+                                            "Receiver task panicked: {e}"
+                                        ))),
                                         Ok(Ok(())) => result,
                                     }
                                 }
@@ -438,7 +442,7 @@ impl Worker {
                     0, // sequence assigned atomically inside commit_node_terminal
                     EventKind::NodeFailed {
                         node_id: node_id.clone(),
-                        error: error.clone(),
+                        error: error.to_string(),
                         attempt,
                         retryable: false,
                     },
@@ -978,7 +982,7 @@ fn parse_payload(payload: &serde_json::Value) -> (String, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::executor::{ExecutionResult, NodeExecutor};
+    use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
     use chrono::Utc;
     use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
     use jamjet_state::{
@@ -1129,7 +1133,7 @@ mod tests {
         async fn execute(
             &self,
             _item: &jamjet_state::backend::WorkItem,
-        ) -> Result<ExecutionResult, String> {
+        ) -> Result<ExecutionResult, ExecutorError> {
             Err("boom".into())
         }
     }
@@ -1285,7 +1289,7 @@ mod tests {
         async fn execute(
             &self,
             _item: &jamjet_state::backend::WorkItem,
-        ) -> Result<ExecutionResult, String> {
+        ) -> Result<ExecutionResult, ExecutorError> {
             self.was_called
                 .store(true, std::sync::atomic::Ordering::SeqCst);
             Err("TrackingExecutor fired — replay must prevent this".into())
@@ -1399,7 +1403,7 @@ mod tests {
             async fn execute(
                 &self,
                 _item: &jamjet_state::backend::WorkItem,
-            ) -> Result<ExecutionResult, String> {
+            ) -> Result<ExecutionResult, ExecutorError> {
                 self.count.fetch_add(1, Ordering::SeqCst);
                 Ok(ExecutionResult {
                     output: serde_json::json!({"fresh": true}),

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -518,49 +518,47 @@ impl Worker {
                         + chrono::Duration::seconds(retry_after_secs as i64))
                     .to_rfc3339();
 
-                    // Append NodeParked before park_work_item (audit event — non-terminal;
-                    // no commit_turn; the item must stay re-claimable). On a stale-fence
-                    // park (Ok(false)) this event is a harmless audit record — the newer
-                    // attempt already owns the item.
-                    let seq = match self.backend.latest_sequence(&execution_id).await {
-                        Ok(s) => s + 1,
-                        Err(e) => {
-                            warn!(
-                                execution_id = %execution_id,
-                                node_id = %node_id,
-                                "Failed to get latest sequence for NodeParked; abandoning: {e}"
-                            );
-                            return Ok(());
-                        }
-                    };
-                    if let Err(e) = self
-                        .backend
-                        .append_event(jamjet_state::Event::new(
-                            execution_id.clone(),
-                            seq,
-                            EventKind::NodeParked {
-                                node_id: node_id.clone(),
-                                attempt: next_attempt,
-                                retry_after: retry_after.clone(),
-                            },
-                        ))
-                        .await
-                    {
-                        warn!(
-                            execution_id = %execution_id,
-                            node_id = %node_id,
-                            "Failed to append NodeParked event; abandoning park: {e}"
-                        );
-                        return Ok(());
-                    }
-
                     // Fence-guarded reset to pending with retry_after backoff.
+                    // Park first; only append NodeParked if the park actually succeeds.
+                    // A stale-fence park (Ok(false)) must NOT produce a false audit record.
                     match self
                         .backend
                         .park_work_item(item_id, lease_fence, &retry_after, next_attempt)
                         .await
                     {
                         Ok(true) => {
+                            // Park succeeded — now record the audit event.
+                            let seq = match self.backend.latest_sequence(&execution_id).await {
+                                Ok(s) => s + 1,
+                                Err(e) => {
+                                    warn!(
+                                        execution_id = %execution_id,
+                                        node_id = %node_id,
+                                        "Failed to get latest sequence for NodeParked; abandoning: {e}"
+                                    );
+                                    return Ok(());
+                                }
+                            };
+                            if let Err(e) = self
+                                .backend
+                                .append_event(jamjet_state::Event::new(
+                                    execution_id.clone(),
+                                    seq,
+                                    EventKind::NodeParked {
+                                        node_id: node_id.clone(),
+                                        attempt: next_attempt,
+                                        retry_after: retry_after.clone(),
+                                    },
+                                ))
+                                .await
+                            {
+                                warn!(
+                                    execution_id = %execution_id,
+                                    node_id = %node_id,
+                                    "Failed to append NodeParked event; abandoning: {e}"
+                                );
+                                return Ok(());
+                            }
                             info!(
                                 execution_id = %execution_id,
                                 node_id = %node_id,
@@ -571,7 +569,7 @@ impl Worker {
                         }
                         Ok(false) => {
                             // Stale fence — a newer attempt already owns this item.
-                            // The NodeParked event already appended is a harmless audit record.
+                            // Do NOT append NodeParked: the park didn't succeed for this attempt.
                             warn!(
                                 execution_id = %execution_id,
                                 node_id = %node_id,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1825,4 +1825,127 @@ mod tests {
             );
         }
     }
+
+    // ── Task 2f-4: exhaustion boundary complement ─────────────────────────────
+
+    /// Penultimate-attempt boundary: when the executor returns `RateLimited` at
+    /// the last attempt index that is still BELOW `max_attempts`, the worker must
+    /// park (not fail terminally).
+    ///
+    /// Complements the two existing exhaustion tests:
+    ///   - `park_on_rate_limit_under_max_attempts` uses attempt=0 (far from the boundary).
+    ///   - `rate_limit_fails_terminally_at_max_attempts` uses attempt=2 (max_attempts-1 → fails).
+    ///
+    /// Here we use attempt=1, max_attempts=3 so next_attempt=2, which satisfies
+    /// `2 < 3` → parks.  This covers the off-by-one: the penultimate attempt must
+    /// produce a `NodeParked` event, NOT a terminal `NodeFailed`.
+    #[tokio::test]
+    async fn rate_limit_parks_at_penultimate_attempt() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        backend
+            .create_execution(sample_execution(&eid))
+            .await
+            .unwrap();
+        backend
+            .store_workflow(jamjet_state::backend::WorkflowDefinition {
+                workflow_id: "test-wf".into(),
+                version: "1.0.0".into(),
+                ir: minimal_ir_json(),
+                created_at: Utc::now(),
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        // attempt=1 (penultimate), max_attempts=3: next_attempt=2 < 3 → parks.
+        backend
+            .enqueue_work_item(jamjet_state::backend::WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "test-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 1,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(RateLimitingExecutor {
+                retry_after_secs: 30,
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+
+        // Must emit exactly one NodeParked (not NodeFailed) at the penultimate attempt.
+        let parked_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeParked { .. }))
+            .count();
+        assert_eq!(
+            parked_count, 1,
+            "penultimate attempt must emit NodeParked, not NodeFailed; got {parked_count}"
+        );
+
+        // Must NOT emit NodeFailed.
+        let failed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeFailed { .. }))
+            .count();
+        assert_eq!(
+            failed_count, 0,
+            "penultimate attempt must NOT emit NodeFailed; got {failed_count}"
+        );
+
+        // NodeParked must carry attempt=2 (next_attempt after attempt=1).
+        let parked_event = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeParked { .. }))
+            .unwrap();
+        if let EventKind::NodeParked { attempt, .. } = &parked_event.kind {
+            assert_eq!(
+                *attempt, 2,
+                "NodeParked.attempt must be 2 (next after penultimate)"
+            );
+        }
+
+        // Item must be re-claimable with attempt=2 (in-memory ignores retry_after window).
+        let re_claimed = backend
+            .claim_work_item("worker-2", &["default"])
+            .await
+            .unwrap();
+        assert!(
+            re_claimed.is_some(),
+            "item must be re-claimable after penultimate park"
+        );
+        assert_eq!(
+            re_claimed.unwrap().attempt,
+            2,
+            "re-claimed item must be at attempt=2"
+        );
+    }
 }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1,6 +1,10 @@
 use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use crate::heartbeat::spawn_heartbeat;
 use chrono::Utc;
+
+/// Cap a provider-supplied Retry-After so an untrusted/huge value can't overflow
+/// the timestamp math or push the backoff into the past. One hour is plenty.
+const MAX_RETRY_AFTER_SECS: u64 = 3_600;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
 use jamjet_core::workflow::ExecutionId;
@@ -507,6 +511,9 @@ impl Worker {
                     // Park the work item — reset to pending with a future not-before time.
                     // retry_after uses the wall clock: this is a scheduling hint for
                     // future claim visibility, not replayed durable state, so real time is correct.
+                    // Clamp the provider-supplied value so a malicious or buggy huge value
+                    // cannot overflow the chrono DateTime addition or cast negative via as i64.
+                    let retry_after_secs = retry_after_secs.min(MAX_RETRY_AFTER_SECS);
                     let retry_after = (Utc::now()
                         + chrono::Duration::seconds(retry_after_secs as i64))
                     .to_rfc3339();
@@ -1495,6 +1502,22 @@ mod tests {
                 "replayed output must match the seeded record"
             );
         }
+    }
+
+    // ── Retry-After clamp ────────────────────────────────────────────────────
+
+    /// Verify that `MAX_RETRY_AFTER_SECS` bounds a u64::MAX value so the chrono
+    /// cast is always safe and the resulting timestamp is in the future.
+    #[test]
+    fn capped_retry_after_clamps_huge_value() {
+        let huge: u64 = u64::MAX;
+        let capped = huge.min(MAX_RETRY_AFTER_SECS);
+        assert_eq!(capped, MAX_RETRY_AFTER_SECS);
+        // Safe to cast — 3600 << i64::MAX.
+        let duration = chrono::Duration::seconds(capped as i64);
+        let ts = chrono::Utc::now() + duration;
+        let now = chrono::Utc::now();
+        assert!(ts > now, "parked timestamp must be in the future");
     }
 
     // ── Rate-limit executor ───────────────────────────────────────────────────

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1,5 +1,6 @@
 use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use crate::heartbeat::spawn_heartbeat;
+use chrono::Utc;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
 use jamjet_core::workflow::ExecutionId;
@@ -108,6 +109,7 @@ impl Worker {
         let node_id = item.node_id.clone();
         let tenant_id = item.tenant_id.clone();
         let attempt = item.attempt;
+        let max_attempts = item.max_attempts;
         let item_id = item.id;
         let lease_fence = item.lease_fence;
 
@@ -436,13 +438,14 @@ impl Worker {
                     Err(e) => return Err(Box::new(e)),
                 }
             }
-            Err(error) => {
+            Err(ExecutorError::Fatal(msg)) => {
+                // Non-retryable failure — terminal NodeFailed via the fenced commit path.
                 let terminal = jamjet_state::Event::new(
                     execution_id.clone(),
                     0, // sequence assigned atomically inside commit_node_terminal
                     EventKind::NodeFailed {
                         node_id: node_id.clone(),
-                        error: error.to_string(),
+                        error: msg.clone(),
                         attempt,
                         retryable: false,
                     },
@@ -453,13 +456,123 @@ impl Worker {
                     .await
                 {
                     Ok(_) => {
-                        warn!(execution_id = %execution_id, node_id = %node_id, attempt, %error, "Node failed");
+                        warn!(execution_id = %execution_id, node_id = %node_id, attempt, error = %msg, "Node failed");
                     }
                     Err(StateBackendError::FenceLost(_)) => {
                         warn!(execution_id = %execution_id, node_id = %node_id, "Fence lost on failure commit; abandoning");
                         return Ok(());
                     }
                     Err(e) => return Err(Box::new(e)),
+                }
+            }
+            Err(ExecutorError::RateLimited { retry_after_secs }) => {
+                let next_attempt = attempt + 1;
+                if next_attempt >= max_attempts {
+                    // Max attempts exhausted — terminal NodeFailed; never parked.
+                    let terminal = jamjet_state::Event::new(
+                        execution_id.clone(),
+                        0,
+                        EventKind::NodeFailed {
+                            node_id: node_id.clone(),
+                            error: format!("rate limited: exhausted {max_attempts} attempts"),
+                            attempt,
+                            retryable: false,
+                        },
+                    );
+                    match self
+                        .backend
+                        .commit_turn(item_id, lease_fence, terminal, false)
+                        .await
+                    {
+                        Ok(_) => {
+                            warn!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                attempt,
+                                max_attempts,
+                                "Node failed: rate limited and max attempts exhausted"
+                            );
+                        }
+                        Err(StateBackendError::FenceLost(_)) => {
+                            warn!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                "Fence lost on rate-limit terminal commit; abandoning"
+                            );
+                            return Ok(());
+                        }
+                        Err(e) => return Err(Box::new(e)),
+                    }
+                } else {
+                    // Park the work item — reset to pending with a future not-before time.
+                    // retry_after uses the wall clock: this is a scheduling hint for
+                    // future claim visibility, not replayed durable state, so real time is correct.
+                    let retry_after = (Utc::now()
+                        + chrono::Duration::seconds(retry_after_secs as i64))
+                    .to_rfc3339();
+
+                    // Append NodeParked before park_work_item (audit event — non-terminal;
+                    // no commit_turn; the item must stay re-claimable). On a stale-fence
+                    // park (Ok(false)) this event is a harmless audit record — the newer
+                    // attempt already owns the item.
+                    let seq = match self.backend.latest_sequence(&execution_id).await {
+                        Ok(s) => s + 1,
+                        Err(e) => {
+                            warn!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                "Failed to get latest sequence for NodeParked; abandoning: {e}"
+                            );
+                            return Ok(());
+                        }
+                    };
+                    if let Err(e) = self
+                        .backend
+                        .append_event(jamjet_state::Event::new(
+                            execution_id.clone(),
+                            seq,
+                            EventKind::NodeParked {
+                                node_id: node_id.clone(),
+                                attempt: next_attempt,
+                                retry_after: retry_after.clone(),
+                            },
+                        ))
+                        .await
+                    {
+                        warn!(
+                            execution_id = %execution_id,
+                            node_id = %node_id,
+                            "Failed to append NodeParked event; abandoning park: {e}"
+                        );
+                        return Ok(());
+                    }
+
+                    // Fence-guarded reset to pending with retry_after backoff.
+                    match self
+                        .backend
+                        .park_work_item(item_id, lease_fence, &retry_after, next_attempt)
+                        .await
+                    {
+                        Ok(true) => {
+                            info!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                attempt = next_attempt,
+                                %retry_after,
+                                "Node parked on rate limit; will retry after backoff"
+                            );
+                        }
+                        Ok(false) => {
+                            // Stale fence — a newer attempt already owns this item.
+                            // The NodeParked event already appended is a harmless audit record.
+                            warn!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                "Stale fence on park; a newer attempt already owns this item — abandoning"
+                            );
+                        }
+                        Err(e) => return Err(Box::new(e)),
+                    }
                 }
             }
         }
@@ -1382,6 +1495,228 @@ mod tests {
                 "replayed output must match the seeded record"
             );
         }
+    }
+
+    // ── Rate-limit executor ───────────────────────────────────────────────────
+
+    /// A stub executor that always returns `ExecutorError::RateLimited`. Used to
+    /// drive the park path and the max-attempts exhaustion path.
+    struct RateLimitingExecutor {
+        retry_after_secs: u64,
+    }
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for RateLimitingExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, ExecutorError> {
+            Err(ExecutorError::RateLimited {
+                retry_after_secs: self.retry_after_secs,
+            })
+        }
+    }
+
+    /// Park path: when the executor returns `RateLimited` and `attempt + 1 < max_attempts`,
+    /// the worker must:
+    /// 1. Emit exactly one `NodeParked` event (non-terminal — no commit_turn).
+    /// 2. Reset the work item to pending via `park_work_item` with incremented attempt.
+    /// 3. NOT emit `NodeFailed` or `NodeCompleted`.
+    ///
+    /// The in-memory backend does not enforce the `retry_after` not-before window,
+    /// so the item is immediately re-claimable in this test.
+    #[tokio::test]
+    async fn park_on_rate_limit_under_max_attempts() {
+        let (backend, eid) = setup_backend().await; // item: attempt=0, max_attempts=3
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(RateLimitingExecutor {
+                retry_after_secs: 5,
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+
+        // Must emit exactly one NodeParked event.
+        let parked_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeParked { .. }))
+            .count();
+        assert_eq!(
+            parked_count, 1,
+            "expected exactly one NodeParked event; got {parked_count}"
+        );
+
+        // Must NOT emit NodeFailed.
+        let failed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeFailed { .. }))
+            .count();
+        assert_eq!(
+            failed_count, 0,
+            "NodeFailed must not be emitted for a parked item; got {failed_count}"
+        );
+
+        // Must NOT emit NodeCompleted.
+        let completed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .count();
+        assert_eq!(
+            completed_count, 0,
+            "NodeCompleted must not be emitted for a parked item; got {completed_count}"
+        );
+
+        // NodeParked must carry the incremented attempt and a future RFC3339 retry_after.
+        let parked_event = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeParked { .. }))
+            .unwrap();
+        if let EventKind::NodeParked {
+            node_id,
+            attempt,
+            retry_after,
+        } = &parked_event.kind
+        {
+            assert_eq!(node_id, "n1", "NodeParked.node_id must be n1");
+            assert_eq!(*attempt, 1, "NodeParked.attempt must be next_attempt (1)");
+            // retry_after must parse as RFC3339 and be in the future.
+            let ra = chrono::DateTime::parse_from_rfc3339(retry_after)
+                .expect("retry_after must be valid RFC3339");
+            assert!(
+                ra > Utc::now(),
+                "retry_after must be in the future; got {retry_after}"
+            );
+        }
+
+        // Work item must be re-claimable with incremented attempt (the in-memory
+        // backend does not enforce the not-before window, so the item is
+        // immediately claimable for test purposes).
+        let re_claimed = backend
+            .claim_work_item("worker-2", &["default"])
+            .await
+            .unwrap();
+        assert!(
+            re_claimed.is_some(),
+            "work item must be re-claimable after park"
+        );
+        assert_eq!(
+            re_claimed.unwrap().attempt,
+            1,
+            "re-claimed item must have attempt=1 after park"
+        );
+    }
+
+    /// Exhaustion path: when the executor returns `RateLimited` and
+    /// `attempt + 1 >= max_attempts`, the worker must emit a terminal
+    /// `NodeFailed { retryable: false }` via `commit_turn` and must NOT park
+    /// the item.
+    #[tokio::test]
+    async fn rate_limit_fails_terminally_at_max_attempts() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        backend
+            .create_execution(sample_execution(&eid))
+            .await
+            .unwrap();
+        backend
+            .store_workflow(jamjet_state::backend::WorkflowDefinition {
+                workflow_id: "test-wf".into(),
+                version: "1.0.0".into(),
+                ir: minimal_ir_json(),
+                created_at: Utc::now(),
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        // Item at attempt=2: next_attempt=3 >= max_attempts=3 → terminal.
+        backend
+            .enqueue_work_item(jamjet_state::backend::WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "test-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 2,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(RateLimitingExecutor {
+                retry_after_secs: 5,
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+
+        // Must emit exactly one NodeFailed with retryable=false.
+        let failed = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeFailed { .. }))
+            .expect("NodeFailed must be emitted at max attempts");
+        if let EventKind::NodeFailed { retryable, .. } = &failed.kind {
+            assert!(
+                !retryable,
+                "NodeFailed must have retryable=false at max attempts"
+            );
+        }
+
+        // Must NOT emit NodeParked.
+        let parked_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeParked { .. }))
+            .count();
+        assert_eq!(
+            parked_count, 0,
+            "NodeParked must not be emitted at max attempts; got {parked_count}"
+        );
+
+        // Must NOT emit NodeCompleted.
+        let completed_count = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .count();
+        assert_eq!(
+            completed_count, 0,
+            "NodeCompleted must not be emitted at max attempts; got {completed_count}"
+        );
     }
 
     /// Record-replay exactly-once: pre-seed the idempotency cache for the step=0

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -22,6 +22,9 @@ from jamjet.model.seam import Model
 from jamjet.model.types import ModelRequest, parse_model_ref
 
 _RATE_LIMIT_FALLBACK_SECS = 5
+# Cap untrusted provider Retry-After so a huge value cannot overflow timestamp math
+# in the Rust worker. Must match MAX_RETRY_AFTER_SECS in runtime/workers/src/worker.rs.
+_MAX_RETRY_AFTER_SECS = 3_600
 
 
 def _extract_retry_after(exc: BaseException) -> int:
@@ -38,13 +41,13 @@ def _extract_retry_after(exc: BaseException) -> int:
         raw = headers.get("retry-after") or headers.get("Retry-After")
         if raw is not None:
             try:
-                return int(raw)
+                return min(int(raw), _MAX_RETRY_AFTER_SECS)
             except (ValueError, TypeError):
                 pass
     val = getattr(exc, "retry_after", None)
     if val is not None:
         try:
-            return int(val)
+            return min(int(val), _MAX_RETRY_AFTER_SECS)
         except (ValueError, TypeError):
             pass
     return _RATE_LIMIT_FALLBACK_SECS

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -21,6 +21,35 @@ from jamjet.model.defaults import default_model_middleware
 from jamjet.model.seam import Model
 from jamjet.model.types import ModelRequest, parse_model_ref
 
+_RATE_LIMIT_FALLBACK_SECS = 5
+
+
+def _extract_retry_after(exc: BaseException) -> int:
+    """Return retry_after seconds from a provider rate-limit exception.
+
+    Checks, in order:
+    1. ``exc.response.headers["retry-after"]`` (set by litellm / openai SDK).
+    2. ``exc.retry_after`` attribute (defensive; uncommon in practice).
+    Falls back to ``_RATE_LIMIT_FALLBACK_SECS`` if nothing is found.
+    """
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", {})
+        raw = headers.get("retry-after") or headers.get("Retry-After")
+        if raw is not None:
+            try:
+                return int(raw)
+            except (ValueError, TypeError):
+                pass
+    val = getattr(exc, "retry_after", None)
+    if val is not None:
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            pass
+    return _RATE_LIMIT_FALLBACK_SECS
+
+
 # Module-level singleton -- created lazily on first call so tests can inject
 # a fake model by monkeypatching _get_model.
 _model: Model | None = None
@@ -63,6 +92,19 @@ async def _handle_complete(request: Request) -> JSONResponse:
         return JSONResponse(result)
     except (KeyError, ValueError) as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception as exc:
+        # Duck-typed check: litellm.exceptions.RateLimitError (and openai.RateLimitError)
+        # carry status_code=429.  We check this without importing litellm at module level
+        # so the sidecar server remains importable when the model extra is absent.
+        # ModelDeniedError has no status_code attribute and will fall through to ``raise``,
+        # preserving the governance fail-closed contract.
+        if getattr(exc, "status_code", None) == 429:
+            retry_after = _extract_retry_after(exc)
+            return JSONResponse(
+                {"error": str(exc), "retry_after": retry_after},
+                status_code=429,
+            )
+        raise
 
 
 async def _handle_health(request: Request) -> JSONResponse:

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -41,13 +41,13 @@ def _extract_retry_after(exc: BaseException) -> int:
         raw = headers.get("retry-after") or headers.get("Retry-After")
         if raw is not None:
             try:
-                return min(int(raw), _MAX_RETRY_AFTER_SECS)
+                return max(0, min(int(raw), _MAX_RETRY_AFTER_SECS))
             except (ValueError, TypeError):
                 pass
     val = getattr(exc, "retry_after", None)
     if val is not None:
         try:
-            return min(int(val), _MAX_RETRY_AFTER_SECS)
+            return max(0, min(int(val), _MAX_RETRY_AFTER_SECS))
         except (ValueError, TypeError):
             pass
     return _RATE_LIMIT_FALLBACK_SECS

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -9,7 +9,12 @@ import httpx
 import pytest
 
 import jamjet.model.sidecar_server as sidecar_module
-from jamjet.model.sidecar_server import _complete, app
+from jamjet.model.sidecar_server import (
+    _RATE_LIMIT_FALLBACK_SECS,
+    _complete,
+    _extract_retry_after,
+    app,
+)
 from jamjet.model.types import ModelResponse
 
 
@@ -261,6 +266,36 @@ async def test_complete_route_rate_limited_propagates_retry_after(
 
     assert resp.status_code == 429
     assert resp.json()["retry_after"] == 30, f"expected 30, got {resp.json()}"
+
+
+def test_extract_retry_after_negative_header_clamps_to_zero() -> None:
+    """A negative Retry-After header value must clamp to 0, never go negative (2f-5)."""
+
+    class _FakeResp:
+        headers = {"retry-after": "-1"}
+
+    class _ExcError(Exception):
+        status_code = 429
+        response = _FakeResp()
+
+    result = _extract_retry_after(_ExcError())
+    assert result == 0, f"expected 0 for Retry-After: -1, got {result}"
+
+
+def test_extract_retry_after_non_numeric_header_falls_back_to_default() -> None:
+    """A non-numeric Retry-After (e.g. an HTTP-date) must not crash; fall back to default (2f-5)."""
+
+    class _FakeResp:
+        headers = {"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"}
+
+    class _ExcError(Exception):
+        status_code = 429
+        response = _FakeResp()
+
+    result = _extract_retry_after(_ExcError())
+    assert result == _RATE_LIMIT_FALLBACK_SECS, (
+        f"non-numeric Retry-After must fall back to {_RATE_LIMIT_FALLBACK_SECS}, got {result}"
+    )
 
 
 async def test_complete_route_model_denied_is_non_200(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -1,4 +1,4 @@
-"""Tests for the Model-seam sidecar server (Task 2e-1).
+"""Tests for the Model-seam sidecar server (Task 2e-1, 2f-5).
 
 Tests the core _complete handler directly (no Starlette required) and also
 exercises the HTTP routes via httpx ASGITransport (starlette is installed).
@@ -178,6 +178,119 @@ async def test_complete_route_missing_model_key(monkeypatch: pytest.MonkeyPatch)
 
     assert resp.status_code == 400
     assert "error" in resp.json()
+
+
+# --------------------------------------------------------------------------- #
+# 2f-5: provider 429 must surface as HTTP 429 with retry_after
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRateLimitResponse:
+    """Minimal response object carrying a Retry-After header."""
+
+    def __init__(self, retry_after: int | None = None) -> None:
+        self.headers: dict[str, str] = {}
+        if retry_after is not None:
+            self.headers["retry-after"] = str(retry_after)
+
+
+class _RateLimitError(Exception):
+    """Stub that mimics litellm.exceptions.RateLimitError without importing litellm.
+
+    The production handler checks ``status_code == 429`` (duck typing), so this
+    stub exercises the exact same code path as the real litellm exception.
+    """
+
+    status_code = 429
+
+    def __init__(self, msg: str = "rate limited", *, retry_after: int | None = None) -> None:
+        super().__init__(msg)
+        self.response = _FakeRateLimitResponse(retry_after=retry_after)
+
+
+class FakeRateLimitModel:
+    """Injects a _RateLimitError (no Retry-After header) into the completion path."""
+
+    async def complete(self, request):  # noqa: ANN001, ANN201
+        raise _RateLimitError("provider rate limit")
+
+
+class FakeRateLimitModelWithRetryAfter:
+    """Injects a _RateLimitError carrying Retry-After: 30 in the response headers."""
+
+    async def complete(self, request):  # noqa: ANN001, ANN201
+        raise _RateLimitError("provider rate limit", retry_after=30)
+
+
+async def test_complete_route_rate_limited_returns_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider 429 must surface as HTTP 429 with retry_after in the body (2f-5)."""
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeRateLimitModel())
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            json={
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 429, f"expected 429, got {resp.status_code}"
+    body = resp.json()
+    assert "retry_after" in body, f"retry_after missing from 429 body: {body}"
+    assert isinstance(body["retry_after"], int), "retry_after must be an integer"
+    assert "error" in body
+
+
+async def test_complete_route_rate_limited_propagates_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry-After header from the provider response must be forwarded in the body (2f-5)."""
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeRateLimitModelWithRetryAfter())
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            json={
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 429
+    assert resp.json()["retry_after"] == 30, f"expected 30, got {resp.json()}"
+
+
+async def test_complete_route_model_denied_is_non_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ModelDeniedError must NOT be caught by the 429 branch (fail-closed preserved).
+
+    Starlette's ServerErrorMiddleware converts unhandled exceptions to 500 in
+    production (uvicorn).  We use ``raise_server_exceptions=False`` so httpx
+    also converts them to 500 rather than re-raising, matching that behaviour.
+    """
+    from jamjet.model.middleware import ModelDeniedError
+
+    class FakeDeniedModel:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            raise ModelDeniedError("model not in allowlist", code="model_not_allowed")
+
+    monkeypatch.setattr(sidecar_module, "_get_model", lambda: FakeDeniedModel())
+
+    # raise_app_exceptions=False mirrors uvicorn: unhandled exceptions become 500.
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/complete",
+            json={
+                "model": "bad/model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code != 200, f"ModelDeniedError must never return 200, got {resp.status_code}"
+    assert resp.status_code != 429, "ModelDeniedError must not be swallowed by the 429 branch"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Track 2f of the ADK build. When a model call hits a provider rate limit (429), the durable engine now PARKS the work item and re-leases it after the provider's backoff, instead of failing the node. A durable agent survives a 429 without losing its turn. After `max_attempts` (the existing work-item field, default 3) it fails terminally.

## How

- **State** (`runtime/state`): a fence-guarded `park_work_item` returns a leased item to `pending`, visible again at `retry_after`, with the attempt bumped and a fresh lease epoch. The `retry_after` visibility column and the claim-time not-before filter already existed (migration 0002), so no new migration. New `NodeParked` audit event (a no-op on replay).
- **Worker** (`runtime/workers`): a new `ExecutorError` enum distinguishes a retryable rate-limit from a fatal error. Only `ModelError::RateLimited` parks; every other error stays terminal. The worker Err-arm parks under the cap, fails terminally at it.
- **Seam** (`sidecar.rs` + `sidecar_server.py`): the Python model-seam sidecar now surfaces a provider 429 with the real `Retry-After`, and the Rust adapter parses it. Before this, a provider 429 inside litellm fell through to a 500 and the node failed terminally, so park-on-429 never fired on the production path. Governance denials still return non-200 (fail-closed preserved).

## Safety

The park is fence-guarded the same way as `commit_turn`: a stale worker cannot park over a newer attempt or a committed node. `retry_after` is wall-clock (a scheduling hint, not replayed state) and is clamped to one hour so an untrusted provider value cannot overflow the timestamp math or push the backoff into the past.

## Review

Subagent-driven, with a whole-branch adversarial review on the durability and fence invariants. The review confirmed fence safety, exactly-once-commit, no infinite retry, and fail-closed governance all hold, and flagged the unclamped `retry_after` (now fixed). Full workspace tests plus the Python suite are green.

## Follow-ups (tracked)

- F-2f-reclaim-fence (pre-existing, benign): the stale-expiry reclaim path does not reset `lease_fence`; `commit_turn` has the same exposure. Defense-in-depth one-liner, not introduced here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate-limited requests now return a retry delay, helping the system pause and try again later instead of failing immediately.
  * Work items can now be temporarily parked and retried automatically when a provider signals rate limiting.

* **Bug Fixes**
  * Improved handling of 429 responses so retry timing is more consistent and safer.
  * Added protections to prevent extreme retry values from causing incorrect backoff behavior.
  * Tightened scheduler handling for parked work items without changing normal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->