### PR TITLE
feat(2g): continue-as-new bounds history for long-running durable agents

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,7 +70,7 @@ anyhow = "1"
 async-trait = "0.1"
 
 # IDs and time
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 ulid = "1"
 

--- a/runtime/api/src/mcp_bridge.rs
+++ b/runtime/api/src/mcp_bridge.rs
@@ -98,6 +98,8 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                     updated_at: now,
                     completed_at: None,
                     session_type: None,
+                    parent_execution_id: None,
+                    segment_number: 0,
                 };
                 let eid = execution.execution_id.clone();
                 backend.create_execution(execution).await.map_err(|e| format!("{e}"))?;

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -222,6 +222,8 @@ async fn start_execution(
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     };
     let execution_id = execution.execution_id.clone();
     backend.create_execution(execution).await?;

--- a/runtime/api/tests/approval_api.rs
+++ b/runtime/api/tests/approval_api.rs
@@ -54,6 +54,8 @@ async fn create_execution(backend: &Arc<dyn StateBackend>) -> ExecutionId {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         })
         .await
         .expect("create_execution");

--- a/runtime/api/tests/approval_e2e.rs
+++ b/runtime/api/tests/approval_e2e.rs
@@ -118,6 +118,8 @@ async fn start() -> Harness {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         })
         .await
         .expect("create_execution");

--- a/runtime/api/tests/execution_e2e.rs
+++ b/runtime/api/tests/execution_e2e.rs
@@ -82,6 +82,8 @@ async fn workflow_runs_to_completion() {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         })
         .await
         .expect("create_execution");

--- a/runtime/api/tests/work_item_genai.rs
+++ b/runtime/api/tests/work_item_genai.rs
@@ -61,6 +61,8 @@ async fn complete_work_item_threads_gen_ai_fields() {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         })
         .await
         .expect("create_execution");
@@ -178,6 +180,8 @@ async fn complete_work_item_without_gen_ai_fields_keeps_backward_compat() {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         })
         .await
         .expect("create_execution");

--- a/runtime/core/src/workflow.rs
+++ b/runtime/core/src/workflow.rs
@@ -129,6 +129,13 @@ pub struct WorkflowExecution {
     /// Session type label for governance and durability classification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_type: Option<SessionType>,
+    /// For a segment chain (continue-as-new): the execution_id of the preceding
+    /// segment. `None` for an original (root) execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_execution_id: Option<ExecutionId>,
+    /// Position of this execution in a segment chain. 0 for a root execution.
+    #[serde(default)]
+    pub segment_number: u32,
 }
 
 #[cfg(test)]

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -192,6 +192,7 @@ mod tests {
             cost_budget_usd: None,
             on_budget_exceeded: None,
             data_policy: None,
+            continue_as_new: false,
         }
     }
 

--- a/runtime/ir/src/workflow.rs
+++ b/runtime/ir/src/workflow.rs
@@ -55,6 +55,10 @@ pub struct WorkflowIr {
     /// If absent, the execution fails with `WorkflowFailed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_budget_exceeded: Option<String>,
+    /// If true, when a budget ceiling is hit the execution rolls over to a new
+    /// segment (continue-as-new) instead of failing. Default: false.
+    #[serde(default)]
+    pub continue_as_new: bool,
     /// Data handling policy (PII redaction + retention controls).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_policy: Option<DataPolicyIr>,
@@ -306,6 +310,7 @@ mod tests {
             token_budget: None,
             cost_budget_usd: None,
             on_budget_exceeded: None,
+            continue_as_new: false,
             data_policy: None,
             state_schema: "schemas.TestState".into(),
             start_node: "start".into(),

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -666,6 +666,8 @@ mod tests {
                 updated_at: now,
                 completed_at: None,
                 session_type: None,
+                parent_execution_id: None,
+                segment_number: 0,
             })
             .await
             .unwrap();

--- a/runtime/state/migrations/0007_segment_links.sql
+++ b/runtime/state/migrations/0007_segment_links.sql
@@ -1,0 +1,5 @@
+-- Migration 0007: continue-as-new segment links. A long-running run is a chain
+-- of executions; segment N+1 carries the materialized state of segment N and
+-- links back via parent_execution_id. segment_number is 0 for an original run.
+ALTER TABLE workflow_executions ADD COLUMN parent_execution_id TEXT;
+ALTER TABLE workflow_executions ADD COLUMN segment_number INTEGER NOT NULL DEFAULT 0;

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -215,6 +215,26 @@ pub trait StateBackend: Send + Sync {
         next_attempt: u32,
     ) -> BackendResult<bool>;
 
+    /// Fence-guarded finalization of a continue-as-new rollover on the OLD execution.
+    ///
+    /// In one transaction:
+    /// 1. Attempt `UPDATE work_items SET status='completed', completed_at=?, lease_expires_at=NULL
+    ///    WHERE id=? AND lease_fence=?`. Zero rows means the fence no longer matches
+    ///    (lease was stolen or item already settled) — rollback and return `Ok(false)`.
+    /// 2. Idempotently mark the execution terminal:
+    ///    `UPDATE workflow_executions SET status='limit_exceeded', updated_at=?, completed_at=COALESCE(completed_at,?)
+    ///    WHERE execution_id=? AND status NOT IN ('completed','failed','cancelled','limit_exceeded')`.
+    ///    (This is a no-op if the execution is already terminal, which is safe.)
+    /// 3. Commit and return `Ok(true)`.
+    ///
+    /// A zombie worker (stale fence) gets `Ok(false)` and must not proceed further.
+    async fn finalize_rollover_fenced(
+        &self,
+        execution_id: &ExecutionId,
+        work_item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool>;
+
     /// Reclaim work items whose lease has expired (worker crashed or stalled).
     ///
     /// For each expired item:

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::event::{Event, EventSequence};
+use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
 use crate::tenant::{Tenant, TenantId, DEFAULT_TENANT};
 use async_trait::async_trait;
@@ -125,6 +125,21 @@ pub trait StateBackend: Send + Sync {
 
     /// Load the latest snapshot for an execution.
     async fn latest_snapshot(&self, execution_id: &ExecutionId) -> BackendResult<Option<Snapshot>>;
+
+    /// Atomically create a continuation segment: the execution row, its seed
+    /// snapshot, the WorkflowStarted + NodeScheduled events, and the start-node
+    /// work item, in one transaction. All-or-nothing so a crash mid-creation
+    /// leaves no partial child. The caller-supplied `execution.execution_id` MUST
+    /// be fresh (not yet committed); the idempotency guard lives in
+    /// `start_next_segment`.
+    async fn create_segment_atomic(
+        &self,
+        execution: WorkflowExecution,
+        seed_snapshot: Snapshot,
+        started_event: EventKind,
+        scheduled_event: EventKind,
+        work_item: WorkItem,
+    ) -> BackendResult<()>;
 
     // ── Idempotency cache (tool_effects) ─────────────────────────────────────
 

--- a/runtime/state/src/event.rs
+++ b/runtime/state/src/event.rs
@@ -372,6 +372,15 @@ pub enum EventKind {
         message: String,
         retryable: bool,
     },
+    /// Audit record written to the OLD execution when a continue-as-new rollover
+    /// occurs. Records which segment was created next and the new execution_id.
+    /// Pure audit — does NOT mutate `MaterializedState`.
+    SegmentBoundary {
+        /// The segment_number of the newly created execution (old + 1).
+        segment_number: u32,
+        /// The execution_id of the new segment (as a string).
+        next_execution_id: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -29,7 +29,7 @@ pub use materializer::{
     apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState,
 };
 pub use memory::InMemoryBackend;
-pub use segment::start_next_segment;
+pub use segment::{segment_chain, start_next_segment};
 pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;
 pub use tenant::{Tenant, TenantId, TenantLimits, TenantStatus, DEFAULT_TENANT};

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -12,6 +12,7 @@ pub mod event;
 pub mod hashing;
 pub mod materializer;
 pub mod memory;
+pub mod segment;
 pub mod snapshot;
 pub mod sqlite;
 pub mod tenant;
@@ -28,6 +29,7 @@ pub use materializer::{
     apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState,
 };
 pub use memory::InMemoryBackend;
+pub use segment::start_next_segment;
 pub use snapshot::Snapshot;
 pub use sqlite::SqliteBackend;
 pub use tenant::{Tenant, TenantId, TenantLimits, TenantStatus, DEFAULT_TENANT};

--- a/runtime/state/src/materializer.rs
+++ b/runtime/state/src/materializer.rs
@@ -143,6 +143,9 @@ pub fn apply_events_seeded(mut base: MaterializedState, events: &[Event]) -> Mat
                 }
                 base.status = WorkflowStatus::Running;
             }
+            // SegmentBoundary is a pure audit record on the OLD (closed) execution.
+            // It links to the new segment but does not mutate this execution's state.
+            EventKind::SegmentBoundary { .. } => {}
             _ => {}
         }
     }

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -571,6 +571,29 @@ impl StateBackend for InMemoryBackend {
         }
     }
 
