### PR TITLE
feat(2i): content-addressed artifact store for large model-node outputs

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -376,7 +376,44 @@ async fn list_events(
 ) -> Result<Json<Value>, ApiError> {
     let backend = state.backend_for(&tenant_id);
     let execution_id = parse_execution_id(&id)?;
-    let events = backend.get_events(&execution_id).await?;
+    let mut events = backend.get_events(&execution_id).await?;
+
+    // Resolve ArtifactRef sentinels in NodeCompleted.output before returning to
+    // the client.  The write path (2i-2) spills large outputs to the artifact
+    // store before commit_turn and replaces the inline value with a
+    // {"$artifact": {...}} sentinel; here we fetch and restore the original.
+    //
+    // A missing artifact (dangling ref) is impossible by the put-then-commit
+    // write-order invariant, but is handled gracefully: the sentinel is kept and
+    // an "unresolved": true flag is added inside the $artifact object.  Never
+    // panics; logs a WARN so the anomaly is visible.
+    for event in &mut events {
+        if let jamjet_state::EventKind::NodeCompleted {
+            output, node_id, ..
+        } = &mut event.kind
+        {
+            let resolved = jamjet_state::resolve_value(output, &*backend).await;
+            match resolved {
+                Ok(v) => *output = v,
+                Err(e) => {
+                    tracing::warn!(
+                        node_id = %node_id,
+                        error = %e,
+                        "artifact resolve failed for NodeCompleted output; \
+                         returning sentinel with unresolved=true"
+                    );
+                    // Add unresolved=true inside the $artifact inner object so
+                    // callers can detect the anomaly without a 5xx.
+                    if let Some(inner) = output.get_mut(jamjet_state::ARTIFACT_SENTINEL_KEY) {
+                        if let Some(obj) = inner.as_object_mut() {
+                            obj.insert("unresolved".to_string(), Value::Bool(true));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     Ok(Json(json!({ "events": events })))
 }
 

--- a/runtime/api/tests/artifact_resolve.rs
+++ b/runtime/api/tests/artifact_resolve.rs
@@ -1,0 +1,283 @@
+//! Task 2i-3: verify that GET /executions/:id/events resolves ArtifactRef
+//! sentinels in NodeCompleted.output before returning the response.
+//!
+//! Covers three cases:
+//!   1. Spilled output (sentinel) -> resolved original value.
+//!   2. Inline output (no sentinel) -> passes through unchanged.
+//!   3. Dangling sentinel (artifact missing) -> 200 with unresolved=true; no panic.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::StateBackend;
+use jamjet_state::event::EventKind;
+use jamjet_state::{ArtifactRef, Event, InMemoryBackend};
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_state(backend: Arc<InMemoryBackend>) -> AppState {
+    let backend_clone = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone() as Arc<dyn jamjet_state::StateBackend>,
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| {
+            backend_clone.clone() as Arc<dyn jamjet_state::StateBackend>
+        }),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn create_execution(backend: &Arc<InMemoryBackend>) -> ExecutionId {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "test-wf".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    execution_id
+}
+
+fn node_completed_kind(node_id: &str, output: Value) -> EventKind {
+    EventKind::NodeCompleted {
+        node_id: node_id.into(),
+        output,
+        state_patch: serde_json::json!({}),
+        duration_ms: 1,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+        idempotency_key: None,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// A spilled NodeCompleted.output (sentinel stored in the event log) must be
+/// resolved back to the original JSON value by GET /executions/:id/events.
+#[tokio::test]
+async fn list_events_resolves_spilled_node_output() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+
+    // Build a large output that exceeds the 8 KB spill threshold.
+    let original_output = serde_json::json!({
+        "content": "a".repeat(10_000),
+        "model": "claude-test",
+        "finish_reason": "stop",
+    });
+
+    // Spill: write the artifact to the store BEFORE appending the event
+    // (mirrors the write-order invariant enforced by the 2i-2 write path).
+    let bytes = serde_json::to_vec(&original_output).expect("serialize");
+    let artifact_ref = backend
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .expect("put_artifact");
+    let sentinel = artifact_ref.to_sentinel();
+
+    // Append a NodeCompleted event that carries the sentinel instead of inline bytes.
+    let seq = backend
+        .latest_sequence(&execution_id)
+        .await
+        .expect("latest_sequence")
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            node_completed_kind("spilled-node", sentinel),
+        ))
+        .await
+        .expect("append_event");
+
+    // GET /executions/:id/events — must return the RESOLVED original output.
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{}/events", execution_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json: Value = body_json(resp.into_body()).await;
+
+    let events = json["events"].as_array().expect("events array");
+    let nc = events
+        .iter()
+        .find(|e| e["kind"]["type"] == "node_completed")
+        .expect("NodeCompleted event must be present");
+
+    let output = &nc["kind"]["output"];
+
+    // Sentinel must be gone — original value is restored.
+    assert!(
+        output.get("$artifact").is_none(),
+        "output must not contain a sentinel after resolve; got: {output}"
+    );
+    assert_eq!(output["model"], "claude-test");
+    assert_eq!(output["finish_reason"], "stop");
+    let content = output["content"].as_str().expect("content is a string");
+    assert_eq!(
+        content.len(),
+        10_000,
+        "resolved content must match original length"
+    );
+}
+
+/// An inline (non-spilled) NodeCompleted.output must be passed through as-is.
+/// resolve_value is a no-op for non-sentinel values.
+#[tokio::test]
+async fn list_events_passes_through_inline_output() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+
+    let inline_output = serde_json::json!({ "status": "ok", "value": 42 });
+
+    let seq = backend
+        .latest_sequence(&execution_id)
+        .await
+        .expect("latest_sequence")
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            node_completed_kind("inline-node", inline_output.clone()),
+        ))
+        .await
+        .expect("append_event");
+
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{}/events", execution_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json: Value = body_json(resp.into_body()).await;
+
+    let events = json["events"].as_array().expect("events array");
+    let nc = events
+        .iter()
+        .find(|e| e["kind"]["type"] == "node_completed")
+        .expect("NodeCompleted event must be present");
+
+    let output = &nc["kind"]["output"];
+    assert_eq!(
+        output, &inline_output,
+        "inline output must pass through unchanged"
+    );
+}
+
+/// A dangling sentinel (artifact missing from the store) must return 200 with
+/// the sentinel still in place and an "unresolved": true flag — never panic or 5xx.
+#[tokio::test]
+async fn list_events_dangling_artifact_ref_returns_unresolved_flag() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+    let app = build_router_with_opts(state, true);
+
+    let execution_id = create_execution(&backend).await;
+
+    // Craft a sentinel whose hash was NEVER put in the store (dangling ref).
+    let dangling_ref = ArtifactRef {
+        hash: "deadbeef".repeat(8), // 64-char hex-shaped string
+        size: 1234,
+        media_type: Some("application/json".into()),
+    };
+    let dangling_sentinel = dangling_ref.to_sentinel();
+
+    let seq = backend
+        .latest_sequence(&execution_id)
+        .await
+        .expect("latest_sequence")
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            node_completed_kind("dangling-node", dangling_sentinel),
+        ))
+        .await
+        .expect("append_event");
+
+    // Must not panic — must return 200.
+    let resp = app
+        .oneshot(
+            Request::get(format!("/executions/{}/events", execution_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "dangling ref must not cause a 5xx"
+    );
+    let json: Value = body_json(resp.into_body()).await;
+
+    let events = json["events"].as_array().expect("events array");
+    let nc = events
+        .iter()
+        .find(|e| e["kind"]["type"] == "node_completed")
+        .expect("NodeCompleted event must be present");
+
+    let output = &nc["kind"]["output"];
+
+    // Sentinel is kept (we cannot resolve), and unresolved=true is added.
+    assert!(
+        output.get("$artifact").is_some(),
+        "sentinel must be present for a dangling ref: {output}"
+    );
+    assert_eq!(
+        output["$artifact"]["unresolved"], true,
+        "unresolved flag must be set for dangling ref: {output}"
+    );
+}

--- a/runtime/state/migrations/0010_artifacts.sql
+++ b/runtime/state/migrations/0010_artifacts.sql
@@ -1,0 +1,14 @@
+-- Migration 0010: content-addressed artifact store. Large payloads (e.g. model
+-- node outputs) are written once keyed by content hash and referenced by a small
+-- ArtifactRef sentinel, shrinking the event log. Tenant-scoped; no cross-tenant
+-- dedup (content-inference safety); write-once (no GC in v1).
+CREATE TABLE IF NOT EXISTS artifacts (
+    tenant_id   TEXT    NOT NULL DEFAULT 'default',
+    hash        TEXT    NOT NULL,
+    bytes       BLOB    NOT NULL,
+    size        INTEGER NOT NULL,
+    media_type  TEXT,
+    created_at  TEXT    NOT NULL,
+    PRIMARY KEY (tenant_id, hash)
+);
+CREATE INDEX IF NOT EXISTS idx_artifacts_hash ON artifacts(hash);

--- a/runtime/state/src/artifact.rs
+++ b/runtime/state/src/artifact.rs
@@ -1,0 +1,147 @@
+//! Content-addressed artifact store helpers.
+//!
+//! Large `serde_json::Value` payloads (model outputs, large state blobs) that
+//! exceed a configurable byte threshold are "spilled" to the artifact store
+//! and replaced inline by a small `ArtifactRef` sentinel value. Readers call
+//! `resolve_value` to restore the original.
+//!
+//! The sentinel shape is:
+//! ```json
+//! { "$artifact": { "hash": "...", "size": 16384, "media_type": "application/json" } }
+//! ```
+//!
+//! The sentinel key `$artifact` is reserved — it must never appear as a real
+//! workflow state key. In practice this is a trivially safe constraint because
+//! workflow state keys come from user-defined YAML node names.
+
+use crate::backend::{BackendResult, StateBackend, StateBackendError};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Sentinel key used to distinguish an ArtifactRef from real data.
+pub const ARTIFACT_SENTINEL_KEY: &str = "$artifact";
+
+/// Default spill threshold: 8 KiB. Values whose serialized JSON byte length
+/// exceeds this are written to the artifact store and replaced by a sentinel.
+/// Override at runtime via the `JAMJET_ARTIFACT_THRESHOLD_BYTES` env var.
+pub const DEFAULT_SPILL_THRESHOLD: usize = 8 * 1024;
+
+/// A reference to a content-addressed artifact stored out-of-band.
+///
+/// Replaces the inline `serde_json::Value` in events and state when the value
+/// exceeds the spill threshold. `hash` is the SHA-256 hex of the stored bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    /// SHA-256 hex of the stored bytes (64 lowercase hex chars).
+    pub hash: String,
+    /// Byte length of the stored content.
+    pub size: u64,
+    /// Optional MIME type (e.g. `"application/json"`, `"text/plain"`).
+    pub media_type: Option<String>,
+}
+
+impl ArtifactRef {
+    /// Serialize this ref into the sentinel JSON value that replaces the
+    /// original payload inline.
+    pub fn to_sentinel(&self) -> Value {
+        json!({
+            ARTIFACT_SENTINEL_KEY: {
+                "hash": self.hash,
+                "size": self.size,
+                "media_type": self.media_type,
+            }
+        })
+    }
+
+    /// Parse an `ArtifactRef` from a sentinel value, or return `None` if the
+    /// value is not a sentinel.
+    pub fn from_sentinel(v: &Value) -> Option<ArtifactRef> {
+        let inner = v.as_object()?.get(ARTIFACT_SENTINEL_KEY)?;
+        let hash = inner.get("hash")?.as_str()?.to_string();
+        let size = inner.get("size")?.as_u64()?;
+        let media_type = inner
+            .get("media_type")
+            .and_then(|m| m.as_str())
+            .map(|s| s.to_string());
+        Some(ArtifactRef {
+            hash,
+            size,
+            media_type,
+        })
+    }
+}
+
+/// If `value` serializes to more than `threshold` bytes, return `Some(bytes)`
+/// (the raw JSON bytes to put in the artifact store). Otherwise return `None`
+/// (the value is small enough to stay inline).
+///
+/// The caller is expected to:
+/// 1. Call `spill_bytes` to check if spilling is needed and get the bytes.
+/// 2. Call `backend.put_artifact(&bytes, media_type)` to get an `ArtifactRef`.
+/// 3. Replace the original value with `artifact_ref.to_sentinel()`.
+pub fn spill_bytes(value: &Value, threshold: usize) -> Option<Vec<u8>> {
+    let bytes = serde_json::to_vec(value).ok()?;
+    if bytes.len() > threshold {
+        Some(bytes)
+    } else {
+        None
+    }
+}
+
+/// Resolve a value: if it is a `{"$artifact": {...}}` sentinel, fetch the
+/// stored bytes from the backend and deserialize back to the original `Value`.
+/// Otherwise return it unchanged.
+///
+/// One-level walk: if the top-level value is not a sentinel but is an object
+/// or array, resolve any sentinel values one level deep. This is sufficient for
+/// the current spill model where the entire node output is spilled as one ref.
+///
+/// A missing artifact (dangling ref) returns a `StateBackendError::NotFound`
+/// rather than panicking.
+pub async fn resolve_value(value: &Value, backend: &dyn StateBackend) -> BackendResult<Value> {
+    // Top-level sentinel?
+    if let Some(artifact_ref) = ArtifactRef::from_sentinel(value) {
+        return resolve_ref(&artifact_ref, backend).await;
+    }
+
+    // Walk one level into objects.
+    if let Some(obj) = value.as_object() {
+        let mut out = serde_json::Map::with_capacity(obj.len());
+        for (k, v) in obj {
+            if let Some(artifact_ref) = ArtifactRef::from_sentinel(v) {
+                out.insert(k.clone(), resolve_ref(&artifact_ref, backend).await?);
+            } else {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+        return Ok(Value::Object(out));
+    }
+
+    // Walk one level into arrays.
+    if let Some(arr) = value.as_array() {
+        let mut out = Vec::with_capacity(arr.len());
+        for v in arr {
+            if let Some(artifact_ref) = ArtifactRef::from_sentinel(v) {
+                out.push(resolve_ref(&artifact_ref, backend).await?);
+            } else {
+                out.push(v.clone());
+            }
+        }
+        return Ok(Value::Array(out));
+    }
+
+    Ok(value.clone())
+}
+
+async fn resolve_ref(
+    artifact_ref: &ArtifactRef,
+    backend: &dyn StateBackend,
+) -> BackendResult<Value> {
+    match backend.get_artifact(&artifact_ref.hash).await? {
+        Some(bytes) => serde_json::from_slice(&bytes).map_err(StateBackendError::Serialization),
+        None => Err(StateBackendError::NotFound(format!(
+            "artifact {} not found (dangling ref)",
+            artifact_ref.hash
+        ))),
+    }
+}

--- a/runtime/state/src/artifact.rs
+++ b/runtime/state/src/artifact.rs
@@ -10,9 +10,26 @@
 //! { "$artifact": { "hash": "...", "size": 16384, "media_type": "application/json" } }
 //! ```
 //!
-//! The sentinel key `$artifact` is reserved — it must never appear as a real
-//! workflow state key. In practice this is a trivially safe constraint because
-//! workflow state keys come from user-defined YAML node names.
+//! ## Sentinel recognition (strict-shape check)
+//!
+//! `ArtifactRef::from_sentinel` is strict: it returns `Some(ref)` ONLY when the
+//! value is `{"$artifact": <obj>}` where:
+//! - `<obj>.hash` is exactly 64 lowercase hex characters (`[0-9a-f]{64}`)
+//! - `<obj>.size` is a non-negative integer
+//! - `<obj>.media_type` (optional) is a string or null
+//!
+//! Any value that has a `$artifact` key but does not match this exact shape is
+//! treated as plain model output and returned **unchanged** by `resolve_value`.
+//!
+//! **Residual**: a model that coincidentally produces `{"$artifact":{"hash":"<64
+//! lowercase hex chars>","size":<int>}}` would be mis-identified as a ref. This
+//! is astronomically unlikely in practice and is a documented limitation.
+//!
+//! ## Spill threshold
+//!
+//! The default threshold is [`DEFAULT_SPILL_THRESHOLD`] (8 KiB). Override at
+//! runtime via the `JAMJET_ARTIFACT_THRESHOLD_BYTES` environment variable. Use
+//! [`artifact_threshold`] to read the effective value.
 
 use crate::backend::{BackendResult, StateBackend, StateBackendError};
 use serde::{Deserialize, Serialize};
@@ -54,11 +71,29 @@ impl ArtifactRef {
     }
 
     /// Parse an `ArtifactRef` from a sentinel value, or return `None` if the
-    /// value is not a sentinel.
+    /// value is not a well-formed sentinel.
+    ///
+    /// Returns `Some(ref)` only when `v` is `{"$artifact": <obj>}` where:
+    /// - `<obj>.hash` is exactly 64 lowercase hex chars (`[0-9a-f]{64}`)
+    /// - `<obj>.size` is a non-negative integer
+    /// - `<obj>.media_type` is absent, null, or a string
+    ///
+    /// Any value that has a `$artifact` key but fails these checks returns
+    /// `None` so `resolve_value` passes it through unchanged (not `unresolved`).
     pub fn from_sentinel(v: &Value) -> Option<ArtifactRef> {
         let inner = v.as_object()?.get(ARTIFACT_SENTINEL_KEY)?;
         let hash = inner.get("hash")?.as_str()?.to_string();
+        // Strict: hash must be exactly 64 lowercase hex characters.
+        if hash.len() != 64 || !hash.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
+            return None;
+        }
         let size = inner.get("size")?.as_u64()?;
+        // media_type must be a string or null/absent.
+        if let Some(mt) = inner.get("media_type") {
+            if !mt.is_null() && mt.as_str().is_none() {
+                return None;
+            }
+        }
         let media_type = inner
             .get("media_type")
             .and_then(|m| m.as_str())
@@ -69,6 +104,28 @@ impl ArtifactRef {
             media_type,
         })
     }
