### PR TITLE
feat(2h): async projector serves the approvals read from a durable projection

### DIFF
--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -159,6 +159,14 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move { scheduler.run().await });
     info!("Scheduler started");
 
+    // Spawn the async projector alongside the scheduler.  Maintains the durable
+    // proj_approvals read-model so the approvals endpoint serves from a projection
+    // instead of replaying the event log on every request.
+    // No shutdown signal wired today — matches the scheduler; follow-up: F-2h-shutdown.
+    let projector = jamjet_scheduler::Projector::new(state.backend.clone());
+    tokio::spawn(async move { projector.run().await });
+    info!("Projector started");
+
     // In dev mode (or when JAMJET_EMBED_WORKERS is set), run an in-process worker
     // pool so submitted workflows actually execute. In production, run dedicated
     // worker processes against the same state backend instead. The base backend

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -437,54 +437,72 @@ async fn list_approvals_for_execution(
     let backend = state.backend_for(&tenant_id);
     let execution_id = parse_execution_id(&id)?;
 
-    // Read from the durable projection (eventually-consistent; lags the write
-    // path by up to one projector tick, ~500 ms).  The write path (submit_approval
-    // in POST /executions/:id/approve) continues to use get_events() for strong
-    // consistency.  The response shape is byte-compatible with the legacy
-    // event-derived approvals_view: { "pending": [...], "decided": [...] }.
-    // Follow-up: F-2h-shutdown (projector graceful shutdown wiring).
+    // Fast path: serve from the durable projection (eventually-consistent; lags
+    // the write path by up to one projector tick, ~500 ms).
+    //
+    // Fallback to event-log replay when the projection is empty.  This covers:
+    // - Running executions not yet visited by the projector (no tick yet).
+    // - Terminal executions that completed before a projector tick (projector
+    //   only scans Running; their events were never folded into proj_approvals).
+    // - Non-default-tenant executions (the projector runs on the base backend
+    //   and writes proj_approvals with tenant_id='default'; reading via
+    //   backend_for(&tenant_id) returns nothing for the real tenant).
+    // - Genuinely-no-approval executions: event replay also returns empty, correct.
+    //
+    // Follow-up: F-2h-tenant (thread tenant into projector writes) + F-2h-terminal
+    // (project terminal executions) will close the coverage gap so the fallback
+    // shrinks to a thin cold-start edge case.
     let rows = backend.get_approval_projection(&execution_id).await?;
 
-    let mut pending: Vec<serde_json::Value> = Vec::new();
-    let mut decided: Vec<serde_json::Value> = Vec::new();
+    if !rows.is_empty() {
+        // Projection fast path: build the response from the durable read model.
+        let mut pending: Vec<serde_json::Value> = Vec::new();
+        let mut decided: Vec<serde_json::Value> = Vec::new();
 
-    for row in &rows {
-        match row.status.as_str() {
-            "pending" => {
-                pending.push(serde_json::json!({
-                    "node_id":   row.node_id,
-                    "tool_name": row.tool_name,
-                    "approver":  row.approver,
-                    "context":   row.context,
-                    "sequence":  row.last_sequence,
-                }));
-            }
-            "approved" => {
-                decided.push(serde_json::json!({
-                    "node_id":  row.node_id,
-                    "status":   "approved",
-                    "user_id":  row.user_id,
-                    "sequence": row.last_sequence,
-                }));
-            }
-            "rejected" => {
-                decided.push(serde_json::json!({
-                    "node_id":  row.node_id,
-                    "status":   "rejected",
-                    "user_id":  row.user_id,
-                    "comment":  row.comment,
-                    "sequence": row.last_sequence,
-                }));
-            }
-            _ => {
-                // Unknown status: skip rather than panic.
+        for row in &rows {
+            match row.status.as_str() {
+                "pending" => {
+                    pending.push(serde_json::json!({
+                        "node_id":   row.node_id,
+                        "tool_name": row.tool_name,
+                        "approver":  row.approver,
+                        "context":   row.context,
+                        "sequence":  row.last_sequence,
+                    }));
+                }
+                "approved" => {
+                    decided.push(serde_json::json!({
+                        "node_id":  row.node_id,
+                        "status":   "approved",
+                        "user_id":  row.user_id,
+                        "sequence": row.last_sequence,
+                    }));
+                }
+                "rejected" => {
+                    decided.push(serde_json::json!({
+                        "node_id":  row.node_id,
+                        "status":   "rejected",
+                        "user_id":  row.user_id,
+                        "comment":  row.comment,
+                        "sequence": row.last_sequence,
+                    }));
+                }
+                _ => {
+                    // Unknown status: skip rather than panic.
+                }
             }
         }
-    }
 
-    Ok(Json(
-        serde_json::json!({ "pending": pending, "decided": decided }),
-    ))
+        Ok(Json(
+            serde_json::json!({ "pending": pending, "decided": decided }),
+        ))
+    } else {
+        // Event-log fallback: guarantees the endpoint is never worse than before
+        // the projection switch (2h-3).  Covers unprojected, terminal, and
+        // non-default-tenant executions until F-2h-tenant + F-2h-terminal land.
+        let events = backend.get_events(&execution_id).await?;
+        Ok(Json(crate::approvals::approvals_view(&events)))
+    }
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -436,8 +436,55 @@ async fn list_approvals_for_execution(
 ) -> Result<Json<Value>, ApiError> {
     let backend = state.backend_for(&tenant_id);
     let execution_id = parse_execution_id(&id)?;
-    let events = backend.get_events(&execution_id).await?;
-    Ok(Json(crate::approvals::approvals_view(&events)))
+
+    // Read from the durable projection (eventually-consistent; lags the write
+    // path by up to one projector tick, ~500 ms).  The write path (submit_approval
+    // in POST /executions/:id/approve) continues to use get_events() for strong
+    // consistency.  The response shape is byte-compatible with the legacy
+    // event-derived approvals_view: { "pending": [...], "decided": [...] }.
+    // Follow-up: F-2h-shutdown (projector graceful shutdown wiring).
+    let rows = backend.get_approval_projection(&execution_id).await?;
+
+    let mut pending: Vec<serde_json::Value> = Vec::new();
+    let mut decided: Vec<serde_json::Value> = Vec::new();
+
+    for row in &rows {
+        match row.status.as_str() {
+            "pending" => {
+                pending.push(serde_json::json!({
+                    "node_id":   row.node_id,
+                    "tool_name": row.tool_name,
+                    "approver":  row.approver,
+                    "context":   row.context,
+                    "sequence":  row.last_sequence,
+                }));
+            }
+            "approved" => {
+                decided.push(serde_json::json!({
+                    "node_id":  row.node_id,
+                    "status":   "approved",
+                    "user_id":  row.user_id,
+                    "sequence": row.last_sequence,
+                }));
+            }
+            "rejected" => {
+                decided.push(serde_json::json!({
+                    "node_id":  row.node_id,
+                    "status":   "rejected",
+                    "user_id":  row.user_id,
+                    "comment":  row.comment,
+                    "sequence": row.last_sequence,
+                }));
+            }
+            _ => {
+                // Unknown status: skip rather than panic.
+            }
+        }
+    }
+
+    Ok(Json(
+        serde_json::json!({ "pending": pending, "decided": decided }),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/tests/approval_api.rs
+++ b/runtime/api/tests/approval_api.rs
@@ -544,3 +544,105 @@ async fn projection_driven_approvals_endpoint() {
         .expect("second tick");
     assert_eq!(resp2, 0, "second tick with no new events applies zero rows");
 }
+
+/// Finding A + B — event-log fallback: an execution that has approval events but
+/// whose projector tick has never run (projection table is empty) must NOT return
+/// an empty list.  The endpoint falls back to event-log replay.
+///
+/// This is the same code path exercised by:
+/// - Terminal executions (projector only scans Running status; terminal execs
+///   never get a row in proj_approvals).
+/// - Non-default-tenant executions (the projector writes proj_approvals with
+///   tenant_id='default'; reading via backend_for(&tenant) returns nothing).
+#[tokio::test]
+async fn list_approvals_fallback_when_not_yet_projected() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "gate").await;
+    let id_str = execution_id.to_string();
+
+    // No projector tick: proj_approvals is empty for this execution.
+    // The endpoint must fall back to event-log replay and return the pending approval.
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{id_str}/approvals"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    let pending = json["pending"]
+        .as_array()
+        .expect("pending must be an array");
+    assert_eq!(
+        pending.len(),
+        1,
+        "endpoint must return the pending approval via fallback when projection is empty"
+    );
+    assert_eq!(
+        pending[0]["node_id"], "gate",
+        "fallback must identify the correct node"
+    );
+    assert!(
+        pending[0]["tool_name"].is_string(),
+        "fallback must return tool_name from event log"
+    );
+    let decided = json["decided"]
+        .as_array()
+        .expect("decided must be an array");
+    assert_eq!(decided.len(), 0, "no decided approvals yet");
+}
+
+/// Finding A + B — projection fast path: once the projector has ticked, the
+/// endpoint serves from proj_approvals (not the event log).
+/// Both paths return the same JSON shape, so the response is byte-compatible.
+#[tokio::test]
+async fn list_approvals_fast_path_from_projection_after_tick() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "check").await;
+    let id_str = execution_id.to_string();
+
+    // Run a projector tick to populate proj_approvals.
+    let projector = Projector::new(backend.clone());
+    projector.tick().await.expect("projector tick");
+
+    // Projection is now populated: endpoint must serve from it (non-empty fast path).
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{id_str}/approvals"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    let pending = json["pending"]
+        .as_array()
+        .expect("pending must be an array");
+    assert_eq!(pending.len(), 1, "one pending approval from projection");
+    assert_eq!(pending[0]["node_id"], "check");
+    assert_eq!(
+        pending[0]["tool_name"], "tool_check",
+        "projection preserves tool_name from ToolApprovalRequired"
+    );
+    assert_eq!(
+        pending[0]["approver"], "human",
+        "projection preserves approver from ToolApprovalRequired"
+    );
+    let decided = json["decided"]
+        .as_array()
+        .expect("decided must be an array");
+    assert_eq!(decided.len(), 0, "no decided approvals");
+}

--- a/runtime/api/tests/approval_api.rs
+++ b/runtime/api/tests/approval_api.rs
@@ -11,8 +11,9 @@ use jamjet_agents::InMemoryAgentRegistry;
 use jamjet_api::{routes::build_router_with_opts, state::AppState};
 use jamjet_audit::{AuditEnricher, NoopAuditBackend};
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_scheduler::Projector;
 use jamjet_state::backend::StateBackend;
-use jamjet_state::event::EventKind;
+use jamjet_state::event::{ApprovalDecision, EventKind};
 use jamjet_state::{Event, InMemoryBackend};
 use serde_json::Value;
 use std::sync::Arc;
@@ -324,6 +325,11 @@ async fn list_approvals_shows_pending_then_decided() {
     seed_approval_required(&backend, &execution_id, "b").await;
     let id_str = execution_id.to_string();
 
+    // The endpoint now reads from the async projection.  Run a tick to
+    // fold the seeded events into the projection before querying.
+    let projector = Projector::new(backend.clone());
+    projector.tick().await.expect("projector tick 1");
+
     // GET /executions/:id/approvals — both pending.
     let resp = router
         .clone()
@@ -356,7 +362,7 @@ async fn list_approvals_shows_pending_then_decided() {
         assert!(p["approver"].is_string(), "pending entry missing approver");
     }
 
-    // Approve node "a".
+    // Approve node "a" via the write path (uses get_events for strong consistency).
     let approve_resp = router
         .clone()
         .oneshot(
@@ -368,6 +374,9 @@ async fn list_approvals_shows_pending_then_decided() {
         .await
         .unwrap();
     assert_eq!(approve_resp.status(), StatusCode::OK);
+
+    // Fold the new ApprovalReceived event into the projection.
+    projector.tick().await.expect("projector tick 2");
 
     // GET again — "a" decided, "b" still pending.
     let resp2 = router
@@ -423,4 +432,115 @@ async fn approve_on_terminal_execution_returns_409() {
         error.contains("Cancelled"),
         "expected terminal status in error, got: {error}"
     );
+}
+
+/// Verify the projection-driven GET /executions/:id/approvals endpoint:
+/// seed approval events, run a projector tick, assert the response shape
+/// matches what the events imply (node, latest status, user, comment, tool_name).
+/// Also covers a Rejected outcome and the "pending" pending-metadata fields
+/// (tool_name, approver) that the legacy approvals_view always returned.
+#[tokio::test]
+async fn projection_driven_approvals_endpoint() {
+    let state = make_state();
+    let backend = state.backend.clone();
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+
+    // Seed: node "gate" gets ToolApprovalRequired, then ApprovalReceived(Rejected).
+    // node "check" stays pending (only ToolApprovalRequired, no decision yet).
+    let seq = backend.latest_sequence(&execution_id).await.unwrap();
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq + 1,
+            EventKind::ToolApprovalRequired {
+                node_id: "gate".into(),
+                tool_name: "run_payment".into(),
+                approver: "compliance".into(),
+                context: serde_json::json!({"amount": 5000}),
+            },
+        ))
+        .await
+        .unwrap();
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq + 2,
+            EventKind::ApprovalReceived {
+                node_id: "gate".into(),
+                user_id: "carol".into(),
+                decision: ApprovalDecision::Rejected,
+                comment: Some("exceeds limit".into()),
+                state_patch: None,
+            },
+        ))
+        .await
+        .unwrap();
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq + 3,
+            EventKind::ToolApprovalRequired {
+                node_id: "check".into(),
+                tool_name: "verify_id".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Run a projector tick to fold events into the projection.
+    let projector = Projector::new(backend.clone());
+    projector.tick().await.expect("projector tick must succeed");
+
+    // Call the endpoint — now served from the projection.
+    let id_str = execution_id.to_string();
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{id_str}/approvals"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+
+    // "check" is pending; "gate" is decided (rejected).
+    let pending = json["pending"]
+        .as_array()
+        .expect("pending must be an array");
+    assert_eq!(pending.len(), 1, "one node still pending");
+    let p = &pending[0];
+    assert_eq!(p["node_id"], "check");
+    assert_eq!(
+        p["tool_name"], "verify_id",
+        "tool_name must be preserved in projection"
+    );
+    assert_eq!(
+        p["approver"], "human",
+        "approver must be preserved in projection"
+    );
+    assert!(p["sequence"].is_number(), "sequence must be present");
+
+    let decided = json["decided"]
+        .as_array()
+        .expect("decided must be an array");
+    assert_eq!(decided.len(), 1, "one node decided");
+    let d = &decided[0];
+    assert_eq!(d["node_id"], "gate");
+    assert_eq!(d["status"], "rejected");
+    assert_eq!(d["user_id"], "carol");
+    assert_eq!(d["comment"], "exceeds limit");
+    assert!(d["sequence"].is_number(), "sequence must be present");
+
+    // Second tick with no new events: idempotent — response unchanged.
+    let resp2 = Projector::new(backend.clone())
+        .tick()
+        .await
+        .expect("second tick");
+    assert_eq!(resp2, 0, "second tick with no new events applies zero rows");
 }

--- a/runtime/scheduler/src/lib.rs
+++ b/runtime/scheduler/src/lib.rs
@@ -7,7 +7,9 @@
 //! 4. Handle retry scheduling on node failure
 //! 5. Wake suspended executions on timer/external-event
 
+pub mod projector;
 pub mod runner;
 pub mod strategy_bridge;
 
+pub use projector::Projector;
 pub use runner::{Scheduler, SchedulerConfig};

--- a/runtime/scheduler/src/projector.rs
+++ b/runtime/scheduler/src/projector.rs
@@ -2,22 +2,34 @@
 //! `proj_approvals` read-model keyed by `(execution_id, node_id)`.
 //!
 //! The projector runs as a background task alongside the scheduler.  Each tick
-//! it: loads all running executions; for each, reads events since its
-//! per-execution checkpoint; folds approval events into the projection (last-
-//! write-wins per node); and advances the checkpoint to the maximum event
-//! sequence seen in the batch regardless of whether any approval rows changed.
-//! This ensures non-approval events do not stall the cursor.
+//! it: paginates over all running executions (avoiding the 100-execution cap);
+//! for each, reads events since its per-execution checkpoint; folds approval
+//! events into the projection using first-decision-wins semantics (matching the
+//! runtime's canonical fold in `approvals.rs`); seeds prior-tick state from the
+//! existing projection so a cross-tick late decision cannot overwrite a decided
+//! node; and advances the checkpoint atomically with ALL changed rows in a
+//! single transaction (via `apply_approval_projection_batch`).
 //!
-//! Crash-safe: the UPSERT and checkpoint advance happen in one transaction
-//! inside `apply_approval_projection`.  A restart re-reads only the delta
-//! since the durable checkpoint.
+//! # Invariants
+//!
+//! - **Atomicity**: the checkpoint advances IFF every changed row in the batch
+//!   committed.  A crash before `commit()` leaves both rows and checkpoint
+//!   unchanged; the next tick re-reads the same events and re-applies.
+//!
+//! - **First-decision-wins**: an `ApprovalReceived` event only transitions a
+//!   node that is currently `"pending"`.  A node that is already `"approved"`
+//!   or `"rejected"` cannot be overwritten by a later decision.  Orphan
+//!   `ApprovalReceived` events (no prior `ToolApprovalRequired`) are ignored.
+//!
+//! - **Full coverage**: `tick()` paginates over all Running executions so the
+//!   100-row default limit cannot silently drop executions beyond the first page.
 
 use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
 use jamjet_state::{
     backend::{ApprovalProjectionRow, BackendResult, StateBackend},
     event::{ApprovalDecision, EventKind},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::warn;
@@ -37,38 +49,67 @@ impl Projector {
 
     /// One projection pass over all running executions.
     ///
-    /// Returns the total number of approval rows written (for tests and
-    /// monitoring).  Non-approval events are consumed and the checkpoint is
-    /// advanced past them, but they do not contribute to the returned count.
+    /// Paginates over Running executions so the 100-row page limit does not
+    /// silently cap coverage.  Returns the total number of approval rows
+    /// written (for tests and monitoring).  Non-approval events are consumed
+    /// and the checkpoint is advanced past them, but they do not contribute to
+    /// the returned count.  Per-execution errors are logged and skipped so a
+    /// single bad execution does not abort the whole tick.
     pub async fn tick(&self) -> BackendResult<usize> {
-        let executions = self
-            .backend
-            .list_executions(Some(WorkflowStatus::Running), 100, 0)
-            .await?;
-
+        let page_size: u32 = 100;
+        let mut offset: u32 = 0;
         let mut total_applied = 0usize;
 
-        for exec in executions {
-            match self.project_execution(&exec.execution_id).await {
-                Ok(n) => total_applied += n,
-                Err(e) => {
-                    warn!(
-                        execution_id = %exec.execution_id,
-                        "Projector: error projecting execution: {e}"
-                    );
+        loop {
+            let page = self
+                .backend
+                .list_executions(Some(WorkflowStatus::Running), page_size, offset)
+                .await?;
+            let page_len = page.len();
+
+            for exec in page {
+                match self.project_execution(&exec.execution_id).await {
+                    Ok(n) => total_applied += n,
+                    Err(e) => {
+                        warn!(
+                            execution_id = %exec.execution_id,
+                            "Projector: error projecting execution: {e}"
+                        );
+                    }
                 }
             }
+
+            if (page_len as u32) < page_size {
+                break;
+            }
+            offset += page_len as u32;
         }
 
         Ok(total_applied)
     }
 
     /// Project a single execution: fetch the event delta, fold approval events,
-    /// and advance the checkpoint to the batch maximum.
+    /// and advance the checkpoint to the batch maximum atomically with all
+    /// changed rows.
     ///
-    /// The checkpoint always reaches `batch_max` whether or not approval rows
-    /// changed — preventing both re-scan (stale cursor) and skip (approval
-    /// after a non-approval tail).
+    /// ### Fold semantics (first-decision-wins, matching `approvals.rs`)
+    ///
+    /// 1. Seed the working node-state from the existing projection
+    ///    (`get_approval_projection`).  This means prior-tick decisions are
+    ///    visible during the fold and cannot be overwritten.
+    /// 2. For each new event in sequence order:
+    ///    - `ToolApprovalRequired` → set node to `"pending"` with
+    ///      tool/approver/context metadata.
+    ///    - `ApprovalReceived` → only if the node is currently `"pending"`,
+    ///      set to `"approved"` / `"rejected"`.  If the node is already
+    ///      decided (or never requested — orphan), ignore the event.
+    /// 3. Emit only the rows for nodes actually modified in this batch.
+    ///
+    /// ### Atomicity
+    ///
+    /// `apply_approval_projection_batch` writes all changed rows AND the
+    /// checkpoint in one `BEGIN IMMEDIATE` transaction.  If the process crashes
+    /// mid-batch, the next tick re-reads from the old checkpoint and re-applies.
     async fn project_execution(&self, execution_id: &ExecutionId) -> BackendResult<usize> {
         let cp = self
             .backend
@@ -84,8 +125,17 @@ impl Projector {
         // Safety: events is non-empty so max() is Some.
         let batch_max = events.iter().map(|e| e.sequence).max().unwrap();
 
-        // Fold approval events (last-write-wins per node_id, ordered by seq).
-        let mut node_map: HashMap<String, ApprovalProjectionRow> = HashMap::new();
+        // Seed working state from the existing projection so prior-tick
+        // decisions are visible during the fold (first-decision-wins across
+        // ticks).
+        let existing = self.backend.get_approval_projection(execution_id).await?;
+        let mut node_map: HashMap<String, ApprovalProjectionRow> = existing
+            .into_iter()
+            .map(|r| (r.node_id.clone(), r))
+            .collect();
+
+        // Track nodes modified in this batch (these are the rows to write).
+        let mut touched: HashSet<String> = HashSet::new();
 
         for event in &events {
             match &event.kind {
@@ -95,6 +145,7 @@ impl Projector {
                     approver,
                     context,
                 } => {
+                    touched.insert(node_id.clone());
                     node_map.insert(
                         node_id.clone(),
                         ApprovalProjectionRow {
@@ -117,26 +168,39 @@ impl Projector {
                     comment,
                     ..
                 } => {
-                    let status = match decision {
-                        ApprovalDecision::Approved => "approved",
-                        ApprovalDecision::Rejected => "rejected",
-                    };
-                    // Pending metadata (tool_name/approver/context) is cleared on
-                    // resolution — the node is no longer waiting for a decision.
-                    node_map.insert(
-                        node_id.clone(),
-                        ApprovalProjectionRow {
-                            execution_id: execution_id.clone(),
-                            node_id: node_id.clone(),
-                            status: status.into(),
-                            user_id: Some(user_id.clone()),
-                            comment: comment.clone(),
-                            last_sequence: event.sequence,
-                            tool_name: None,
-                            approver: None,
-                            context: None,
-                        },
-                    );
+                    // First-decision-wins: only transition a node that is
+                    // currently pending.  A decided node (approved / rejected)
+                    // and an orphan (never requested) are both ignored.
+                    let currently_pending = node_map
+                        .get(node_id)
+                        .map(|r| r.status == "pending")
+                        .unwrap_or(false);
+
+                    if currently_pending {
+                        touched.insert(node_id.clone());
+                        let status = match decision {
+                            ApprovalDecision::Approved => "approved",
+                            ApprovalDecision::Rejected => "rejected",
+                        };
+                        // Pending metadata (tool_name/approver/context) is
+                        // cleared on resolution — the node is no longer
+                        // waiting for a decision.
+                        node_map.insert(
+                            node_id.clone(),
+                            ApprovalProjectionRow {
+                                execution_id: execution_id.clone(),
+                                node_id: node_id.clone(),
+                                status: status.into(),
+                                user_id: Some(user_id.clone()),
+                                comment: comment.clone(),
+                                last_sequence: event.sequence,
+                                tool_name: None,
+                                approver: None,
+                                context: None,
+                            },
+                        );
+                    }
+                    // else: orphan or already-decided → ignore.
                 }
                 _ => {
                     // Non-approval event: ignored for content, but the cursor
@@ -145,20 +209,28 @@ impl Projector {
             }
         }
 
-        if !node_map.is_empty() {
-            let count = node_map.len();
-            for row in node_map.into_values() {
-                // apply_approval_projection atomically UPSERTs the row AND sets
-                // the checkpoint to batch_max.  For the second and later rows in
-                // the same batch the checkpoint write is idempotent (same value).
-                self.backend
-                    .apply_approval_projection(row, "approvals", batch_max)
-                    .await?;
-            }
+        // Collect only the rows that were modified in this batch.
+        let rows_to_write: Vec<ApprovalProjectionRow> = touched
+            .iter()
+            .filter_map(|node_id| node_map.remove(node_id))
+            .collect();
+
+        if !rows_to_write.is_empty() {
+            let count = rows_to_write.len();
+            // Atomic: all rows + checkpoint in one transaction.
+            self.backend
+                .apply_approval_projection_batch(
+                    rows_to_write,
+                    "approvals",
+                    execution_id,
+                    batch_max,
+                )
+                .await?;
             Ok(count)
         } else {
-            // Batch had events but none were approval events.  Advance the
-            // checkpoint only so this tail is not re-scanned next tick.
+            // Batch had events but none produced approval changes (all
+            // non-approval, all orphan decisions, or all late post-decision
+            // events).  Advance the checkpoint so this tail is not re-scanned.
             self.backend
                 .set_projector_checkpoint("approvals", execution_id, batch_max)
                 .await?;
@@ -264,11 +336,10 @@ mod tests {
     }
 
     /// Test 1: ToolApprovalRequired followed by ApprovalReceived(Approved) for the
-    /// same node.  Projector must surface the LAST event (last-write-wins) as
-    /// "approved", advance the checkpoint to the max sequence, and be idempotent
-    /// on a second tick.
+    /// same node in the same tick.  First-decision-wins within a batch: approved
+    /// wins; checkpoint advances to max sequence; second tick is a no-op.
     #[tokio::test]
-    async fn last_write_wins_and_checkpoint_idempotent() {
+    async fn approved_beats_prior_pending_and_checkpoint_idempotent() {
         let backend = Arc::new(InMemoryBackend::new());
         let exec = ExecutionId::new();
         backend
@@ -299,7 +370,7 @@ mod tests {
         assert_eq!(rows[0].node_id, "nodeA");
         assert_eq!(
             rows[0].status, "approved",
-            "last-write-wins: granted overrides pending"
+            "approved overrides pending within the same batch"
         );
         assert_eq!(rows[0].user_id.as_deref(), Some("alice"));
 
@@ -324,10 +395,11 @@ mod tests {
         assert_eq!(rows2, rows, "projection unchanged after idle tick");
     }
 
-    /// Test 2: After an Approved row, appending an ApprovalReceived(Rejected)
-    /// updates the same node to "rejected" and advances the checkpoint.
+    /// Test 2 (first-decision-wins, cross-tick): nodeA is approved in tick 1.
+    /// A late Rejected event arriving in tick 2 must be ignored — the earlier
+    /// approved decision stands.  The checkpoint still advances.
     #[tokio::test]
-    async fn denied_overwrites_approved() {
+    async fn late_decision_ignored_after_first_approval() {
         let backend = Arc::new(InMemoryBackend::new());
         let exec = ExecutionId::new();
         backend
@@ -350,8 +422,9 @@ mod tests {
             .unwrap();
 
         let projector = Projector::new(backend.clone());
-        projector.tick().await.unwrap();
+        projector.tick().await.unwrap(); // Tick 1: nodeA approved.
 
+        // Late rejection arrives after the first decision.
         let seq_rejected = backend
             .append_event(ev_approval_received(
                 &exec,
@@ -362,22 +435,31 @@ mod tests {
             .await
             .unwrap();
 
+        // Tick 2: the late rejection is ignored because nodeA is already decided.
         let applied = projector.tick().await.unwrap();
-        assert_eq!(applied, 1, "one row updated to rejected");
+        assert_eq!(
+            applied, 0,
+            "late rejection ignored: nodeA already approved (first-decision-wins)"
+        );
 
         let rows = backend.get_approval_projection(&exec).await.unwrap();
         assert_eq!(rows.len(), 1, "still exactly one row (upsert)");
-        assert_eq!(rows[0].status, "rejected");
-        assert_eq!(rows[0].user_id.as_deref(), Some("bob"));
+        assert_eq!(
+            rows[0].status, "approved",
+            "approved must not be overwritten"
+        );
+        assert_eq!(
+            rows[0].user_id.as_deref(),
+            Some("alice"),
+            "alice's approval stands"
+        );
 
+        // Checkpoint still advances past the ignored event.
         let cp = backend
             .get_projector_checkpoint("approvals", &exec)
             .await
             .unwrap();
-        assert_eq!(
-            cp, seq_rejected,
-            "checkpoint advanced to rejected event seq"
-        );
+        assert_eq!(cp, seq_rejected, "checkpoint advances past the late event");
     }
 
     /// Test 3: A batch where the highest-sequence events are NON-approval events
@@ -407,7 +489,7 @@ mod tests {
         let applied = projector.tick().await.unwrap();
 
         // node_map has nodeA (pending from ToolApprovalRequired).
-        // batch_max = seq_completed; apply_approval_projection advances checkpoint there.
+        // batch_max = seq_completed; apply_approval_projection_batch advances checkpoint there.
         assert_eq!(applied, 1, "pending row written");
 
         let rows = backend.get_approval_projection(&exec).await.unwrap();
@@ -577,7 +659,9 @@ mod tests {
             .find(|r| r.node_id == "nodeB")
             .expect("nodeB must be added by the restart tick");
 
-        // nodeA was NOT re-read: still approved (seq 1..N excluded by checkpoint).
+        // nodeA was NOT re-read from events: still approved (seq 1..N excluded by
+        // checkpoint).  The seeded state from get_approval_projection confirmed its
+        // "approved" status and the late-rejection path correctly ignored it.
         assert_eq!(row_a.status, "approved", "nodeA must not be re-processed");
         assert_eq!(row_a.user_id.as_deref(), Some("alice"));
 
@@ -675,13 +759,12 @@ mod tests {
     ///   - nodeC (Requested only): status="pending", tool_name and approver
     ///     preserved from the ToolApprovalRequired event.
     ///
-    /// Crash-mid-apply safety note: `apply_approval_projection` and the checkpoint
-    /// advance share one SQLite transaction (proven by the 2h-1 atomic tests in
-    /// state/tests/projector.rs).  A checkpoint can therefore never be observed as
-    /// advanced past an unapplied approval row — it is structurally impossible to
-    /// land in a state where the checkpoint says "seq N processed" but the row for
-    /// that seq is absent from proj_approvals.  Rely on that atomic test rather
-    /// than duplicating a forced-failure scenario here.
+    /// Crash-mid-apply safety note: `apply_approval_projection_batch` and the
+    /// checkpoint advance share one SQLite transaction (proven by the 2h-1
+    /// atomic tests in state/tests/projector.rs).  A checkpoint can therefore
+    /// never be observed as advanced past an unapplied approval row — it is
+    /// structurally impossible to land in a state where the checkpoint says
+    /// "seq N processed" but the row for that seq is absent from proj_approvals.
     #[tokio::test]
     async fn read_fidelity_three_node_abc() {
         let backend = Arc::new(InMemoryBackend::new());
@@ -777,5 +860,258 @@ mod tests {
             "pending row must preserve approver from ToolApprovalRequired event"
         );
         assert!(row_c.user_id.is_none(), "pending row has no user_id");
+    }
+
+    // ── C1: batch atomicity ───────────────────────────────────────────────────
+
+    /// C1: A batch with 3 Required events (nodes A, B, C) in one tick must write
+    /// all 3 rows and advance the checkpoint to batch_max in one atomic apply.
+    ///
+    /// The single-transaction guarantee means a crash mid-batch leaves NO rows
+    /// committed and the checkpoint un-advanced; the next tick re-reads the same
+    /// events and re-applies correctly.  (The happy-path here proves the all-3
+    /// case; the rollback guarantee is structural — one `BEGIN IMMEDIATE` in
+    /// `apply_approval_projection_batch`.)
+    #[tokio::test]
+    async fn batch_atomic_three_nodes_all_committed() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        let _seq_a = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        let _seq_b = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeB"))
+            .await
+            .unwrap();
+        let seq_c = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeC"))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.expect("tick must succeed");
+        assert_eq!(applied, 3, "all 3 nodes written in one atomic batch apply");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 3, "all 3 rows present after batch apply");
+
+        let node_ids: Vec<&str> = rows.iter().map(|r| r.node_id.as_str()).collect();
+        assert!(node_ids.contains(&"nodeA"), "nodeA must be in projection");
+        assert!(node_ids.contains(&"nodeB"), "nodeB must be in projection");
+        assert!(node_ids.contains(&"nodeC"), "nodeC must be in projection");
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp, seq_c,
+            "checkpoint == batch_max: all rows + checkpoint committed atomically"
+        );
+    }
+
+    // ── I2: pagination ────────────────────────────────────────────────────────
+
+    /// I2: Create 105 Running executions (> one 100-row page) each with a pending
+    /// approval.  A single tick() must project ALL 105; none dropped due to the
+    /// old hard-coded limit=100,offset=0 query.
+    #[tokio::test]
+    async fn pagination_covers_more_than_100_running_executions() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let count = 105usize;
+        let mut exec_ids = Vec::with_capacity(count);
+
+        for _ in 0..count {
+            let exec = ExecutionId::new();
+            backend
+                .create_execution(running_execution(&exec))
+                .await
+                .unwrap();
+            backend
+                .append_event(ev_tool_approval_required(&exec, "nodeA"))
+                .await
+                .unwrap();
+            exec_ids.push(exec);
+        }
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.expect("tick must succeed");
+        assert_eq!(
+            applied, count,
+            "all {count} executions must be projected (pagination works)"
+        );
+
+        // Verify every execution individually has its row.
+        let mut missing = 0usize;
+        for exec in &exec_ids {
+            let rows = backend.get_approval_projection(exec).await.unwrap();
+            if rows.is_empty() {
+                missing += 1;
+            }
+        }
+        assert_eq!(
+            missing, 0,
+            "every execution must have a projected row — {missing} were missing"
+        );
+    }
+
+    // ── I3: first-decision-wins ───────────────────────────────────────────────
+
+    /// I3a: Required(s1) + Approved-alice(s2) + Rejected-bob(s3) in one tick →
+    /// projection shows approved/alice (first decision wins within batch).
+    #[tokio::test]
+    async fn first_decision_wins_approved_beats_same_tick_rejection() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+        let seq_last = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "bob",
+                ApprovalDecision::Rejected,
+            ))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.expect("tick must succeed");
+        assert_eq!(applied, 1, "exactly one row written");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].status, "approved",
+            "first decision wins: approved/alice beats rejected/bob"
+        );
+        assert_eq!(rows[0].user_id.as_deref(), Some("alice"));
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp, seq_last,
+            "checkpoint advances to batch_max even though last event was ignored"
+        );
+    }
+
+    /// I3b: Orphan ApprovalReceived (no prior ToolApprovalRequired) must not
+    /// create a projection row.  The checkpoint still advances.
+    #[tokio::test]
+    async fn orphan_approval_received_creates_no_row() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        let seq = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.expect("tick must succeed");
+        assert_eq!(applied, 0, "orphan ApprovalReceived must not create a row");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert!(rows.is_empty(), "no projection rows for orphan decision");
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp, seq, "checkpoint still advances past orphan event");
+    }
+
+    /// I3c: Decision split across two ticks — Required+Approved in tick 1, a late
+    /// Rejected in tick 2.  Projection stays approved (seed-from-existing-projection
+    /// path: nodeA is "approved" at tick-2 seed time, so the Rejected is ignored).
+    #[tokio::test]
+    async fn cross_tick_first_decision_wins_stays_approved() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        projector.tick().await.unwrap(); // Tick 1: nodeA approved.
+
+        // Late rejection arrives in a separate tick.
+        let seq_late = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "bob",
+                ApprovalDecision::Rejected,
+            ))
+            .await
+            .unwrap();
+
+        let applied = projector.tick().await.expect("tick 2 must succeed");
+        assert_eq!(
+            applied, 0,
+            "late rejection ignored: nodeA already decided in prior tick"
+        );
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].status, "approved",
+            "nodeA stays approved after cross-tick late rejection"
+        );
+        assert_eq!(rows[0].user_id.as_deref(), Some("alice"));
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp, seq_late, "checkpoint advances past the ignored event");
     }
 }

--- a/runtime/scheduler/src/projector.rs
+++ b/runtime/scheduler/src/projector.rs
@@ -1,0 +1,458 @@
+//! Async approval projector — consumes the event log and maintains a durable
+//! `proj_approvals` read-model keyed by `(execution_id, node_id)`.
+//!
+//! The projector runs as a background task alongside the scheduler.  Each tick
+//! it: loads all running executions; for each, reads events since its
+//! per-execution checkpoint; folds approval events into the projection (last-
+//! write-wins per node); and advances the checkpoint to the maximum event
+//! sequence seen in the batch regardless of whether any approval rows changed.
+//! This ensures non-approval events do not stall the cursor.
+//!
+//! Crash-safe: the UPSERT and checkpoint advance happen in one transaction
+//! inside `apply_approval_projection`.  A restart re-reads only the delta
+//! since the durable checkpoint.
+
+use jamjet_core::workflow::{ExecutionId, WorkflowStatus};
+use jamjet_state::{
+    backend::{ApprovalProjectionRow, BackendResult, StateBackend},
+    event::{ApprovalDecision, EventKind},
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::warn;
+
+/// Async read-model projector.
+///
+/// Maintains the `proj_approvals` projection by tailing each running
+/// execution's event log and folding approval events into durable rows.
+pub struct Projector {
+    backend: Arc<dyn StateBackend>,
+}
+
+impl Projector {
+    pub fn new(backend: Arc<dyn StateBackend>) -> Self {
+        Self { backend }
+    }
+
+    /// One projection pass over all running executions.
+    ///
+    /// Returns the total number of approval rows written (for tests and
+    /// monitoring).  Non-approval events are consumed and the checkpoint is
+    /// advanced past them, but they do not contribute to the returned count.
+    pub async fn tick(&self) -> BackendResult<usize> {
+        let executions = self
+            .backend
+            .list_executions(Some(WorkflowStatus::Running), 100, 0)
+            .await?;
+
+        let mut total_applied = 0usize;
+
+        for exec in executions {
+            match self.project_execution(&exec.execution_id).await {
+                Ok(n) => total_applied += n,
+                Err(e) => {
+                    warn!(
+                        execution_id = %exec.execution_id,
+                        "Projector: error projecting execution: {e}"
+                    );
+                }
+            }
+        }
+
+        Ok(total_applied)
+    }
+
+    /// Project a single execution: fetch the event delta, fold approval events,
+    /// and advance the checkpoint to the batch maximum.
+    ///
+    /// The checkpoint always reaches `batch_max` whether or not approval rows
+    /// changed — preventing both re-scan (stale cursor) and skip (approval
+    /// after a non-approval tail).
+    async fn project_execution(&self, execution_id: &ExecutionId) -> BackendResult<usize> {
+        let cp = self
+            .backend
+            .get_projector_checkpoint("approvals", execution_id)
+            .await?;
+
+        let events = self.backend.get_events_since(execution_id, cp).await?;
+
+        if events.is_empty() {
+            return Ok(0);
+        }
+
+        // Safety: events is non-empty so max() is Some.
+        let batch_max = events.iter().map(|e| e.sequence).max().unwrap();
+
+        // Fold approval events (last-write-wins per node_id, ordered by seq).
+        let mut node_map: HashMap<String, ApprovalProjectionRow> = HashMap::new();
+
+        for event in &events {
+            match &event.kind {
+                EventKind::ToolApprovalRequired { node_id, .. } => {
+                    node_map.insert(
+                        node_id.clone(),
+                        ApprovalProjectionRow {
+                            execution_id: execution_id.clone(),
+                            node_id: node_id.clone(),
+                            status: "pending".into(),
+                            user_id: None,
+                            comment: None,
+                            last_sequence: event.sequence,
+                        },
+                    );
+                }
+                EventKind::ApprovalReceived {
+                    node_id,
+                    user_id,
+                    decision,
+                    comment,
+                    ..
+                } => {
+                    let status = match decision {
+                        ApprovalDecision::Approved => "approved",
+                        ApprovalDecision::Rejected => "rejected",
+                    };
+                    node_map.insert(
+                        node_id.clone(),
+                        ApprovalProjectionRow {
+                            execution_id: execution_id.clone(),
+                            node_id: node_id.clone(),
+                            status: status.into(),
+                            user_id: Some(user_id.clone()),
+                            comment: comment.clone(),
+                            last_sequence: event.sequence,
+                        },
+                    );
+                }
+                _ => {
+                    // Non-approval event: ignored for content, but the cursor
+                    // still advances to batch_max below so it is not re-scanned.
+                }
+            }
+        }
+
+        if !node_map.is_empty() {
+            let count = node_map.len();
+            for row in node_map.into_values() {
+                // apply_approval_projection atomically UPSERTs the row AND sets
+                // the checkpoint to batch_max.  For the second and later rows in
+                // the same batch the checkpoint write is idempotent (same value).
+                self.backend
+                    .apply_approval_projection(row, "approvals", batch_max)
+                    .await?;
+            }
+            Ok(count)
+        } else {
+            // Batch had events but none were approval events.  Advance the
+            // checkpoint only so this tail is not re-scanned next tick.
+            self.backend
+                .set_projector_checkpoint("approvals", execution_id, batch_max)
+                .await?;
+            Ok(0)
+        }
+    }
+
+    /// Background loop: tick then sleep 500 ms, forever.
+    ///
+    /// Mirrors the scheduler's cadence.  There is no graceful-shutdown wiring
+    /// today (follow-up: F-2h-shutdown).
+    pub async fn run(self) {
+        loop {
+            if let Err(e) = self.tick().await {
+                warn!("Projector tick error: {e}");
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+    use jamjet_state::{
+        backend::StateBackend,
+        event::{ApprovalDecision, Event, EventKind},
+        InMemoryBackend,
+    };
+    use serde_json::json;
+
+    fn running_execution(id: &ExecutionId) -> WorkflowExecution {
+        let now = Utc::now();
+        WorkflowExecution {
+            execution_id: id.clone(),
+            workflow_id: "wf-projector-test".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        }
+    }
+
+    fn ev_tool_approval_required(exec: &ExecutionId, node: &str) -> Event {
+        Event::new(
+            exec.clone(),
+            0, // sequence overwritten by InMemoryBackend::append_event
+            EventKind::ToolApprovalRequired {
+                node_id: node.into(),
+                tool_name: format!("tool_{node}"),
+                approver: "human".into(),
+                context: json!({}),
+            },
+        )
+    }
+
+    fn ev_approval_received(
+        exec: &ExecutionId,
+        node: &str,
+        user: &str,
+        decision: ApprovalDecision,
+    ) -> Event {
+        Event::new(
+            exec.clone(),
+            0,
+            EventKind::ApprovalReceived {
+                node_id: node.into(),
+                user_id: user.into(),
+                decision,
+                comment: None,
+                state_patch: None,
+            },
+        )
+    }
+
+    fn ev_node_completed(exec: &ExecutionId, node: &str) -> Event {
+        Event::new(
+            exec.clone(),
+            0,
+            EventKind::NodeCompleted {
+                node_id: node.into(),
+                output: json!({}),
+                state_patch: json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+                cost_usd: None,
+                provenance: None,
+                idempotency_key: None,
+            },
+        )
+    }
+
+    /// Test 1: ToolApprovalRequired followed by ApprovalReceived(Approved) for the
+    /// same node.  Projector must surface the LAST event (last-write-wins) as
+    /// "approved", advance the checkpoint to the max sequence, and be idempotent
+    /// on a second tick.
+    #[tokio::test]
+    async fn last_write_wins_and_checkpoint_idempotent() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        let _seq_req = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        let seq_grant = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.expect("first tick must succeed");
+        assert_eq!(applied, 1, "one approval row written");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 1, "exactly one projected row");
+        assert_eq!(rows[0].node_id, "nodeA");
+        assert_eq!(
+            rows[0].status, "approved",
+            "last-write-wins: granted overrides pending"
+        );
+        assert_eq!(rows[0].user_id.as_deref(), Some("alice"));
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp, seq_grant, "checkpoint at max sequence in batch");
+
+        // Second tick: no new events → 0 applied, checkpoint stable.
+        let applied2 = projector.tick().await.expect("second tick must succeed");
+        assert_eq!(applied2, 0, "second tick is a no-op");
+
+        let cp2 = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp2, seq_grant, "checkpoint unchanged after idle tick");
+
+        // Row unchanged too.
+        let rows2 = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows2, rows, "projection unchanged after idle tick");
+    }
+
+    /// Test 2: After an Approved row, appending an ApprovalReceived(Rejected)
+    /// updates the same node to "rejected" and advances the checkpoint.
+    #[tokio::test]
+    async fn denied_overwrites_approved() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        projector.tick().await.unwrap();
+
+        let seq_rejected = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "bob",
+                ApprovalDecision::Rejected,
+            ))
+            .await
+            .unwrap();
+
+        let applied = projector.tick().await.unwrap();
+        assert_eq!(applied, 1, "one row updated to rejected");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 1, "still exactly one row (upsert)");
+        assert_eq!(rows[0].status, "rejected");
+        assert_eq!(rows[0].user_id.as_deref(), Some("bob"));
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp, seq_rejected,
+            "checkpoint advanced to rejected event seq"
+        );
+    }
+
+    /// Test 3: A batch where the highest-sequence events are NON-approval events
+    /// (NodeCompleted appended after ToolApprovalRequired).  The checkpoint must
+    /// advance to the non-approval tail seq (batch_max), and a second tick must
+    /// NOT re-scan or re-apply the approval event.
+    #[tokio::test]
+    async fn non_approval_tail_advances_checkpoint_no_rescan() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        // Approval at seq S1; non-approval at seq S2 > S1.
+        let _seq_req = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        let seq_completed = backend
+            .append_event(ev_node_completed(&exec, "nodeA"))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.unwrap();
+
+        // node_map has nodeA (pending from ToolApprovalRequired).
+        // batch_max = seq_completed; apply_approval_projection advances checkpoint there.
+        assert_eq!(applied, 1, "pending row written");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, "pending");
+
+        // KEY: checkpoint is at seq_completed (batch_max), NOT at the approval seq.
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp, seq_completed,
+            "checkpoint must equal batch_max (non-approval tail seq)"
+        );
+
+        // Second tick: get_events_since(exec, seq_completed) = [] → no re-scan.
+        let applied2 = projector.tick().await.unwrap();
+        assert_eq!(applied2, 0, "no re-scan after non-approval tail");
+
+        let cp2 = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp2, seq_completed, "checkpoint stable after idle tick");
+    }
+
+    /// Test 4: A batch with ONLY non-approval events.  No approval rows written;
+    /// checkpoint advances past them via set_projector_checkpoint.
+    #[tokio::test]
+    async fn non_approval_only_batch_advances_checkpoint() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        let seq_completed = backend
+            .append_event(ev_node_completed(&exec, "nodeA"))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        let applied = projector.tick().await.unwrap();
+        assert_eq!(applied, 0, "no approval rows for non-approval-only batch");
+
+        let cp = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp, seq_completed,
+            "checkpoint advances past non-approval events"
+        );
+
+        // Second tick: idempotent.
+        let applied2 = projector.tick().await.unwrap();
+        assert_eq!(applied2, 0, "second tick is a no-op");
+    }
+}