+    async fn finalize_rollover_fenced(
+        &self,
+        execution_id: &ExecutionId,
+        work_item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        // Fence check: only the current holder may finalize.
+        match self.work_items.get(&work_item_id) {
+            Some(entry) if entry.lease_fence == lease_fence => {}
+            _ => return Ok(false),
+        }
+        // Fence matched — settle the work item.
+        self.work_items.remove(&work_item_id);
+        // Idempotent terminal update on the execution.
+        if let Some(mut entry) = self.executions.get_mut(execution_id) {
+            if !entry.status.is_terminal() {
+                entry.status = WorkflowStatus::LimitExceeded;
+                entry.updated_at = Utc::now();
+            }
+        }
+        Ok(true)
+    }
+
     async fn reclaim_expired_leases(&self) -> BackendResult<ReclaimResult> {
         let now = Utc::now();
         let mut result = ReclaimResult::default();

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -255,6 +255,55 @@ impl StateBackend for InMemoryBackend {
         Ok(())
     }
 
+    async fn create_segment_atomic(
+        &self,
+        execution: WorkflowExecution,
+        seed_snapshot: Snapshot,
+        started_event: EventKind,
+        scheduled_event: EventKind,
+        work_item: WorkItem,
+    ) -> BackendResult<()> {
+        // In-memory has no ACID crash-durability, but we replicate the write
+        // order of the SQLite impl so behavior is consistent in tests.
+        let exec_id = execution.execution_id.clone();
+
+        // 1. Execution row.
+        self.executions.insert(exec_id.clone(), execution);
+
+        // 2. Seed snapshot.
+        self.snapshots
+            .entry(exec_id.clone())
+            .or_default()
+            .push(seed_snapshot);
+
+        // 3. WorkflowStarted — replicates append_event's fetch_add for sequence.
+        let seq1 = self.next_sequence.fetch_add(1, Ordering::SeqCst);
+        let ev1 = Event {
+            id: Uuid::new_v4(),
+            execution_id: exec_id.clone(),
+            sequence: seq1,
+            kind: started_event,
+            created_at: Utc::now(),
+        };
+        self.events.entry(exec_id.clone()).or_default().push(ev1);
+
+        // 4. NodeScheduled.
+        let seq2 = self.next_sequence.fetch_add(1, Ordering::SeqCst);
+        let ev2 = Event {
+            id: Uuid::new_v4(),
+            execution_id: exec_id.clone(),
+            sequence: seq2,
+            kind: scheduled_event,
+            created_at: Utc::now(),
+        };
+        self.events.entry(exec_id.clone()).or_default().push(ev2);
+
+        // 5. Start-node work item.
+        self.work_items.insert(work_item.id, work_item);
+
+        Ok(())
+    }
+
     async fn latest_snapshot(&self, execution_id: &ExecutionId) -> BackendResult<Option<Snapshot>> {
         Ok(self
             .snapshots

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -13,7 +13,6 @@ use crate::backend::{BackendResult, StateBackend, WorkItem};
 use crate::event::{Event, EventKind};
 use crate::materializer::MaterializedState;
 use crate::snapshot::Snapshot;
-use crate::tenant::DEFAULT_TENANT;
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use uuid::Uuid;
@@ -31,7 +30,7 @@ use uuid::Uuid;
 ///
 /// # Returns
 /// The `ExecutionId` of the newly created segment execution.
-// Eight parameters are required by the plan interface; suppressing the lint rather
+// Nine parameters are required by the plan interface; suppressing the lint rather
 // than breaking the caller signature with a builder/struct at this stage.
 #[allow(clippy::too_many_arguments)]
 pub async fn start_next_segment(
@@ -43,6 +42,7 @@ pub async fn start_next_segment(
     next_segment_number: u32,
     start_node_id: &str,
     queue_type: &str,
+    tenant_id: &str,
 ) -> BackendResult<ExecutionId> {
     let new_id = ExecutionId::new();
     let now = Utc::now();
@@ -112,7 +112,7 @@ pub async fn start_next_segment(
             lease_expires_at: None,
             worker_id: None,
             lease_fence: 0,
-            tenant_id: DEFAULT_TENANT.to_string(),
+            tenant_id: tenant_id.to_string(),
         })
         .await?;
 

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -38,6 +38,13 @@ use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use uuid::Uuid;
 
+/// Stable UUID namespace for deterministic segment child IDs.
+///
+/// This constant is fixed forever — changing it would make existing segment
+/// chains unresolvable after a crash-recovery cycle.  The value was chosen
+/// as a random v4 UUID and then frozen.
+const SEGMENT_NS: Uuid = Uuid::from_u128(0x6a8e_f5c3_d3a4_4b9c_8b2e_4f5d_6e7a_8c9bu128);
+
 /// Create segment N+1: a fresh execution linked to `parent_id`, seeded with the
 /// carried materialized state, ready to resume the workflow from its start node.
 ///
@@ -45,12 +52,26 @@ use uuid::Uuid;
 /// seq 2 + work-item enqueue). The seed snapshot written here ensures that
 /// `materialize(new_id)` returns the carried state, not an empty base.
 ///
+/// # Child ID stability (crash safety)
+/// The child `ExecutionId` is derived deterministically via UUID v5 from the
+/// parent id and segment number, so a re-run after a crash between
+/// `start_next_segment` and the `SegmentBoundary` append always produces the
+/// SAME child id.  Combined with the idempotency guard at the top of this
+/// function (returns early if the child already exists), a double invocation
+/// cannot fork the segment chain into two concurrent children.
+///
+/// # Seed snapshot sequence space (SQLite correctness)
+/// The seed snapshot is anchored at `at_sequence = 0` (`Snapshot::seed_for_segment`),
+/// NOT at the parent's `last_sequence`.  SQLite `get_events_since` filters with
+/// `sequence > at_sequence`; seeding from the parent sequence would drop every
+/// child event with a sequence <= that value (child events start at 1).
+///
 /// # State carry invariant
 /// `new_exec.initial_input == new_exec.current_state == carried_state.current_state`
 /// (byte-identical canonical JSON).
 ///
 /// # Returns
-/// The `ExecutionId` of the newly created segment execution.
+/// The `ExecutionId` of the newly created (or pre-existing idempotent) segment.
 // Nine parameters are required by the plan interface; suppressing the lint rather
 // than breaking the caller signature with a builder/struct at this stage.
 #[allow(clippy::too_many_arguments)]
@@ -65,7 +86,22 @@ pub async fn start_next_segment(
     queue_type: &str,
     tenant_id: &str,
 ) -> BackendResult<ExecutionId> {
-    let new_id = ExecutionId::new();
+    // Derive a DETERMINISTIC child id from the parent id + segment number.
+    // This guarantees that a re-run after a crash always targets the same
+    // child row, preventing a second random child from forking the chain.
+    let child_uuid = Uuid::new_v5(
+        &SEGMENT_NS,
+        format!("{}:{}", parent_id.0, next_segment_number).as_bytes(),
+    );
+    let new_id = ExecutionId(child_uuid);
+
+    // Idempotency guard: if a prior attempt already created the child (crash
+    // between this function and the caller's SegmentBoundary append), return
+    // the existing id without re-seeding or re-enqueuing.
+    if backend.get_execution(&new_id).await?.is_some() {
+        return Ok(new_id);
+    }
+
     let now = Utc::now();
 
     // Step 1: create the new execution row with carried state as seed.
@@ -88,7 +124,10 @@ pub async fn start_next_segment(
 
     // Step 2: write the seed snapshot so `materialize(new_id)` picks up the
     // carried state as its base without replaying the parent's event log.
-    let seed = Snapshot::from_materialized(new_id.clone(), carried_state);
+    // IMPORTANT: seed at at_sequence=0 (child's own sequence space), NOT at
+    // the parent's last_sequence.  See `Snapshot::seed_for_segment` for the
+    // full rationale.
+    let seed = Snapshot::seed_for_segment(new_id.clone(), &carried_state.current_state);
     backend.write_snapshot(seed).await?;
 
     // Step 3: WorkflowStarted at sequence 1 (mirrors routes.rs).

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -31,7 +31,7 @@
 //! materialize output unchanged.
 
 use crate::backend::{BackendResult, StateBackend, WorkItem};
-use crate::event::{Event, EventKind};
+use crate::event::EventKind;
 use crate::materializer::MaterializedState;
 use crate::snapshot::Snapshot;
 use chrono::Utc;
@@ -70,6 +70,13 @@ const SEGMENT_NS: Uuid = Uuid::from_u128(0x6a8e_f5c3_d3a4_4b9c_8b2e_4f5d_6e7a_8c
 /// `new_exec.initial_input == new_exec.current_state == carried_state.current_state`
 /// (byte-identical canonical JSON).
 ///
+/// # Atomicity
+/// The 5 backend writes (execution, snapshot, 2 events, work item) are
+/// performed inside a single transaction via `create_segment_atomic`. A crash
+/// mid-creation rolls back entirely; the idempotency guard at the top of this
+/// function is now sound — the child row exists if and only if the whole
+/// segment committed.
+///
 /// # Returns
 /// The `ExecutionId` of the newly created (or pre-existing idempotent) segment.
 // Nine parameters are required by the plan interface; suppressing the lint rather
@@ -95,85 +102,69 @@ pub async fn start_next_segment(
     );
     let new_id = ExecutionId(child_uuid);
 
-    // Idempotency guard: if a prior attempt already created the child (crash
-    // between this function and the caller's SegmentBoundary append), return
-    // the existing id without re-seeding or re-enqueuing.
+    // Idempotency guard: if the child execution row already exists, a prior
+    // create_segment_atomic committed successfully — the row exists if and
+    // ONLY IF the whole segment committed atomically (execution + snapshot +
+    // 2 events + work item). A crashed partial create would have rolled back,
+    // leaving no row here. This check is now SOUND.
     if backend.get_execution(&new_id).await?.is_some() {
         return Ok(new_id);
     }
 
     let now = Utc::now();
 
-    // Step 1: create the new execution row with carried state as seed.
-    backend
-        .create_execution(WorkflowExecution {
-            execution_id: new_id.clone(),
-            workflow_id: workflow_id.to_string(),
-            workflow_version: workflow_version.to_string(),
-            status: WorkflowStatus::Running,
-            initial_input: carried_state.current_state.clone(),
-            current_state: carried_state.current_state.clone(),
-            started_at: now,
-            updated_at: now,
-            completed_at: None,
-            session_type: None,
-            parent_execution_id: Some(parent_id.clone()),
-            segment_number: next_segment_number,
-        })
-        .await?;
+    let execution = WorkflowExecution {
+        execution_id: new_id.clone(),
+        workflow_id: workflow_id.to_string(),
+        workflow_version: workflow_version.to_string(),
+        status: WorkflowStatus::Running,
+        initial_input: carried_state.current_state.clone(),
+        current_state: carried_state.current_state.clone(),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+        parent_execution_id: Some(parent_id.clone()),
+        segment_number: next_segment_number,
+    };
 
-    // Step 2: write the seed snapshot so `materialize(new_id)` picks up the
-    // carried state as its base without replaying the parent's event log.
-    // IMPORTANT: seed at at_sequence=0 (child's own sequence space), NOT at
-    // the parent's last_sequence.  See `Snapshot::seed_for_segment` for the
-    // full rationale.
+    // Seed at at_sequence=0 (child sequence space). See Snapshot::seed_for_segment.
     let seed = Snapshot::seed_for_segment(new_id.clone(), &carried_state.current_state);
-    backend.write_snapshot(seed).await?;
 
-    // Step 3: WorkflowStarted at sequence 1 (mirrors routes.rs).
-    backend
-        .append_event(Event::new(
-            new_id.clone(),
-            1,
-            EventKind::WorkflowStarted {
-                workflow_id: workflow_id.to_string(),
-                workflow_version: workflow_version.to_string(),
-                initial_input: carried_state.current_state.clone(),
-            },
-        ))
-        .await?;
+    let started_event = EventKind::WorkflowStarted {
+        workflow_id: workflow_id.to_string(),
+        workflow_version: workflow_version.to_string(),
+        initial_input: carried_state.current_state.clone(),
+    };
 
-    // Step 4: NodeScheduled at sequence 2 (mirrors routes.rs).
-    backend
-        .append_event(Event::new(
-            new_id.clone(),
-            2,
-            EventKind::NodeScheduled {
-                node_id: start_node_id.to_string(),
-                queue_type: queue_type.to_string(),
-            },
-        ))
-        .await?;
+    let scheduled_event = EventKind::NodeScheduled {
+        node_id: start_node_id.to_string(),
+        queue_type: queue_type.to_string(),
+    };
 
-    // Step 5: enqueue the start-node work item (mirrors routes.rs).
+    let work_item = WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: new_id.clone(),
+        node_id: start_node_id.to_string(),
+        queue_type: queue_type.to_string(),
+        payload: serde_json::json!({
+            "workflow_id": workflow_id,
+            "workflow_version": workflow_version,
+        }),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: now,
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: tenant_id.to_string(),
+    };
+
+    // ONE atomic call: execution + snapshot + 2 events + work item in one
+    // transaction. A crash mid-creation rolls back entirely; the idempotency
+    // guard above is now sound (row exists ↔ whole segment committed).
     backend
-        .enqueue_work_item(WorkItem {
-            id: Uuid::new_v4(),
-            execution_id: new_id.clone(),
-            node_id: start_node_id.to_string(),
-            queue_type: queue_type.to_string(),
-            payload: serde_json::json!({
-                "workflow_id": workflow_id,
-                "workflow_version": workflow_version,
-            }),
-            attempt: 0,
-            max_attempts: 3,
-            created_at: now,
-            lease_expires_at: None,
-            worker_id: None,
-            lease_fence: 0,
-            tenant_id: tenant_id.to_string(),
-        })
+        .create_segment_atomic(execution, seed, started_event, scheduled_event, work_item)
         .await?;
 
     Ok(new_id)

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -1,0 +1,120 @@
+//! Continue-as-new: create the state-seeded continuation execution (segment N+1).
+//!
+//! A long-running durable agent bounds its event-log/replay cost by rolling over
+//! to a new execution at a strategy ceiling. `start_next_segment` mirrors the
+//! execution-creation pattern in `api/src/routes.rs` (WorkflowStarted seq 1 +
+//! NodeScheduled seq 2 + work-item enqueue), substituting the carried
+//! `MaterializedState.current_state` as the new execution's seed.
+//!
+//! The seed snapshot written here means `materialize(new_id)` loads only the new
+//! segment's own events (bounded replay), not the parent's full history.
+
+use crate::backend::{BackendResult, StateBackend, WorkItem};
+use crate::event::{Event, EventKind};
+use crate::materializer::MaterializedState;
+use crate::snapshot::Snapshot;
+use crate::tenant::DEFAULT_TENANT;
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use uuid::Uuid;
+
+/// Create segment N+1: a fresh execution linked to `parent_id`, seeded with the
+/// carried materialized state, ready to resume the workflow from its start node.
+///
+/// Mirrors `routes.rs` execution-creation (WorkflowStarted seq 1 + NodeScheduled
+/// seq 2 + work-item enqueue). The seed snapshot written here ensures that
+/// `materialize(new_id)` returns the carried state, not an empty base.
+///
+/// # State carry invariant
+/// `new_exec.initial_input == new_exec.current_state == carried_state.current_state`
+/// (byte-identical canonical JSON).
+///
+/// # Returns
+/// The `ExecutionId` of the newly created segment execution.
+// Eight parameters are required by the plan interface; suppressing the lint rather
+// than breaking the caller signature with a builder/struct at this stage.
+#[allow(clippy::too_many_arguments)]
+pub async fn start_next_segment(
+    backend: &dyn StateBackend,
+    parent_id: &ExecutionId,
+    carried_state: &MaterializedState,
+    workflow_id: &str,
+    workflow_version: &str,
+    next_segment_number: u32,
+    start_node_id: &str,
+    queue_type: &str,
+) -> BackendResult<ExecutionId> {
+    let new_id = ExecutionId::new();
+    let now = Utc::now();
+
+    // Step 1: create the new execution row with carried state as seed.
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: new_id.clone(),
+            workflow_id: workflow_id.to_string(),
+            workflow_version: workflow_version.to_string(),
+            status: WorkflowStatus::Running,
+            initial_input: carried_state.current_state.clone(),
+            current_state: carried_state.current_state.clone(),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: Some(parent_id.clone()),
+            segment_number: next_segment_number,
+        })
+        .await?;
+
+    // Step 2: write the seed snapshot so `materialize(new_id)` picks up the
+    // carried state as its base without replaying the parent's event log.
+    let seed = Snapshot::from_materialized(new_id.clone(), carried_state);
+    backend.write_snapshot(seed).await?;
+
+    // Step 3: WorkflowStarted at sequence 1 (mirrors routes.rs).
+    backend
+        .append_event(Event::new(
+            new_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: workflow_id.to_string(),
+                workflow_version: workflow_version.to_string(),
+                initial_input: carried_state.current_state.clone(),
+            },
+        ))
+        .await?;
+
+    // Step 4: NodeScheduled at sequence 2 (mirrors routes.rs).
+    backend
+        .append_event(Event::new(
+            new_id.clone(),
+            2,
+            EventKind::NodeScheduled {
+                node_id: start_node_id.to_string(),
+                queue_type: queue_type.to_string(),
+            },
+        ))
+        .await?;
+
+    // Step 5: enqueue the start-node work item (mirrors routes.rs).
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: new_id.clone(),
+            node_id: start_node_id.to_string(),
+            queue_type: queue_type.to_string(),
+            payload: serde_json::json!({
+                "workflow_id": workflow_id,
+                "workflow_version": workflow_version,
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.to_string(),
+        })
+        .await?;
+
+    Ok(new_id)
+}

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -1,4 +1,5 @@
-//! Continue-as-new: create the state-seeded continuation execution (segment N+1).
+//! Continue-as-new: create the state-seeded continuation execution (segment N+1)
+//! and walk the segment chain.
 //!
 //! A long-running durable agent bounds its event-log/replay cost by rolling over
 //! to a new execution at a strategy ceiling. `start_next_segment` mirrors the
@@ -8,6 +9,26 @@
 //!
 //! The seed snapshot written here means `materialize(new_id)` loads only the new
 //! segment's own events (bounded replay), not the parent's full history.
+//!
+//! ## Continue-as-new caveats
+//!
+//! F-2g-timers: a timer that was registered against the OLD execution_id will not
+//! automatically fire into the new segment. The timer table references
+//! execution_id; after rollover, the old execution is in a terminal completed
+//! state and the scheduler drops its ExecProgress. Any pending timer for the old
+//! execution_id simply fires against a closed log and has no effect on the new
+//! segment. Carry-over of pending timers across a rollover boundary is future work
+//! (F-2g-timers).
+//!
+//! In-flight / parked items at rollover: the rollover fires at the strategy-limit
+//! point (same semantics as the existing limit-terminate path). A work item that
+//! was parked (retry_after = future) when the limit is hit will eventually be
+//! claimed by a worker, execute, and attempt commit_turn against the OLD
+//! (completed) execution. That commit lands on the closed event log and is inert:
+//! it does not affect the new segment's state. This is safe but should be logged
+//! by the worker's commit path. The test `inert_old_segment_does_not_leak` proves
+//! that a late append to the old terminal execution leaves the new segment's
+//! materialize output unchanged.
 
 use crate::backend::{BackendResult, StateBackend, WorkItem};
 use crate::event::{Event, EventKind};
@@ -117,4 +138,53 @@ pub async fn start_next_segment(
         .await?;
 
     Ok(new_id)
+}
+
+/// Maximum number of hops allowed when walking the segment chain. A well-formed
+/// chain is acyclic; exceeding this limit indicates data corruption or a cycle.
+const SEGMENT_CHAIN_MAX_DEPTH: usize = 10_000;
+
+/// Walk the segment chain backward from any segment to the root, returning the
+/// `ExecutionId`s from root..=given in ascending segment order.
+///
+/// The result is ordered root-first (lowest segment_number first). For a
+/// 3-segment chain `root -> seg1 -> seg2`, `segment_chain(backend, &seg2_id)`
+/// returns `[root_id, seg1_id, seg2_id]`.
+///
+/// # Errors
+/// Returns an error if `get_execution` fails for any node in the chain, if any
+/// node in the chain does not exist, or if the chain depth exceeds
+/// [`SEGMENT_CHAIN_MAX_DEPTH`] (cycle guard).
+pub async fn segment_chain(
+    backend: &dyn StateBackend,
+    id: &ExecutionId,
+) -> BackendResult<Vec<ExecutionId>> {
+    let mut chain: Vec<ExecutionId> = Vec::new();
+    let mut current = id.clone();
+
+    loop {
+        if chain.len() >= SEGMENT_CHAIN_MAX_DEPTH {
+            return Err(crate::backend::StateBackendError::Database(format!(
+                "segment_chain exceeded max depth ({SEGMENT_CHAIN_MAX_DEPTH}): \
+                 possible cycle starting near {current}"
+            )));
+        }
+
+        let exec = backend.get_execution(&current).await?.ok_or_else(|| {
+            crate::backend::StateBackendError::NotFound(format!(
+                "segment_chain: execution {current} not found"
+            ))
+        })?;
+
+        chain.push(current.clone());
+
+        match exec.parent_execution_id {
+            None => break,
+            Some(parent) => current = parent,
+        }
+    }
+
+    // We walked tail-to-root; reverse so root is first.
+    chain.reverse();
+    Ok(chain)
 }

--- a/runtime/state/src/snapshot.rs
+++ b/runtime/state/src/snapshot.rs
@@ -59,6 +59,32 @@ impl Snapshot {
         }
     }
 
+    /// Build the seed snapshot for a new segment (continue-as-new child).
+    ///
+    /// The seed is anchored at `at_sequence = 0` and `last_sequence = 0` so
+    /// that `materialize(child)` folds ALL of the child's own events (which
+    /// start at sequence 1) on top of it.  Using `from_materialized` here
+    /// would copy the PARENT's `last_sequence` (e.g. 50) into the seed, and
+    /// SQLite's `get_events_since(child, 50)` would silently drop every child
+    /// event with sequence <= 50 — freezing the child's state forever.
+    ///
+    /// `completed_nodes` and `active_nodes` are empty because the new segment
+    /// re-enters at its start node with a clean node graph; the carried value
+    /// lives only in `current_state` / `initial_input`.
+    pub fn seed_for_segment(execution_id: ExecutionId, current_state: &serde_json::Value) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            execution_id,
+            at_sequence: 0,
+            state: current_state.clone(),
+            status: jamjet_core::workflow::WorkflowStatus::Running,
+            completed_nodes: std::collections::HashMap::new(),
+            active_nodes: std::collections::HashSet::new(),
+            last_sequence: 0,
+            created_at: Utc::now(),
+        }
+    }
+
     /// Build a snapshot directly from a `MaterializedState`, capturing the
     /// full per-turn resume base.
     pub fn from_materialized(

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1077,6 +1077,59 @@ impl StateBackend for SqliteBackend {
         Ok(rows_affected > 0)
     }
 
+    #[instrument(skip(self), fields(execution_id = %execution_id, item_id = %work_item_id, fence = lease_fence))]
+    async fn finalize_rollover_fenced(
+        &self,
+        execution_id: &ExecutionId,
+        work_item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        let exec_id_str = execution_id_str(execution_id);
+        let item_id_str = work_item_id.to_string();
+        let now = Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // 1. Fence-gated settle of the work item.
+        let rows = sqlx::query(
+            "UPDATE work_items SET status = 'completed', completed_at = ?, lease_expires_at = NULL \
+             WHERE id = ? AND lease_fence = ?",
+        )
+        .bind(&now)
+        .bind(&item_id_str)
+        .bind(lease_fence)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+
+        if rows == 0 {
+            tx.rollback().await.map_err(map_db_err)?;
+            return Ok(false);
+        }
+
+        // 2. Idempotent terminal update: only transitions non-terminal executions.
+        sqlx::query(
+            "UPDATE workflow_executions \
+             SET status = 'limit_exceeded', updated_at = ?, completed_at = COALESCE(completed_at, ?) \
+             WHERE execution_id = ? \
+             AND status NOT IN ('completed', 'failed', 'cancelled', 'limit_exceeded')",
+        )
+        .bind(&now)
+        .bind(&now)
+        .bind(&exec_id_str)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(true)
+    }
+
     #[instrument(skip(self, terminal_event), fields(item_id = %item_id, fence = lease_fence))]
     async fn commit_turn(
         &self,
@@ -1750,5 +1803,148 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0]["chunk"], 0);
         assert_eq!(events[1]["chunk"], 1);