+}
+
+/// Parse a `JAMJET_ARTIFACT_THRESHOLD_BYTES` env-var string into a `usize`,
+/// falling back to [`DEFAULT_SPILL_THRESHOLD`] on absence or invalid input.
+/// Accepts the optional env value directly so the logic is testable without
+/// mutating the process environment.
+fn parse_threshold(val: Option<&str>) -> usize {
+    val.and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_SPILL_THRESHOLD)
+}
+
+/// Return the effective spill threshold in bytes.
+///
+/// Reads `JAMJET_ARTIFACT_THRESHOLD_BYTES` from the environment; returns
+/// [`DEFAULT_SPILL_THRESHOLD`] (8 KiB) if the variable is absent or not a
+/// valid `usize`.
+pub fn artifact_threshold() -> usize {
+    parse_threshold(
+        std::env::var("JAMJET_ARTIFACT_THRESHOLD_BYTES")
+            .ok()
+            .as_deref(),
+    )
 }
 
 /// If `value` serializes to more than `threshold` bytes, return `Some(bytes)`
@@ -143,5 +200,26 @@ async fn resolve_ref(
             "artifact {} not found (dangling ref)",
             artifact_ref.hash
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `parse_threshold` must return the default when no override is supplied,
+    /// the parsed value when a valid decimal string is given, and the default
+    /// again when the string is not a valid `usize`. Tested without mutating
+    /// the process environment so the test is safe for parallel runs.
+    #[test]
+    fn parse_threshold_defaults_and_overrides() {
+        assert_eq!(parse_threshold(None), DEFAULT_SPILL_THRESHOLD);
+        assert_eq!(parse_threshold(Some("4096")), 4096);
+        assert_eq!(parse_threshold(Some("0")), 0);
+        assert_eq!(
+            parse_threshold(Some("not_a_number")),
+            DEFAULT_SPILL_THRESHOLD
+        );
+        assert_eq!(parse_threshold(Some("")), DEFAULT_SPILL_THRESHOLD);
     }
 }

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -1,3 +1,4 @@
+use crate::artifact::ArtifactRef;
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
 use crate::tenant::{Tenant, TenantId, DEFAULT_TENANT};