--- a/runtime/scheduler/src/projector.rs
+++ b/runtime/scheduler/src/projector.rs
@@ -116,7 +116,12 @@ impl Projector {
             .get_projector_checkpoint("approvals", execution_id)
             .await?;
 
-        let events = self.backend.get_events_since(execution_id, cp).await?;
+        let mut events = self.backend.get_events_since(execution_id, cp).await?;
+        // Defensive sort: the trait contract requires ascending sequence order, but
+        // sort here so the fold is correct regardless of backend implementation.
+        // An ApprovalReceived processed before its ToolApprovalRequired (reversed
+        // delivery) would be treated as an orphan, leaving the node stuck pending.
+        events.sort_by_key(|e| e.sequence);
 
         if events.is_empty() {
             return Ok(0);
@@ -1113,5 +1118,61 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cp, seq_late, "checkpoint advances past the ignored event");
+    }
+
+    /// Finding C — the fold must process events in sequence order.
+    /// Without the sort, an ApprovalReceived delivered before its
+    /// ToolApprovalRequired (reversed delivery) would be treated as an orphan
+    /// and the node would be left pending even after approval.
+    ///
+    /// The InMemoryBackend always returns events in ascending sequence order so
+    /// the sort is a no-op here; this test documents what the sort guards against
+    /// by verifying the sort places Required (seq 1) before Received (seq 2)
+    /// when the input vec is constructed in reverse delivery order.
+    #[test]
+    fn sort_by_sequence_places_required_before_received() {
+        use jamjet_state::event::{ApprovalDecision, Event as StateEvent, EventKind};
+        let exec = ExecutionId::new();
+        let received_first = StateEvent::new(
+            exec.clone(),
+            2,
+            EventKind::ApprovalReceived {
+                node_id: "nodeA".into(),
+                user_id: "alice".into(),
+                decision: ApprovalDecision::Approved,
+                comment: None,
+                state_patch: None,
+            },
+        );
+        let required_second = StateEvent::new(
+            exec.clone(),
+            1,
+            EventKind::ToolApprovalRequired {
+                node_id: "nodeA".into(),
+                tool_name: "tool_nodeA".into(),
+                approver: "human".into(),
+                context: serde_json::json!({}),
+            },
+        );
+        // Simulate reversed delivery: Received (seq 2) arrives before Required (seq 1).
+        let mut events = vec![received_first, required_second];
+        events.sort_by_key(|e| e.sequence);
+        // After sort: seq 1 (Required) must be first.
+        assert_eq!(
+            events[0].sequence, 1,
+            "Required (seq 1) must come first after sort"
+        );
+        assert_eq!(
+            events[1].sequence, 2,
+            "Received (seq 2) must come second after sort"
+        );
+        assert!(
+            matches!(&events[0].kind, EventKind::ToolApprovalRequired { node_id, .. } if node_id == "nodeA"),
+            "first event after sort must be ToolApprovalRequired"
+        );
+        assert!(
+            matches!(&events[1].kind, EventKind::ApprovalReceived { node_id, .. } if node_id == "nodeA"),
+            "second event after sort must be ApprovalReceived"
+        );
     }
 }