+    }
+
+    #[tokio::test]
+    async fn finalize_rollover_fenced_matching_fence_marks_terminal_and_settles() {
+        use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+
+        let db = open_test_db().await;
+
+        // Create an execution in Running state.
+        let exec_id = ExecutionId::new();
+        let now = chrono::Utc::now();
+        db.create_execution(WorkflowExecution {
+            execution_id: exec_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .unwrap();
+
+        // Enqueue and claim a work item so it gets a real fence.
+        let wi_id = uuid::Uuid::new_v4();
+        db.enqueue_work_item(crate::backend::WorkItem {
+            id: wi_id,
+            execution_id: exec_id.clone(),
+            node_id: "n1".into(),
+            queue_type: "default".into(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        })
+        .await
+        .unwrap();
+
+        let claimed = db
+            .claim_work_item("w1", &["default"])
+            .await
+            .unwrap()
+            .expect("must be claimable");
+        let fence = claimed.lease_fence;
+        assert!(fence != 0, "claimed fence must be non-zero");
+
+        // finalize_rollover_fenced with MATCHING fence must return true,
+        // mark execution LimitExceeded, and settle the work item.
+        let settled = db
+            .finalize_rollover_fenced(&exec_id, wi_id, fence)
+            .await
+            .expect("finalize_rollover_fenced must not error");
+        assert!(settled, "matching fence must return true");
+
+        let exec = db.get_execution(&exec_id).await.unwrap().unwrap();
+        assert_eq!(
+            exec.status,
+            WorkflowStatus::LimitExceeded,
+            "execution must be LimitExceeded after finalize_rollover_fenced"
+        );
+
+        // Work item must be gone (completed).
+        let not_claimable = db.claim_work_item("w2", &["default"]).await.unwrap();
+        assert!(
+            not_claimable.is_none(),
+            "work item must be settled (not re-claimable)"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_rollover_fenced_stale_fence_is_noop() {
+        use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+
+        let db = open_test_db().await;
+
+        let exec_id = ExecutionId::new();
+        let now = chrono::Utc::now();
+        db.create_execution(WorkflowExecution {
+            execution_id: exec_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .unwrap();
+
+        let wi_id = uuid::Uuid::new_v4();
+        db.enqueue_work_item(crate::backend::WorkItem {
+            id: wi_id,
+            execution_id: exec_id.clone(),
+            node_id: "n1".into(),
+            queue_type: "default".into(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        })
+        .await
+        .unwrap();
+
+        let claimed = db
+            .claim_work_item("w1", &["default"])
+            .await
+            .unwrap()
+            .expect("must be claimable");
+        let real_fence = claimed.lease_fence;
+
+        // Present a STALE fence (real_fence + 1 is never a valid fence).
+        let stale_fence = real_fence + 1;
+        let settled = db
+            .finalize_rollover_fenced(&exec_id, wi_id, stale_fence)
+            .await
+            .expect("stale fence must not error — just Ok(false)");
+        assert!(!settled, "stale fence must return false (no-op)");
+
+        // Execution must still be Running (zombie did not mark it terminal).
+        let exec = db.get_execution(&exec_id).await.unwrap().unwrap();
+        assert_eq!(
+            exec.status,
+            WorkflowStatus::Running,
+            "execution must remain Running after stale-fence finalize attempt"
+        );
     }
 }

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -626,6 +626,166 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    async fn create_segment_atomic(
+        &self,
+        execution: WorkflowExecution,
+        seed_snapshot: Snapshot,
+        started_event: EventKind,
+        scheduled_event: EventKind,
+        work_item: WorkItem,
+    ) -> BackendResult<()> {
+        // Serialize all data before opening the transaction (avoids holding
+        // the write lock while doing JSON serialization).
+        let exec_id_str = execution_id_str(&execution.execution_id);
+        let exec_status = status_to_str(&execution.status);
+        let initial_input_json = serde_json::to_string(&execution.initial_input)?;
+        let current_state_json = serde_json::to_string(&execution.current_state)?;
+        let exec_started_at = execution.started_at.to_rfc3339();
+        let exec_updated_at = execution.updated_at.to_rfc3339();
+        let exec_completed_at = execution.completed_at.map(|dt| dt.to_rfc3339());
+        let parent_id = execution.parent_execution_id.as_ref().map(execution_id_str);
+        let segment_number = execution.segment_number as i64;
+
+        let snap_id = seed_snapshot.id.to_string();
+        let snap_state_json = serde_json::to_string(&seed_snapshot.state)?;
+        let snap_created_at = seed_snapshot.created_at.to_rfc3339();
+        let snap_status_str = status_to_str(&seed_snapshot.status);
+        let snap_completed_json = serde_json::to_string(&seed_snapshot.completed_nodes)?;
+        let snap_active_json = serde_json::to_string(&seed_snapshot.active_nodes)?;
+
+        let ev1_id = Uuid::new_v4().to_string();
+        let ev1_kind_json = serde_json::to_string(&started_event)?;
+        let ev1_created_at = Utc::now().to_rfc3339();
+
+        let ev2_id = Uuid::new_v4().to_string();
+        let ev2_kind_json = serde_json::to_string(&scheduled_event)?;
+        let ev2_created_at = Utc::now().to_rfc3339();
+
+        let wi_id = work_item.id.to_string();
+        let wi_exec_id = execution_id_str(&work_item.execution_id);
+        let wi_payload_json = serde_json::to_string(&work_item.payload)?;
+        let wi_created_at = work_item.created_at.to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // 1. Execution row.
+        sqlx::query(
+            r#"INSERT INTO workflow_executions
+               (execution_id, workflow_id, workflow_version, status, initial_input, current_state,
+                started_at, updated_at, completed_at, parent_execution_id, segment_number)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&exec_id_str)
+        .bind(&execution.workflow_id)
+        .bind(&execution.workflow_version)
+        .bind(exec_status)
+        .bind(&initial_input_json)
+        .bind(&current_state_json)
+        .bind(&exec_started_at)
+        .bind(&exec_updated_at)
+        .bind(exec_completed_at.as_deref())
+        .bind(parent_id.as_deref())
+        .bind(segment_number)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 2. Seed snapshot.
+        sqlx::query(
+            r#"INSERT OR REPLACE INTO snapshots
+               (id, execution_id, at_sequence, state_json, created_at, status,
+                completed_nodes_json, active_nodes_json, last_sequence)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&snap_id)
+        .bind(&exec_id_str)
+        .bind(seed_snapshot.at_sequence)
+        .bind(&snap_state_json)
+        .bind(&snap_created_at)
+        .bind(snap_status_str)
+        .bind(&snap_completed_json)
+        .bind(&snap_active_json)
+        .bind(seed_snapshot.last_sequence)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 3. WorkflowStarted at seq 1. Replicate append_event's SELECT MAX+1 logic
+        //    inside the txn so sequence assignment is correct even if this method is
+        //    ever called on a non-fresh execution.
+        let seq1_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&exec_id_str)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let seq1: i64 = seq1_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at)
+               VALUES (?, ?, ?, ?, ?)"#,
+        )
+        .bind(&ev1_id)
+        .bind(&exec_id_str)
+        .bind(seq1)
+        .bind(&ev1_kind_json)
+        .bind(&ev1_created_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 4. NodeScheduled at seq 2 (MAX is now 1 after the insertion above).
+        let seq2_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&exec_id_str)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let seq2: i64 = seq2_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at)
+               VALUES (?, ?, ?, ?, ?)"#,
+        )
+        .bind(&ev2_id)
+        .bind(&exec_id_str)
+        .bind(seq2)
+        .bind(&ev2_kind_json)
+        .bind(&ev2_created_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 5. Start-node work item. Rolls back (with execution + snapshot + events)
+        //    on any failure — no partial child is ever left behind.
+        sqlx::query(
+            r#"INSERT INTO work_items
+               (id, execution_id, node_id, queue_type, payload_json, attempt, max_attempts,
+                status, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)"#,
+        )
+        .bind(&wi_id)
+        .bind(&wi_exec_id)
+        .bind(&work_item.node_id)
+        .bind(&work_item.queue_type)
+        .bind(&wi_payload_json)
+        .bind(work_item.attempt as i64)
+        .bind(work_item.max_attempts as i64)
+        .bind(&wi_created_at)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
     #[instrument(skip(self), fields(execution_id = %execution_id))]
     async fn latest_snapshot(&self, execution_id: &ExecutionId) -> BackendResult<Option<Snapshot>> {
         let id_str = execution_id_str(execution_id);

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -188,6 +188,13 @@ fn row_to_execution(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkflowExec
         .map(parse_datetime)
         .transpose()?;
 
+    let parent_execution_id: Option<ExecutionId> = row
+        .try_get::<Option<&str>, _>("parent_execution_id")
+        .map_err(map_db_err)?
+        .map(parse_execution_id)
+        .transpose()?;
+    let segment_number: u32 = row.try_get::<i64, _>("segment_number").unwrap_or(0).max(0) as u32;
+
     Ok(WorkflowExecution {
         execution_id,
         workflow_id: row
@@ -203,6 +210,8 @@ fn row_to_execution(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkflowExec
         updated_at,
         completed_at,
         session_type: None,
+        parent_execution_id,
+        segment_number,
     })
 }
 
@@ -340,12 +349,14 @@ impl StateBackend for SqliteBackend {
         let started_at = execution.started_at.to_rfc3339();
         let updated_at = execution.updated_at.to_rfc3339();
         let completed_at = execution.completed_at.map(|dt| dt.to_rfc3339());
+        let parent_id = execution.parent_execution_id.as_ref().map(execution_id_str);
+        let segment_number = execution.segment_number as i64;
 
         sqlx::query(
             r#"INSERT INTO workflow_executions
                (execution_id, workflow_id, workflow_version, status, initial_input, current_state,
-                started_at, updated_at, completed_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                started_at, updated_at, completed_at, parent_execution_id, segment_number)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution.workflow_id)
@@ -356,6 +367,8 @@ impl StateBackend for SqliteBackend {
         .bind(&started_at)
         .bind(&updated_at)
         .bind(completed_at.as_deref())
+        .bind(parent_id.as_deref())
+        .bind(segment_number)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?;
@@ -1406,6 +1419,8 @@ mod tests {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         }
     }
 

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1006,6 +1006,61 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(rows_affected > 0)
     }
 
+    #[instrument(skip(self), fields(tenant = %self.tenant_id, execution_id = %execution_id, item_id = %work_item_id, fence = lease_fence))]
+    async fn finalize_rollover_fenced(
+        &self,
+        execution_id: &ExecutionId,
+        work_item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        let exec_id_str = execution_id_str(execution_id);
+        let item_id_str = work_item_id.to_string();
+        let now = Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // 1. Fence-gated settle — tenant-scoped.
+        let rows = sqlx::query(
+            "UPDATE work_items SET status = 'completed', completed_at = ?, lease_expires_at = NULL \
+             WHERE id = ? AND lease_fence = ? AND tenant_id = ?",
+        )
+        .bind(&now)
+        .bind(&item_id_str)
+        .bind(lease_fence)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+
+        if rows == 0 {
+            tx.rollback().await.map_err(map_db_err)?;
+            return Ok(false);
+        }
+
+        // 2. Idempotent terminal update — tenant-scoped.
+        sqlx::query(
+            "UPDATE workflow_executions \
+             SET status = 'limit_exceeded', updated_at = ?, completed_at = COALESCE(completed_at, ?) \
+             WHERE execution_id = ? AND tenant_id = ? \
+             AND status NOT IN ('completed', 'failed', 'cancelled', 'limit_exceeded')",
+        )
+        .bind(&now)
+        .bind(&now)
+        .bind(&exec_id_str)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(true)
+    }
+
     #[instrument(skip(self, terminal_event), fields(tenant = %self.tenant_id, item_id = %item_id))]
     async fn commit_turn(
         &self,

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -549,6 +549,166 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
+    async fn create_segment_atomic(
+        &self,
+        execution: WorkflowExecution,
+        seed_snapshot: Snapshot,
+        started_event: EventKind,
+        scheduled_event: EventKind,
+        work_item: WorkItem,
+    ) -> BackendResult<()> {
+        let exec_id_str = execution_id_str(&execution.execution_id);
+        let exec_status = status_to_str(&execution.status);
+        let initial_input_json = serde_json::to_string(&execution.initial_input)?;
+        let current_state_json = serde_json::to_string(&execution.current_state)?;
+        let exec_started_at = execution.started_at.to_rfc3339();
+        let exec_updated_at = execution.updated_at.to_rfc3339();
+        let exec_completed_at = execution.completed_at.map(|dt| dt.to_rfc3339());
+        let parent_id = execution.parent_execution_id.as_ref().map(execution_id_str);
+        let segment_number = execution.segment_number as i64;
+
+        let snap_id = seed_snapshot.id.to_string();
+        let snap_state_json = serde_json::to_string(&seed_snapshot.state)?;
+        let snap_created_at = seed_snapshot.created_at.to_rfc3339();
+        let snap_status_str = status_to_str(&seed_snapshot.status);
+        let snap_completed_json = serde_json::to_string(&seed_snapshot.completed_nodes)?;
+        let snap_active_json = serde_json::to_string(&seed_snapshot.active_nodes)?;
+
+        let ev1_id = Uuid::new_v4().to_string();
+        let ev1_kind_json = serde_json::to_string(&started_event)?;
+        let ev1_created_at = Utc::now().to_rfc3339();
+
+        let ev2_id = Uuid::new_v4().to_string();
+        let ev2_kind_json = serde_json::to_string(&scheduled_event)?;
+        let ev2_created_at = Utc::now().to_rfc3339();
+
+        let wi_id = work_item.id.to_string();
+        let wi_exec_id = execution_id_str(&work_item.execution_id);
+        let wi_payload_json = serde_json::to_string(&work_item.payload)?;
+        let wi_created_at = work_item.created_at.to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // 1. Execution row (tenant-scoped).
+        sqlx::query(
+            r#"INSERT INTO workflow_executions
+               (execution_id, workflow_id, workflow_version, status, initial_input, current_state,
+                started_at, updated_at, completed_at, tenant_id, parent_execution_id, segment_number)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&exec_id_str)
+        .bind(&execution.workflow_id)
+        .bind(&execution.workflow_version)
+        .bind(exec_status)
+        .bind(&initial_input_json)
+        .bind(&current_state_json)
+        .bind(&exec_started_at)
+        .bind(&exec_updated_at)
+        .bind(exec_completed_at.as_deref())
+        .bind(&self.tenant_id.0)
+        .bind(parent_id.as_deref())
+        .bind(segment_number)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 2. Seed snapshot (tenant-scoped).
+        sqlx::query(
+            r#"INSERT OR REPLACE INTO snapshots
+               (id, execution_id, at_sequence, state_json, created_at, tenant_id, status,
+                completed_nodes_json, active_nodes_json, last_sequence)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&snap_id)
+        .bind(&exec_id_str)
+        .bind(seed_snapshot.at_sequence)
+        .bind(&snap_state_json)
+        .bind(&snap_created_at)
+        .bind(&self.tenant_id.0)
+        .bind(snap_status_str)
+        .bind(&snap_completed_json)
+        .bind(&snap_active_json)
+        .bind(seed_snapshot.last_sequence)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 3. WorkflowStarted at seq 1 (replicate append_event's SELECT MAX+1).
+        let seq1_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&exec_id_str)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let seq1: i64 = seq1_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&ev1_id)
+        .bind(&exec_id_str)
+        .bind(seq1)
+        .bind(&ev1_kind_json)
+        .bind(&ev1_created_at)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 4. NodeScheduled at seq 2.
+        let seq2_row = sqlx::query(
+            "SELECT COALESCE(MAX(sequence), 0) + 1 AS seq FROM events WHERE execution_id = ?",
+        )
+        .bind(&exec_id_str)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+        let seq2: i64 = seq2_row.try_get::<i64, _>("seq").map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO events (id, execution_id, sequence, kind_json, created_at, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&ev2_id)
+        .bind(&exec_id_str)
+        .bind(seq2)
+        .bind(&ev2_kind_json)
+        .bind(&ev2_created_at)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        // 5. Start-node work item (tenant-scoped).
+        sqlx::query(
+            r#"INSERT INTO work_items
+               (id, execution_id, node_id, queue_type, payload_json, attempt, max_attempts,
+                status, created_at, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)"#,
+        )
+        .bind(&wi_id)
+        .bind(&wi_exec_id)
+        .bind(&work_item.node_id)
+        .bind(&work_item.queue_type)
+        .bind(&wi_payload_json)
+        .bind(work_item.attempt as i64)
+        .bind(work_item.max_attempts as i64)
+        .bind(&wi_created_at)
+        .bind(&self.tenant_id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
     #[instrument(skip(self), fields(tenant = %self.tenant_id, execution_id = %execution_id))]
     async fn latest_snapshot(&self, execution_id: &ExecutionId) -> BackendResult<Option<Snapshot>> {
         let id_str = execution_id_str(execution_id);

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -103,6 +103,13 @@ fn row_to_execution(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkflowExec
         .map(parse_datetime)
         .transpose()?;
 
+    let parent_execution_id: Option<ExecutionId> = row
+        .try_get::<Option<&str>, _>("parent_execution_id")
+        .map_err(map_db_err)?
+        .map(parse_execution_id)
+        .transpose()?;
+    let segment_number: u32 = row.try_get::<i64, _>("segment_number").unwrap_or(0).max(0) as u32;
+
     Ok(WorkflowExecution {
         execution_id,
         workflow_id: row
@@ -118,6 +125,8 @@ fn row_to_execution(row: &sqlx::sqlite::SqliteRow) -> BackendResult<WorkflowExec
         updated_at,
         completed_at,
         session_type: None,
+        parent_execution_id,
+        segment_number,
     })
 }
 
@@ -252,12 +261,14 @@ impl StateBackend for TenantScopedSqliteBackend {
         let started_at = execution.started_at.to_rfc3339();
         let updated_at = execution.updated_at.to_rfc3339();
         let completed_at = execution.completed_at.map(|dt| dt.to_rfc3339());
+        let parent_id = execution.parent_execution_id.as_ref().map(execution_id_str);
+        let segment_number = execution.segment_number as i64;
 
         sqlx::query(
             r#"INSERT INTO workflow_executions
                (execution_id, workflow_id, workflow_version, status, initial_input, current_state,
-                started_at, updated_at, completed_at, tenant_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                started_at, updated_at, completed_at, tenant_id, parent_execution_id, segment_number)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&id)
         .bind(&execution.workflow_id)
@@ -269,6 +280,8 @@ impl StateBackend for TenantScopedSqliteBackend {
         .bind(&updated_at)
         .bind(completed_at.as_deref())
         .bind(&self.tenant_id.0)
+        .bind(parent_id.as_deref())
+        .bind(segment_number)
         .execute(&self.pool)
         .await
         .map_err(map_db_err)?;

--- a/runtime/state/tests/commit_turn.rs
+++ b/runtime/state/tests/commit_turn.rs
@@ -41,6 +41,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/durability.rs
+++ b/runtime/state/tests/durability.rs
@@ -44,6 +44,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -36,6 +36,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -60,6 +60,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/memory_backend.rs
+++ b/runtime/state/tests/memory_backend.rs
@@ -24,6 +24,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/park.rs
+++ b/runtime/state/tests/park.rs
@@ -39,6 +39,8 @@ fn sample_execution(id: &ExecutionId) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -10,9 +10,11 @@
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
-    backend::StateBackend, materialize, Event, EventKind, InMemoryBackend, SqliteBackend,
+    backend::StateBackend, content_hash, materialize, start_next_segment, Event, EventKind,
+    InMemoryBackend, MaterializedState, SqliteBackend,
 };
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
@@ -277,7 +279,156 @@ async fn memory_segment_boundary_event_is_materialize_noop() {
 
 // ── Tenant-scoped backend ─────────────────────────────────────────────────────
 
-/// Same linked-execution round-trip on the tenant-scoped SQLite backend.
+// ── start_next_segment helpers ────────────────────────────────────────────────
+
+/// Builds a `MaterializedState` representing the terminal state of a segment.
+/// Carries a non-trivial nested JSON value so byte-identity is meaningful.
+fn carried_materialized_state() -> MaterializedState {
+    MaterializedState {
+        current_state: json!({
+            "counter": 42,
+            "nested": { "a": [1, 2, 3] },
+            "carried": true
+        }),
+        status: WorkflowStatus::Running,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 0,
+    }
+}
+
+/// Run the full `start_next_segment` assertion suite against any `StateBackend`.
+async fn assert_start_next_segment(backend: &dyn StateBackend) {
+    let parent_id = ExecutionId::new();
+    // Parent execution must exist (FK-safe even though column is nullable TEXT).
+    backend
+        .create_execution(root_execution(&parent_id))
+        .await
+        .expect("create parent");
+
+    let carried = carried_materialized_state();
+
+    let new_id = start_next_segment(
+        backend, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general",
+    )
+    .await
+    .expect("start_next_segment must succeed");
+
+    // ── New execution exists with a DIFFERENT id ──────────────────────────
+    assert_ne!(new_id, parent_id, "new_id must differ from parent_id");
+
+    let new_exec = backend
+        .get_execution(&new_id)
+        .await
+        .expect("get_execution")
+        .expect("new execution must exist");
+
+    // ── Lineage fields ────────────────────────────────────────────────────
+    assert_eq!(
+        new_exec.parent_execution_id.as_ref(),
+        Some(&parent_id),
+        "parent_execution_id must link back to parent"
+    );
+    assert_eq!(
+        new_exec.segment_number, 1,
+        "segment_number must be next_segment_number"
+    );
+
+    // ── Carried state ─────────────────────────────────────────────────────
+    assert_eq!(
+        new_exec.initial_input, carried.current_state,
+        "initial_input must equal the carried current_state"
+    );
+    assert_eq!(
+        new_exec.current_state, carried.current_state,
+        "current_state must equal the carried current_state"
+    );
+
+    // ── Byte-identity ─────────────────────────────────────────────────────
+    assert_eq!(
+        content_hash(&new_exec.current_state),
+        content_hash(&carried.current_state),
+        "content_hash of new current_state must match the carried state"
+    );
+
+    // ── Seed snapshot ─────────────────────────────────────────────────────
+    let snap = backend
+        .latest_snapshot(&new_id)
+        .await
+        .expect("latest_snapshot")
+        .expect("seed snapshot must exist");
+    assert_eq!(
+        snap.state, carried.current_state,
+        "seed snapshot state must equal the carried current_state"
+    );
+
+    // ── materialize returns carried state ─────────────────────────────────
+    let mat = materialize(backend, &new_id)
+        .await
+        .expect("materialize must succeed");
+    assert_eq!(
+        mat.current_state, carried.current_state,
+        "materialize(new_id).current_state must equal the carried state"
+    );
+
+    // ── Events: WorkflowStarted (seq 1) then NodeScheduled (seq 2) ────────
+    let events = backend.get_events(&new_id).await.expect("get_events");
+    assert_eq!(events.len(), 2, "must have exactly 2 events");
+    assert!(
+        matches!(events[0].kind, EventKind::WorkflowStarted { .. }),
+        "first event must be WorkflowStarted"
+    );
+    assert_eq!(events[0].sequence, 1, "WorkflowStarted must be seq 1");
+    match &events[1].kind {
+        EventKind::NodeScheduled {
+            node_id,
+            queue_type,
+        } => {
+            assert_eq!(node_id, "start", "NodeScheduled node_id must be 'start'");
+            assert_eq!(
+                queue_type, "general",
+                "NodeScheduled queue_type must be 'general'"
+            );
+        }
+        other => panic!("expected NodeScheduled, got {other:?}"),
+    }
+    assert_eq!(events[1].sequence, 2, "NodeScheduled must be seq 2");
+
+    // ── Work item is enqueued and claimable ───────────────────────────────
+    let item = backend
+        .claim_work_item("test-worker-1", &["general"])
+        .await
+        .expect("claim_work_item")
+        .expect("a work item must be available");
+    assert_eq!(
+        item.execution_id, new_id,
+        "work item must belong to the new segment"
+    );
+    assert_eq!(
+        item.node_id, "start",
+        "work item must target the start node"
+    );
+}
+
+// ── start_next_segment tests — SQLite ─────────────────────────────────────────
+
+/// `start_next_segment` creates the linked, state-seeded continuation on SQLite.
+#[tokio::test]
+async fn sqlite_start_next_segment() {
+    let db = open_sqlite().await;
+    assert_start_next_segment(&db).await;
+}
+
+// ── start_next_segment tests — in-memory ──────────────────────────────────────
+
+/// `start_next_segment` creates the linked, state-seeded continuation in memory.
+#[tokio::test]
+async fn memory_start_next_segment() {
+    let backend = InMemoryBackend::new();
+    assert_start_next_segment(&backend).await;
+}
+
+// ── Same linked-execution round-trip on the tenant-scoped SQLite backend.
 #[tokio::test]
 async fn tenant_scoped_linked_execution_round_trips() {
     use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -10,11 +10,13 @@
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
-    backend::StateBackend, content_hash, materialize, segment_chain, start_next_segment, Event,
-    EventKind, InMemoryBackend, MaterializedState, SqliteBackend,
+    backend::{StateBackend, WorkItem},
+    content_hash, materialize, segment_chain, start_next_segment, Event, EventKind,
+    InMemoryBackend, MaterializedState, Snapshot, SqliteBackend,
 };
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
@@ -1085,5 +1087,215 @@ async fn sqlite_idempotent_start_next_segment_prevents_double_roll() {
         second.is_none(),
         "queue must be empty after draining the single work item; \
          a second item means the idempotency guard did not prevent re-enqueue"
+    );
+}
+
+// ── 2g partial-creation gap fix: all-artifacts regression guard ───────────────
+
+/// Generic helper: after `start_next_segment`, ALL 5 artifacts (execution, snapshot,
+/// WorkflowStarted seq1, NodeScheduled seq2, claimable work item) must exist.
+/// This is the regression guard that proves the partial-creation gap is closed.
+async fn assert_all_artifacts_present(backend: &dyn StateBackend) {
+    let parent_id = ExecutionId::new();
+    backend
+        .create_execution(root_execution(&parent_id))
+        .await
+        .expect("create parent");
+    let carried = carried_materialized_state();
+
+    let new_id = start_next_segment(
+        backend, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment");
+
+    // 1. Execution row exists.
+    assert!(
+        backend
+            .get_execution(&new_id)
+            .await
+            .expect("get_execution")
+            .is_some(),
+        "child execution row must exist"
+    );
+
+    // 2. Seed snapshot exists.
+    assert!(
+        backend
+            .latest_snapshot(&new_id)
+            .await
+            .expect("latest_snapshot")
+            .is_some(),
+        "seed snapshot must exist"
+    );
+
+    // 3. Both seed events exist with correct sequences.
+    let events = backend.get_events(&new_id).await.expect("get_events");
+    assert_eq!(events.len(), 2, "must have exactly 2 seed events");
+    assert!(
+        matches!(events[0].kind, EventKind::WorkflowStarted { .. }),
+        "event[0] must be WorkflowStarted"
+    );
+    assert_eq!(events[0].sequence, 1, "WorkflowStarted must be seq 1");
+    assert!(
+        matches!(events[1].kind, EventKind::NodeScheduled { .. }),
+        "event[1] must be NodeScheduled"
+    );
+    assert_eq!(events[1].sequence, 2, "NodeScheduled must be seq 2");
+
+    // 4. A CLAIMABLE work item exists. This is the key regression guard:
+    //    before the fix a partial-created child had no work item, so this
+    //    claim would return None and the continuation would be stuck forever.
+    let item = backend
+        .claim_work_item("regression-guard-worker", &["general"])
+        .await
+        .expect("claim_work_item")
+        .expect("a work item MUST be claimable: partial-creation gap would leave child stuck");
+    assert_eq!(
+        item.execution_id, new_id,
+        "work item must belong to the new segment"
+    );
+    assert_eq!(
+        item.node_id, "start",
+        "work item must target the start node"
+    );
+}
+
+/// Regression guard — SQLite: child always has a claimable work item (partial-creation
+/// gap is closed).
+#[tokio::test]
+async fn sqlite_all_artifacts_present_after_start_next_segment() {
+    let db = open_sqlite().await;
+    assert_all_artifacts_present(&db).await;
+}
+
+/// Regression guard — in-memory: child always has a claimable work item.
+#[tokio::test]
+async fn memory_all_artifacts_present_after_start_next_segment() {
+    let backend = InMemoryBackend::new();
+    assert_all_artifacts_present(&backend).await;
+}
+
+/// Regression guard — tenant-scoped: child always has a claimable work item.
+#[tokio::test]
+async fn tenant_scoped_all_artifacts_present_after_start_next_segment() {
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+    let tenant_id = TenantId::from("artifacts-acme");
+    let scoped_admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+    scoped_admin
+        .create_tenant(Tenant {
+            id: tenant_id.clone(),
+            name: "ArtifactsAcme".into(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("register tenant");
+
+    let scoped = db.for_tenant(tenant_id);
+    assert_all_artifacts_present(&scoped).await;
+}
+
+/// Atomic rollback: if the work item INSERT fails (duplicate id conflict), the
+/// execution row (and snapshot + events) must be rolled back — no partial child.
+///
+/// Calls `create_segment_atomic` directly so we can supply a known work_item id
+/// that we pre-insert to trigger the constraint violation.
+///
+/// The in-memory backend is NOT tested for rollback here: its DashMap inserts
+/// have no ACID rollback, so a failure mid-way leaves the execution row inserted
+/// (by design — the in-memory backend has no crash-durability guarantee). The
+/// all-artifacts tests + SQLite transaction code review cover atomicity for the
+/// durable path.
+#[tokio::test]
+async fn sqlite_segment_atomic_rollback_on_work_item_conflict() {
+    let db = open_sqlite().await;
+    let parent_id = ExecutionId::new();
+    db.create_execution(root_execution(&parent_id))
+        .await
+        .expect("create parent");
+
+    // Pre-insert a work item with a known id to force a UNIQUE(id) conflict.
+    let conflicting_id = Uuid::new_v4();
+    db.enqueue_work_item(WorkItem {
+        id: conflicting_id,
+        execution_id: parent_id.clone(),
+        node_id: "placeholder".into(),
+        queue_type: "general".into(),
+        payload: serde_json::json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: "default".into(),
+    })
+    .await
+    .expect("pre-insert conflicting work item");
+
+    // Build the child segment artifacts — use the same conflicting_id for the work item.
+    let child_id = ExecutionId::new();
+    let carried = carried_materialized_state();
+
+    let exec = WorkflowExecution {
+        execution_id: child_id.clone(),
+        workflow_id: "seg-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: carried.current_state.clone(),
+        current_state: carried.current_state.clone(),
+        started_at: Utc::now(),
+        updated_at: Utc::now(),
+        completed_at: None,
+        session_type: None,
+        parent_execution_id: Some(parent_id.clone()),
+        segment_number: 1,
+    };
+    let seed = Snapshot::seed_for_segment(child_id.clone(), &carried.current_state);
+    let started = EventKind::WorkflowStarted {
+        workflow_id: "seg-wf".into(),
+        workflow_version: "1.0.0".into(),
+        initial_input: carried.current_state.clone(),
+    };
+    let scheduled = EventKind::NodeScheduled {
+        node_id: "start".into(),
+        queue_type: "general".into(),
+    };
+    let wi = WorkItem {
+        id: conflicting_id, // DUPLICATE — triggers UNIQUE(id) conflict at step 5
+        execution_id: child_id.clone(),
+        node_id: "start".into(),
+        queue_type: "general".into(),
+        payload: serde_json::json!({"workflow_id": "seg-wf", "workflow_version": "1.0.0"}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: "default".into(),
+    };
+
+    // create_segment_atomic must fail at the work item INSERT.
+    let result = db
+        .create_segment_atomic(exec, seed, started, scheduled, wi)
+        .await;
+    assert!(
+        result.is_err(),
+        "create_segment_atomic must fail on duplicate work_item id"
+    );
+
+    // KEY ASSERTION: execution row must NOT exist — the transaction rolled back.
+    let fetched = db.get_execution(&child_id).await.expect("get_execution");
+    assert!(
+        fetched.is_none(),
+        "execution row must be rolled back on atomic failure — partial child not left behind"
     );
 }

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -546,11 +546,16 @@ async fn assert_segment_chain_lineage(backend: &dyn StateBackend) {
     .await
     .expect("start_next_segment seg1");
 
-    // Drain the work item so a second claim does not interfere.
-    backend
+    // Drain seg1's continuation work item; assert it is claimable.
+    let wi_seg1 = backend
         .claim_work_item("cleanup-chain-1", &["general"])
         .await
-        .ok();
+        .expect("claim_work_item must not error")
+        .expect("seg1 continuation work item must be claimable");
+    assert_eq!(
+        wi_seg1.execution_id, seg1_id,
+        "seg1 work item must belong to seg1"
+    );
 
     let seg2_carried = MaterializedState {
         current_state: json!({ "counter": 2 }),
@@ -574,11 +579,16 @@ async fn assert_segment_chain_lineage(backend: &dyn StateBackend) {
     .await
     .expect("start_next_segment seg2");
 
-    // Drain so the queue does not leak into other tests.
-    backend
+    // Drain seg2's continuation work item; assert it is claimable.
+    let wi_seg2 = backend
         .claim_work_item("cleanup-chain-2", &["general"])
         .await
-        .ok();
+        .expect("claim_work_item must not error")
+        .expect("seg2 continuation work item must be claimable");
+    assert_eq!(
+        wi_seg2.execution_id, seg2_id,
+        "seg2 work item must belong to seg2"
+    );
 
     // Walk the chain from seg2 back to root.
     let chain = segment_chain(backend, &seg2_id)
@@ -676,10 +686,16 @@ async fn sqlite_bounded_replay_independent_of_root_event_count() {
     .await
     .expect("start_next_segment");
 
-    // Drain the work item (not needed for this test's logic).
-    db.claim_work_item("cleanup-bounded", &["general"])
+    // Drain seg1's continuation work item; assert it is claimable.
+    let wi_bounded = db
+        .claim_work_item("cleanup-bounded", &["general"])
         .await
-        .ok();
+        .expect("claim_work_item must not error")
+        .expect("seg1 continuation work item must be claimable");
+    assert_eq!(
+        wi_bounded.execution_id, seg1_id,
+        "bounded-replay work item must belong to seg1"
+    );
 
     // Seg1's event count is SMALL and independent of root's 50 events.
     let seg1_events = db.get_events(&seg1_id).await.expect("get_events seg1");
@@ -752,7 +768,15 @@ async fn sqlite_inert_old_segment_does_not_leak() {
     .await
     .expect("start_next_segment");
 
-    db.claim_work_item("cleanup-inert", &["general"]).await.ok();
+    let wi_inert = db
+        .claim_work_item("cleanup-inert", &["general"])
+        .await
+        .expect("claim_work_item must not error")
+        .expect("seg1 continuation work item must be claimable");
+    assert_eq!(
+        wi_inert.execution_id, seg1_id,
+        "inert-old-segment work item must belong to seg1"
+    );
 
     // Capture seg1's state BEFORE the late commit.
     let seg1_before = materialize(&db, &seg1_id)
@@ -844,10 +868,15 @@ async fn assert_two_rollover_byte_identity(backend: &dyn StateBackend) {
     .await
     .expect("start_next_segment seg1");
 
-    backend
+    let wi_ro1 = backend
         .claim_work_item("cleanup-2ro-1", &["general"])
         .await
-        .ok();
+        .expect("claim_work_item must not error")
+        .expect("seg1 continuation work item must be claimable after first rollover");
+    assert_eq!(
+        wi_ro1.execution_id, seg1_id,
+        "first rollover work item must belong to seg1"
+    );
 
     // Verify seg1 carries the state byte-identically.
     let seg1_exec = backend
@@ -872,10 +901,15 @@ async fn assert_two_rollover_byte_identity(backend: &dyn StateBackend) {
     .await
     .expect("start_next_segment seg2");
 
-    backend
+    let wi_ro2 = backend
         .claim_work_item("cleanup-2ro-2", &["general"])
         .await
-        .ok();
+        .expect("claim_work_item must not error")
+        .expect("seg2 continuation work item must be claimable after second rollover");
+    assert_eq!(
+        wi_ro2.execution_id, seg2_id,
+        "second rollover work item must belong to seg2"
+    );
 
     let seg2_exec = backend
         .get_execution(&seg2_id)
@@ -982,8 +1016,16 @@ async fn sqlite_child_forward_progress_after_rollover() {
     .await
     .expect("start_next_segment");
 
-    // Drain the start-node work item.
-    db.claim_work_item("cleanup-fwd", &["general"]).await.ok();
+    // Drain the start-node work item; assert it is claimable (regression guard).
+    let wi_fwd = db
+        .claim_work_item("cleanup-fwd", &["general"])
+        .await
+        .expect("claim_work_item must not error")
+        .expect("child start-node work item must be claimable");
+    assert_eq!(
+        wi_fwd.execution_id, seg1_id,
+        "forward-progress work item must belong to seg1"
+    );
 
     // Drive a state mutation on the child at seq 3 (after WorkflowStarted=1,
     // NodeScheduled=2).  state_patch sets counter to 100.

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -934,3 +934,156 @@ async fn tenant_scoped_two_rollover_byte_identity() {
     let scoped = db.for_tenant(tenant_id);
     assert_two_rollover_byte_identity(&scoped).await;
 }
+
+// ── C2 regression: SQLite child forward-progress after rollover ───────────────
+
+/// Regression test for the "frozen child state" bug on SQLite.
+///
+/// Root with `last_sequence = 50` rolls over to seg1.  A `NodeCompleted`
+/// event is then appended to seg1 at sequence 3 with `state_patch = {"counter": 100}`.
+///
+/// BUG (before fix): `Snapshot::from_materialized` seeded the child snapshot at
+/// `at_sequence = 50` (the parent's last_sequence).  SQLite's
+/// `get_events_since(seg1, 50)` returns only events with `sequence > 50`, so
+/// the child's seq-1/2/3 events were ALL silently dropped.
+/// `materialize(seg1)` returned `{"counter": 0}` — frozen at the carried value.
+///
+/// FIX: `Snapshot::seed_for_segment` anchors the seed at `at_sequence = 0`.
+/// `get_events_since(seg1, 0)` returns all child events; the patch is applied;
+/// `materialize(seg1).current_state["counter"]` must equal 100.
+#[tokio::test]
+async fn sqlite_child_forward_progress_after_rollover() {
+    let db = open_sqlite().await;
+
+    let parent_id = ExecutionId::new();
+    db.create_execution(root_execution(&parent_id))
+        .await
+        .expect("create parent");
+
+    // Give the parent 50 events so its event log is large.
+    append_many_events(&db, &parent_id, 1, 50).await;
+
+    // Build carried state with last_sequence = 50 — this is exactly the
+    // value that Snapshot::from_materialized would have copied into at_sequence,
+    // causing child seq 1/2/3 to be silently dropped.
+    let carried = MaterializedState {
+        current_state: json!({ "counter": 0 }),
+        status: WorkflowStatus::Running,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 50,
+    };
+
+    let seg1_id = start_next_segment(
+        &db, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment");
+
+    // Drain the start-node work item.
+    db.claim_work_item("cleanup-fwd", &["general"]).await.ok();
+
+    // Drive a state mutation on the child at seq 3 (after WorkflowStarted=1,
+    // NodeScheduled=2).  state_patch sets counter to 100.
+    db.append_event(Event::new(
+        seg1_id.clone(),
+        3,
+        EventKind::NodeCompleted {
+            node_id: "step_1".into(),
+            output: json!({ "result": "ok" }),
+            state_patch: json!({ "counter": 100 }),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: None,
+        },
+    ))
+    .await
+    .expect("append NodeCompleted on child");
+
+    // Before fix: returns {"counter": 0} (frozen — at_sequence=50 dropped seq 1/2/3).
+    // After fix:  returns {"counter": 100} (at_sequence=0 folds all child events).
+    let mat = materialize(&db, &seg1_id).await.expect("materialize child");
+
+    assert_eq!(
+        mat.current_state["counter"], 100,
+        "child state must reflect the post-rollover NodeCompleted commit on SQLite; \
+         got {:?} — value 0 means the frozen-state bug is still present",
+        mat.current_state
+    );
+}
+
+// ── C1 regression: pre-boundary crash cannot fork child segment ───────────────
+
+/// Regression test for the "crash double-roll" / "state fork" bug.
+///
+/// BUG (before fix): `new_id = ExecutionId::new()` was random on each call.
+/// A crash between `start_next_segment` and the `SegmentBoundary` append caused
+/// the worker to reclaim the parent item, pass the double-roll guard (no
+/// SegmentBoundary yet), and call `start_next_segment` again — creating a SECOND
+/// child with a different random id.  Two independent children each held a copy
+/// of the carried state, forking the segment chain.
+///
+/// FIX: the child id is now deterministic (UUID v5 of parent+segment_number) and
+/// `start_next_segment` is idempotent: a second call with the same arguments
+/// detects the existing child and returns early without re-seeding or re-enqueuing.
+///
+/// This test simulates the crash window by calling `start_next_segment` twice
+/// with identical arguments and asserting:
+/// - Both calls return the SAME child `ExecutionId`.
+/// - Exactly ONE work item is enqueued (the second call was a no-op).
+#[tokio::test]
+async fn sqlite_idempotent_start_next_segment_prevents_double_roll() {
+    let db = open_sqlite().await;
+
+    let parent_id = ExecutionId::new();
+    db.create_execution(root_execution(&parent_id))
+        .await
+        .expect("create parent");
+
+    let carried = carried_materialized_state();
+
+    // First invocation: creates the child execution + seed + 2 events + work item.
+    let id1 = start_next_segment(
+        &db, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("first start_next_segment");
+
+    // Second invocation: simulates re-run after a crash before SegmentBoundary.
+    // Must return the SAME id and must NOT enqueue a duplicate work item.
+    let id2 = start_next_segment(
+        &db, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("second start_next_segment (idempotent re-run)");
+
+    assert_eq!(
+        id1, id2,
+        "second call must return the same child ExecutionId as the first (deterministic id)"
+    );
+
+    // Claim the one expected work item.
+    let item = db
+        .claim_work_item("dedup-check-1", &["general"])
+        .await
+        .expect("claim_work_item")
+        .expect("exactly one work item must exist");
+    assert_eq!(item.execution_id, id1, "work item must belong to the child");
+
+    // The queue must now be empty — no second work item was enqueued.
+    let second = db
+        .claim_work_item("dedup-check-2", &["general"])
+        .await
+        .expect("claim second");
+    assert!(
+        second.is_none(),
+        "queue must be empty after draining the single work item; \
+         a second item means the idempotency guard did not prevent re-enqueue"
+    );
+}

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -10,8 +10,8 @@
 use chrono::Utc;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{
-    backend::StateBackend, content_hash, materialize, start_next_segment, Event, EventKind,
-    InMemoryBackend, MaterializedState, SqliteBackend,
+    backend::StateBackend, content_hash, materialize, segment_chain, start_next_segment, Event,
+    EventKind, InMemoryBackend, MaterializedState, SqliteBackend,
 };
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
@@ -474,4 +474,463 @@ async fn tenant_scoped_linked_execution_round_trips() {
 
     assert_eq!(fetched.segment_number, 1);
     assert_eq!(fetched.parent_execution_id.as_ref(), Some(&parent_id));
+}
+
+// ── segment_chain helper ──────────────────────────────────────────────────────
+
+/// Appends `count` minimal events to `exec_id` starting at sequence `start_seq`.
+/// Uses bare `NodeCompleted` events with a null state_patch (no state mutation).
+async fn append_many_events(
+    backend: &dyn StateBackend,
+    exec_id: &ExecutionId,
+    start_seq: i64,
+    count: usize,
+) {
+    for i in 0..count {
+        let seq = start_seq + i as i64;
+        backend
+            .append_event(Event::new(
+                exec_id.clone(),
+                seq,
+                EventKind::NodeCompleted {
+                    node_id: "loop_body".into(),
+                    output: json!({}),
+                    state_patch: json!({}),
+                    duration_ms: 1,
+                    gen_ai_system: None,
+                    gen_ai_model: None,
+                    input_tokens: None,
+                    output_tokens: None,
+                    finish_reason: None,
+                    cost_usd: None,
+                    provenance: None,
+                    idempotency_key: None,
+                },
+            ))
+            .await
+            .expect("append_many_events: append failed");
+    }
+}
+
+/// Generic lineage test: root -> seg1 -> seg2.
+/// `segment_chain(backend, &seg2_id)` must return [root_id, seg1_id, seg2_id],
+/// each with the correct segment_number (0, 1, 2).
+async fn assert_segment_chain_lineage(backend: &dyn StateBackend) {
+    let root_id = ExecutionId::new();
+    backend
+        .create_execution(root_execution(&root_id))
+        .await
+        .expect("create root");
+
+    let seg1_carried = MaterializedState {
+        current_state: json!({ "counter": 1 }),
+        status: WorkflowStatus::Running,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 0,
+    };
+
+    let seg1_id = start_next_segment(
+        backend,
+        &root_id,
+        &seg1_carried,
+        "seg-wf",
+        "1.0.0",
+        1,
+        "start",
+        "general",
+        "default",
+    )
+    .await
+    .expect("start_next_segment seg1");
+
+    // Drain the work item so a second claim does not interfere.
+    backend
+        .claim_work_item("cleanup-chain-1", &["general"])
+        .await
+        .ok();
+
+    let seg2_carried = MaterializedState {
+        current_state: json!({ "counter": 2 }),
+        status: WorkflowStatus::Running,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 0,
+    };
+
+    let seg2_id = start_next_segment(
+        backend,
+        &seg1_id,
+        &seg2_carried,
+        "seg-wf",
+        "1.0.0",
+        2,
+        "start",
+        "general",
+        "default",
+    )
+    .await
+    .expect("start_next_segment seg2");
+
+    // Drain so the queue does not leak into other tests.
+    backend
+        .claim_work_item("cleanup-chain-2", &["general"])
+        .await
+        .ok();
+
+    // Walk the chain from seg2 back to root.
+    let chain = segment_chain(backend, &seg2_id)
+        .await
+        .expect("segment_chain must succeed");
+
+    assert_eq!(chain.len(), 3, "chain must have 3 entries");
+    assert_eq!(chain[0], root_id, "chain[0] must be root");
+    assert_eq!(chain[1], seg1_id, "chain[1] must be seg1");
+    assert_eq!(chain[2], seg2_id, "chain[2] must be seg2");
+
+    // Verify segment_number is monotonically 0, 1, 2.
+    for (expected_seg_num, exec_id) in [(0u32, &chain[0]), (1u32, &chain[1]), (2u32, &chain[2])] {
+        let exec = backend
+            .get_execution(exec_id)
+            .await
+            .expect("get_execution")
+            .expect("execution must exist");
+        assert_eq!(
+            exec.segment_number, expected_seg_num,
+            "segment_number mismatch at position {expected_seg_num}"
+        );
+    }
+}
+
+// ── 2g-4 Task 1: segment_chain — SQLite, in-memory, tenant-scoped ─────────────
+
+#[tokio::test]
+async fn sqlite_segment_chain_lineage() {
+    let db = open_sqlite().await;
+    assert_segment_chain_lineage(&db).await;
+}
+
+#[tokio::test]
+async fn memory_segment_chain_lineage() {
+    let backend = InMemoryBackend::new();
+    assert_segment_chain_lineage(&backend).await;
+}
+
+#[tokio::test]
+async fn tenant_scoped_segment_chain_lineage() {
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+    let tenant_id = TenantId::from("chain-acme");
+    let scoped_admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+    scoped_admin
+        .create_tenant(Tenant {
+            id: tenant_id.clone(),
+            name: "ChainAcme".into(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("register tenant");
+
+    let scoped = db.for_tenant(tenant_id);
+    assert_segment_chain_lineage(&scoped).await;
+}
+
+// ── 2g-4 Task 2: bounded-replay proof (SQLite; event count independence) ──────
+
+/// THE proof of 2g: adding 50 events to the root execution must NOT inflate
+/// the new segment's event count or replay cost.
+///
+/// Root gets 50 events (seq 1..=50).
+/// `start_next_segment` seeds seg1 with root's materialized state.
+/// `get_events(seg1).len()` must equal 2 (WorkflowStarted + NodeScheduled).
+/// `materialize(seg1).current_state` must equal the carried state.
+#[tokio::test]
+async fn sqlite_bounded_replay_independent_of_root_event_count() {
+    let db = open_sqlite().await;
+
+    let root_id = ExecutionId::new();
+    db.create_execution(root_execution(&root_id))
+        .await
+        .expect("create root");
+
+    // Give the root a large event log (50 events, seq 1..=50).
+    append_many_events(&db, &root_id, 1, 50).await;
+
+    let root_events = db.get_events(&root_id).await.expect("get_events root");
+    assert_eq!(root_events.len(), 50, "root must have 50 events");
+
+    // The root's terminal materialized state (after all 50 events).
+    let root_mat = materialize(&db, &root_id).await.expect("materialize root");
+
+    let seg1_id = start_next_segment(
+        &db, &root_id, &root_mat, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment");
+
+    // Drain the work item (not needed for this test's logic).
+    db.claim_work_item("cleanup-bounded", &["general"])
+        .await
+        .ok();
+
+    // Seg1's event count is SMALL and independent of root's 50 events.
+    let seg1_events = db.get_events(&seg1_id).await.expect("get_events seg1");
+    assert_eq!(
+        seg1_events.len(),
+        2,
+        "seg1 must have exactly 2 events (WorkflowStarted + NodeScheduled), got {}",
+        seg1_events.len()
+    );
+    assert!(
+        matches!(seg1_events[0].kind, EventKind::WorkflowStarted { .. }),
+        "seg1 event[0] must be WorkflowStarted"
+    );
+    assert!(
+        matches!(seg1_events[1].kind, EventKind::NodeScheduled { .. }),
+        "seg1 event[1] must be NodeScheduled"
+    );
+
+    // materialize(seg1) returns the carried state WITHOUT reading root's 50 events.
+    let seg1_mat = materialize(&db, &seg1_id).await.expect("materialize seg1");
+    assert_eq!(
+        seg1_mat.current_state, root_mat.current_state,
+        "seg1.current_state must equal the carried root state"
+    );
+
+    // Seed snapshot for seg1 exists and reflects the carried state.
+    let snap = db
+        .latest_snapshot(&seg1_id)
+        .await
+        .expect("latest_snapshot")
+        .expect("seed snapshot must exist");
+    assert_eq!(
+        snap.state, root_mat.current_state,
+        "seed snapshot must carry the root's terminal state"
+    );
+}
+
+// ── 2g-4 Task 3: inert old segment — late commit does not leak into new seg ───
+
+/// A late event appended to the OLD (terminal) execution after rollover must NOT
+/// change `materialize(seg1).current_state`. Proves the inert-old-segment
+/// invariant stated in the Global Constraints.
+#[tokio::test]
+async fn sqlite_inert_old_segment_does_not_leak() {
+    let db = open_sqlite().await;
+
+    let root_id = ExecutionId::new();
+    db.create_execution(root_execution(&root_id))
+        .await
+        .expect("create root");
+
+    // Append one event to root so it is non-empty, then roll over.
+    db.append_event(Event::new(
+        root_id.clone(),
+        1,
+        EventKind::WorkflowStarted {
+            workflow_id: "seg-wf".into(),
+            workflow_version: "1.0.0".into(),
+            initial_input: json!({ "counter": 0 }),
+        },
+    ))
+    .await
+    .expect("append WorkflowStarted to root");
+
+    let root_mat = materialize(&db, &root_id).await.expect("materialize root");
+
+    let seg1_id = start_next_segment(
+        &db, &root_id, &root_mat, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment");
+
+    db.claim_work_item("cleanup-inert", &["general"]).await.ok();
+
+    // Capture seg1's state BEFORE the late commit.
+    let seg1_before = materialize(&db, &seg1_id)
+        .await
+        .expect("materialize seg1 before late commit");
+
+    // Simulate a late / parked NodeCompleted arriving on the OLD execution
+    // with a conflicting state_patch.
+    db.append_event(Event::new(
+        root_id.clone(),
+        2,
+        EventKind::NodeCompleted {
+            node_id: "late_node".into(),
+            output: json!({ "result": "LATE" }),
+            state_patch: json!({ "counter": 999, "injected": true }),
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: None,
+        },
+    ))
+    .await
+    .expect("late append on old execution must succeed (appends to closed log)");
+
+    // seg1's materialized state is UNCHANGED.
+    let seg1_after = materialize(&db, &seg1_id)
+        .await
+        .expect("materialize seg1 after late commit");
+
+    assert_eq!(
+        seg1_after.current_state, seg1_before.current_state,
+        "inert-old-segment: a late commit on the old execution must not change the new segment's state"
+    );
+    assert_eq!(
+        content_hash(&seg1_after.current_state),
+        content_hash(&seg1_before.current_state),
+        "content_hash must be unchanged after late commit on old execution"
+    );
+}
+
+// ── 2g-4/2g-5 Task 4: 2-rollover byte-identity across backends ───────────────
+
+/// Carry a non-trivial nested JSON state through TWO rollovers (root -> seg1 ->
+/// seg2). The state must arrive byte-identical at seg2 (`content_hash` equal
+/// end-to-end). Tested on SQLite, in-memory, and tenant-scoped backends.
+async fn assert_two_rollover_byte_identity(backend: &dyn StateBackend) {
+    let nested_state = json!({
+        "counter": 7,
+        "items": [{"k": "v"}, {"k": "w"}],
+        "deep": {"a": {"b": [1, 2, 3]}}
+    });
+
+    let root_id = ExecutionId::new();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: root_id.clone(),
+            workflow_id: "seg-wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: nested_state.clone(),
+            current_state: nested_state.clone(),
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create root");
+
+    let root_mat = MaterializedState {
+        current_state: nested_state.clone(),
+        status: WorkflowStatus::Running,
+        completed_nodes: HashMap::new(),
+        active_nodes: HashSet::new(),
+        last_sequence: 0,
+    };
+
+    // root -> seg1
+    let seg1_id = start_next_segment(
+        backend, &root_id, &root_mat, "seg-wf", "1.0.0", 1, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment seg1");
+
+    backend
+        .claim_work_item("cleanup-2ro-1", &["general"])
+        .await
+        .ok();
+
+    // Verify seg1 carries the state byte-identically.
+    let seg1_exec = backend
+        .get_execution(&seg1_id)
+        .await
+        .expect("get seg1")
+        .expect("seg1 must exist");
+    assert_eq!(
+        content_hash(&seg1_exec.current_state),
+        content_hash(&nested_state),
+        "seg1.current_state hash must match original"
+    );
+
+    // seg1 -> seg2 (second rollover), seeded from materialize(seg1).
+    let seg1_mat = materialize(backend, &seg1_id)
+        .await
+        .expect("materialize seg1");
+
+    let seg2_id = start_next_segment(
+        backend, &seg1_id, &seg1_mat, "seg-wf", "1.0.0", 2, "start", "general", "default",
+    )
+    .await
+    .expect("start_next_segment seg2");
+
+    backend
+        .claim_work_item("cleanup-2ro-2", &["general"])
+        .await
+        .ok();
+
+    let seg2_exec = backend
+        .get_execution(&seg2_id)
+        .await
+        .expect("get seg2")
+        .expect("seg2 must exist");
+
+    // Byte-identity end-to-end: seg2.current_state hash == original nested_state hash.
+    assert_eq!(
+        content_hash(&seg2_exec.current_state),
+        content_hash(&nested_state),
+        "seg2.current_state hash must match the original nested state after 2 rollovers"
+    );
+
+    // Lineage chain from seg2 gives [root, seg1, seg2].
+    let chain = segment_chain(backend, &seg2_id)
+        .await
+        .expect("segment_chain from seg2");
+    assert_eq!(
+        chain,
+        vec![root_id.clone(), seg1_id.clone(), seg2_id.clone()]
+    );
+}
+
+#[tokio::test]
+async fn sqlite_two_rollover_byte_identity() {
+    let db = open_sqlite().await;
+    assert_two_rollover_byte_identity(&db).await;
+}
+
+#[tokio::test]
+async fn memory_two_rollover_byte_identity() {
+    let backend = InMemoryBackend::new();
+    assert_two_rollover_byte_identity(&backend).await;
+}
+
+#[tokio::test]
+async fn tenant_scoped_two_rollover_byte_identity() {
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+    let tenant_id = TenantId::from("bytecheck-acme");
+    let scoped_admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+    scoped_admin
+        .create_tenant(Tenant {
+            id: tenant_id.clone(),
+            name: "ByteCheckAcme".into(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("register tenant");
+
+    let scoped = db.for_tenant(tenant_id);
+    assert_two_rollover_byte_identity(&scoped).await;
 }

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -1,0 +1,326 @@
+//! TDD tests for segment lineage columns and `SegmentBoundary` event.
+//!
+//! Tests written RED before the model fields existed; turned GREEN after:
+//! - `WorkflowExecution::parent_execution_id` and `::segment_number`
+//! - `EventKind::SegmentBoundary { segment_number, next_execution_id }`
+//! - migration 0007_segment_links.sql
+//! - `create_execution` / `get_execution` wired to the two new DB columns
+//! - `apply_events_seeded` explicit no-op arm for `SegmentBoundary`
+
+use chrono::Utc;
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::{
+    backend::StateBackend, materialize, Event, EventKind, InMemoryBackend, SqliteBackend,
+};
+use serde_json::json;
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+async fn open_sqlite() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite for segment tests")
+}
+
+fn root_execution(id: &ExecutionId) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "seg-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({ "counter": 0 }),
+        current_state: json!({ "counter": 0 }),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
+    }
+}
+
+fn child_execution(
+    id: &ExecutionId,
+    parent: &ExecutionId,
+    segment_number: u32,
+) -> WorkflowExecution {
+    let now = Utc::now();
+    WorkflowExecution {
+        execution_id: id.clone(),
+        workflow_id: "seg-wf".into(),
+        workflow_version: "1.0.0".into(),
+        status: WorkflowStatus::Running,
+        initial_input: json!({ "counter": 42, "carried": true }),
+        current_state: json!({ "counter": 42, "carried": true }),
+        started_at: now,
+        updated_at: now,
+        completed_at: None,
+        session_type: None,
+        parent_execution_id: Some(parent.clone()),
+        segment_number,
+    }
+}
+
+// ── SQLite backend ────────────────────────────────────────────────────────────
+
+/// A child execution (segment 1) carries `parent_execution_id` and
+/// `segment_number=1` round-trip through SQLite.
+#[tokio::test]
+async fn sqlite_linked_execution_round_trips() {
+    let db = open_sqlite().await;
+
+    let parent_id = ExecutionId::new();
+    db.create_execution(root_execution(&parent_id))
+        .await
+        .expect("create root");
+
+    let child_id = ExecutionId::new();
+    db.create_execution(child_execution(&child_id, &parent_id, 1))
+        .await
+        .expect("create child");
+
+    let fetched = db
+        .get_execution(&child_id)
+        .await
+        .expect("get_execution")
+        .expect("child must exist");
+
+    assert_eq!(fetched.segment_number, 1, "segment_number must be 1");
+    assert_eq!(
+        fetched.parent_execution_id.as_ref(),
+        Some(&parent_id),
+        "parent_execution_id must match"
+    );
+    assert_eq!(
+        fetched.current_state,
+        json!({ "counter": 42, "carried": true })
+    );
+}
+
+/// A root execution (no parent) reads back `segment_number=0` and
+/// `parent_execution_id=None` from SQLite.
+#[tokio::test]
+async fn sqlite_root_execution_has_defaults() {
+    let db = open_sqlite().await;
+
+    let root_id = ExecutionId::new();
+    db.create_execution(root_execution(&root_id))
+        .await
+        .expect("create root");
+
+    let fetched = db
+        .get_execution(&root_id)
+        .await
+        .expect("get_execution")
+        .expect("root must exist");
+
+    assert_eq!(fetched.segment_number, 0, "root segment_number must be 0");
+    assert!(
+        fetched.parent_execution_id.is_none(),
+        "root parent_execution_id must be None"
+    );
+}
+
+/// Appending a `SegmentBoundary` event then materializing the OLD execution
+/// does NOT change `current_state` — it is a pure audit record.
+#[tokio::test]
+async fn sqlite_segment_boundary_event_is_materialize_noop() {
+    let db = open_sqlite().await;
+
+    let exec_id = ExecutionId::new();
+    let next_id = ExecutionId::new();
+    db.create_execution(root_execution(&exec_id))
+        .await
+        .expect("create root");
+
+    // Append a WorkflowStarted so the execution is in Running state.
+    db.append_event(Event::new(
+        exec_id.clone(),
+        1,
+        EventKind::WorkflowStarted {
+            workflow_id: "seg-wf".into(),
+            workflow_version: "1.0.0".into(),
+            initial_input: json!({ "counter": 0 }),
+        },
+    ))
+    .await
+    .expect("append WorkflowStarted");
+
+    // Materialize before SegmentBoundary.
+    let before = materialize(&db, &exec_id)
+        .await
+        .expect("materialize before");
+    let state_before = before.current_state.clone();
+
+    // Append the SegmentBoundary audit event.
+    db.append_event(Event::new(
+        exec_id.clone(),
+        2,
+        EventKind::SegmentBoundary {
+            segment_number: 1,
+            next_execution_id: next_id.to_string(),
+        },
+    ))
+    .await
+    .expect("append SegmentBoundary");
+
+    // Materialize after SegmentBoundary — state must be unchanged.
+    let after = materialize(&db, &exec_id).await.expect("materialize after");
+    assert_eq!(
+        after.current_state, state_before,
+        "SegmentBoundary must not mutate current_state"
+    );
+    assert_eq!(after.last_sequence, 2, "last_sequence must advance to 2");
+}
+
+// ── In-memory backend ─────────────────────────────────────────────────────────
+
+/// Same linked-execution round-trip, but on the in-memory backend.
+#[tokio::test]
+async fn memory_linked_execution_round_trips() {
+    let backend = InMemoryBackend::new();
+
+    let parent_id = ExecutionId::new();
+    backend
+        .create_execution(root_execution(&parent_id))
+        .await
+        .expect("create root");
+
+    let child_id = ExecutionId::new();
+    backend
+        .create_execution(child_execution(&child_id, &parent_id, 1))
+        .await
+        .expect("create child");
+
+    let fetched = backend
+        .get_execution(&child_id)
+        .await
+        .expect("get_execution")
+        .expect("child must exist");
+
+    assert_eq!(fetched.segment_number, 1);
+    assert_eq!(fetched.parent_execution_id.as_ref(), Some(&parent_id));
+}
+
+/// Root execution defaults on the in-memory backend.
+#[tokio::test]
+async fn memory_root_execution_has_defaults() {
+    let backend = InMemoryBackend::new();
+
+    let root_id = ExecutionId::new();
+    backend
+        .create_execution(root_execution(&root_id))
+        .await
+        .expect("create root");
+
+    let fetched = backend
+        .get_execution(&root_id)
+        .await
+        .expect("get_execution")
+        .expect("root must exist");
+
+    assert_eq!(fetched.segment_number, 0);
+    assert!(fetched.parent_execution_id.is_none());
+}
+
+/// `SegmentBoundary` is a materialize no-op on the in-memory backend.
+#[tokio::test]
+async fn memory_segment_boundary_event_is_materialize_noop() {
+    let backend = InMemoryBackend::new();
+
+    let exec_id = ExecutionId::new();
+    let next_id = ExecutionId::new();
+    backend
+        .create_execution(root_execution(&exec_id))
+        .await
+        .expect("create root");
+
+    backend
+        .append_event(Event::new(
+            exec_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "seg-wf".into(),
+                workflow_version: "1.0.0".into(),
+                initial_input: json!({ "counter": 0 }),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+
+    let before = materialize(&backend, &exec_id)
+        .await
+        .expect("materialize before");
+    let state_before = before.current_state.clone();
+
+    backend
+        .append_event(Event::new(
+            exec_id.clone(),
+            2,
+            EventKind::SegmentBoundary {
+                segment_number: 1,
+                next_execution_id: next_id.to_string(),
+            },
+        ))
+        .await
+        .expect("append SegmentBoundary");
+
+    let after = materialize(&backend, &exec_id)
+        .await
+        .expect("materialize after");
+    assert_eq!(
+        after.current_state, state_before,
+        "SegmentBoundary must not mutate current_state"
+    );
+}
+
+// ── Tenant-scoped backend ─────────────────────────────────────────────────────
+
+/// Same linked-execution round-trip on the tenant-scoped SQLite backend.
+#[tokio::test]
+async fn tenant_scoped_linked_execution_round_trips() {
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+
+    // Register a non-default tenant.
+    let tenant_id = TenantId::from("acme");
+    let scoped_admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+    scoped_admin
+        .create_tenant(Tenant {
+            id: tenant_id.clone(),
+            name: "Acme".into(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("register tenant");
+
+    let scoped = db.for_tenant(tenant_id);
+
+    let parent_id = ExecutionId::new();
+    scoped
+        .create_execution(root_execution(&parent_id))
+        .await
+        .expect("create root");
+
+    let child_id = ExecutionId::new();
+    scoped
+        .create_execution(child_execution(&child_id, &parent_id, 1))
+        .await
+        .expect("create child");
+
+    let fetched = scoped
+        .get_execution(&child_id)
+        .await
+        .expect("get_execution")
+        .expect("child must exist");
+
+    assert_eq!(fetched.segment_number, 1);
+    assert_eq!(fetched.parent_execution_id.as_ref(), Some(&parent_id));
+}

--- a/runtime/state/tests/segment.rs
+++ b/runtime/state/tests/segment.rs
@@ -309,7 +309,7 @@ async fn assert_start_next_segment(backend: &dyn StateBackend) {
     let carried = carried_materialized_state();
 
     let new_id = start_next_segment(
-        backend, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general",
+        backend, &parent_id, &carried, "seg-wf", "1.0.0", 1, "start", "general", "default",
     )
     .await
     .expect("start_next_segment must succeed");

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -49,6 +49,8 @@ fn sample_execution(workflow_id: &str) -> WorkflowExecution {
         updated_at: now,
         completed_at: None,
         session_type: None,
+        parent_execution_id: None,
+        segment_number: 0,
     }
 }
 

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 const MAX_RETRY_AFTER_SECS: u64 = 3_600;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
-use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
+use jamjet_core::workflow::ExecutionId;
 use jamjet_ir::workflow::{NodeDef, WorkflowIr};
 use jamjet_policy::autonomy::{AutonomyContext, AutonomyDecision, AutonomyEnforcer};
 use jamjet_policy::engine::node_kind_tag;
@@ -379,6 +379,7 @@ impl Worker {
                                             &tenant_id,
                                             item_id,
                                             &queue_type,
+                                            lease_fence,
                                         )
                                         .await;
                                 }
@@ -1115,6 +1116,7 @@ impl Worker {
         tenant_id: &str,
         item_id: WorkItemId,
         queue_type: &str,
+        lease_fence: i64,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Double-roll guard: check SegmentBoundary event OR terminal status.
         let events = self.backend.get_events(execution_id).await?;
@@ -1126,7 +1128,25 @@ impl Worker {
                 execution_id = %execution_id,
                 "continue-as-new: SegmentBoundary already exists; skipping duplicate rollover"
             );
-            let _ = self.backend.complete_work_item(item_id).await;
+            // Fence-guarded: ensure the old execution is terminal AND settle the
+            // work item atomically. Handles Major-2: a crash before
+            // update_execution_status leaves the execution non-terminal; the
+            // retry hits `already` and finalizes via this path.
+            // Ok(false) = stale fence (zombie); log and return without error.
+            match self
+                .backend
+                .finalize_rollover_fenced(execution_id, item_id, lease_fence)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        execution_id = %execution_id,
+                        "continue-as-new already-branch: stale fence — another worker owns this item"
+                    );
+                }
+                Err(e) => return Err(e.to_string().into()),
+            }
             return Ok(());
         }
 
@@ -1142,7 +1162,17 @@ impl Worker {
                 status = ?exec.status,
                 "continue-as-new: old execution already terminal; skipping rollover"
             );
-            let _ = self.backend.complete_work_item(item_id).await;
+            // Fence-guarded settle: idempotent — the terminal update is a no-op
+            // since the execution is already terminal; only the work item settle
+            // is meaningful (fence-guarded against zombie workers).
+            match self
+                .backend
+                .finalize_rollover_fenced(execution_id, item_id, lease_fence)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => return Err(e.to_string().into()),
+            }
             return Ok(());
         }
 
@@ -1180,13 +1210,24 @@ impl Worker {
             ))
             .await?;
 
-        // Mark old execution terminal (LimitExceeded = clean terminal, NOT failed).
-        self.backend
-            .update_execution_status(execution_id, WorkflowStatus::LimitExceeded)
-            .await?;
-
-        // Clean up the current work item so it doesn't linger as a claimed item.
-        let _ = self.backend.complete_work_item(item_id).await;
+        // Fence-guarded finalization: marks old execution terminal (LimitExceeded)
+        // AND settles the work item in one transaction. Ok(false) = stale fence
+        // (zombie worker — another lease holder now owns this item).
+        match self
+            .backend
+            .finalize_rollover_fenced(execution_id, item_id, lease_fence)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    execution_id = %execution_id,
+                    "continue-as-new: stale fence during finalization — new lease holder owns the item"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e.to_string().into()),
+        }
 
         info!(
             old_execution_id = %execution_id,
@@ -2434,6 +2475,125 @@ mod tests {
                 .count(),
             1,
             "must still have exactly one SegmentBoundary event after double-roll attempt"
+        );
+    }
+
+    /// Regression test for Major-2: crash after SegmentBoundary but before terminal marking.
+    ///
+    /// Simulates: the worker appended SegmentBoundary to the old execution and created the
+    /// new segment, then crashed before calling update_execution_status (old execution is
+    /// still Running). On retry, the worker hits the `already` branch and must mark the
+    /// old execution LimitExceeded via finalize_rollover_fenced.
+    #[tokio::test]
+    async fn continue_as_new_already_branch_marks_old_execution_terminal() {
+        let (backend, old_eid) = setup_budget_backend(true).await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("tool", Arc::new(BudgetTriggerExecutor));
+
+        // First rollover: succeeds normally.
+        let item1 = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item1 must be claimable");
+        worker
+            .execute_item(item1)
+            .await
+            .expect("first rollover must succeed");
+
+        // Verify old execution is now terminal.
+        let exec_after_first = backend
+            .get_execution(&old_eid)
+            .await
+            .unwrap()
+            .expect("old execution must exist");
+        assert_eq!(exec_after_first.status, WorkflowStatus::LimitExceeded);
+
+        // Simulate crash-before-terminal: reset the old execution back to Running.
+        // This represents what would have happened if the worker crashed between
+        // appending SegmentBoundary and calling update_execution_status.
+        backend
+            .update_execution_status(&old_eid, WorkflowStatus::Running)
+            .await
+            .expect("reset status for crash simulation");
+
+        let exec_reset = backend
+            .get_execution(&old_eid)
+            .await
+            .unwrap()
+            .expect("old execution must exist after reset");
+        assert_eq!(
+            exec_reset.status,
+            WorkflowStatus::Running,
+            "status must be reset to Running"
+        );
+
+        // Enqueue a second work item for the old execution (as crash-recovery reclaim would do).
+        backend
+            .enqueue_work_item(jamjet_state::backend::WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: old_eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "seg-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 0,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        // Claim the retry item for the OLD execution.
+        // Drain any new segment item first if it comes up first.
+        let item2a = backend
+            .claim_work_item("test-worker-retry", &["default"])
+            .await
+            .unwrap()
+            .expect("must be claimable");
+
+        let item2_old = if item2a.execution_id != old_eid {
+            backend
+                .claim_work_item("test-worker-retry2", &["default"])
+                .await
+                .unwrap()
+                .expect("old execution's retry item must be claimable")
+        } else {
+            item2a
+        };
+
+        assert_eq!(
+            item2_old.execution_id, old_eid,
+            "retry item must belong to old execution"
+        );
+
+        worker
+            .execute_item(item2_old)
+            .await
+            .expect("retry rollover (already branch) must succeed");
+
+        // KEY ASSERTION (Major-2 regression): old execution must now be terminal.
+        let exec_final = backend
+            .get_execution(&old_eid)
+            .await
+            .unwrap()
+            .expect("old execution must exist");
+        assert_eq!(
+            exec_final.status,
+            WorkflowStatus::LimitExceeded,
+            "Major-2 regression: old execution must be LimitExceeded after already-branch finalization; \
+             got {:?} — means crash-before-terminal was not repaired",
+            exec_final.status
         );
     }
 }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1154,6 +1154,8 @@ mod tests {
             updated_at: now,
             completed_at: None,
             session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
         }
     }
 

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 const MAX_RETRY_AFTER_SECS: u64 = 3_600;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
-use jamjet_core::workflow::ExecutionId;
+use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
 use jamjet_ir::workflow::{NodeDef, WorkflowIr};
 use jamjet_policy::autonomy::{AutonomyContext, AutonomyDecision, AutonomyEnforcer};
 use jamjet_policy::engine::node_kind_tag;
@@ -17,6 +17,7 @@ use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemI
 use jamjet_state::budget::BudgetState;
 use jamjet_state::content_hash;
 use jamjet_state::event::EventKind;
+use jamjet_state::{materialize, start_next_segment};
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -112,6 +113,7 @@ impl Worker {
         let execution_id = item.execution_id.clone();
         let node_id = item.node_id.clone();
         let tenant_id = item.tenant_id.clone();
+        let queue_type = item.queue_type.clone();
         let attempt = item.attempt;
         let max_attempts = item.max_attempts;
         let item_id = item.id;
@@ -367,6 +369,19 @@ impl Worker {
                                 .await
                             {
                                 heartbeat.abort();
+                                if ir.continue_as_new {
+                                    return self
+                                        .rollover_segment(
+                                            &execution_id,
+                                            &ir,
+                                            &workflow_id,
+                                            &workflow_version,
+                                            &tenant_id,
+                                            item_id,
+                                            &queue_type,
+                                        )
+                                        .await;
+                                }
                                 return r;
                             }
                             Ok(result)
@@ -1080,6 +1095,107 @@ impl Worker {
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("workflow {workflow_id} v{workflow_version} not found"))?;
         serde_json::from_value(def.ir).map_err(|e| e.to_string())
+    }
+
+    // ── Continue-as-new rollover ──────────────────────────────────────────────
+
+    /// Perform a continue-as-new rollover at the strategy ceiling.
+    ///
+    /// Crash-safety order: create new segment FIRST (durable), THEN append
+    /// SegmentBoundary to old execution, THEN mark old execution terminal.
+    /// Double-roll guard: if the old execution already has a SegmentBoundary event
+    /// OR is already terminal, skip the rollover (idempotent on re-run after crash).
+    #[allow(clippy::too_many_arguments)]
+    async fn rollover_segment(
+        &self,
+        execution_id: &ExecutionId,
+        ir: &WorkflowIr,
+        workflow_id: &str,
+        workflow_version: &str,
+        tenant_id: &str,
+        item_id: WorkItemId,
+        queue_type: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Double-roll guard: check SegmentBoundary event OR terminal status.
+        let events = self.backend.get_events(execution_id).await?;
+        let already = events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }));
+        if already {
+            warn!(
+                execution_id = %execution_id,
+                "continue-as-new: SegmentBoundary already exists; skipping duplicate rollover"
+            );
+            let _ = self.backend.complete_work_item(item_id).await;
+            return Ok(());
+        }
+
+        let exec = self
+            .backend
+            .get_execution(execution_id)
+            .await?
+            .ok_or_else(|| format!("execution {execution_id} not found for rollover"))?;
+
+        if exec.status.is_terminal() {
+            warn!(
+                execution_id = %execution_id,
+                status = ?exec.status,
+                "continue-as-new: old execution already terminal; skipping rollover"
+            );
+            let _ = self.backend.complete_work_item(item_id).await;
+            return Ok(());
+        }
+
+        let next_seg = exec.segment_number + 1;
+        let start_node_id = ir.start_node.as_str();
+
+        // Materialize carried state.
+        let mat = materialize(self.backend.as_ref(), execution_id).await?;
+
+        // ORDER: new segment FIRST (crash-safe chain), THEN SegmentBoundary audit,
+        // THEN terminal status on old execution.
+        let next_id = start_next_segment(
+            self.backend.as_ref(),
+            execution_id,
+            &mat,
+            workflow_id,
+            workflow_version,
+            next_seg,
+            start_node_id,
+            queue_type,
+            tenant_id,
+        )
+        .await?;
+
+        // Append SegmentBoundary to the OLD execution's event log (pure audit).
+        let seq = self.backend.latest_sequence(execution_id).await? + 1;
+        self.backend
+            .append_event(jamjet_state::Event::new(
+                execution_id.clone(),
+                seq,
+                EventKind::SegmentBoundary {
+                    segment_number: next_seg,
+                    next_execution_id: next_id.to_string(),
+                },
+            ))
+            .await?;
+
+        // Mark old execution terminal (LimitExceeded = clean terminal, NOT failed).
+        self.backend
+            .update_execution_status(execution_id, WorkflowStatus::LimitExceeded)
+            .await?;
+
+        // Clean up the current work item so it doesn't linger as a claimed item.
+        let _ = self.backend.complete_work_item(item_id).await;
+
+        info!(
+            old_execution_id = %execution_id,
+            new_execution_id = %next_id,
+            segment_number = next_seg,
+            "continue-as-new: rolled over to new segment"
+        );
+
+        Ok(())
     }
 }
 
@@ -1969,6 +2085,355 @@ mod tests {
             re_claimed.unwrap().attempt,
             2,
             "re-claimed item must be at attempt=2"
+        );
+    }
+
+    // ── Continue-as-new tests (Task 2g-3) ────────────────────────────────────
+
+    /// Returns 1 input token -- triggers any IR with token_budget.total_tokens: 0.
+    struct BudgetTriggerExecutor;
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for BudgetTriggerExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, ExecutorError> {
+            Ok(ExecutionResult {
+                output: serde_json::json!({}),
+                state_patch: serde_json::json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: Some(1), // triggers total_tokens budget check
+                output_tokens: None,
+                finish_reason: None,
+            })
+        }
+    }
+
+    fn budget_ceiling_ir_json(continue_as_new: bool) -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "seg-wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "continue_as_new": continue_as_new,
+            "token_budget": { "total_tokens": 0 }, // any >0 tokens exceeds this
+            "nodes": {
+                "n1": {
+                    "id": "n1",
+                    "kind": {
+                        "type": "tool",
+                        "tool_ref": "stub",
+                        "input_mapping": {},
+                        "output_schema": "{}"
+                    }
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {}
+        })
+    }
+
+    async fn setup_budget_backend(continue_as_new: bool) -> (Arc<InMemoryBackend>, ExecutionId) {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+
+        let now = Utc::now();
+        backend
+            .create_execution(WorkflowExecution {
+                execution_id: eid.clone(),
+                workflow_id: "seg-wf".into(),
+                workflow_version: "1.0.0".into(),
+                status: WorkflowStatus::Running,
+                initial_input: serde_json::json!({ "counter": 5 }),
+                current_state: serde_json::json!({ "counter": 5 }),
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                session_type: None,
+                parent_execution_id: None,
+                segment_number: 0,
+            })
+            .await
+            .unwrap();
+
+        backend
+            .store_workflow(jamjet_state::backend::WorkflowDefinition {
+                workflow_id: "seg-wf".into(),
+                version: "1.0.0".into(),
+                ir: budget_ceiling_ir_json(continue_as_new),
+                created_at: Utc::now(),
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+
+        backend
+            .enqueue_work_item(jamjet_state::backend::WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "seg-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 0,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        (backend, eid)
+    }
+
+    /// With `continue_as_new: true`, hitting the token budget ceiling must roll
+    /// over to a new linked segment instead of returning Err.
+    #[tokio::test]
+    async fn continue_as_new_rolls_over_at_budget_ceiling() {
+        let (backend, old_eid) = setup_budget_backend(true).await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("tool", Arc::new(BudgetTriggerExecutor));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        let result = worker.execute_item(item).await;
+        assert!(
+            result.is_ok(),
+            "execute_item must return Ok(()) after rollover; got: {result:?}"
+        );
+
+        let old_events = backend.get_events(&old_eid).await.unwrap();
+        let boundary = old_events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }))
+            .expect("old execution must have a SegmentBoundary event");
+
+        let (next_seg, next_id_str) = match &boundary.kind {
+            EventKind::SegmentBoundary {
+                segment_number,
+                next_execution_id,
+            } => (*segment_number, next_execution_id.clone()),
+            _ => unreachable!(),
+        };
+        assert_eq!(next_seg, 1, "segment_number in SegmentBoundary must be 1");
+
+        let old_exec = backend
+            .get_execution(&old_eid)
+            .await
+            .unwrap()
+            .expect("old execution must still exist");
+        assert_eq!(
+            old_exec.status,
+            WorkflowStatus::LimitExceeded,
+            "old execution must be LimitExceeded, not Failed"
+        );
+
+        // ExecutionId Display is "exec_{uuid_simple}" (no hyphens). Strip the prefix
+        // and parse the simple UUID to reconstruct the ExecutionId.
+        let new_eid = if next_id_str.starts_with("exec_") {
+            let uuid_str = next_id_str.trim_start_matches("exec_");
+            ExecutionId(uuid::Uuid::parse_str(uuid_str).expect("valid uuid"))
+        } else {
+            ExecutionId(uuid::Uuid::parse_str(&next_id_str).expect("valid uuid"))
+        };
+
+        let new_exec = backend
+            .get_execution(&new_eid)
+            .await
+            .unwrap()
+            .expect("new execution must exist");
+
+        assert_eq!(
+            new_exec.parent_execution_id.as_ref(),
+            Some(&old_eid),
+            "new execution must link to the old execution"
+        );
+        assert_eq!(
+            new_exec.segment_number, 1,
+            "new execution must have segment_number = 1"
+        );
+
+        let old_mat = jamjet_state::materialize(backend.as_ref(), &old_eid)
+            .await
+            .expect("materialize old execution");
+        assert_eq!(
+            new_exec.current_state, old_mat.current_state,
+            "new execution current_state must equal old execution's materialized current_state"
+        );
+
+        let new_item = backend
+            .claim_work_item("test-worker-2", &["default"])
+            .await
+            .unwrap()
+            .expect("new execution must have a claimable work item");
+        assert_eq!(
+            new_item.execution_id, new_eid,
+            "new work item must belong to the new segment execution"
+        );
+        assert_eq!(
+            new_item.node_id, "n1",
+            "new work item must target the start node"
+        );
+    }
+
+    /// With `continue_as_new: false`, budget ceiling must return Err (old behavior).
+    #[tokio::test]
+    async fn continue_as_new_false_keeps_old_terminate_behavior() {
+        let (backend, old_eid) = setup_budget_backend(false).await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("tool", Arc::new(BudgetTriggerExecutor));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        let result = worker.execute_item(item).await;
+        assert!(
+            result.is_err(),
+            "with continue_as_new=false, execute_item must return Err on budget ceiling"
+        );
+
+        let old_events = backend.get_events(&old_eid).await.unwrap();
+        let boundary_count = old_events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }))
+            .count();
+        assert_eq!(
+            boundary_count, 0,
+            "no SegmentBoundary event when continue_as_new=false"
+        );
+
+        let old_exec = backend
+            .get_execution(&old_eid)
+            .await
+            .unwrap()
+            .expect("old execution must still exist");
+        assert_ne!(
+            old_exec.status,
+            WorkflowStatus::LimitExceeded,
+            "old execution must NOT be LimitExceeded when continue_as_new=false"
+        );
+    }
+
+    /// Double-roll guard: a second work item for the OLD execution after a
+    /// successful rollover must not create a second new segment.
+    #[tokio::test]
+    async fn continue_as_new_double_roll_guard() {
+        let (backend, old_eid) = setup_budget_backend(true).await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("tool", Arc::new(BudgetTriggerExecutor));
+
+        // First rollover.
+        let item1 = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item1 must be claimable");
+        worker
+            .execute_item(item1)
+            .await
+            .expect("first rollover must succeed");
+
+        // Verify first rollover happened.
+        let old_events = backend.get_events(&old_eid).await.unwrap();
+        assert_eq!(
+            old_events
+                .iter()
+                .filter(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }))
+                .count(),
+            1,
+            "must have exactly one SegmentBoundary after first rollover"
+        );
+
+        // Simulate a second work item arriving for the OLD execution
+        // (e.g., crash-recovery re-enqueue scenario).
+        backend
+            .enqueue_work_item(jamjet_state::backend::WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: old_eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "seg-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 0,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        // Claim items until we find the OLD execution's second item.
+        let item2a = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        let item2_old = if item2a.execution_id != old_eid {
+            backend
+                .claim_work_item("test-worker", &["default"])
+                .await
+                .unwrap()
+                .expect("old execution's second item must be claimable")
+        } else {
+            item2a
+        };
+
+        assert_eq!(
+            item2_old.execution_id, old_eid,
+            "item2_old must belong to the OLD execution"
+        );
+
+        let result = worker.execute_item(item2_old).await;
+        assert!(
+            result.is_ok(),
+            "double-roll guard path must return Ok(()): {result:?}"
+        );
+
+        let old_events_after = backend.get_events(&old_eid).await.unwrap();
+        assert_eq!(
+            old_events_after
+                .iter()
+                .filter(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }))
+                .count(),
+            1,
+            "must still have exactly one SegmentBoundary event after double-roll attempt"
         );
     }
 }


### PR DESCRIPTION
## What

Track 2g of the ADK build. A long-running durable agent can now bound its event-log and replay growth by continuing as new: at its strategy ceiling, instead of terminating, it starts a fresh linked execution (segment N+1) seeded with the carried-forward state. Each segment is its own execution, so replay, idempotency, and step-counting stay scoped per segment and never accumulate across a long run.

## How

- **Model:** a new linked execution per segment (`parent_execution_id` + `segment_number` on `workflow_executions`, migration 0007), a `SegmentBoundary` event, and a `segment_chain` helper to walk the lineage. New executions are an already-understood primitive, so the event/snapshot/work-item read paths are unchanged.
- **Carry:** `start_next_segment` seeds the new execution with the prior segment's materialized state, byte-identical, via an at-sequence-zero seed snapshot so the continuation starts from the carried state and makes forward progress in its own sequence space.
- **Trigger:** a `continue_as_new` toggle on the workflow. When the strategy ceiling is hit, the worker rolls over instead of terminating (off by default, so existing behavior is unchanged).
- **Atomicity:** segment creation (execution row + seed snapshot + the two start events + the work item) happens in a single transaction, so a crash mid-creation rolls back entirely and never strands a continuation without a work item.

## Safety

This is durability-critical and got a thorough adversarial review, which caught and forced fixes for three real issues before merge:

- A crash window that could fork a run into two live segments, closed with a deterministic segment id and idempotent creation.
- Carried state being silently frozen on the SQLite backend (the in-memory test backend masked it), closed by seeding the child snapshot in its own sequence space, with a forward-progress regression test.
- A non-atomic creation path that could strand a continuation, closed with the single transaction above and a rollback test.

The bounded-replay test proves the point: a parent with 50 events rolls over to a child that replays just 2, independent of the parent's history.

## Caveats and follow-ups

- F-2g-timers: a timer bound to the old execution does not yet fire into the new segment (carry-over is future work). A late or parked commit on the old terminal segment is inert and does not leak into the new one (proven by test).
- F-2g-auto: an automatic rollover boundary independent of a strategy limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workflow continuation when a run hits its budget limit, creating a new segment instead of failing.
  * Added execution lineage tracking so related runs can be linked together and reviewed in order.
* **Bug Fixes**
  * Improved atomic creation of continued executions to avoid partial or inconsistent workflow records.
  * Updated worker behavior to prevent duplicate rollover attempts and preserve stable execution state.
* **Tests**
  * Expanded coverage for segment rollover, lineage, and backend consistency across storage implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->