@@ -180,6 +181,26 @@ pub trait StateBackend: Send + Sync {
     /// Recorded atomically inside `commit_turn` when the terminal event is a
     /// `NodeCompleted` with `idempotency_key = Some(k)`.
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>>;
+
+    // ── Content-addressed artifact store ─────────────────────────────────────
+
+    /// Store bytes in the CAS, keyed by their SHA-256 hash.
+    ///
+    /// Uses `INSERT OR IGNORE` so writing the same bytes twice is idempotent:
+    /// only one row is ever stored per `(tenant_id, hash)`.
+    ///
+    /// Returns the `ArtifactRef` describing the stored content. Callers must
+    /// call this BEFORE `commit_turn` so that no event ever references an
+    /// artifact row that doesn't exist yet (put-then-commit write-order invariant).
+    async fn put_artifact(
+        &self,
+        bytes: &[u8],
+        media_type: Option<&str>,
+    ) -> BackendResult<ArtifactRef>;
+
+    /// Retrieve artifact bytes by hash (tenant-scoped). Returns `None` if the
+    /// artifact does not exist for this tenant.
+    async fn get_artifact(&self, hash: &str) -> BackendResult<Option<Vec<u8>>>;
 
     // ── Queue (simple Postgres/SQLite backed queue in v1) ────────────────
 

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -59,6 +59,18 @@ pub fn content_hash(value: &Value) -> String {
     hex
 }
 
+/// Lowercase hex SHA-256 of raw bytes. Used by the artifact store to hash
+/// the stored blob directly (not canonical JSON), so the hash matches the
+/// stored bytes exactly regardless of JSON key ordering.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
 pub mod approvals;
+pub mod artifact;
 pub mod backend;
 pub mod budget;
 pub mod event;
@@ -18,13 +19,16 @@ pub mod sqlite;
 pub mod tenant;
 pub mod tenant_scoped;
 
+pub use artifact::{
+    resolve_value, spill_bytes, ArtifactRef, ARTIFACT_SENTINEL_KEY, DEFAULT_SPILL_THRESHOLD,
+};
 pub use backend::{
     ApiToken, ApprovalProjectionRow, BackendResult, ReclaimResult, StateBackend, StateBackendError,
     WorkItem, WorkItemId, WorkflowDefinition,
 };
 pub use budget::BudgetState;
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
-pub use hashing::{canonical_json, content_hash};
+pub use hashing::{canonical_json, content_hash, sha256_hex};
 pub use materializer::{
     apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState,
 };

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -20,7 +20,8 @@ pub mod tenant;
 pub mod tenant_scoped;
 
 pub use artifact::{
-    resolve_value, spill_bytes, ArtifactRef, ARTIFACT_SENTINEL_KEY, DEFAULT_SPILL_THRESHOLD,
+    artifact_threshold, resolve_value, spill_bytes, ArtifactRef, ARTIFACT_SENTINEL_KEY,
+    DEFAULT_SPILL_THRESHOLD,
 };
 pub use backend::{
     ApiToken, ApprovalProjectionRow, BackendResult, ReclaimResult, StateBackend, StateBackendError,

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -45,6 +45,8 @@ pub struct InMemoryBackend {
     proj_approvals: DashMap<(String, String), crate::backend::ApprovalProjectionRow>,
     /// Projector checkpoints. Key = (projection_name, execution_id as String).
     projector_checkpoints: DashMap<(String, String), i64>,
+    /// Content-addressed artifact store. Key = (tenant_id, hash).
+    artifacts: DashMap<(String, String), (Vec<u8>, Option<String>)>,
 }
 
 impl InMemoryBackend {
@@ -64,6 +66,7 @@ impl InMemoryBackend {
             tool_effects: DashMap::new(),
             proj_approvals: DashMap::new(),
             projector_checkpoints: DashMap::new(),
+            artifacts: DashMap::new(),
         }
     }
 
@@ -321,6 +324,33 @@ impl StateBackend for InMemoryBackend {
 
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
         Ok(self.tool_effects.get(key).map(|r| r.value().clone()))
+    }
+
+    // ── Content-addressed artifact store ─────────────────────────────────────
+
+    async fn put_artifact(
+        &self,
+        bytes: &[u8],
+        media_type: Option<&str>,
+    ) -> BackendResult<crate::artifact::ArtifactRef> {
+        let hash = crate::hashing::sha256_hex(bytes);
+        let size = bytes.len() as u64;
+        // Dedupe: only insert if not already present (INSERT OR IGNORE semantics).
+        self.artifacts
+            .entry(("default".to_string(), hash.clone()))
+            .or_insert_with(|| (bytes.to_vec(), media_type.map(|s| s.to_string())));
+        Ok(crate::artifact::ArtifactRef {
+            hash,
+            size,
+            media_type: media_type.map(|s| s.to_string()),
+        })
+    }
+
+    async fn get_artifact(&self, hash: &str) -> BackendResult<Option<Vec<u8>>> {
+        Ok(self
+            .artifacts
+            .get(&("default".to_string(), hash.to_string()))
+            .map(|r| r.value().0.clone()))
     }
 
     // ── Work queue ───────────────────────────────────────────────────

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -858,6 +858,49 @@ impl StateBackend for SqliteBackend {
         Ok(Some(result_json))
     }
 
+    // ── Content-addressed artifact store ─────────────────────────────────────
+
+    async fn put_artifact(
+        &self,
+        bytes: &[u8],
+        media_type: Option<&str>,
+    ) -> BackendResult<crate::artifact::ArtifactRef> {
+        let hash = crate::hashing::sha256_hex(bytes);
+        let size = bytes.len() as u64;
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        sqlx::query(
+            r#"INSERT OR IGNORE INTO artifacts
+               (tenant_id, hash, bytes, size, media_type, created_at)
+               VALUES ('default', ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&hash)
+        .bind(bytes)
+        .bind(size as i64)
+        .bind(media_type)
+        .bind(&created_at)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        Ok(crate::artifact::ArtifactRef {
+            hash,
+            size,
+            media_type: media_type.map(|s| s.to_string()),
+        })
+    }
+
+    async fn get_artifact(&self, hash: &str) -> BackendResult<Option<Vec<u8>>> {
+        let row =
+            sqlx::query("SELECT bytes FROM artifacts WHERE tenant_id = 'default' AND hash = ?")
+                .bind(hash)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(map_db_err)?;
+
+        Ok(row.map(|r| r.get::<Vec<u8>, _>("bytes")))
+    }
+
     // ── Work item queue ───────────────────────────────────────────────────
 
     #[instrument(skip(self, item), fields(execution_id = %item.execution_id, node_id = %item.node_id))]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -785,6 +785,50 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(Some(result_json))
     }
 
+    // ── Content-addressed artifact store ─────────────────────────────────────
+
+    async fn put_artifact(
+        &self,
+        bytes: &[u8],
+        media_type: Option<&str>,
+    ) -> BackendResult<crate::artifact::ArtifactRef> {
+        let hash = crate::hashing::sha256_hex(bytes);
+        let size = bytes.len() as u64;
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        sqlx::query(
+            r#"INSERT OR IGNORE INTO artifacts
+               (tenant_id, hash, bytes, size, media_type, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
+        )
+        .bind(&self.tenant_id.0)
+        .bind(&hash)
+        .bind(bytes)
+        .bind(size as i64)
+        .bind(media_type)
+        .bind(&created_at)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        Ok(crate::artifact::ArtifactRef {
+            hash,
+            size,
+            media_type: media_type.map(|s| s.to_string()),
+        })
+    }
+
+    async fn get_artifact(&self, hash: &str) -> BackendResult<Option<Vec<u8>>> {
+        let row = sqlx::query("SELECT bytes FROM artifacts WHERE tenant_id = ? AND hash = ?")
+            .bind(&self.tenant_id.0)
+            .bind(hash)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+
+        Ok(row.map(|r| r.get::<Vec<u8>, _>("bytes")))
+    }
+
     // ── Work item queue ───────────────────────────────────────────────────
 
     #[instrument(skip(self, item), fields(tenant = %self.tenant_id, execution_id = %item.execution_id))]

--- a/runtime/state/tests/artifacts.rs
+++ b/runtime/state/tests/artifacts.rs
@@ -22,6 +22,13 @@ use serde_json::json;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+// Finding 4 (pool isolation) assessment: SqliteBackend::connect uses
+// SqlitePool::connect_with(opts) without capping max_connections, so multiple
+// connections to sqlite::memory: would each see an empty database.  However,
+// #[tokio::test] uses a single-threaded executor and the pool's
+// min_connections=0 default ensures at most one connection is ever live within
+// a test.  Tests pass by the sequential, single-connection guarantee of the
+// single-threaded runtime, NOT by luck.  No fix needed; risk is theoretical.
 async fn open_db() -> SqliteBackend {
     SqliteBackend::open("sqlite::memory:")
         .await
@@ -217,11 +224,73 @@ fn artifact_ref_sentinel_round_trip() {
     assert_eq!(parsed, artifact_ref);
 }
 
+/// Finding 1 — strict sentinel validation: `from_sentinel` must return `None`
+/// for any `$artifact` payload that does not match the exact expected shape.
+/// This prevents model-emitted objects that happen to contain `"$artifact"` from
+/// being mis-identified as refs and triggering spurious CAS lookups.
 #[test]
 fn artifact_ref_from_sentinel_returns_none_for_non_sentinel() {
+    // Plain objects and scalars without the $artifact key.
     assert!(ArtifactRef::from_sentinel(&json!({"foo": "bar"})).is_none());
     assert!(ArtifactRef::from_sentinel(&json!("just a string")).is_none());
     assert!(ArtifactRef::from_sentinel(&json!(42)).is_none());
+
+    // $artifact present but inner value is not an object.
+    assert!(ArtifactRef::from_sentinel(&json!({"$artifact": "foo"})).is_none());
+
+    // $artifact is an object but missing required fields.
+    assert!(ArtifactRef::from_sentinel(&json!({"$artifact": {}})).is_none());
+    assert!(ArtifactRef::from_sentinel(&json!({"$artifact": {"hash": "short"}})).is_none());
+
+    // $artifact has hash + size but hash is too short (not 64 hex chars).
+    // Without the strict-shape check this previously returned Some — the key
+    // regression case that motivated Finding 1.
+    assert!(
+        ArtifactRef::from_sentinel(&json!({"$artifact": {"hash": "tooshort", "size": 10}}))
+            .is_none(),
+        "short hash with size must not parse as an ArtifactRef"
+    );
+
+    // 64-char uppercase hex — fails because sentinel requires lowercase.
+    let upper_hash = "A".repeat(64);
+    assert!(
+        ArtifactRef::from_sentinel(&json!({"$artifact": {"hash": upper_hash, "size": 10}}))
+            .is_none(),
+        "uppercase hex hash must not parse as an ArtifactRef"
+    );
+}
+
+/// Finding 1 — a non-conforming `$artifact` object must be returned UNCHANGED
+/// by `resolve_value`, NOT treated as `unresolved` or yielding a NotFound error.
+/// This covers the case where a model emits an object with a `$artifact` key
+/// that does not satisfy the strict-shape check (missing size, short hash, etc.).
+#[tokio::test]
+async fn resolve_value_non_conforming_artifact_key_returns_unchanged() {
+    let backend = InMemoryBackend::new();
+
+    // Short hash + size: currently would error without the strict check.
+    let v = json!({"$artifact": {"hash": "tooshort", "size": 10}});
+    let result = resolve_value(&v, &backend).await.unwrap();
+    assert_eq!(
+        result, v,
+        "non-conforming $artifact must pass through unchanged"
+    );
+
+    // Object with $artifact key but no size — also non-conforming.
+    let v2 = json!({"$artifact": {"not": "a ref"}});
+    let result2 = resolve_value(&v2, &backend).await.unwrap();
+    assert_eq!(
+        result2, v2,
+        "missing-fields $artifact must pass through unchanged"
+    );
+
+    // Plain string inside $artifact — non-conforming.
+    let v3 = json!({"$artifact": "just a string"});
+    let result3 = resolve_value(&v3, &backend).await.unwrap();
+    assert_eq!(
+        result3, v3,
+        "string-valued $artifact must pass through unchanged"
+    );
 }
 
 // ── spill_bytes threshold behaviour ──────────────────────────────────────────

--- a/runtime/state/tests/artifacts.rs
+++ b/runtime/state/tests/artifacts.rs
@@ -1,0 +1,347 @@
+//! TDD tests for the content-addressed artifact store (Task 2i-1).
+//!
+//! Written RED (failing) before implementing artifact.rs + backend methods;
+//! turned GREEN after implementing put_artifact / get_artifact + ArtifactRef
+//! + spill_bytes + resolve_value in all three backends.
+//!
+//! Coverage:
+//! - SQLite backend (unscoped, "default" tenant)
+//! - TenantScopedSqliteBackend (two tenants: isolation + per-tenant dedupe)
+//! - InMemoryBackend
+//! - ArtifactRef sentinel round-trip
+//! - spill_bytes threshold behaviour
+//! - resolve_value happy-path + missing-artifact error path
+
+use jamjet_state::{
+    artifact::{resolve_value, spill_bytes, ArtifactRef, ARTIFACT_SENTINEL_KEY},
+    backend::StateBackend,
+    hashing::sha256_hex,
+    InMemoryBackend, SqliteBackend, TenantId,
+};
+use serde_json::json;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn open_db() -> SqliteBackend {
+    SqliteBackend::open("sqlite::memory:")
+        .await
+        .expect("failed to open in-memory SQLite for artifact tests")
+}
+
+// ── SQLite backend (unscoped / "default" tenant) ──────────────────────────────
+
+#[tokio::test]
+async fn sqlite_put_returns_stable_hash_and_size() {
+    let db = open_db().await;
+    let bytes = b"hello world";
+    let artifact_ref = db.put_artifact(bytes, Some("text/plain")).await.unwrap();
+
+    assert_eq!(artifact_ref.size, 11);
+    assert_eq!(artifact_ref.hash.len(), 64);
+    assert!(artifact_ref.hash.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(artifact_ref.media_type, Some("text/plain".to_string()));
+
+    // Hash must equal sha256_hex of the raw bytes.
+    assert_eq!(artifact_ref.hash, sha256_hex(bytes));
+}
+
+#[tokio::test]
+async fn sqlite_get_returns_original_bytes() {
+    let db = open_db().await;
+    let bytes = b"hello world";
+    let artifact_ref = db.put_artifact(bytes, Some("text/plain")).await.unwrap();
+
+    let retrieved = db.get_artifact(&artifact_ref.hash).await.unwrap();
+    assert_eq!(retrieved, Some(bytes.to_vec()));
+}
+
+#[tokio::test]
+async fn sqlite_put_same_bytes_twice_dedupes() {
+    let db = open_db().await;
+    let bytes = b"deduplication test payload";
+
+    let ref1 = db.put_artifact(bytes, None).await.unwrap();
+    let ref2 = db.put_artifact(bytes, None).await.unwrap();
+
+    // Same hash returned both times.
+    assert_eq!(ref1.hash, ref2.hash);
+
+    // Only one row in the table — verify via a raw count.
+    let pool = db.pool();
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE hash = ?")
+        .bind(&ref1.hash)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.0, 1,
+        "expected exactly one row after two identical puts"
+    );
+}
+
+#[tokio::test]
+async fn sqlite_get_missing_hash_returns_none() {
+    let db = open_db().await;
+    let result = db
+        .get_artifact("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+        .await
+        .unwrap();
+    assert_eq!(result, None);
+}
+
+// ── TenantScopedSqliteBackend — isolation + per-tenant dedupe ────────────────
+
+#[tokio::test]
+async fn tenant_scoped_isolation_a_cannot_read_b_artifact() {
+    let db = open_db().await;
+    let backend_a = db.for_tenant(TenantId::from("tenant-a"));
+    let backend_b = db.for_tenant(TenantId::from("tenant-b"));
+
+    let bytes = b"secret payload for A only";
+    let artifact_ref = backend_a.put_artifact(bytes, None).await.unwrap();
+
+    // tenant-B cannot read tenant-A's artifact.
+    let result_b = backend_b.get_artifact(&artifact_ref.hash).await.unwrap();
+    assert_eq!(result_b, None, "tenant-B must not see tenant-A's artifact");
+
+    // tenant-A can still read it.
+    let result_a = backend_a.get_artifact(&artifact_ref.hash).await.unwrap();
+    assert_eq!(result_a, Some(bytes.to_vec()));
+}
+
+#[tokio::test]
+async fn tenant_scoped_identical_content_stored_twice() {
+    let db = open_db().await;
+    let backend_a = db.for_tenant(TenantId::from("tenant-a"));
+    let backend_b = db.for_tenant(TenantId::from("tenant-b"));
+
+    let bytes = b"common template value";
+    let ref_a = backend_a.put_artifact(bytes, None).await.unwrap();
+    let ref_b = backend_b.put_artifact(bytes, None).await.unwrap();
+
+    // Same hash (same content).
+    assert_eq!(ref_a.hash, ref_b.hash);
+
+    // But two distinct rows (different tenant_id).
+    let pool = db.pool();
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE hash = ?")
+        .bind(&ref_a.hash)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.0, 2,
+        "identical content for two tenants must produce two rows"
+    );
+}
+
+#[tokio::test]
+async fn tenant_scoped_put_dedupes_within_same_tenant() {
+    let db = open_db().await;
+    let backend = db.for_tenant(TenantId::from("tenant-c"));
+
+    let bytes = b"tenant-c payload";
+    let ref1 = backend.put_artifact(bytes, None).await.unwrap();
+    let ref2 = backend.put_artifact(bytes, None).await.unwrap();
+    assert_eq!(ref1.hash, ref2.hash);
+
+    let pool = db.pool();
+    let row: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE hash = ? AND tenant_id = 'tenant-c'")
+            .bind(&ref1.hash)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.0, 1, "one row per (tenant, hash)");
+}
+
+// ── InMemoryBackend ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn memory_put_returns_stable_hash_and_size() {
+    let backend = InMemoryBackend::new();
+    let bytes = b"hello world";
+    let artifact_ref = backend
+        .put_artifact(bytes, Some("text/plain"))
+        .await
+        .unwrap();
+
+    assert_eq!(artifact_ref.size, 11);
+    assert_eq!(artifact_ref.hash, sha256_hex(bytes));
+    assert_eq!(artifact_ref.media_type, Some("text/plain".to_string()));
+}
+
+#[tokio::test]
+async fn memory_get_returns_original_bytes() {
+    let backend = InMemoryBackend::new();
+    let bytes = b"memory backend payload";
+    let artifact_ref = backend.put_artifact(bytes, None).await.unwrap();
+
+    let retrieved = backend.get_artifact(&artifact_ref.hash).await.unwrap();
+    assert_eq!(retrieved, Some(bytes.to_vec()));
+}
+
+#[tokio::test]
+async fn memory_put_same_bytes_twice_dedupes() {
+    let backend = InMemoryBackend::new();
+    let bytes = b"dedupe in memory";
+    let ref1 = backend.put_artifact(bytes, None).await.unwrap();
+    let ref2 = backend.put_artifact(bytes, None).await.unwrap();
+    assert_eq!(ref1.hash, ref2.hash);
+    // No assertion on row count (DashMap entry = 1 by construction via or_insert_with).
+}
+
+#[tokio::test]
+async fn memory_get_missing_returns_none() {
+    let backend = InMemoryBackend::new();
+    let result = backend
+        .get_artifact("0000000000000000000000000000000000000000000000000000000000000000")
+        .await
+        .unwrap();
+    assert_eq!(result, None);
+}
+
+// ── ArtifactRef sentinel helpers ──────────────────────────────────────────────
+
+#[test]
+fn artifact_ref_sentinel_round_trip() {
+    let artifact_ref = ArtifactRef {
+        hash: "abc123".repeat(10) + "abcd", // 64 chars
+        size: 16384,
+        media_type: Some("application/json".to_string()),
+    };
+    let sentinel = artifact_ref.to_sentinel();
+    assert!(sentinel.get(ARTIFACT_SENTINEL_KEY).is_some());
+
+    let parsed = ArtifactRef::from_sentinel(&sentinel).unwrap();
+    assert_eq!(parsed, artifact_ref);
+}
+
+#[test]
+fn artifact_ref_from_sentinel_returns_none_for_non_sentinel() {
+    assert!(ArtifactRef::from_sentinel(&json!({"foo": "bar"})).is_none());
+    assert!(ArtifactRef::from_sentinel(&json!("just a string")).is_none());
+    assert!(ArtifactRef::from_sentinel(&json!(42)).is_none());
+}
+
+// ── spill_bytes threshold behaviour ──────────────────────────────────────────
+
+#[test]
+fn spill_bytes_small_value_stays_inline() {
+    let small = json!({"key": "short value"});
+    // 1 MiB threshold — tiny value must stay inline.
+    assert!(spill_bytes(&small, 1 << 20).is_none());
+}
+
+#[test]
+fn spill_bytes_large_value_returns_bytes() {
+    // A string value serialized to JSON will exceed 8 bytes easily.
+    let long_str: String = "x".repeat(100);
+    let large = json!(long_str);
+    let bytes = spill_bytes(&large, 8).expect("expected Some(bytes) for large value");
+    // Bytes must be valid JSON that deserializes back to the same value.
+    let roundtripped: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(roundtripped, large);
+}
+
+#[test]
+fn spill_bytes_at_threshold_boundary() {
+    // A value whose serialized form is exactly `threshold` bytes stays inline
+    // (not strictly greater than).
+    let s = "a".repeat(8); // JSON: "aaaaaaaa" = 10 bytes (with quotes)
+    let v = json!(s);
+    let serialized = serde_json::to_vec(&v).unwrap();
+    let threshold = serialized.len();
+
+    // Exactly at threshold: no spill (> not >=).
+    assert!(spill_bytes(&v, threshold).is_none());
+    // One byte below: also no spill.
+    assert!(spill_bytes(&v, threshold + 1).is_none());
+    // One byte above threshold: spill.
+    assert!(spill_bytes(&v, threshold - 1).is_some());
+}
+
+// ── resolve_value round-trip ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sqlite_resolve_value_round_trip() {
+    let db = open_db().await;
+
+    let original = json!({
+        "content": "a model response that is large enough to be interesting",
+        "model": "claude-3-5-sonnet",
+        "finish_reason": "end_turn",
+    });
+
+    // Spill it (use threshold 8 to force spill).
+    let bytes = spill_bytes(&original, 8).expect("value should exceed 8-byte threshold");
+    let artifact_ref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = artifact_ref.to_sentinel();
+
+    // Resolve back.
+    let resolved = resolve_value(&sentinel, &db).await.unwrap();
+    assert_eq!(resolved, original);
+}
+
+#[tokio::test]
+async fn memory_resolve_value_round_trip() {
+    let backend = InMemoryBackend::new();
+
+    let original = json!(["item1", "item2", {"nested": true}]);
+    let bytes = spill_bytes(&original, 8).expect("array should exceed 8-byte threshold");
+    let artifact_ref = backend
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = artifact_ref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &backend).await.unwrap();
+    assert_eq!(resolved, original);
+}
+
+#[tokio::test]
+async fn resolve_value_non_sentinel_passes_through() {
+    let backend = InMemoryBackend::new();
+    let plain = json!({"not": "a sentinel"});
+    let resolved = resolve_value(&plain, &backend).await.unwrap();
+    assert_eq!(resolved, plain);
+}
+
+#[tokio::test]
+async fn resolve_value_missing_artifact_returns_error() {
+    let db = open_db().await;
+    let dangling_ref = ArtifactRef {
+        hash: "a".repeat(64),
+        size: 42,
+        media_type: None,
+    };
+    let sentinel = dangling_ref.to_sentinel();
+    let result = resolve_value(&sentinel, &db).await;
+    assert!(
+        result.is_err(),
+        "dangling ref must return an error, not panic"
+    );
+}
+
+#[tokio::test]
+async fn resolve_value_walks_object_one_level() {
+    let db = open_db().await;
+
+    let inner = json!({"big": "payload content here"});
+    let bytes = spill_bytes(&inner, 8).unwrap();
+    let artifact_ref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = artifact_ref.to_sentinel();
+
+    // Wrap in an outer object.
+    let outer = json!({ "output": sentinel, "meta": "unchanged" });
+    let resolved = resolve_value(&outer, &db).await.unwrap();
+
+    assert_eq!(resolved["output"], inner);
+    assert_eq!(resolved["meta"], json!("unchanged"));
+}