--- a/runtime/scheduler/src/projector.rs
+++ b/runtime/scheduler/src/projector.rs
@@ -468,4 +468,314 @@ mod tests {
         let applied2 = projector.tick().await.unwrap();
         assert_eq!(applied2, 0, "second tick is a no-op");
     }
+
+    // ── 2h-4 hardening tests ──────────────────────────────────────────────────
+
+    /// Test 5 (2h-4): A brand-new Projector (simulating a process restart) resumes
+    /// from the durable checkpoint rather than reprocessing all events from the
+    /// start.
+    ///
+    /// Phase 1: seed events seq 1..N for nodeA (Requested + Approved), run tick(),
+    /// assert checkpoint=N.  Phase 2: construct a SECOND Projector over the same
+    /// backend (no in-memory state carried — process restart), append events
+    /// seq N+1..M for nodeB (Requested + Rejected), run tick().  Assert:
+    ///   - checkpoint advances to M.
+    ///   - nodeA remains "approved" (seq 1..N were NOT re-read by projector2).
+    ///   - nodeB is "rejected" (seq N+1..M were processed correctly).
+    ///   - Structural proof: the checkpoint equalled N before the restart tick, so
+    ///     get_events_since(exec, N) returned only seq > N, which excludes seq 1..N.
+    #[tokio::test]
+    async fn checkpoint_resume_after_restart() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        // Phase 1: events up to N (nodeA: Requested seq 1, Approved seq 2).
+        let _seq_req_a = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        let seq_n = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        // First projector instance (original process).
+        let projector1 = Projector::new(backend.clone());
+        let applied1 = projector1.tick().await.unwrap();
+        assert_eq!(applied1, 1, "phase 1: one row applied");
+
+        let cp_before_restart = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp_before_restart, seq_n,
+            "checkpoint at N after phase-1 tick"
+        );
+
+        let rows_phase1 = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows_phase1.len(), 1);
+        assert_eq!(rows_phase1[0].status, "approved");
+
+        // Phase 2: append new events (seq N+1..M) to simulate work arriving post-restart.
+        let _seq_req_b = backend
+            .append_event(ev_tool_approval_required(&exec, "nodeB"))
+            .await
+            .unwrap();
+        let seq_m = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeB",
+                "bob",
+                ApprovalDecision::Rejected,
+            ))
+            .await
+            .unwrap();
+        assert!(
+            seq_m > seq_n,
+            "M > N: new events are strictly after the pre-restart checkpoint"
+        );
+
+        // BRAND-NEW Projector — no in-memory state carried (simulated restart).
+        let projector2 = Projector::new(backend.clone());
+        let applied2 = projector2.tick().await.unwrap();
+
+        // The new projector reads events since N (get_events_since(exec, N))
+        // and processes ONLY nodeB (seq N+1..M).
+        assert_eq!(
+            applied2, 1,
+            "restart tick: only events > N are processed (no re-scan of seq 1..N)"
+        );
+
+        let cp_after_restart = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(
+            cp_after_restart, seq_m,
+            "checkpoint advances to M after restart tick"
+        );
+
+        let rows_final = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows_final.len(), 2, "both nodes present in projection");
+
+        let row_a = rows_final
+            .iter()
+            .find(|r| r.node_id == "nodeA")
+            .expect("nodeA must remain in projection after restart");
+        let row_b = rows_final
+            .iter()
+            .find(|r| r.node_id == "nodeB")
+            .expect("nodeB must be added by the restart tick");
+
+        // nodeA was NOT re-read: still approved (seq 1..N excluded by checkpoint).
+        assert_eq!(row_a.status, "approved", "nodeA must not be re-processed");
+        assert_eq!(row_a.user_id.as_deref(), Some("alice"));
+
+        // nodeB was processed from the delta (seq N+1..M).
+        assert_eq!(row_b.status, "rejected");
+        assert_eq!(row_b.user_id.as_deref(), Some("bob"));
+
+        // Structural proof: checkpoint was N before the restart tick.
+        assert_eq!(cp_before_restart, seq_n);
+    }
+
+    /// Test 6 (2h-4): Idempotent re-apply at scale — multiple nodes with
+    /// interleaved Requested/Approved/Rejected events.  Running tick() twice
+    /// yields an identical projection and a stable checkpoint, confirming that
+    /// the UPSERT-keyed write is a pure function of the events.
+    #[tokio::test]
+    async fn multi_node_idempotent_retick() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        // Five interleaved events across three nodes.
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap(); // seq 1
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeB"))
+            .await
+            .unwrap(); // seq 2
+        backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap(); // seq 3
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeC"))
+            .await
+            .unwrap(); // seq 4
+        let seq_last = backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeB",
+                "bob",
+                ApprovalDecision::Rejected,
+            ))
+            .await
+            .unwrap(); // seq 5
+
+        let projector = Projector::new(backend.clone());
+
+        // First tick: projects all three nodes in one batch.
+        let applied1 = projector.tick().await.unwrap();
+        assert_eq!(applied1, 3, "three nodes written on first tick");
+
+        let rows1 = backend.get_approval_projection(&exec).await.unwrap();
+        let cp1 = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp1, seq_last, "checkpoint at last seq after first tick");
+        assert_eq!(rows1.len(), 3);
+
+        // Second tick with no new events: must be a no-op.
+        let applied2 = projector.tick().await.unwrap();
+        assert_eq!(applied2, 0, "second tick must apply zero rows (idempotent)");
+
+        let rows2 = backend.get_approval_projection(&exec).await.unwrap();
+        let cp2 = backend
+            .get_projector_checkpoint("approvals", &exec)
+            .await
+            .unwrap();
+        assert_eq!(cp2, cp1, "checkpoint stable after second tick");
+        // Projection is a pure function of the events regardless of tick count.
+        assert_eq!(
+            rows2, rows1,
+            "projection content identical after idempotent second tick"
+        );
+    }
+
+    /// Test 7 (2h-4): Read fidelity — for a three-node approval event sequence,
+    /// the durable projection returned by get_approval_projection faithfully
+    /// represents the latest approval state implied by the events:
+    ///   - nodeA (Requested → Approved): status="approved", user_id="alice",
+    ///     tool_name cleared (node is resolved).
+    ///   - nodeB (Requested → Rejected with comment): status="rejected",
+    ///     user_id="bob", comment="exceeds limit", tool_name cleared.
+    ///   - nodeC (Requested only): status="pending", tool_name and approver
+    ///     preserved from the ToolApprovalRequired event.
+    ///
+    /// Crash-mid-apply safety note: `apply_approval_projection` and the checkpoint
+    /// advance share one SQLite transaction (proven by the 2h-1 atomic tests in
+    /// state/tests/projector.rs).  A checkpoint can therefore never be observed as
+    /// advanced past an unapplied approval row — it is structurally impossible to
+    /// land in a state where the checkpoint says "seq N processed" but the row for
+    /// that seq is absent from proj_approvals.  Rely on that atomic test rather
+    /// than duplicating a forced-failure scenario here.
+    #[tokio::test]
+    async fn read_fidelity_three_node_abc() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let exec = ExecutionId::new();
+        backend
+            .create_execution(running_execution(&exec))
+            .await
+            .unwrap();
+
+        // nodeA: Requested → Approved.
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeA"))
+            .await
+            .unwrap();
+        backend
+            .append_event(ev_approval_received(
+                &exec,
+                "nodeA",
+                "alice",
+                ApprovalDecision::Approved,
+            ))
+            .await
+            .unwrap();
+
+        // nodeB: Requested → Rejected with a comment.
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeB"))
+            .await
+            .unwrap();
+        backend
+            .append_event(Event::new(
+                exec.clone(),
+                0, // sequence assigned by append_event
+                EventKind::ApprovalReceived {
+                    node_id: "nodeB".into(),
+                    user_id: "bob".into(),
+                    decision: ApprovalDecision::Rejected,
+                    comment: Some("exceeds limit".into()),
+                    state_patch: None,
+                },
+            ))
+            .await
+            .unwrap();
+
+        // nodeC: Requested only — stays pending.
+        backend
+            .append_event(ev_tool_approval_required(&exec, "nodeC"))
+            .await
+            .unwrap();
+
+        let projector = Projector::new(backend.clone());
+        projector.tick().await.expect("tick must succeed");
+
+        let rows = backend.get_approval_projection(&exec).await.unwrap();
+        assert_eq!(rows.len(), 3, "one projection row per node");
+
+        let find = |node: &str| {
+            rows.iter()
+                .find(|r| r.node_id == node)
+                .unwrap_or_else(|| panic!("projection row missing for {node}"))
+        };
+
+        // nodeA: approved, user identified, pending metadata cleared.
+        let row_a = find("nodeA");
+        assert_eq!(row_a.status, "approved");
+        assert_eq!(row_a.user_id.as_deref(), Some("alice"));
+        assert!(
+            row_a.tool_name.is_none(),
+            "approved row must not carry tool_name"
+        );
+
+        // nodeB: rejected, user identified, comment preserved, pending metadata cleared.
+        let row_b = find("nodeB");
+        assert_eq!(row_b.status, "rejected");
+        assert_eq!(row_b.user_id.as_deref(), Some("bob"));
+        assert_eq!(row_b.comment.as_deref(), Some("exceeds limit"));
+        assert!(
+            row_b.tool_name.is_none(),
+            "rejected row must not carry tool_name"
+        );
+
+        // nodeC: pending, tool_name and approver preserved from ToolApprovalRequired.
+        let row_c = find("nodeC");
+        assert_eq!(row_c.status, "pending");
+        assert_eq!(
+            row_c.tool_name.as_deref(),
+            Some("tool_nodeC"),
+            "pending row must preserve tool_name from ToolApprovalRequired event"
+        );
+        assert_eq!(
+            row_c.approver.as_deref(),
+            Some("human"),
+            "pending row must preserve approver from ToolApprovalRequired event"
+        );
+        assert!(row_c.user_id.is_none(), "pending row has no user_id");
+    }
 }