--- a/runtime/state/tests/artifacts.rs
+++ b/runtime/state/tests/artifacts.rs
@@ -345,3 +345,304 @@ async fn resolve_value_walks_object_one_level() {
     assert_eq!(resolved["output"], inner);
     assert_eq!(resolved["meta"], json!("unchanged"));
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 2i-4 — new coverage only; does NOT duplicate any 2i-1/2/3 tests.
+//
+// Not re-tested here (already covered):
+//   - put/get basics + basic 2-put dedupe (2i-1: sqlite_put_*/sqlite_get_*/memory_*)
+//   - get_artifact tenant isolation (2i-1: tenant_scoped_isolation_*)
+//   - sentinel helpers (2i-1: artifact_ref_*)
+//   - spill_bytes threshold logic incl. boundary (2i-1: spill_bytes_*)
+//   - sqlite + memory resolve round-trips (2i-1: sqlite_resolve_*/memory_resolve_*)
+//   - dangling-ref via unscoped SQLite (2i-1: resolve_value_missing_artifact_returns_error)
+//   - object-level walk (2i-1: resolve_value_walks_object_one_level)
+//   - API endpoint resolve (2i-3: artifact_resolve.rs)
+//   - worker spill path (2i-2: worker.rs)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// == Group A: Round-trip fidelity — four value shapes =========================
+//
+// Each shape is exercised through the full chain:
+//   spill_bytes → put_artifact → to_sentinel → resolve_value → original value
+// All use threshold=8 to force spilling even for tiny payloads.
+
+/// Plain JSON string, well above threshold.
+#[tokio::test]
+async fn round_trip_string_value_above_threshold() {
+    let db = open_db().await;
+    let original = json!("The quick brown fox jumps over the lazy dog. ".repeat(20));
+
+    let bytes = spill_bytes(&original, 8).expect("long string must exceed 8-byte threshold");
+    let aref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = aref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &db).await.unwrap();
+    assert_eq!(resolved, original, "string round-trip must be byte-perfect");
+}
+
+/// Five-level-deep JSON object, above threshold.
+#[tokio::test]
+async fn round_trip_deeply_nested_object_above_threshold() {
+    let db = open_db().await;
+    let data = "a".repeat(200);
+    let original = json!({
+        "level1": {
+            "level2": {
+                "level3": {
+                    "level4": {
+                        "level5": {
+                            "data": data,
+                            "tags": ["alpha", "beta", "gamma"],
+                            "count": 42
+                        }
+                    },
+                    "sibling": "value at l3"
+                }
+            },
+            "meta": {"created": "2026-06-26", "version": 3}
+        }
+    });
+
+    let bytes =
+        spill_bytes(&original, 8).expect("deeply-nested object must exceed 8-byte threshold");
+    let aref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = aref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &db).await.unwrap();
+    assert_eq!(
+        resolved, original,
+        "deeply-nested object round-trip must be byte-perfect"
+    );
+}
+
+/// Array of heterogeneous objects, above threshold.
+#[tokio::test]
+async fn round_trip_array_of_objects_above_threshold() {
+    let db = open_db().await;
+    let long_payload = "x".repeat(300);
+    let original = json!([
+        {"id": 1, "name": "alpha", "tags": ["a", "b"], "active": true},
+        {"id": 2, "name": "beta", "scores": [1.1, 2.2, 3.3], "meta": null},
+        {"id": 3, "name": "gamma", "nested": {"x": 10, "y": 20}},
+        {"id": 4, "payload": long_payload}
+    ]);
+
+    let bytes = spill_bytes(&original, 8).expect("array of objects must exceed 8-byte threshold");
+    let aref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = aref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &db).await.unwrap();
+    assert_eq!(
+        resolved, original,
+        "array-of-objects round-trip must be byte-perfect"
+    );
+}
+
+/// Object containing multi-script unicode, emojis, and JSON escape sequences.
+#[tokio::test]
+async fn round_trip_unicode_and_special_chars_above_threshold() {
+    let db = open_db().await;
+    let long_unicode = "音楽".repeat(100);
+    let original = json!({
+        "emoji": "🚀🌍🤖🦀",
+        "cjk": "日本語テスト中文测试한국어",
+        "arabic": "مرحبا بالعالم",
+        "escapes": "tab:\there\nnewline and \"quotes\"",
+        "long_unicode": long_unicode
+    });
+
+    let bytes = spill_bytes(&original, 8).expect("unicode object must exceed 8-byte threshold");
+    let aref = db
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = aref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &db).await.unwrap();
+    assert_eq!(
+        resolved, original,
+        "unicode round-trip must preserve all multi-byte code points exactly"
+    );
+}
+
+// == Group B: Below-threshold stays inline ====================================
+
+/// For each of the four shape categories, a value whose serialized size is
+/// BELOW the threshold must produce `None` from `spill_bytes` — the value
+/// stays inline and no artifact store write is needed.
+#[test]
+fn below_threshold_all_four_shapes_stay_inline() {
+    let large_threshold = 1 << 20; // 1 MiB — all values here fit comfortably
+
+    assert!(
+        spill_bytes(&json!("short string"), large_threshold).is_none(),
+        "small string must stay inline"
+    );
+    assert!(
+        spill_bytes(&json!({"level1": {"level2": "v"}}), large_threshold).is_none(),
+        "small nested object must stay inline"
+    );
+    assert!(
+        spill_bytes(&json!([{"a": 1}, {"b": 2}]), large_threshold).is_none(),
+        "small array of objects must stay inline"
+    );
+    assert!(
+        spill_bytes(&json!({"emoji": "🦀"}), large_threshold).is_none(),
+        "small unicode value must stay inline"
+    );
+}
+
+// == Group C: Dedupe at scale + hash stability ================================
+
+/// The same 50 KB blob put 10 times must produce exactly ONE row (INSERT OR
+/// IGNORE) and an identical hash on every call (hash stability / content-
+/// addressed guarantee). Supplements the existing 2-put test.
+#[tokio::test]
+async fn dedupe_at_scale_fifty_kb_blob_put_ten_times() {
+    let db = open_db().await;
+
+    // 50 KB of repeating bytes — realistic large model-output size.
+    let blob: Vec<u8> = (0u8..=255).cycle().take(50 * 1024).collect();
+    let mut reference_hash = String::new();
+
+    for i in 0..10usize {
+        let aref = db
+            .put_artifact(&blob, Some("application/octet-stream"))
+            .await
+            .unwrap();
+        if i == 0 {
+            reference_hash = aref.hash.clone();
+        } else {
+            assert_eq!(
+                aref.hash, reference_hash,
+                "hash must be identical on every put (hash stability, call {i})"
+            );
+        }
+    }
+
+    // Exactly one row — INSERT OR IGNORE deduped all subsequent writes.
+    let pool = db.pool();
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE hash = ?")
+        .bind(&reference_hash)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        row.0, 1,
+        "10 identical puts must produce exactly one row (dedupe at scale)"
+    );
+}
+
+/// Two different 50 KB blobs must each land in their own row with distinct hashes.
+#[tokio::test]
+async fn dedupe_two_distinct_blobs_produce_two_rows_and_different_hashes() {
+    let db = open_db().await;
+
+    let blob_a: Vec<u8> = vec![0xAA; 50 * 1024];
+    let blob_b: Vec<u8> = vec![0xBB; 50 * 1024];
+
+    let ref_a = db.put_artifact(&blob_a, None).await.unwrap();
+    let ref_b = db.put_artifact(&blob_b, None).await.unwrap();
+
+    assert_ne!(
+        ref_a.hash, ref_b.hash,
+        "distinct blobs must hash to distinct values"
+    );
+
+    let pool = db.pool();
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE hash IN (?, ?)")
+        .bind(&ref_a.hash)
+        .bind(&ref_b.hash)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0, 2, "two distinct blobs must occupy two separate rows");
+}
+
+// == Group D: Tenant isolation hard case — resolve_value cross-tenant =========
+//
+// 2i-1 tested get_artifact isolation. 2i-4 adds the resolve_value path:
+// tenant-B resolving tenant-A's sentinel must fail (no cross-tenant read).
+
+#[tokio::test]
+async fn tenant_cross_resolve_value_returns_error_no_cross_tenant_read() {
+    let db = open_db().await;
+    let backend_a = db.for_tenant(TenantId::from("tenant-a-xr"));
+    let backend_b = db.for_tenant(TenantId::from("tenant-b-xr"));
+
+    let original = json!({"secret": "tenant-A-only", "data": "x".repeat(200)});
+    let bytes = spill_bytes(&original, 8).unwrap();
+    let aref = backend_a
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    // B gets A's sentinel but tries to resolve it through B's backend.
+    let sentinel_a = aref.to_sentinel();
+
+    let result = resolve_value(&sentinel_a, &backend_b).await;
+    assert!(
+        result.is_err(),
+        "tenant-B must not resolve tenant-A's sentinel (no cross-tenant read); got Ok"
+    );
+}
+
+// == Group E: Cross-backend — TenantScopedSqliteBackend full round-trip =======
+//
+// 2i-1 proved put/get per-tenant; 2i-4 proves the full
+// spill → put → sentinel → resolve cycle through TenantScopedSqliteBackend.
+
+#[tokio::test]
+async fn tenant_scoped_full_spill_resolve_round_trip() {
+    let db = open_db().await;
+    let backend = db.for_tenant(TenantId::from("tenant-rtt"));
+
+    let original = json!({
+        "tenant": "tenant-rtt",
+        "payload": "z".repeat(300),
+        "tags": ["tag1", "tag2", "tag3"]
+    });
+
+    let bytes = spill_bytes(&original, 8).unwrap();
+    let aref = backend
+        .put_artifact(&bytes, Some("application/json"))
+        .await
+        .unwrap();
+    let sentinel = aref.to_sentinel();
+
+    let resolved = resolve_value(&sentinel, &backend).await.unwrap();
+    assert_eq!(
+        resolved, original,
+        "tenant-scoped spill+resolve must be byte-perfect"
+    );
+}
+
+/// Dangling ref through a TenantScopedSqliteBackend must return Err, not panic.
+/// Complements `resolve_value_missing_artifact_returns_error` (unscoped SQLite).
+#[tokio::test]
+async fn tenant_scoped_dangling_ref_returns_error_no_panic() {
+    let db = open_db().await;
+    let backend = db.for_tenant(TenantId::from("tenant-dangling"));
+
+    let dangling = ArtifactRef {
+        hash: "b".repeat(64),
+        size: 100,
+        media_type: Some("application/json".to_string()),
+    };
+    let sentinel = dangling.to_sentinel();
+
+    let result = resolve_value(&sentinel, &backend).await;
+    assert!(
+        result.is_err(),
+        "dangling ref via TenantScopedSqliteBackend must return Err, never panic"
+    );
+}

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -5,6 +5,15 @@ use chrono::Utc;
 /// Cap a provider-supplied Retry-After so an untrusted/huge value can't overflow
 /// the timestamp math or push the backoff into the past. One hour is plenty.
 const MAX_RETRY_AFTER_SECS: u64 = 3_600;
+
+/// Byte threshold above which a model-node event output is spilled to the
+/// content-addressed artifact store and replaced by an `ArtifactRef` sentinel.
+///
+/// 8 KiB keeps 2-3 short model turns inline. A 4 000-token response (~16 KB)
+/// is always spilled. Only the EVENT output is affected; `state_patch` and
+/// `current_state` stay inline so replay and the materializer are unaffected.
+/// Configurable at runtime via `JAMJET_ARTIFACT_THRESHOLD_BYTES` (future).
+const ARTIFACT_THRESHOLD: usize = 8 * 1024;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
 use jamjet_core::workflow::ExecutionId;
@@ -17,6 +26,7 @@ use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemI
 use jamjet_state::budget::BudgetState;
 use jamjet_state::content_hash;
 use jamjet_state::event::EventKind;
+use jamjet_state::spill_bytes;
 use jamjet_state::{materialize, start_next_segment};
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
@@ -418,12 +428,39 @@ impl Worker {
                     );
                 }
 
+                // Spill the event output to the artifact store if above the
+                // threshold. Write-order invariant: the artifact is persisted
+                // BEFORE the NodeCompleted event that references it. A crash
+                // between put_artifact and commit_turn produces an orphaned
+                // artifact (benign, write-once) but NEVER a dangling ref in an
+                // event, because commit_turn has not been called yet.
+                //
+                // SCOPE: only the EVENT output is spilled here. state_patch
+                // stays inline so the materializer + replay path (which reads
+                // state_patch to advance current_state) are completely
+                // unaffected. Snapshot / state spill is F-2i-snapshot.
+                let event_output = {
+                    let maybe_bytes = spill_bytes(&exec_result.output, ARTIFACT_THRESHOLD);
+                    if let Some(bytes) = maybe_bytes {
+                        match self
+                            .backend
+                            .put_artifact(&bytes, Some("application/json"))
+                            .await
+                        {
+                            Ok(artifact_ref) => artifact_ref.to_sentinel(),
+                            Err(e) => return Err(Box::new(e)),
+                        }
+                    } else {
+                        exec_result.output
+                    }
+                };
+
                 let terminal = jamjet_state::Event::new(
                     execution_id.clone(),
                     0, // sequence assigned atomically inside commit_turn
                     EventKind::NodeCompleted {
                         node_id: node_id.clone(),
-                        output: exec_result.output,
+                        output: event_output,
                         state_patch: exec_result.state_patch,
                         duration_ms,
                         gen_ai_system: exec_result.gen_ai_system,
@@ -1263,7 +1300,7 @@ mod tests {
     use jamjet_state::{
         backend::{StateBackend, WorkItem, WorkflowDefinition},
         event::EventKind,
-        InMemoryBackend,
+        ArtifactRef, InMemoryBackend,
     };
     use std::sync::Arc;
     use uuid::Uuid;
@@ -2594,6 +2631,241 @@ mod tests {
             "Major-2 regression: old execution must be LimitExceeded after already-branch finalization; \
              got {:?} — means crash-before-terminal was not repaired",
             exec_final.status
+        );
+    }
+
+    // ── Artifact spill tests ──────────────────────────────────────────────────
+
+    /// Stub executor that returns a fixed `output` value and an empty
+    /// `state_patch`. Used to drive the spill path without a real model adapter.
+    struct FixedOutputExecutor {
+        output: serde_json::Value,
+    }
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for FixedOutputExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, ExecutorError> {
+            Ok(ExecutionResult {
+                output: self.output.clone(),
+                state_patch: serde_json::json!({}),
+                duration_ms: 0,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+            })
+        }
+    }
+
+    /// Minimal workflow IR whose single node has kind `"model"`. The executor
+    /// registered under `"model"` is what `execute_item` dispatches to.
+    fn model_ir_json() -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "model-wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": {
+                "n1": {
+                    "id": "n1",
+                    "kind": {
+                        "type": "model",
+                        "model_ref": "fake",
+                        "prompt_ref": "",
+                        "output_schema": "{}"
+                    }
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {}
+        })
+    }
+
+    /// Set up an in-memory backend with a `model-wf` workflow and one enqueued
+    /// work item whose `queue_type` is `"model"`.
+    async fn setup_model_backend() -> (Arc<InMemoryBackend>, ExecutionId) {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        let now = Utc::now();
+        backend
+            .create_execution(jamjet_core::workflow::WorkflowExecution {
+                execution_id: eid.clone(),
+                workflow_id: "model-wf".into(),
+                workflow_version: "1.0.0".into(),
+                status: WorkflowStatus::Running,
+                initial_input: serde_json::json!({}),
+                current_state: serde_json::json!({}),
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                session_type: None,
+                parent_execution_id: None,
+                segment_number: 0,
+            })
+            .await
+            .unwrap();
+        backend
+            .store_workflow(WorkflowDefinition {
+                workflow_id: "model-wf".into(),
+                version: "1.0.0".into(),
+                ir: model_ir_json(),
+                created_at: Utc::now(),
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        backend
+            .enqueue_work_item(WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "model".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "model-wf",
+                    "workflow_version": "1.0.0"
+                }),
+                attempt: 0,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+        (backend, eid)
+    }
+
+    /// A model-node output that exceeds ARTIFACT_THRESHOLD (8 KiB) must be
+    /// spilled to the artifact store. The NodeCompleted event must carry an
+    /// ArtifactRef sentinel (not the inline 32 KiB payload). A round-trip via
+    /// `backend.get_artifact` must restore the original value exactly.
+    /// The state_patch must remain inline (never spilled) so the replay path
+    /// is unaffected.
+    #[tokio::test]
+    async fn large_model_output_is_spilled_to_artifact_store() {
+        // 32 KiB content string — well above the 8 KiB ARTIFACT_THRESHOLD.
+        let large_content = "x".repeat(32 * 1024);
+        let large_output = serde_json::json!({ "content": large_content });
+
+        let (backend, eid) = setup_model_backend().await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["model".into()],
+        )
+        .register_executor(
+            "model",
+            Arc::new(FixedOutputExecutor {
+                output: large_output.clone(),
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["model"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        worker.execute_item(item).await.unwrap();
+
+        // Locate the NodeCompleted event.
+        let events = backend.get_events(&eid).await.unwrap();
+        let event = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .expect("NodeCompleted event must exist");
+
+        let (event_output, state_patch) = match &event.kind {
+            EventKind::NodeCompleted {
+                output,
+                state_patch,
+                ..
+            } => (output, state_patch),
+            _ => unreachable!(),
+        };
+
+        // Event output must be a sentinel — NOT the inline 32 KiB value.
+        assert!(
+            event_output.get("$artifact").is_some(),
+            "expected ArtifactRef sentinel in NodeCompleted.output; got: {event_output}"
+        );
+
+        // Round-trip: bytes fetched from the store must deserialize to the original output.
+        let artifact_ref =
+            ArtifactRef::from_sentinel(event_output).expect("sentinel must parse as ArtifactRef");
+        let stored_bytes = backend
+            .get_artifact(&artifact_ref.hash)
+            .await
+            .unwrap()
+            .expect("artifact must be present in the store after spill");
+        let restored: serde_json::Value =
+            serde_json::from_slice(&stored_bytes).expect("stored bytes must round-trip to Value");
+        assert_eq!(
+            restored, large_output,
+            "round-trip fidelity: restored value must equal the original output"
+        );
+
+        // state_patch stays inline — the replay/materializer path must be unaffected.
+        assert!(
+            state_patch.get("$artifact").is_none(),
+            "state_patch must not be spilled; got: {state_patch}"
+        );
+    }
+
+    /// A model-node output below ARTIFACT_THRESHOLD stays inline in the
+    /// NodeCompleted event — no spill, no sentinel.
+    #[tokio::test]
+    async fn small_model_output_stays_inline() {
+        let small_output = serde_json::json!({ "content": "short response" });
+
+        let (backend, eid) = setup_model_backend().await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["model".into()],
+        )
+        .register_executor(
+            "model",
+            Arc::new(FixedOutputExecutor {
+                output: small_output.clone(),
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["model"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        worker.execute_item(item).await.unwrap();
+
+        let events = backend.get_events(&eid).await.unwrap();
+        let event = events
+            .iter()
+            .find(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+            .expect("NodeCompleted event must exist");
+
+        let event_output = match &event.kind {
+            EventKind::NodeCompleted { output, .. } => output,
+            _ => unreachable!(),
+        };
+
+        // Small output must be stored inline — no ArtifactRef sentinel.
+        assert!(
+            event_output.get("$artifact").is_none(),
+            "small output must stay inline; got sentinel: {event_output}"
+        );
+        assert_eq!(
+            *event_output, small_output,
+            "inline output must equal the original value"
         );
     }
 }

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -6,14 +6,6 @@ use chrono::Utc;
 /// the timestamp math or push the backoff into the past. One hour is plenty.
 const MAX_RETRY_AFTER_SECS: u64 = 3_600;
 
-/// Byte threshold above which a model-node event output is spilled to the
-/// content-addressed artifact store and replaced by an `ArtifactRef` sentinel.
-///
-/// 8 KiB keeps 2-3 short model turns inline. A 4 000-token response (~16 KB)
-/// is always spilled. Only the EVENT output is affected; `state_patch` and
-/// `current_state` stay inline so replay and the materializer are unaffected.
-/// Configurable at runtime via `JAMJET_ARTIFACT_THRESHOLD_BYTES` (future).
-const ARTIFACT_THRESHOLD: usize = 8 * 1024;
 use jamjet_agents::AgentRegistry;
 use jamjet_core::node::NodeKind;
 use jamjet_core::workflow::ExecutionId;
@@ -27,7 +19,7 @@ use jamjet_state::budget::BudgetState;
 use jamjet_state::content_hash;
 use jamjet_state::event::EventKind;
 use jamjet_state::spill_bytes;
-use jamjet_state::{materialize, start_next_segment};
+use jamjet_state::{artifact_threshold, materialize, start_next_segment};
 use jamjet_telemetry::{gen_ai_attrs, metrics, record_gen_ai_usage};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -429,7 +421,8 @@ impl Worker {
                 }
 
                 // Spill the event output to the artifact store if above the
-                // threshold. Write-order invariant: the artifact is persisted
+                // threshold. The threshold is read from JAMJET_ARTIFACT_THRESHOLD_BYTES
+                // (default 8 KiB). Write-order invariant: the artifact is persisted
                 // BEFORE the NodeCompleted event that references it. A crash
                 // between put_artifact and commit_turn produces an orphaned
                 // artifact (benign, write-once) but NEVER a dangling ref in an
@@ -440,7 +433,7 @@ impl Worker {
                 // state_patch to advance current_state) are completely
                 // unaffected. Snapshot / state spill is F-2i-snapshot.
                 let event_output = {
-                    let maybe_bytes = spill_bytes(&exec_result.output, ARTIFACT_THRESHOLD);
+                    let maybe_bytes = spill_bytes(&exec_result.output, artifact_threshold());
                     if let Some(bytes) = maybe_bytes {
                         match self
                             .backend
@@ -2745,15 +2738,15 @@ mod tests {
         (backend, eid)
     }
 
-    /// A model-node output that exceeds ARTIFACT_THRESHOLD (8 KiB) must be
-    /// spilled to the artifact store. The NodeCompleted event must carry an
-    /// ArtifactRef sentinel (not the inline 32 KiB payload). A round-trip via
-    /// `backend.get_artifact` must restore the original value exactly.
-    /// The state_patch must remain inline (never spilled) so the replay path
-    /// is unaffected.
+    /// A model-node output that exceeds the spill threshold (default 8 KiB, set
+    /// via `JAMJET_ARTIFACT_THRESHOLD_BYTES`) must be spilled to the artifact
+    /// store. The NodeCompleted event must carry an ArtifactRef sentinel (not
+    /// the inline 32 KiB payload). A round-trip via `backend.get_artifact` must
+    /// restore the original value exactly. The state_patch must remain inline
+    /// (never spilled) so the replay path is unaffected.
     #[tokio::test]
     async fn large_model_output_is_spilled_to_artifact_store() {
-        // 32 KiB content string — well above the 8 KiB ARTIFACT_THRESHOLD.
+        // 32 KiB content string — well above the default 8 KiB threshold.
         let large_content = "x".repeat(32 * 1024);
         let large_output = serde_json::json!({ "content": large_content });
 
@@ -2821,7 +2814,7 @@ mod tests {
         );
     }
 
-    /// A model-node output below ARTIFACT_THRESHOLD stays inline in the
+    /// A model-node output below the spill threshold stays inline in the
     /// NodeCompleted event — no spill, no sentinel.
     #[tokio::test]
     async fn small_model_output_stays_inline() {


### PR DESCRIPTION
## What

Track 2i of the ADK build. Large model-node outputs are no longer inlined in the event log. A `NodeCompleted.output` above 8KB is written once to a content-addressed `artifacts` store (keyed by its content hash) and replaced inline by a small `ArtifactRef` sentinel; readers resolve the ref back to the content. Identical outputs dedupe automatically.

## How

- **Store** (migration 0010): an `artifacts(tenant_id, hash, bytes, size, media_type)` table. `put_artifact` hashes the raw bytes (SHA-256) and INSERT-OR-IGNOREs (so identical content is one row); `get_artifact` reads by hash. Tenant-scoped, so identical content in two tenants is stored twice (no cross-tenant dedup, which avoids a content-inference oracle).
- **Spill on write** (worker): when a model node's output exceeds the threshold, the worker writes the artifact and then records the sentinel in the event. The artifact is always written before the event, so a crash in between leaves a harmless write-once orphan, never a dangling reference.
- **Resolve on read** (`/events`): the events endpoint resolves sentinels back to the original output before serializing. A missing artifact returns an `unresolved` flag rather than panicking.

## Scope and safety

This is the safe first slice: only the event's audit `output` is spilled. `state_patch` and `current_state` stay inline, so replay, the materializer, and the idempotency cache are untouched. A whole-branch adversarial review confirmed the crux: nothing in the engine consumes a node's output from `completed_nodes` for logic (inter-node data flows exclusively through `state_patch`/`current_state`, which is never spilled), so a spilled output becoming a sentinel breaks no downstream behavior. Round-trip fidelity, write-order, replay, and tenant isolation were all verified, with 31 store tests plus worker and endpoint tests.

## Follow-ups (tracked)

- F-2i-snapshot: spill the per-turn snapshot `completed_nodes` outputs (the larger quadratic win) — needs resolve in the materializer/state read path.
- F-2i-tenant: a tenant-scoped worker must write artifacts under the execution's tenant (the base worker writes the default scope today; no leak, but resolve would miss for a non-default tenant worker).
- F-2i-size (upper size bound / streaming), F-2i-gc (reference-counting + GC; v1 is write-once), F-2i-tooleffects (the duplicate copy in `tool_effects`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large execution outputs may now be stored separately and returned as resolved results in event history.
  * Added support for preserving artifact references when output is too large to keep inline.

* **Bug Fixes**
  * Event requests now handle missing referenced artifacts gracefully instead of failing.
  * Small outputs remain unchanged, while resolved outputs are returned in their original form when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->