--- a/runtime/scheduler/src/projector.rs
+++ b/runtime/scheduler/src/projector.rs
@@ -89,7 +89,12 @@ impl Projector {
 
         for event in &events {
             match &event.kind {
-                EventKind::ToolApprovalRequired { node_id, .. } => {
+                EventKind::ToolApprovalRequired {
+                    node_id,
+                    tool_name,
+                    approver,
+                    context,
+                } => {
                     node_map.insert(
                         node_id.clone(),
                         ApprovalProjectionRow {
@@ -99,6 +104,9 @@ impl Projector {
                             user_id: None,
                             comment: None,
                             last_sequence: event.sequence,
+                            tool_name: Some(tool_name.clone()),
+                            approver: Some(approver.clone()),
+                            context: Some(context.clone()),
                         },
                     );
                 }
@@ -113,6 +121,8 @@ impl Projector {
                         ApprovalDecision::Approved => "approved",
                         ApprovalDecision::Rejected => "rejected",
                     };
+                    // Pending metadata (tool_name/approver/context) is cleared on
+                    // resolution — the node is no longer waiting for a decision.
                     node_map.insert(
                         node_id.clone(),
                         ApprovalProjectionRow {
@@ -122,6 +132,9 @@ impl Projector {
                             user_id: Some(user_id.clone()),
                             comment: comment.clone(),
                             last_sequence: event.sequence,
+                            tool_name: None,
+                            approver: None,
+                            context: None,
                         },
                     );
                 }

--- a/runtime/state/migrations/0008_projector.sql
+++ b/runtime/state/migrations/0008_projector.sql
@@ -1,0 +1,23 @@
+-- Migration 0008: async read-model projector. proj_approvals is the projected
+-- read side for the approvals endpoint; projector_checkpoints records how far each
+-- named projection has consumed each execution's event stream (resume after restart).
+CREATE TABLE IF NOT EXISTS proj_approvals (
+    execution_id  TEXT    NOT NULL,
+    node_id       TEXT    NOT NULL,
+    status        TEXT    NOT NULL,
+    user_id       TEXT,
+    comment       TEXT,
+    last_sequence INTEGER NOT NULL,
+    tenant_id     TEXT    NOT NULL DEFAULT 'default',
+    updated_at    TEXT    NOT NULL,
+    PRIMARY KEY (execution_id, node_id)
+);
+CREATE INDEX IF NOT EXISTS idx_proj_approvals_exec ON proj_approvals(execution_id);
+CREATE TABLE IF NOT EXISTS projector_checkpoints (
+    projection_name TEXT    NOT NULL,
+    execution_id    TEXT    NOT NULL,
+    last_sequence   INTEGER NOT NULL,
+    tenant_id       TEXT    NOT NULL DEFAULT 'default',
+    updated_at      TEXT    NOT NULL,
+    PRIMARY KEY (projection_name, execution_id)
+);

--- a/runtime/state/migrations/0009_proj_approvals_pending_fields.sql
+++ b/runtime/state/migrations/0009_proj_approvals_pending_fields.sql
@@ -1,0 +1,8 @@
+-- Migration 0009: add pending-approval metadata columns to proj_approvals.
+-- These fields are populated from ToolApprovalRequired events so that the
+-- GET /executions/:id/approvals endpoint can serve the full pending-approval
+-- shape (tool_name, approver, context) without reading the event log.
+-- Cleared to NULL when a node transitions to "approved" or "rejected".
+ALTER TABLE proj_approvals ADD COLUMN tool_name    TEXT;
+ALTER TABLE proj_approvals ADD COLUMN approver     TEXT;
+ALTER TABLE proj_approvals ADD COLUMN context_json TEXT;

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -5,6 +5,22 @@ use async_trait::async_trait;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use thiserror::Error;
 
+/// A projected approval row — the CQRS read-model for a single (execution,
+/// node) pair, maintained asynchronously by the projector.
+///
+/// Keyed by `(execution_id, node_id)`; `status` is the latest approval state
+/// (`"pending"`, `"granted"`, `"denied"`). `last_sequence` is the event
+/// sequence that produced this row (used for idempotent re-application).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApprovalProjectionRow {
+    pub execution_id: ExecutionId,
+    pub node_id: String,
+    pub status: String,
+    pub user_id: Option<String>,
+    pub comment: Option<String>,
+    pub last_sequence: i64,
+}
+
 /// Workflow definition stored in the registry (the compiled IR as JSON).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WorkflowDefinition {
@@ -257,6 +273,35 @@ pub trait StateBackend: Send + Sync {
 
     /// Validate a plaintext API token. Returns the token info if valid and not revoked.
     async fn validate_token(&self, token: &str) -> BackendResult<Option<ApiToken>>;
+
+    // ── Async read-model projector ───────────────────────────────────────────
+
+    /// Atomically UPSERT an approval projection row AND advance the named
+    /// projection's checkpoint for this execution to `new_checkpoint`, in one
+    /// transaction.  Crash-safe: if the process dies between the UPSERT and the
+    /// checkpoint write they are the same commit, so neither can be partially
+    /// applied.
+    async fn apply_approval_projection(
+        &self,
+        row: ApprovalProjectionRow,
+        projection_name: &str,
+        new_checkpoint: i64,
+    ) -> BackendResult<()>;
+
+    /// All approval projection rows for an execution (the projected read model).
+    async fn get_approval_projection(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<Vec<ApprovalProjectionRow>>;
+
+    /// Current checkpoint (last consumed sequence) for (projection_name,
+    /// execution_id).  Returns 0 if no checkpoint exists yet — the projector
+    /// will re-read from the beginning of the event log.
+    async fn get_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<i64>;
 
     // ── Tenant management ───────────────────────────────────────────────
 

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -299,6 +299,26 @@ pub trait StateBackend: Send + Sync {
         new_checkpoint: i64,
     ) -> BackendResult<()>;
 
+    /// Atomically UPSERT all approval projection rows for one execution AND
+    /// advance the named projection's checkpoint to `new_checkpoint`, in ONE
+    /// transaction.
+    ///
+    /// This is the correct primitive to use when a tick produces multiple
+    /// changed nodes: a crash after writing row 1 but before row 2 would
+    /// otherwise leave the checkpoint advanced past unwritten rows.  With this
+    /// method the checkpoint advances IFF every row in the batch committed.
+    ///
+    /// If `rows` is empty the checkpoint is still advanced (callers that want
+    /// to skip the checkpoint update when there is nothing to write should
+    /// check before calling).
+    async fn apply_approval_projection_batch(
+        &self,
+        rows: Vec<ApprovalProjectionRow>,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()>;
+
     /// All approval projection rows for an execution (the projected read model).
     async fn get_approval_projection(
         &self,

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -9,16 +9,27 @@ use thiserror::Error;
 /// node) pair, maintained asynchronously by the projector.
 ///
 /// Keyed by `(execution_id, node_id)`; `status` is the latest approval state
-/// (`"pending"`, `"granted"`, `"denied"`). `last_sequence` is the event
+/// (`"pending"`, `"approved"`, `"rejected"`). `last_sequence` is the event
 /// sequence that produced this row (used for idempotent re-application).
+///
+/// `tool_name`, `approver`, and `context` are populated only for `"pending"`
+/// rows (from `ToolApprovalRequired`); they are cleared to `None` when the
+/// node transitions to `"approved"` or `"rejected"`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ApprovalProjectionRow {
     pub execution_id: ExecutionId,
     pub node_id: String,
+    /// `"pending"` | `"approved"` | `"rejected"`
     pub status: String,
     pub user_id: Option<String>,
     pub comment: Option<String>,
     pub last_sequence: i64,
+    /// Populated for `"pending"` rows from `ToolApprovalRequired.tool_name`.
+    pub tool_name: Option<String>,
+    /// Populated for `"pending"` rows from `ToolApprovalRequired.approver`.
+    pub approver: Option<String>,
+    /// Populated for `"pending"` rows from `ToolApprovalRequired.context`.
+    pub context: Option<serde_json::Value>,
 }
 
 /// Workflow definition stored in the registry (the compiled IR as JSON).

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -136,6 +136,7 @@ pub trait StateBackend: Send + Sync {
     async fn get_events(&self, execution_id: &ExecutionId) -> BackendResult<Vec<Event>>;
 
     /// Load events since a given sequence number (exclusive).
+    /// Returns events in ascending `sequence` order.
     async fn get_events_since(
         &self,
         execution_id: &ExecutionId,

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -303,6 +303,19 @@ pub trait StateBackend: Send + Sync {
         execution_id: &ExecutionId,
     ) -> BackendResult<i64>;
 
+    /// Advance the projector checkpoint for (projection_name, execution_id)
+    /// to `new_checkpoint` WITHOUT writing any projection row.
+    ///
+    /// Used when a batch of events contained NO approval events (only
+    /// non-approval events) — the checkpoint must still advance to `batch_max`
+    /// so those events are not re-scanned on the next tick.
+    async fn set_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()>;
+
     // ── Tenant management ───────────────────────────────────────────────
 
     /// Create a new tenant.

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -19,8 +19,8 @@ pub mod tenant;
 pub mod tenant_scoped;
 
 pub use backend::{
-    ApiToken, BackendResult, ReclaimResult, StateBackend, StateBackendError, WorkItem, WorkItemId,
-    WorkflowDefinition,
+    ApiToken, ApprovalProjectionRow, BackendResult, ReclaimResult, StateBackend, StateBackendError,
+    WorkItem, WorkItemId, WorkflowDefinition,
 };
 pub use budget::BudgetState;
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -714,6 +714,17 @@ impl StateBackend for InMemoryBackend {
             .unwrap_or(0))
     }
 
+    async fn set_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let key = (projection_name.to_string(), execution_id.0.to_string());
+        self.projector_checkpoints.insert(key, new_checkpoint);
+        Ok(())
+    }
+
     // ── Tenants ──────────────────────────────────────────────────────
 
     async fn create_tenant(&self, tenant: Tenant) -> BackendResult<()> {

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -686,6 +686,25 @@ impl StateBackend for InMemoryBackend {
         Ok(())
     }
 
+    async fn apply_approval_projection_batch(
+        &self,
+        rows: Vec<crate::backend::ApprovalProjectionRow>,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        // In-memory: DashMap operations are individually atomic; we apply all
+        // rows then the checkpoint in a tight synchronous sequence with no
+        // await between them — sufficient for single-threaded test use.
+        for row in rows {
+            let key = (row.execution_id.0.to_string(), row.node_id.clone());
+            self.proj_approvals.insert(key, row);
+        }
+        let cp_key = (projection_name.to_string(), execution_id.0.to_string());
+        self.projector_checkpoints.insert(cp_key, new_checkpoint);
+        Ok(())
+    }
+
     async fn get_approval_projection(
         &self,
         execution_id: &ExecutionId,

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -41,6 +41,10 @@ pub struct InMemoryBackend {
     /// Idempotency cache: idempotency_key -> result_json.
     /// Mirrors the `tool_effects` table in the SQLite backends.
     tool_effects: DashMap<String, serde_json::Value>,
+    /// Projected approval read-model. Key = (execution_id as String, node_id).
+    proj_approvals: DashMap<(String, String), crate::backend::ApprovalProjectionRow>,
+    /// Projector checkpoints. Key = (projection_name, execution_id as String).
+    projector_checkpoints: DashMap<(String, String), i64>,
 }
 
 impl InMemoryBackend {
@@ -58,6 +62,8 @@ impl InMemoryBackend {
             lease_epochs: DashMap::new(),
             store_term: AtomicI64::new(0),
             tool_effects: DashMap::new(),
+            proj_approvals: DashMap::new(),
+            projector_checkpoints: DashMap::new(),
         }
     }
 
@@ -661,6 +667,51 @@ impl StateBackend for InMemoryBackend {
 
     async fn validate_token(&self, token: &str) -> BackendResult<Option<ApiToken>> {
         Ok(self.tokens.get(token).map(|r| r.value().clone()))
+    }
+
+    // ── Async read-model projector ────────────────────────────────────
+
+    async fn apply_approval_projection(
+        &self,
+        row: crate::backend::ApprovalProjectionRow,
+        projection_name: &str,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        // In-memory: no ACID atomicity, but both writes happen in the same
+        // synchronous step so there is no observable gap in tests.
+        let key = (row.execution_id.0.to_string(), row.node_id.clone());
+        self.proj_approvals.insert(key, row.clone());
+        let cp_key = (projection_name.to_string(), row.execution_id.0.to_string());
+        self.projector_checkpoints.insert(cp_key, new_checkpoint);
+        Ok(())
+    }
+
+    async fn get_approval_projection(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<Vec<crate::backend::ApprovalProjectionRow>> {
+        let exec_str = execution_id.0.to_string();
+        let mut rows: Vec<crate::backend::ApprovalProjectionRow> = self
+            .proj_approvals
+            .iter()
+            .filter(|e| e.key().0 == exec_str)
+            .map(|e| e.value().clone())
+            .collect();
+        rows.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(rows)
+    }
+
+    async fn get_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<i64> {
+        let key = (projection_name.to_string(), execution_id.0.to_string());
+        Ok(self
+            .projector_checkpoints
+            .get(&key)
+            .map(|v| *v.value())
+            .unwrap_or(0))
     }
 
     // ── Tenants ──────────────────────────────────────────────────────

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1621,15 +1621,25 @@ impl StateBackend for SqliteBackend {
             .await
             .map_err(map_db_err)?;
 
+        let context_json = row
+            .context
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+
         sqlx::query(
             r#"INSERT INTO proj_approvals
-               (execution_id, node_id, status, user_id, comment, last_sequence, tenant_id, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'default', ?)
+               (execution_id, node_id, status, user_id, comment, last_sequence,
+                tool_name, approver, context_json, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'default', ?)
                ON CONFLICT(execution_id, node_id) DO UPDATE SET
                  status        = excluded.status,
                  user_id       = excluded.user_id,
                  comment       = excluded.comment,
                  last_sequence = excluded.last_sequence,
+                 tool_name     = excluded.tool_name,
+                 approver      = excluded.approver,
+                 context_json  = excluded.context_json,
                  updated_at    = excluded.updated_at"#,
         )
         .bind(&exec_id_str)
@@ -1638,6 +1648,9 @@ impl StateBackend for SqliteBackend {
         .bind(&row.user_id)
         .bind(&row.comment)
         .bind(row.last_sequence)
+        .bind(&row.tool_name)
+        .bind(&row.approver)
+        .bind(&context_json)
         .bind(&now)
         .execute(&mut *tx)
         .await
@@ -1669,7 +1682,8 @@ impl StateBackend for SqliteBackend {
     ) -> BackendResult<Vec<crate::backend::ApprovalProjectionRow>> {
         let id_str = execution_id_str(execution_id);
         let rows = sqlx::query(
-            "SELECT node_id, status, user_id, comment, last_sequence \
+            "SELECT node_id, status, user_id, comment, last_sequence, \
+                    tool_name, approver, context_json \
              FROM proj_approvals WHERE execution_id = ? ORDER BY node_id",
         )
         .bind(&id_str)
@@ -1679,6 +1693,12 @@ impl StateBackend for SqliteBackend {
 
         rows.iter()
             .map(|r| {
+                let context_json: Option<String> = r
+                    .try_get::<Option<String>, _>("context_json")
+                    .map_err(map_db_err)?;
+                let context = context_json
+                    .map(|s| serde_json::from_str::<serde_json::Value>(&s))
+                    .transpose()?;
                 Ok(crate::backend::ApprovalProjectionRow {
                     execution_id: execution_id.clone(),
                     node_id: r.try_get::<String, _>("node_id").map_err(map_db_err)?,
@@ -1690,6 +1710,13 @@ impl StateBackend for SqliteBackend {
                         .try_get::<Option<String>, _>("comment")
                         .map_err(map_db_err)?,
                     last_sequence: r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?,
+                    tool_name: r
+                        .try_get::<Option<String>, _>("tool_name")
+                        .map_err(map_db_err)?,
+                    approver: r
+                        .try_get::<Option<String>, _>("approver")
+                        .map_err(map_db_err)?,
+                    context,
                 })
             })
             .collect()

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1603,6 +1603,119 @@ impl StateBackend for SqliteBackend {
         };
         Ok(Some(info))
     }
+
+    // ── Async read-model projector ──────────────────────────────────────────
+
+    async fn apply_approval_projection(
+        &self,
+        row: crate::backend::ApprovalProjectionRow,
+        projection_name: &str,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let exec_id_str = execution_id_str(&row.execution_id);
+        let now = Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO proj_approvals
+               (execution_id, node_id, status, user_id, comment, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'default', ?)
+               ON CONFLICT(execution_id, node_id) DO UPDATE SET
+                 status        = excluded.status,
+                 user_id       = excluded.user_id,
+                 comment       = excluded.comment,
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(&exec_id_str)
+        .bind(&row.node_id)
+        .bind(&row.status)
+        .bind(&row.user_id)
+        .bind(&row.comment)
+        .bind(row.last_sequence)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, 'default', ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&exec_id_str)
+        .bind(new_checkpoint)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn get_approval_projection(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<Vec<crate::backend::ApprovalProjectionRow>> {
+        let id_str = execution_id_str(execution_id);
+        let rows = sqlx::query(
+            "SELECT node_id, status, user_id, comment, last_sequence \
+             FROM proj_approvals WHERE execution_id = ? ORDER BY node_id",
+        )
+        .bind(&id_str)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        rows.iter()
+            .map(|r| {
+                Ok(crate::backend::ApprovalProjectionRow {
+                    execution_id: execution_id.clone(),
+                    node_id: r.try_get::<String, _>("node_id").map_err(map_db_err)?,
+                    status: r.try_get::<String, _>("status").map_err(map_db_err)?,
+                    user_id: r
+                        .try_get::<Option<String>, _>("user_id")
+                        .map_err(map_db_err)?,
+                    comment: r
+                        .try_get::<Option<String>, _>("comment")
+                        .map_err(map_db_err)?,
+                    last_sequence: r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?,
+                })
+            })
+            .collect()
+    }
+
+    async fn get_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<i64> {
+        let id_str = execution_id_str(execution_id);
+        let row = sqlx::query(
+            "SELECT last_sequence FROM projector_checkpoints \
+             WHERE projection_name = ? AND execution_id = ?",
+        )
+        .bind(projection_name)
+        .bind(&id_str)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        match row {
+            Some(r) => Ok(r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?),
+            None => Ok(0),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1676,6 +1676,80 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    async fn apply_approval_projection_batch(
+        &self,
+        rows: Vec<crate::backend::ApprovalProjectionRow>,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let exec_id_str = execution_id_str(execution_id);
+        let now = Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        for row in rows {
+            let context_json = row
+                .context
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()?;
+
+            sqlx::query(
+                r#"INSERT INTO proj_approvals
+                   (execution_id, node_id, status, user_id, comment, last_sequence,
+                    tool_name, approver, context_json, tenant_id, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'default', ?)
+                   ON CONFLICT(execution_id, node_id) DO UPDATE SET
+                     status        = excluded.status,
+                     user_id       = excluded.user_id,
+                     comment       = excluded.comment,
+                     last_sequence = excluded.last_sequence,
+                     tool_name     = excluded.tool_name,
+                     approver      = excluded.approver,
+                     context_json  = excluded.context_json,
+                     updated_at    = excluded.updated_at"#,
+            )
+            .bind(&exec_id_str)
+            .bind(&row.node_id)
+            .bind(&row.status)
+            .bind(&row.user_id)
+            .bind(&row.comment)
+            .bind(row.last_sequence)
+            .bind(&row.tool_name)
+            .bind(&row.approver)
+            .bind(&context_json)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
+
+        // Advance checkpoint once for the whole batch.
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, 'default', ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&exec_id_str)
+        .bind(new_checkpoint)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
     async fn get_approval_projection(
         &self,
         execution_id: &ExecutionId,

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1716,6 +1716,32 @@ impl StateBackend for SqliteBackend {
             None => Ok(0),
         }
     }
+
+    async fn set_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let id_str = execution_id_str(execution_id);
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, 'default', ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&id_str)
+        .bind(new_checkpoint)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1745,6 +1745,33 @@ impl StateBackend for TenantScopedSqliteBackend {
             None => Ok(0),
         }
     }
+
+    async fn set_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let id_str = execution_id_str(execution_id);
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&id_str)
+        .bind(new_checkpoint)
+        .bind(&self.tenant_id.0)
+        .bind(&now)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+        Ok(())
+    }
 }
 
 /// Parse a datetime that might be either RFC 3339 or SQLite's `datetime('now')` format.

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1628,6 +1628,123 @@ impl StateBackend for TenantScopedSqliteBackend {
         }
         Ok(())
     }
+
+    // ── Async read-model projector ──────────────────────────────────────────
+
+    async fn apply_approval_projection(
+        &self,
+        row: crate::backend::ApprovalProjectionRow,
+        projection_name: &str,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let exec_id_str = execution_id_str(&row.execution_id);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO proj_approvals
+               (execution_id, node_id, status, user_id, comment, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(execution_id, node_id) DO UPDATE SET
+                 status        = excluded.status,
+                 user_id       = excluded.user_id,
+                 comment       = excluded.comment,
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(&exec_id_str)
+        .bind(&row.node_id)
+        .bind(&row.status)
+        .bind(&row.user_id)
+        .bind(&row.comment)
+        .bind(row.last_sequence)
+        .bind(&self.tenant_id.0)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&exec_id_str)
+        .bind(new_checkpoint)
+        .bind(&self.tenant_id.0)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
+    async fn get_approval_projection(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<Vec<crate::backend::ApprovalProjectionRow>> {
+        let id_str = execution_id_str(execution_id);
+        let rows = sqlx::query(
+            "SELECT node_id, status, user_id, comment, last_sequence \
+             FROM proj_approvals WHERE execution_id = ? AND tenant_id = ? ORDER BY node_id",
+        )
+        .bind(&id_str)
+        .bind(&self.tenant_id.0)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        rows.iter()
+            .map(|r| {
+                Ok(crate::backend::ApprovalProjectionRow {
+                    execution_id: execution_id.clone(),
+                    node_id: r.try_get::<String, _>("node_id").map_err(map_db_err)?,
+                    status: r.try_get::<String, _>("status").map_err(map_db_err)?,
+                    user_id: r
+                        .try_get::<Option<String>, _>("user_id")
+                        .map_err(map_db_err)?,
+                    comment: r
+                        .try_get::<Option<String>, _>("comment")
+                        .map_err(map_db_err)?,
+                    last_sequence: r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?,
+                })
+            })
+            .collect()
+    }
+
+    async fn get_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+    ) -> BackendResult<i64> {
+        let id_str = execution_id_str(execution_id);
+        let row = sqlx::query(
+            "SELECT last_sequence FROM projector_checkpoints \
+             WHERE projection_name = ? AND execution_id = ? AND tenant_id = ?",
+        )
+        .bind(projection_name)
+        .bind(&id_str)
+        .bind(&self.tenant_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        match row {
+            Some(r) => Ok(r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?),
+            None => Ok(0),
+        }
+    }
 }
 
 /// Parse a datetime that might be either RFC 3339 or SQLite's `datetime('now')` format.

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1703,6 +1703,82 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
+    async fn apply_approval_projection_batch(
+        &self,
+        rows: Vec<crate::backend::ApprovalProjectionRow>,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> BackendResult<()> {
+        let exec_id_str = execution_id_str(execution_id);
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        for row in rows {
+            let context_json = row
+                .context
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()?;
+
+            sqlx::query(
+                r#"INSERT INTO proj_approvals
+                   (execution_id, node_id, status, user_id, comment, last_sequence,
+                    tool_name, approver, context_json, tenant_id, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(execution_id, node_id) DO UPDATE SET
+                     status        = excluded.status,
+                     user_id       = excluded.user_id,
+                     comment       = excluded.comment,
+                     last_sequence = excluded.last_sequence,
+                     tool_name     = excluded.tool_name,
+                     approver      = excluded.approver,
+                     context_json  = excluded.context_json,
+                     updated_at    = excluded.updated_at"#,
+            )
+            .bind(&exec_id_str)
+            .bind(&row.node_id)
+            .bind(&row.status)
+            .bind(&row.user_id)
+            .bind(&row.comment)
+            .bind(row.last_sequence)
+            .bind(&row.tool_name)
+            .bind(&row.approver)
+            .bind(&context_json)
+            .bind(&self.tenant_id.0)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+        }
+
+        // Advance checkpoint once for the whole batch.
+        sqlx::query(
+            r#"INSERT INTO projector_checkpoints
+               (projection_name, execution_id, last_sequence, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(projection_name, execution_id) DO UPDATE SET
+                 last_sequence = excluded.last_sequence,
+                 updated_at    = excluded.updated_at"#,
+        )
+        .bind(projection_name)
+        .bind(&exec_id_str)
+        .bind(new_checkpoint)
+        .bind(&self.tenant_id.0)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?;
+
+        tx.commit().await.map_err(map_db_err)?;
+        Ok(())
+    }
+
     async fn get_approval_projection(
         &self,
         execution_id: &ExecutionId,

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1646,15 +1646,25 @@ impl StateBackend for TenantScopedSqliteBackend {
             .await
             .map_err(map_db_err)?;
 
+        let context_json = row
+            .context
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+
         sqlx::query(
             r#"INSERT INTO proj_approvals
-               (execution_id, node_id, status, user_id, comment, last_sequence, tenant_id, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               (execution_id, node_id, status, user_id, comment, last_sequence,
+                tool_name, approver, context_json, tenant_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(execution_id, node_id) DO UPDATE SET
                  status        = excluded.status,
                  user_id       = excluded.user_id,
                  comment       = excluded.comment,
                  last_sequence = excluded.last_sequence,
+                 tool_name     = excluded.tool_name,
+                 approver      = excluded.approver,
+                 context_json  = excluded.context_json,
                  updated_at    = excluded.updated_at"#,
         )
         .bind(&exec_id_str)
@@ -1663,6 +1673,9 @@ impl StateBackend for TenantScopedSqliteBackend {
         .bind(&row.user_id)
         .bind(&row.comment)
         .bind(row.last_sequence)
+        .bind(&row.tool_name)
+        .bind(&row.approver)
+        .bind(&context_json)
         .bind(&self.tenant_id.0)
         .bind(&now)
         .execute(&mut *tx)
@@ -1696,7 +1709,8 @@ impl StateBackend for TenantScopedSqliteBackend {
     ) -> BackendResult<Vec<crate::backend::ApprovalProjectionRow>> {
         let id_str = execution_id_str(execution_id);
         let rows = sqlx::query(
-            "SELECT node_id, status, user_id, comment, last_sequence \
+            "SELECT node_id, status, user_id, comment, last_sequence, \
+                    tool_name, approver, context_json \
              FROM proj_approvals WHERE execution_id = ? AND tenant_id = ? ORDER BY node_id",
         )
         .bind(&id_str)
@@ -1707,6 +1721,12 @@ impl StateBackend for TenantScopedSqliteBackend {
 
         rows.iter()
             .map(|r| {
+                let context_json: Option<String> = r
+                    .try_get::<Option<String>, _>("context_json")
+                    .map_err(map_db_err)?;
+                let context = context_json
+                    .map(|s| serde_json::from_str::<serde_json::Value>(&s))
+                    .transpose()?;
                 Ok(crate::backend::ApprovalProjectionRow {
                     execution_id: execution_id.clone(),
                     node_id: r.try_get::<String, _>("node_id").map_err(map_db_err)?,
@@ -1718,6 +1738,13 @@ impl StateBackend for TenantScopedSqliteBackend {
                         .try_get::<Option<String>, _>("comment")
                         .map_err(map_db_err)?,
                     last_sequence: r.try_get::<i64, _>("last_sequence").map_err(map_db_err)?,
+                    tool_name: r
+                        .try_get::<Option<String>, _>("tool_name")
+                        .map_err(map_db_err)?,
+                    approver: r
+                        .try_get::<Option<String>, _>("approver")
+                        .map_err(map_db_err)?,
+                    context,
                 })
             })
             .collect()

--- a/runtime/state/tests/projector.rs
+++ b/runtime/state/tests/projector.rs
@@ -30,6 +30,9 @@ fn granted_row(execution_id: ExecutionId) -> ApprovalProjectionRow {
         user_id: Some("alice".into()),
         comment: Some("looks good".into()),
         last_sequence: 5,
+        tool_name: None,
+        approver: None,
+        context: None,
     }
 }
 
@@ -84,6 +87,9 @@ async fn assert_upsert_idempotency(backend: &dyn StateBackend) {
         user_id: Some("bob".into()),
         comment: None,
         last_sequence: 9,
+        tool_name: None,
+        approver: None,
+        context: None,
     };
     backend
         .apply_approval_projection(updated, "approvals", 9)
@@ -129,6 +135,9 @@ async fn assert_two_nodes_same_execution(backend: &dyn StateBackend) {
         user_id: None,
         comment: None,
         last_sequence: 3,
+        tool_name: None,
+        approver: None,
+        context: None,
     };
     let row_b = ApprovalProjectionRow {
         execution_id: exec.clone(),
@@ -137,6 +146,9 @@ async fn assert_two_nodes_same_execution(backend: &dyn StateBackend) {
         user_id: None,
         comment: None,
         last_sequence: 7,
+        tool_name: None,
+        approver: None,
+        context: None,
     };
 
     backend
@@ -301,6 +313,9 @@ async fn tenant_isolation() {
                 user_id: None,
                 comment: None,
                 last_sequence: 1,
+                tool_name: None,
+                approver: None,
+                context: None,
             },
             "approvals",
             1,

--- a/runtime/state/tests/projector.rs
+++ b/runtime/state/tests/projector.rs
@@ -1,0 +1,327 @@
+//! TDD tests for the async read-model projector (Task 2h-1).
+//!
+//! Covers:
+//! (a) apply_approval_projection then read-back: row present, checkpoint advanced.
+//! (b) Re-apply for the same (exec, node) with different status: UPSERT leaves one
+//!     row, checkpoint advances.
+//! (c) get_projector_checkpoint for an unseen execution returns 0.
+//!
+//! Run on SQLite, in-memory, and tenant-scoped backends.
+//!
+//! Written RED (trait stubs only, no impls) before the implementations existed;
+//! turned GREEN after adding the three backend methods.
+
+use jamjet_core::workflow::ExecutionId;
+use jamjet_state::{backend::StateBackend, ApprovalProjectionRow, InMemoryBackend, SqliteBackend};
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+async fn open_sqlite() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite for projector tests")
+}
+
+fn granted_row(execution_id: ExecutionId) -> ApprovalProjectionRow {
+    ApprovalProjectionRow {
+        execution_id,
+        node_id: "nodeA".into(),
+        status: "granted".into(),
+        user_id: Some("alice".into()),
+        comment: Some("looks good".into()),
+        last_sequence: 5,
+    }
+}
+
+// ── Generic test body (runs against any StateBackend) ────────────────────────
+
+/// (a) apply then get_approval_projection returns the row;
+///     get_projector_checkpoint returns the checkpoint.
+async fn assert_apply_and_read(backend: &dyn StateBackend) {
+    let exec = ExecutionId::new();
+    let row = granted_row(exec.clone());
+
+    backend
+        .apply_approval_projection(row.clone(), "approvals", 5)
+        .await
+        .expect("apply_approval_projection must succeed");
+
+    let rows = backend
+        .get_approval_projection(&exec)
+        .await
+        .expect("get_approval_projection must succeed");
+    assert_eq!(rows.len(), 1, "must have exactly one projected row");
+    let r = &rows[0];
+    assert_eq!(r.node_id, "nodeA");
+    assert_eq!(r.status, "granted");
+    assert_eq!(r.user_id.as_deref(), Some("alice"));
+    assert_eq!(r.comment.as_deref(), Some("looks good"));
+    assert_eq!(r.last_sequence, 5);
+
+    let cp = backend
+        .get_projector_checkpoint("approvals", &exec)
+        .await
+        .expect("get_projector_checkpoint must succeed");
+    assert_eq!(cp, 5, "checkpoint must be 5 after first apply");
+}
+
+/// (b) Re-apply for same (exec, nodeA) with updated status/checkpoint:
+///     still ONE row (UPSERT idempotency), status updated, checkpoint advanced.
+async fn assert_upsert_idempotency(backend: &dyn StateBackend) {
+    let exec = ExecutionId::new();
+
+    // First apply: granted at seq 5.
+    backend
+        .apply_approval_projection(granted_row(exec.clone()), "approvals", 5)
+        .await
+        .expect("first apply");
+
+    // Re-apply same (exec, nodeA) with status="denied" at checkpoint 9.
+    let updated = ApprovalProjectionRow {
+        execution_id: exec.clone(),
+        node_id: "nodeA".into(),
+        status: "denied".into(),
+        user_id: Some("bob".into()),
+        comment: None,
+        last_sequence: 9,
+    };
+    backend
+        .apply_approval_projection(updated, "approvals", 9)
+        .await
+        .expect("second apply (upsert)");
+
+    let rows = backend
+        .get_approval_projection(&exec)
+        .await
+        .expect("get_approval_projection");
+    assert_eq!(rows.len(), 1, "UPSERT must leave exactly one row");
+    let r = &rows[0];
+    assert_eq!(r.status, "denied", "status must be updated to denied");
+    assert_eq!(r.user_id.as_deref(), Some("bob"));
+    assert!(r.comment.is_none(), "comment must be cleared");
+    assert_eq!(r.last_sequence, 9, "last_sequence must be updated to 9");
+
+    let cp = backend
+        .get_projector_checkpoint("approvals", &exec)
+        .await
+        .expect("get_projector_checkpoint after second apply");
+    assert_eq!(cp, 9, "checkpoint must advance to 9");
+}
+
+/// (c) get_projector_checkpoint for an unseen execution returns 0 (not an error).
+async fn assert_unknown_checkpoint_is_zero(backend: &dyn StateBackend) {
+    let unseen = ExecutionId::new();
+    let cp = backend
+        .get_projector_checkpoint("approvals", &unseen)
+        .await
+        .expect("get_projector_checkpoint must not error for unseen execution");
+    assert_eq!(cp, 0, "unseen execution must yield checkpoint 0");
+}
+
+/// Two nodes in the same execution each get their own row.
+async fn assert_two_nodes_same_execution(backend: &dyn StateBackend) {
+    let exec = ExecutionId::new();
+
+    let row_a = ApprovalProjectionRow {
+        execution_id: exec.clone(),
+        node_id: "nodeA".into(),
+        status: "granted".into(),
+        user_id: None,
+        comment: None,
+        last_sequence: 3,
+    };
+    let row_b = ApprovalProjectionRow {
+        execution_id: exec.clone(),
+        node_id: "nodeB".into(),
+        status: "pending".into(),
+        user_id: None,
+        comment: None,
+        last_sequence: 7,
+    };
+
+    backend
+        .apply_approval_projection(row_a, "approvals", 3)
+        .await
+        .expect("apply nodeA");
+    backend
+        .apply_approval_projection(row_b, "approvals", 7)
+        .await
+        .expect("apply nodeB");
+
+    let rows = backend
+        .get_approval_projection(&exec)
+        .await
+        .expect("get_approval_projection");
+    // Rows are ordered by node_id ascending.
+    assert_eq!(rows.len(), 2, "must have two rows for two nodes");
+    assert_eq!(rows[0].node_id, "nodeA");
+    assert_eq!(rows[1].node_id, "nodeB");
+
+    // Checkpoint reflects the last apply (nodeB at 7).
+    let cp = backend
+        .get_projector_checkpoint("approvals", &exec)
+        .await
+        .expect("checkpoint");
+    assert_eq!(cp, 7);
+}
+
+// ── SQLite backend ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sqlite_apply_and_read() {
+    let db = open_sqlite().await;
+    assert_apply_and_read(&db).await;
+}
+
+#[tokio::test]
+async fn sqlite_upsert_idempotency() {
+    let db = open_sqlite().await;
+    assert_upsert_idempotency(&db).await;
+}
+
+#[tokio::test]
+async fn sqlite_unknown_checkpoint_is_zero() {
+    let db = open_sqlite().await;
+    assert_unknown_checkpoint_is_zero(&db).await;
+}
+
+#[tokio::test]
+async fn sqlite_two_nodes_same_execution() {
+    let db = open_sqlite().await;
+    assert_two_nodes_same_execution(&db).await;
+}
+
+// ── In-memory backend ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn memory_apply_and_read() {
+    let backend = InMemoryBackend::new();
+    assert_apply_and_read(&backend).await;
+}
+
+#[tokio::test]
+async fn memory_upsert_idempotency() {
+    let backend = InMemoryBackend::new();
+    assert_upsert_idempotency(&backend).await;
+}
+
+#[tokio::test]
+async fn memory_unknown_checkpoint_is_zero() {
+    let backend = InMemoryBackend::new();
+    assert_unknown_checkpoint_is_zero(&backend).await;
+}
+
+#[tokio::test]
+async fn memory_two_nodes_same_execution() {
+    let backend = InMemoryBackend::new();
+    assert_two_nodes_same_execution(&backend).await;
+}
+
+// ── Tenant-scoped backend ─────────────────────────────────────────────────────
+
+async fn open_tenant_scoped() -> jamjet_state::TenantScopedSqliteBackend {
+    use chrono::Utc;
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+    let tenant_id = TenantId::from("proj-acme");
+    let scoped_admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+    scoped_admin
+        .create_tenant(Tenant {
+            id: tenant_id.clone(),
+            name: "ProjAcme".into(),
+            status: TenantStatus::Active,
+            policy: None,
+            limits: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("register tenant");
+
+    db.for_tenant(tenant_id)
+}
+
+#[tokio::test]
+async fn tenant_apply_and_read() {
+    let scoped = open_tenant_scoped().await;
+    assert_apply_and_read(&scoped).await;
+}
+
+#[tokio::test]
+async fn tenant_upsert_idempotency() {
+    let scoped = open_tenant_scoped().await;
+    assert_upsert_idempotency(&scoped).await;
+}
+
+#[tokio::test]
+async fn tenant_unknown_checkpoint_is_zero() {
+    let scoped = open_tenant_scoped().await;
+    assert_unknown_checkpoint_is_zero(&scoped).await;
+}
+
+#[tokio::test]
+async fn tenant_isolation() {
+    // Two tenants with the same execution_id must not see each other's rows.
+    use chrono::Utc;
+    use jamjet_state::tenant::{Tenant, TenantId, TenantStatus};
+
+    let db = open_sqlite().await;
+    let admin = db.for_tenant(TenantId::default());
+    let now = Utc::now();
+
+    for name in ["alpha", "beta"] {
+        admin
+            .create_tenant(Tenant {
+                id: TenantId::from(name),
+                name: name.into(),
+                status: TenantStatus::Active,
+                policy: None,
+                limits: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .await
+            .expect("register tenant");
+    }
+
+    let alpha = db.for_tenant(TenantId::from("alpha"));
+    let beta = db.for_tenant(TenantId::from("beta"));
+
+    // Use the SAME execution_id string in both tenants.
+    let shared_exec = ExecutionId::new();
+
+    alpha
+        .apply_approval_projection(
+            ApprovalProjectionRow {
+                execution_id: shared_exec.clone(),
+                node_id: "nodeX".into(),
+                status: "granted".into(),
+                user_id: None,
+                comment: None,
+                last_sequence: 1,
+            },
+            "approvals",
+            1,
+        )
+        .await
+        .expect("alpha apply");
+
+    // Beta must see no rows for this execution.
+    let beta_rows = beta
+        .get_approval_projection(&shared_exec)
+        .await
+        .expect("beta get");
+    assert!(
+        beta_rows.is_empty(),
+        "tenant beta must not see tenant alpha's projection rows"
+    );
+
+    // Beta checkpoint must be 0 (unseen).
+    let beta_cp = beta
+        .get_projector_checkpoint("approvals", &shared_exec)
+        .await
+        .expect("beta checkpoint");
+    assert_eq!(beta_cp, 0, "beta must not inherit alpha's checkpoint");
+}


### PR DESCRIPTION
## What

Track 2h of the ADK build. Adds an asynchronous read-model projector so a read endpoint serves from a cheap durable projection instead of replaying the whole event log per request. Vertical slice: the approvals read. The write path (commit_turn, the worker's replay and idempotency) is unchanged and remains the source of truth.

## How

- **Projection + checkpoint** (migrations 0008, 0009): a `proj_approvals` table holds the latest approval state per execution and node; `projector_checkpoints` records how far the projection has consumed each execution's event stream so it resumes after a restart.
- **Projector** (`scheduler/src/projector.rs`): a background task, spawned alongside the scheduler, that tails each running execution's events from its checkpoint, folds the approval events, and applies the whole batch plus the checkpoint advance in a single transaction. The fold is first-decision-wins (a decision only resolves a still-pending node), matching what the runtime actually enacts.
- **Endpoint** (`GET /executions/:id/approvals`): now reads the projection. The response is byte-compatible with the previous replay-and-filter output (same fields, same status strings). The read is eventually-consistent and lags the write path by at most one projector tick.

## Safety

This got a whole-branch adversarial review, which caught and forced fixes for three issues before merge:

- A multi-row batch that advanced the checkpoint per row, so a crash mid-batch could permanently drop approvals. Fixed by applying the whole batch and the checkpoint in one transaction.
- A hardcoded 100-execution cap that would skip projecting the rest. Fixed with pagination.
- A last-write-wins fold that disagreed with the runtime on a concurrent approve/reject race. Fixed to first-decision-wins, matching the canonical fold.

The checkpoint-resume test proves a fresh projector resumes from the durable checkpoint without reprocessing or skipping, and the read-fidelity test proves the projection matches the approval state implied by the events.

## Follow-ups (tracked)

- F-2h-global-cursor: a global event cursor so the projector catches up across all executions in one query per tick instead of per-execution fan-out.
- F-2h-tenant: the projector runs on the base tenant scope today; non-default tenants need tenant-aware projection before a multi-tenant rollout (no cross-tenant leak; restrictive filter).
- F-2h-more-projections, F-2h-shutdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approvals are now served from a durable projection, improving response reliability and reducing repeated event-log replay.
  * A background projector now keeps approval data up to date automatically.
  * Approval responses now preserve pending and decided details, including metadata such as tool, approver, and context when available.

* **Bug Fixes**
  * Unknown approval states are safely ignored instead of failing requests.
  * Projection processing now handles repeated runs and late-arriving updates more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->