### PR TITLE
feat(2j): durable agents from the authoring API (Agent.run_durable + agent-loop IR)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,11 @@
 # JamJet Examples
 
+**Featured:** [`database-guard/`](./database-guard/) - a prompt injection tricks an
+agent into deleting the production database; JamJet blocks every destructive call
+before it runs and mints a verifiable AgentBoundary receipt. Deterministic by
+default (no API key), `--live` runs a real model. Source for the demo video; see
+its [`VIDEO-SCRIPT.md`](./database-guard/VIDEO-SCRIPT.md).
+
 Numbered examples in this directory:
 
 - `01-block-unsafe-tool/` - JamJet blocks a destructive tool call before execution.
@@ -10,6 +16,17 @@ Numbered examples in this directory:
 
 Each example is self-contained. The fifth example includes its own virtual
 environment setup script and runs without a model API key.
+
+## Durable agents (Python)
+
+- `react-agent-durable/` - a ReAct-style `Agent` (model + two `@tool` functions +
+  instructions) that runs on the durable, event-sourced engine via
+  `agent.run_durable(prompt)`. Authoring is identical to the in-process path;
+  calling `run_durable` compiles the agent to an agent-loop IR (`model -> tools ->
+  model`) and drives a durable execution, so the run gets the event log, replay,
+  idempotency, and park-on-429. The model call still goes through the governed
+  seam, and the `@tool` functions run on a separate `jamjet worker`. See
+  `react-agent-durable/README.md` for the engine, sidecar, and worker commands.
 
 ## Java
 

--- a/examples/react-agent-durable/README.md
+++ b/examples/react-agent-durable/README.md
@@ -1,0 +1,111 @@
+# react-agent-durable
+
+A small ReAct-style agent (model + two `@tool` functions + instructions) that runs
+on the durable, event-sourced JamJet engine via `Agent.run_durable(prompt)`.
+
+Authoring the agent is the same as the in-process path. Calling `run_durable`
+compiles it to an **agent-loop IR** (`model -> tools -> model`, statically
+unrolled and bounded by `max_turns`) and drives a durable execution, so the run
+gets the event log, replay, idempotency, park-on-429, and artifacts for free. The
+model call still goes through the governed model seam, and the `@tool` functions
+run on a separate `jamjet worker` process.
+
+## Files
+
+- `weather_agent.py` - the `@tool` functions (`get_weather`, `add`) and the
+  `build_agent()` factory. Imported by both the runner and the worker.
+- `main.py` - calls `await agent.run_durable(prompt)` and prints the answer.
+
+## Why the tools live in their own module
+
+The compiled IR records each tool as `{name: "weather_agent:<fn>"}` (module +
+qualname). The `jamjet worker` resolves that reference by **importing
+`weather_agent`**, so the tool functions must live in an importable module, not in
+`__main__`. That is why `main.py` does `from weather_agent import build_agent`
+instead of defining the tools inline.
+
+## Prerequisites
+
+- The `jamjet` Python package installed (`pip install jamjet`, or use the dev repo
+  with `uv run` from `sdk/python/`).
+- A model provider key for the sidecar, for example `ANTHROPIC_API_KEY`.
+- The engine binary: `jamjet dev` downloads it on first run, or build it locally
+  with `jamjet dev --build`.
+
+## Run it (four terminals)
+
+The engine routes every model call to the sidecar when `JAMJET_MODEL_SEAM_URL` is
+set, and it probes the sidecar's `/health` at startup, so **start the sidecar
+first**.
+
+```bash
+# Terminal 1 - model sidecar (the governed seam that calls the provider)
+export ANTHROPIC_API_KEY=sk-ant-...
+uvicorn jamjet.model.sidecar_server:app --host 127.0.0.1 --port 4280
+
+# Terminal 2 - the durable engine on http://localhost:7700, routed to the sidecar
+export JAMJET_MODEL_SEAM_URL=http://127.0.0.1:4280
+jamjet dev                 # first run: `jamjet dev --build`
+
+# Terminal 3 - the Python tool worker (drains the python_tool queue)
+cd examples/react-agent-durable
+PYTHONPATH=. jamjet worker \
+  --runtime http://localhost:7700 \
+  --queue python_tool \
+  --modules weather_agent
+
+# Terminal 4 - run the agent
+cd examples/react-agent-durable
+python main.py
+```
+
+`PYTHONPATH=.` puts this directory on the worker's import path so it can import
+`weather_agent`; run the worker from this directory.
+
+Expected output (Terminal 4): the model's final answer, followed by the tool calls
+it made durably, for example:
+
+```
+answer: It is sunny in Paris, and 19 + 23 = 42.
+
+  tool get_weather({'city': 'Paris'}) -> sunny, 24C
+  tool add({'a': 19, 'b': 23}) -> 42
+```
+
+In Terminal 3 you will see each `python_tool` work item claimed and completed; the
+engine's event log records the `model` node's `tool_calls`, then the tool-dispatch
+`NodeCompleted`, then the next `model` node.
+
+## Without the sidecar
+
+If you do not set `JAMJET_MODEL_SEAM_URL`, the engine calls the provider directly
+through its native adapters (it still needs `ANTHROPIC_API_KEY` in the engine's
+environment). The sidecar path is preferred because it runs the governed seam
+middleware (allowlist, PII, metering) around the model call.
+
+## In-process comparison (no services)
+
+The same agent runs in process without any of the above:
+
+```python
+import asyncio
+from weather_agent import build_agent
+
+print(asyncio.run(build_agent().run("What's the weather in Paris?")).output)
+```
+
+`Agent.run()` (a pure in-process loop) and `Agent.run_durable()` (the engine)
+produce the same answer shape. The SDK proves this with a parity test
+(`tests/test_agent_durable_loop_parity.py`): it drives the **real** compiled IR
+and the **real** tool-dispatch helper through the engine's control flow with a
+deterministic mock model, and asserts the `model -> tool -> model` loop runs, the
+tool is invoked, and the final answer matches the in-process run.
+
+## Notes and limits
+
+- `max_turns` bounds the static unroll. The v1 loop runs the unroll to completion;
+  the per-turn gate that would short-circuit as soon as the model returns a final
+  answer is not yet wired into the engine, so size `max_turns` to the conversation
+  depth you expect. The extracted answer is the last model turn's output.
+- Tool results are threaded back to the model as conversation text. Full
+  assistant/tool message-role fidelity through the engine is a follow-up.

--- a/examples/react-agent-durable/README.md
+++ b/examples/react-agent-durable/README.md
@@ -65,7 +65,7 @@ python main.py
 Expected output (Terminal 4): the model's final answer, followed by the tool calls
 it made durably, for example:
 
-```
+```text
 answer: It is sunny in Paris, and 19 + 23 = 42.
 
   tool get_weather({'city': 'Paris'}) -> sunny, 24C
@@ -104,10 +104,12 @@ tool is invoked, and the final answer matches the in-process run.
 ## Limitations (v1)
 
 - **Bounded `max_turns`, no early exit yet.** `max_turns` bounds the static
-  unroll and the loop runs it to completion. The per-turn gate that would
-  short-circuit as soon as the model returns a final answer is not yet wired
-  into the engine (F-2j-dynamic-loop), so size `max_turns` to the conversation
-  depth you expect. The extracted answer is the last model turn's output.
+  unroll (that many tool turns, then a final answer-only model turn) and the loop
+  runs it to completion. The per-turn gate that would short-circuit as soon as the
+  model returns a final answer is not yet wired into the engine
+  (F-2j-dynamic-loop), so size `max_turns` to the conversation depth you expect.
+  The extracted answer is that final model turn's output, which consumes the last
+  tool results.
 - **The model is re-invoked every remaining turn (cost).** Because there is no
   early exit, a real model is called once per turn for all `max_turns`, so cost
   scales with `max_turns` and the answer can drift across turns.
@@ -115,9 +117,13 @@ tool is invoked, and the final answer matches the in-process run.
   back to the model as conversation text; the Rust `ChatMessage` carries only
   `role` + `content`, so full assistant/tool message-role fidelity through the
   engine is a follow-up (F-2j-chatmessage-fidelity).
-- **A `@tool`'s return value merge-patches execution state.** A `python_tool`
-  node's return dict is applied as a `state_patch` (top-level keys replace, the
-  rest merge). This is how the loop threads `{"messages": [...]}` into the next
-  turn. Avoid returning reserved loop keys like `messages` or
-  `last_model_output` from a plain `@tool`, or you will clobber loop state
+- **The tool-dispatch node owns the `messages` state-patch, not your `@tool`.**
+  In this durable loop the `python_tool` node runs `dispatch_tool_calls` (not your
+  `@tool` directly): it executes the model's requested calls, appends each tool's
+  return value as a `role: tool` message, and returns `{"messages": [...]}`. That
+  return dict is applied as the node's `state_patch` (top-level keys replace, the
+  rest merge), which threads the accumulated conversation into the next turn. Your
+  `@tool` functions just return a result (string or JSON) that becomes tool-message
+  content — they never return the reserved loop keys (`messages`,
+  `last_model_output`), which the dispatch node and model node manage
   (F-2j-statepatch-namespace).

--- a/examples/react-agent-durable/README.md
+++ b/examples/react-agent-durable/README.md
@@ -101,11 +101,23 @@ and the **real** tool-dispatch helper through the engine's control flow with a
 deterministic mock model, and asserts the `model -> tool -> model` loop runs, the
 tool is invoked, and the final answer matches the in-process run.
 
-## Notes and limits
+## Limitations (v1)
 
-- `max_turns` bounds the static unroll. The v1 loop runs the unroll to completion;
-  the per-turn gate that would short-circuit as soon as the model returns a final
-  answer is not yet wired into the engine, so size `max_turns` to the conversation
+- **Bounded `max_turns`, no early exit yet.** `max_turns` bounds the static
+  unroll and the loop runs it to completion. The per-turn gate that would
+  short-circuit as soon as the model returns a final answer is not yet wired
+  into the engine (F-2j-dynamic-loop), so size `max_turns` to the conversation
   depth you expect. The extracted answer is the last model turn's output.
-- Tool results are threaded back to the model as conversation text. Full
-  assistant/tool message-role fidelity through the engine is a follow-up.
+- **The model is re-invoked every remaining turn (cost).** Because there is no
+  early exit, a real model is called once per turn for all `max_turns`, so cost
+  scales with `max_turns` and the answer can drift across turns.
+- **Tool-message fidelity is lossy across turns.** Tool results are threaded
+  back to the model as conversation text; the Rust `ChatMessage` carries only
+  `role` + `content`, so full assistant/tool message-role fidelity through the
+  engine is a follow-up (F-2j-chatmessage-fidelity).
+- **A `@tool`'s return value merge-patches execution state.** A `python_tool`
+  node's return dict is applied as a `state_patch` (top-level keys replace, the
+  rest merge). This is how the loop threads `{"messages": [...]}` into the next
+  turn. Avoid returning reserved loop keys like `messages` or
+  `last_model_output` from a plain `@tool`, or you will clobber loop state
+  (F-2j-statepatch-namespace).

--- a/examples/react-agent-durable/main.py
+++ b/examples/react-agent-durable/main.py
@@ -1,0 +1,42 @@
+"""Run the durable ReAct agent against a local JamJet engine.
+
+``Agent.run_durable`` compiles the agent to an agent-loop IR (``model -> tools ->
+model``, statically unrolled and bounded by ``max_turns``), registers it on the
+engine, starts an execution seeded with the system+user messages and the tool
+resolver map, polls to a terminal state, and extracts an ``AgentResult`` with the
+SAME shape as the in-process ``Agent.run``.
+
+This is the full-stack demonstration. It needs the running services described in
+README.md (the engine, the model sidecar, and a python_tool worker). Run it with::
+
+    python main.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from weather_agent import build_agent
+
+# The local dev engine (`jamjet dev`) listens on 7700. `run_durable`'s own
+# default points elsewhere, so we pass the engine URL explicitly.
+RUNTIME_URL = "http://localhost:7700"
+PROMPT = "What's the weather in Paris right now, and what is 19 plus 23?"
+
+
+async def main() -> None:
+    agent = build_agent()
+    print(f"> {PROMPT}\n")
+    # `max_turns` bounds the static unroll. Size it to the conversation depth you
+    # expect: the v1 loop runs the unroll to completion (the per-turn gate's
+    # short-circuit on a final answer is a roadmap item), so the answer is the
+    # last model turn's output.
+    result = await agent.run_durable(PROMPT, max_turns=3, runtime_url=RUNTIME_URL)
+
+    print(f"answer: {result.output}\n")
+    for call in result.tool_calls:
+        print(f"  tool {call['tool']}({call['input']}) -> {call['output']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/react-agent-durable/main.py
+++ b/examples/react-agent-durable/main.py
@@ -18,8 +18,8 @@ import asyncio
 
 from weather_agent import build_agent
 
-# The local dev engine (`jamjet dev`) listens on 7700. `run_durable`'s own
-# default points elsewhere, so we pass the engine URL explicitly.
+# The local dev engine (`jamjet dev`) listens on 7700, which is also
+# `run_durable`'s default; we pass it explicitly here to make the target clear.
 RUNTIME_URL = "http://localhost:7700"
 PROMPT = "What's the weather in Paris right now, and what is 19 plus 23?"
 

--- a/examples/react-agent-durable/weather_agent.py
+++ b/examples/react-agent-durable/weather_agent.py
@@ -1,0 +1,48 @@
+"""Tools + agent factory for the durable ReAct example.
+
+This module is imported by BOTH the runner (``main.py``) and the durable Python
+tool worker (``jamjet worker --modules weather_agent``). Keeping the ``@tool``
+functions and the ``Agent`` factory HERE — not in ``main.py`` / ``__main__`` — is
+what makes the durable run actually resolve its tools: the compiled agent-loop IR
+records each tool as ``{name: "weather_agent:<fn>"}`` (module + qualname), and the
+worker resolves that reference by importing this module. A tool defined in
+``__main__`` could never be resolved by the separate worker process.
+"""
+
+from __future__ import annotations
+
+from jamjet import Agent, tool
+
+
+@tool
+async def get_weather(city: str) -> str:
+    """Return a short current-weather report for a city."""
+    table = {
+        "paris": "sunny, 24C",
+        "london": "cloudy, 17C",
+        "tokyo": "rainy, 21C",
+        "new york": "windy, 15C",
+    }
+    return table.get(city.strip().lower(), f"clear skies over {city}, 20C")
+
+
+@tool
+async def add(a: float, b: float) -> str:
+    """Add two numbers and return the sum as text."""
+    return f"{a + b:g}"
+
+
+def build_agent() -> Agent:
+    """Construct the durable ReAct agent (model + tools + instructions).
+
+    ``strategy="react"`` makes the in-process ``Agent.run()`` use the same
+    ``model -> tool -> model`` loop the durable agent-loop IR encodes, so the two
+    paths produce the same answer shape (see ``tests/`` parity test in the SDK).
+    """
+    return Agent(
+        "react-weather",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather, add],
+        instructions=("You are a concise assistant. Use the tools when they help, then give a short final answer."),
+        strategy="react",
+    )

--- a/runtime/core/src/node.rs
+++ b/runtime/core/src/node.rs
@@ -35,6 +35,10 @@ pub enum NodeKind {
         prompt_ref: String,
         output_schema: String,
         system_prompt: Option<String>,
+        /// OpenAI-format tool/function schemas offered to the model for this call.
+        /// Empty means no tools are offered (standard text completion).
+        #[serde(default)]
+        tools: Vec<serde_json::Value>,
     },
 
     /// Python function, HTTP endpoint, or gRPC tool.
@@ -346,6 +350,7 @@ mod tests {
             prompt_ref: "prompts/summarize.md".into(),
             output_schema: "schemas.Summary".into(),
             system_prompt: None,
+            tools: vec![],
         };
         assert_eq!(node.queue_type(), QueueType::Model);
         assert!(node.is_durable());

--- a/runtime/models/src/adapter.rs
+++ b/runtime/models/src/adapter.rs
@@ -178,3 +178,23 @@ pub trait ModelAdapter: Send + Sync {
         request: StructuredRequest,
     ) -> Result<ModelResponse, ModelError>;
 }
+
+/// One-time warning that a native (direct-to-provider) adapter received tool
+/// schemas it does not forward.
+///
+/// The native adapters (anthropic/openai/google/ollama) map only `role` +
+/// `content` and never send `request.tools` to the provider, so a Model call
+/// that carries tools silently no-ops and an agent tool loop degenerates. Tool
+/// calls must route through the model-seam sidecar (`JAMJET_MODEL_SEAM_URL`),
+/// which forwards tools. Logged once per process so a degenerate loop's
+/// repeated calls do not spam the log.
+pub(crate) fn warn_tools_not_forwarded(adapter: &'static str) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            adapter,
+            "tools provided but this adapter does not forward them; \
+             use the model seam sidecar (JAMJET_MODEL_SEAM_URL) for tool calls"
+        );
+    });
+}

--- a/runtime/models/src/adapter.rs
+++ b/runtime/models/src/adapter.rs
@@ -80,11 +80,27 @@ pub struct ModelConfig {
     pub stop_sequences: Option<Vec<String>>,
 }
 
+/// A tool call returned by the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    /// Provider-issued call id (e.g. "call_abc123").
+    pub id: String,
+    /// Name of the tool to invoke (matches a name in the request `tools` list).
+    pub name: String,
+    /// Arguments as a JSON value.  Providers (and the Python sidecar) normalise
+    /// the arguments string to a JSON object when possible; callers should
+    /// tolerate a `Value::String` if the model emits malformed JSON.
+    pub arguments: serde_json::Value,
+}
+
 /// A request to a chat model.
 #[derive(Debug, Clone)]
 pub struct ModelRequest {
     pub messages: Vec<ChatMessage>,
     pub config: ModelConfig,
+    /// OpenAI-format tool/function schemas passed to the model.  Empty means no
+    /// tools are offered to the model for this call.
+    pub tools: Vec<serde_json::Value>,
 }
 
 impl ModelRequest {
@@ -92,11 +108,17 @@ impl ModelRequest {
         Self {
             messages,
             config: ModelConfig::default(),
+            tools: vec![],
         }
     }
 
     pub fn with_config(mut self, config: ModelConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    pub fn with_tools(mut self, tools: Vec<serde_json::Value>) -> Self {
+        self.tools = tools;
         self
     }
 }
@@ -113,7 +135,8 @@ pub struct StructuredRequest {
 /// A response from a chat model.
 #[derive(Debug, Clone)]
 pub struct ModelResponse {
-    /// The generated text content.
+    /// The generated text content.  Empty string when finish_reason is
+    /// "tool_calls" (the model is requesting tool invocations, not producing text).
     pub content: String,
     /// The model that actually served the request (may differ from requested).
     pub model: String,
@@ -125,6 +148,8 @@ pub struct ModelResponse {
     pub output_tokens: u64,
     /// Structured output parsed from JSON (for `structured_output()` calls).
     pub structured: Option<serde_json::Value>,
+    /// Tool calls requested by the model.  Empty when finish_reason != "tool_calls".
+    pub tool_calls: Vec<ToolCall>,
 }
 
 // ── Trait ─────────────────────────────────────────────────────────────────────

--- a/runtime/models/src/adapter.rs
+++ b/runtime/models/src/adapter.rs
@@ -179,22 +179,31 @@ pub trait ModelAdapter: Send + Sync {
     ) -> Result<ModelResponse, ModelError>;
 }
 
-/// One-time warning that a native (direct-to-provider) adapter received tool
-/// schemas it does not forward.
+/// One-time-per-adapter warning that a native (direct-to-provider) adapter
+/// received tool schemas it does not forward.
 ///
 /// The native adapters (anthropic/openai/google/ollama) map only `role` +
 /// `content` and never send `request.tools` to the provider, so a Model call
 /// that carries tools silently no-ops and an agent tool loop degenerates. Tool
 /// calls must route through the model-seam sidecar (`JAMJET_MODEL_SEAM_URL`),
-/// which forwards tools. Logged once per process so a degenerate loop's
-/// repeated calls do not spam the log.
+/// which forwards tools. Logged once per distinct adapter so a degenerate loop's
+/// repeated calls do not spam the log, while a second adapter still gets its own
+/// warning (a single global `Once` would let the first adapter silence the rest).
 pub(crate) fn warn_tools_not_forwarded(adapter: &'static str) {
-    static WARNED: std::sync::Once = std::sync::Once::new();
-    WARNED.call_once(|| {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static WARNED: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
+    let warned = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
+    // `insert` returns true the first time this adapter name is seen.
+    if warned
+        .lock()
+        .expect("warn_tools_not_forwarded mutex poisoned")
+        .insert(adapter)
+    {
         tracing::warn!(
             adapter,
             "tools provided but this adapter does not forward them; \
              use the model seam sidecar (JAMJET_MODEL_SEAM_URL) for tool calls"
         );
-    });
+    }
 }

--- a/runtime/models/src/anthropic.rs
+++ b/runtime/models/src/anthropic.rs
@@ -4,8 +4,8 @@
 //! Reads `ANTHROPIC_API_KEY` from the environment.
 
 use crate::adapter::{
-    ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError, ModelRequest, ModelResponse,
-    StructuredRequest,
+    warn_tools_not_forwarded, ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError,
+    ModelRequest, ModelResponse, StructuredRequest,
 };
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -176,6 +176,12 @@ impl ModelAdapter for AnthropicAdapter {
         gen_ai.usage.output_tokens = tracing::field::Empty,
     ))]
     async fn chat(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        // Native adapter: tools are not forwarded to the provider. Warn (once) so
+        // a tool-carrying call does not silently degenerate the agent loop.
+        if !request.tools.is_empty() {
+            warn_tools_not_forwarded(self.system_name());
+        }
+
         let model = request
             .config
             .model

--- a/runtime/models/src/anthropic.rs
+++ b/runtime/models/src/anthropic.rs
@@ -154,6 +154,7 @@ impl AnthropicAdapter {
             input_tokens,
             output_tokens,
             structured: None,
+            tool_calls: vec![],
         })
     }
 }
@@ -224,6 +225,7 @@ impl ModelAdapter for AnthropicAdapter {
         let chat_req = ModelRequest {
             messages: request.messages,
             config,
+            tools: vec![],
         };
         let mut response = self.chat(chat_req).await?;
 

--- a/runtime/models/src/google.rs
+++ b/runtime/models/src/google.rs
@@ -5,8 +5,8 @@
 //! Uses the REST API directly (no SDK dependency).
 
 use crate::adapter::{
-    ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError, ModelRequest, ModelResponse,
-    StructuredRequest,
+    warn_tools_not_forwarded, ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError,
+    ModelRequest, ModelResponse, StructuredRequest,
 };
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -207,6 +207,12 @@ impl ModelAdapter for GoogleAdapter {
         gen_ai.usage.output_tokens = tracing::field::Empty,
     ))]
     async fn chat(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        // Native adapter: tools are not forwarded to the provider. Warn (once) so
+        // a tool-carrying call does not silently degenerate the agent loop.
+        if !request.tools.is_empty() {
+            warn_tools_not_forwarded(self.system_name());
+        }
+
         let model = request
             .config
             .model

--- a/runtime/models/src/google.rs
+++ b/runtime/models/src/google.rs
@@ -185,6 +185,7 @@ impl GoogleAdapter {
             input_tokens,
             output_tokens,
             structured: None,
+            tool_calls: vec![],
         })
     }
 }

--- a/runtime/models/src/ollama.rs
+++ b/runtime/models/src/ollama.rs
@@ -149,6 +149,7 @@ impl OllamaAdapter {
             input_tokens,
             output_tokens,
             structured: None,
+            tool_calls: vec![],
         })
     }
 }

--- a/runtime/models/src/ollama.rs
+++ b/runtime/models/src/ollama.rs
@@ -5,8 +5,8 @@
 //! Uses Ollama's native /api/chat endpoint for accurate token counts.
 
 use crate::adapter::{
-    ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError, ModelRequest, ModelResponse,
-    StructuredRequest,
+    warn_tools_not_forwarded, ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError,
+    ModelRequest, ModelResponse, StructuredRequest,
 };
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -171,6 +171,12 @@ impl ModelAdapter for OllamaAdapter {
         gen_ai.usage.output_tokens = tracing::field::Empty,
     ))]
     async fn chat(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        // Native adapter: tools are not forwarded to the provider. Warn (once) so
+        // a tool-carrying call does not silently degenerate the agent loop.
+        if !request.tools.is_empty() {
+            warn_tools_not_forwarded(self.system_name());
+        }
+
         let model = request
             .config
             .model

--- a/runtime/models/src/openai.rs
+++ b/runtime/models/src/openai.rs
@@ -5,8 +5,8 @@
 //! Also works with OpenAI-compatible APIs (e.g. local Ollama) via `base_url`.
 
 use crate::adapter::{
-    ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError, ModelRequest, ModelResponse,
-    StructuredRequest,
+    warn_tools_not_forwarded, ChatMessage, ChatRole, ModelAdapter, ModelConfig, ModelError,
+    ModelRequest, ModelResponse, StructuredRequest,
 };
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -186,6 +186,12 @@ impl ModelAdapter for OpenAiAdapter {
         gen_ai.usage.output_tokens = tracing::field::Empty,
     ))]
     async fn chat(&self, request: ModelRequest) -> Result<ModelResponse, ModelError> {
+        // Native adapter: tools are not forwarded to the provider. Warn (once) so
+        // a tool-carrying call does not silently degenerate the agent loop.
+        if !request.tools.is_empty() {
+            warn_tools_not_forwarded(self.system_name());
+        }
+
         let model = request
             .config
             .model

--- a/runtime/models/src/openai.rs
+++ b/runtime/models/src/openai.rs
@@ -164,6 +164,7 @@ impl OpenAiAdapter {
             input_tokens,
             output_tokens,
             structured: None,
+            tool_calls: vec![],
         })
     }
 }

--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -112,6 +112,29 @@ impl SidecarModelAdapter {
             })
             .collect();
 
+        // 2j fail-closed: when the model is requesting tool calls, this data drives
+        // tool dispatch and tool_call_id correlation downstream. A missing/empty
+        // array, or a call with a blank id or name, would silently degrade to
+        // "no tool executed" or mismatched correlation — a provider/sidecar bug
+        // must surface as an error here rather than as a wrong answer.
+        if finish_reason == "tool_calls" {
+            if tool_calls.is_empty() {
+                return Err(ModelError::Serialization(
+                    "sidecar finish_reason is 'tool_calls' but tool_calls is missing or empty"
+                        .to_string(),
+                ));
+            }
+            if let Some(bad) = tool_calls
+                .iter()
+                .find(|tc| tc.id.is_empty() || tc.name.is_empty())
+            {
+                return Err(ModelError::Serialization(format!(
+                    "sidecar tool_call missing id or name (id={:?}, name={:?})",
+                    bad.id, bad.name
+                )));
+            }
+        }
+
         Ok(ModelResponse {
             content,
             model,
@@ -575,6 +598,71 @@ mod tests {
         assert_eq!(tc.id, "c1");
         assert_eq!(tc.name, "get_weather");
         assert_eq!(tc.arguments, serde_json::json!({"city": "SF"}));
+    }
+
+    // 2j fail-closed: finish_reason "tool_calls" but no tool_calls array must Err,
+    // not silently degrade to an empty dispatch.
+    #[tokio::test]
+    async fn chat_errors_when_tool_calls_missing_for_tool_finish() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": null, "role": "assistant"},
+                "finish_reason": "tool_calls",
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "model": "anthropic/claude-sonnet-4-6"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::Serialization(_))),
+            "finish_reason tool_calls with no tool_calls must Err, got {result:?}"
+        );
+    }
+
+    // 2j fail-closed: a tool_call missing its id (or name) must Err — a blank id
+    // would break tool_call_id correlation downstream.
+    #[tokio::test]
+    async fn chat_errors_when_tool_call_missing_id() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": null, "role": "assistant"},
+                "tool_calls": [{"name": "get_weather", "arguments": {"city": "SF"}}],
+                "finish_reason": "tool_calls",
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "model": "anthropic/claude-sonnet-4-6"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("what's the weather?")]);
+        let result = adapter.chat(req).await;
+
+        assert!(
+            matches!(result, Err(ModelError::Serialization(_))),
+            "tool_call with a blank id must Err, got {result:?}"
+        );
     }
 
     // 2j-1: tools forwarded — a request with non-empty tools sends them in the POST body.

--- a/runtime/models/src/sidecar.rs
+++ b/runtime/models/src/sidecar.rs
@@ -10,7 +10,7 @@
 //! - `GET /health` → `{ok:true}`
 
 use crate::adapter::{
-    ChatRole, ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest,
+    ChatRole, ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest, ToolCall,
 };
 use async_trait::async_trait;
 use serde_json::{json, Value};
@@ -97,6 +97,21 @@ impl SidecarModelAdapter {
             )
         })?;
 
+        // Parse tool_calls when the sidecar surfaces them (finish_reason == "tool_calls").
+        // The sidecar normalises arguments to a JSON object when possible; we store
+        // whatever Value arrives (object or string) so no information is lost.
+        let tool_calls: Vec<ToolCall> = json["tool_calls"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|tc| ToolCall {
+                id: tc["id"].as_str().unwrap_or("").to_string(),
+                name: tc["name"].as_str().unwrap_or("").to_string(),
+                arguments: tc["arguments"].clone(),
+            })
+            .collect();
+
         Ok(ModelResponse {
             content,
             model,
@@ -104,6 +119,7 @@ impl SidecarModelAdapter {
             input_tokens,
             output_tokens,
             structured: None,
+            tool_calls,
         })
     }
 
@@ -160,6 +176,11 @@ impl ModelAdapter for SidecarModelAdapter {
         if let Some(max) = request.config.max_tokens {
             body["max_tokens"] = json!(max);
         }
+        // Forward tool schemas to the sidecar when tools are offered; the governed
+        // seam (allowlist + PII + metering middleware) still runs on the sidecar side.
+        if !request.tools.is_empty() {
+            body["tools"] = json!(request.tools);
+        }
 
         let resp_json = self.call_complete(body).await?;
         self.parse_response(resp_json)
@@ -181,6 +202,7 @@ impl ModelAdapter for SidecarModelAdapter {
         let chat_req = ModelRequest {
             messages: request.messages,
             config,
+            tools: vec![],
         };
         let mut response = self.chat(chat_req).await?;
 
@@ -519,6 +541,71 @@ mod tests {
             matches!(result, Err(ModelError::Serialization(_))),
             "health guard must reject a non-JSON 200 body, got {result:?}"
         );
+    }
+
+    // 2j-1: tool_calls round-trip — sidecar returns tool_calls -> ModelResponse.tool_calls populated.
+    #[tokio::test]
+    async fn chat_returns_tool_calls_from_sidecar() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": null, "role": "assistant"},
+                "tool_calls": [{"id": "c1", "name": "get_weather", "arguments": {"city": "SF"}}],
+                "finish_reason": "tool_calls",
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "model": "anthropic/claude-sonnet-4-6"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("what's the weather?")]);
+        let resp = adapter.chat(req).await.expect("chat should succeed");
+
+        assert_eq!(resp.finish_reason, "tool_calls");
+        assert_eq!(resp.tool_calls.len(), 1);
+        let tc = &resp.tool_calls[0];
+        assert_eq!(tc.id, "c1");
+        assert_eq!(tc.name, "get_weather");
+        assert_eq!(tc.arguments, serde_json::json!({"city": "SF"}));
+    }
+
+    // 2j-1: tools forwarded — a request with non-empty tools sends them in the POST body.
+    #[tokio::test]
+    async fn chat_sends_tools_in_post_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/v1/complete")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"tools":[{"type":"function","function":{"name":"get_weather"}}]}"#.into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                "message": {"content": "ok", "role": "assistant"},
+                "finish_reason": "stop",
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "model": "anthropic/claude-sonnet-4-6"
+            }"#,
+            )
+            .create_async()
+            .await;
+
+        let adapter = SidecarModelAdapter::new(server.url());
+        let req = ModelRequest::new(vec![ChatMessage::user("hi")]).with_tools(vec![
+            serde_json::json!({"type": "function", "function": {"name": "get_weather"}}),
+        ]);
+        adapter.chat(req).await.expect("chat should succeed");
     }
 
     // I4: missing output_tokens must cause chat() to return Err, not a zero-metered response.

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -374,6 +374,53 @@ impl Scheduler {
                     );
                 }
 
+                // For Model nodes, enrich the payload with model configuration and tool
+                // schemas so the model worker is self-contained.
+                if let NodeKind::Model {
+                    model_ref,
+                    system_prompt,
+                    tools,
+                    ..
+                } = &node.kind
+                {
+                    let obj = payload
+                        .as_object_mut()
+                        .expect("payload is always a JSON object");
+                    // Resolve model identifier from the IR's named models map.
+                    let model_id = ir
+                        .models
+                        .get(model_ref.as_str())
+                        .map(|cfg| {
+                            if cfg.provider.is_empty() {
+                                cfg.model.clone()
+                            } else {
+                                format!("{}/{}", cfg.provider, cfg.model)
+                            }
+                        })
+                        .unwrap_or_else(|| model_ref.clone());
+                    obj.insert("model".into(), serde_json::Value::String(model_id));
+                    // Optional model config overrides.
+                    if let Some(cfg) = ir.models.get(model_ref.as_str()) {
+                        if let Some(temp) = cfg.temperature {
+                            obj.insert("temperature".into(), serde_json::json!(temp));
+                        }
+                        if let Some(mt) = cfg.max_tokens {
+                            obj.insert("max_tokens".into(), serde_json::json!(mt));
+                        }
+                    }
+                    // Node-level system prompt.
+                    if let Some(sp) = system_prompt {
+                        obj.insert(
+                            "system_prompt".into(),
+                            serde_json::Value::String(sp.clone()),
+                        );
+                    }
+                    // Tool schemas — passed to the model so it can emit tool_calls.
+                    if !tools.is_empty() {
+                        obj.insert("tools".into(), serde_json::Value::Array(tools.clone()));
+                    }
+                }
+
                 let item = WorkItem {
                     id: Uuid::new_v4(),
                     execution_id: execution_id.clone(),
@@ -1188,5 +1235,117 @@ mod tests {
         assert_eq!(item.payload["workflow_id"], "wf");
         assert_eq!(item.payload["workflow_version"], "0.1.0");
         assert_eq!(item.payload["node_id"], "py_step");
+    }
+
+    /// A single-node workflow whose only step is a `Model` node with tools.
+    fn model_node_ir() -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": "model_step",
+            "nodes": {
+                "model_step": {
+                    "id": "model_step",
+                    "kind": {
+                        "type": "model",
+                        "model_ref": "test_model",
+                        "prompt_ref": "prompts/test.md",
+                        "output_schema": "",
+                        "system_prompt": "You are a test assistant.",
+                        "tools": [
+                            {"type": "function", "function": {"name": "get_weather", "description": "Get the weather", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}},
+                            {"type": "function", "function": {"name": "search_web", "description": "Search the web", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}}}
+                        ]
+                    },
+                    "retry_policy": null,
+                    "node_timeout_secs": null,
+                    "description": null,
+                    "labels": {}
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {
+                "test_model": {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "timeout_secs": null,
+                    "retry_policy": null,
+                    "temperature": null,
+                    "max_tokens": 1024
+                }
+            },
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        })
+    }
+
+    /// The scheduler must enrich a `Model` work-item payload with `model`,
+    /// `max_tokens`, `system_prompt`, and `tools` so the model worker is
+    /// self-contained.
+    #[tokio::test]
+    async fn model_node_tools_payload_is_enriched() {
+        let (s, b, e) = setup(model_node_ir()).await;
+
+        // Seed some accumulated state.
+        append(
+            &b,
+            &e,
+            node_completed("prev_node", serde_json::json!({ "key": "value" })),
+        )
+        .await;
+
+        // Tick: `model_step` is the start node with no predecessors — runnable.
+        tick(&s, &e).await;
+
+        // Claim the work item from the model queue.
+        let item = b
+            .claim_work_item("test-worker", &["model"])
+            .await
+            .expect("backend claim must not error")
+            .expect("a Model node must produce exactly one work item");
+
+        // Queue type
+        assert_eq!(item.queue_type, "model");
+
+        // Model identifier resolved from IR models map.
+        assert_eq!(
+            item.payload["model"], "anthropic/claude-sonnet-4-6",
+            "payload must carry the resolved model identifier"
+        );
+
+        // max_tokens from model config.
+        assert_eq!(
+            item.payload["max_tokens"], 1024,
+            "payload must carry max_tokens from model config"
+        );
+
+        // system_prompt from node definition.
+        assert_eq!(
+            item.payload["system_prompt"], "You are a test assistant.",
+            "payload must carry the node-level system prompt"
+        );
+
+        // Tools array must be present and have the expected length.
+        assert!(
+            item.payload["tools"].is_array(),
+            "payload.tools must be a JSON array"
+        );
+        assert_eq!(
+            item.payload["tools"].as_array().unwrap().len(),
+            2,
+            "payload.tools must contain all 2 tool schemas"
+        );
+
+        // Base fields must still be present.
+        assert_eq!(item.payload["workflow_id"], "wf");
+        assert_eq!(item.payload["workflow_version"], "0.1.0");
+        assert_eq!(item.payload["node_id"], "model_step");
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -419,6 +419,15 @@ impl Scheduler {
                     if !tools.is_empty() {
                         obj.insert("tools".into(), serde_json::Value::Array(tools.clone()));
                     }
+                    // Running conversation history — thread the accumulated
+                    // `messages` from state into the payload so each turn's model
+                    // call sees the full history (the agent loop accumulates them
+                    // in `state["messages"]`; the executor builds its ChatMessage
+                    // list from this when the node carries no inline `prompt`).
+                    // Without this the loop cannot feed tool results forward.
+                    if let Some(messages) = progress.final_state.get("messages") {
+                        obj.insert("messages".into(), messages.clone());
+                    }
                 }
 
                 let item = WorkItem {
@@ -618,6 +627,24 @@ impl ExecProgress {
                             self.rejected.insert(node_id.clone(), reason);
                         }
                     }
+                }
+            }
+            EventKind::WorkflowStarted {
+                initial_input: serde_json::Value::Object(input),
+                ..
+            } => {
+                // Seed the running state from the execution's `initial_input` so
+                // the FIRST node sees it — e.g. the agent loop's seeded
+                // `messages` (system + user) and the `{name: "module:function"}`
+                // tool-resolver map, which turn 0's model node and every
+                // tool-dispatch node read before any node has produced a
+                // `state_patch`. Mirrors the state materializer, which starts
+                // `current_state` from `initial_input` before folding patches,
+                // so the scheduler's `final_state` stays consistent with the
+                // persisted `current_state`. A non-object `initial_input` falls
+                // through to the no-op arm (nothing to seed).
+                for (k, v) in input {
+                    self.final_state.insert(k.clone(), v.clone());
                 }
             }
             _ => {}
@@ -1347,5 +1374,82 @@ mod tests {
         assert_eq!(item.payload["workflow_id"], "wf");
         assert_eq!(item.payload["workflow_version"], "0.1.0");
         assert_eq!(item.payload["node_id"], "model_step");
+    }
+
+    /// 2j-4 G1a: a `WorkflowStarted` event seeds `final_state` from its
+    /// `initial_input` so the first node (turn 0's model node, every
+    /// tool-dispatch node) sees the seeded `messages` + tool-resolver `tools`
+    /// map before any node has produced a `state_patch`.
+    #[tokio::test]
+    async fn workflow_started_seeds_final_state_from_initial_input() {
+        let progress = fold_events(vec![EventKind::WorkflowStarted {
+            workflow_id: "wf".into(),
+            workflow_version: "0.1.0".into(),
+            initial_input: serde_json::json!({
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi"}
+                ],
+                "tools": {"get_weather": "myapp.tools:get_weather"}
+            }),
+        }]);
+
+        assert_eq!(
+            progress.final_state["messages"]
+                .as_array()
+                .expect("seeded messages must be an array")
+                .len(),
+            2,
+            "initial_input.messages must seed final_state.messages"
+        );
+        assert_eq!(
+            progress.final_state["tools"]["get_weather"], "myapp.tools:get_weather",
+            "initial_input.tools resolver map must seed final_state.tools"
+        );
+    }
+
+    /// 2j-4 G1b: the Model work-item payload must carry the running `messages`
+    /// threaded from state (seeded here via `initial_input`) so each turn's
+    /// model call sees the accumulated conversation history.
+    #[tokio::test]
+    async fn model_node_payload_carries_messages_from_state() {
+        let (s, b, e) = setup(model_node_ir()).await;
+
+        // Seed the running conversation the way `start_execution` does — a
+        // WorkflowStarted event whose initial_input carries `messages`.
+        append(
+            &b,
+            &e,
+            EventKind::WorkflowStarted {
+                workflow_id: "wf".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({
+                    "messages": [
+                        {"role": "system", "content": "You are a test assistant."},
+                        {"role": "user", "content": "What is the weather in London?"}
+                    ]
+                }),
+            },
+        )
+        .await;
+
+        tick(&s, &e).await;
+
+        let item = b
+            .claim_work_item("test-worker", &["model"])
+            .await
+            .expect("backend claim must not error")
+            .expect("a Model node must produce exactly one work item");
+
+        let messages = item.payload["messages"]
+            .as_array()
+            .expect("payload.messages must be a JSON array threaded from state");
+        assert_eq!(
+            messages.len(),
+            2,
+            "payload.messages must carry the full accumulated conversation"
+        );
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["content"], "What is the weather in London?");
     }
 }

--- a/runtime/workers/src/executors/model_node.rs
+++ b/runtime/workers/src/executors/model_node.rs
@@ -230,6 +230,40 @@ mod tests {
         kind: FakeKind,
     }
 
+    /// Records the `ModelRequest` it is called with so a test can assert how the
+    /// executor mapped the work-item payload (e.g. `messages`) into the request.
+    struct CapturingAdapter {
+        captured: Arc<std::sync::Mutex<Option<ModelRequest>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ModelAdapter for CapturingAdapter {
+        fn system_name(&self) -> &'static str {
+            "capturing"
+        }
+        fn default_model(&self) -> &str {
+            "fake-model"
+        }
+        async fn chat(&self, req: ModelRequest) -> Result<ModelResponse, ModelError> {
+            *self.captured.lock().unwrap() = Some(req);
+            Ok(ModelResponse {
+                content: "ok".to_string(),
+                model: "fake-model".to_string(),
+                finish_reason: "stop".to_string(),
+                input_tokens: 1,
+                output_tokens: 1,
+                structured: None,
+                tool_calls: vec![],
+            })
+        }
+        async fn structured_output(
+            &self,
+            _req: StructuredRequest,
+        ) -> Result<ModelResponse, ModelError> {
+            unimplemented!()
+        }
+    }
+
     #[async_trait::async_trait]
     impl ModelAdapter for FakeAdapter {
         fn system_name(&self) -> &'static str {
@@ -440,5 +474,76 @@ mod tests {
             sp_tool_calls.is_empty(),
             "expected empty tool_calls in state_patch"
         );
+    }
+
+    /// 2j-4 G1: when the work-item payload carries a `messages` array (and no
+    /// inline `prompt`, as the agent-loop IR emits), the executor must build the
+    /// `ModelRequest.messages` (ChatMessage list) from it — preserving order and
+    /// content so each turn's model call sees the accumulated conversation.
+    /// (Role mapping: system->System, user->User, assistant->Assistant; any
+    /// other role, e.g. a `tool` result, flattens to User — a deliberate v1
+    /// simplification since ChatMessage carries only role + content.)
+    #[tokio::test]
+    async fn executor_maps_payload_messages_into_request() {
+        use jamjet_models::adapter::ChatRole;
+
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let registry = Arc::new(
+            ModelRegistry::new()
+                .register(Arc::new(CapturingAdapter {
+                    captured: captured.clone(),
+                }))
+                .with_default("capturing"),
+        );
+        let executor = ModelNodeExecutor::new(registry);
+
+        let item = WorkItem {
+            id: uuid::Uuid::new_v4(),
+            execution_id: jamjet_core::workflow::ExecutionId::new(),
+            node_id: "model_step".into(),
+            queue_type: "model".into(),
+            payload: serde_json::json!({
+                "model": "fake-model",
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "What is the weather?"},
+                    {"role": "assistant", "content": "Let me check."},
+                    {"role": "tool", "content": "72F and sunny"}
+                ]
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        };
+
+        executor
+            .execute(&item)
+            .await
+            .expect("execute with messages must not error");
+
+        let req = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("the adapter must have captured a request");
+
+        assert_eq!(
+            req.messages.len(),
+            4,
+            "all 4 conversation messages must be threaded into the request"
+        );
+        assert!(matches!(req.messages[0].role, ChatRole::System));
+        assert_eq!(req.messages[0].content, "You are helpful.");
+        assert!(matches!(req.messages[1].role, ChatRole::User));
+        assert_eq!(req.messages[1].content, "What is the weather?");
+        assert!(matches!(req.messages[2].role, ChatRole::Assistant));
+        assert_eq!(req.messages[2].content, "Let me check.");
+        // `tool` role flattens to User; its content is still carried forward.
+        assert!(matches!(req.messages[3].role, ChatRole::User));
+        assert_eq!(req.messages[3].content, "72F and sunny");
     }
 }

--- a/runtime/workers/src/executors/model_node.rs
+++ b/runtime/workers/src/executors/model_node.rs
@@ -102,9 +102,20 @@ impl NodeExecutor for ModelNodeExecutor {
             stop_sequences: None,
         };
 
+        // Read tool schemas from the work-item payload (scheduler-enriched from the
+        // IR Model node's `tools` field).
+        let tools: Vec<serde_json::Value> = item
+            .payload
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
         debug!(model = %model, messages = messages.len(), "Calling model");
 
-        let request = ModelRequest::new(messages).with_config(config);
+        let request = ModelRequest::new(messages)
+            .with_config(config)
+            .with_tools(tools);
         // Intercept RateLimited before erasing the type. ONLY RateLimited becomes
         // ExecutorError::RateLimited; every other ModelError variant becomes Fatal.
         let response = match self.registry.chat(request).await {
@@ -117,16 +128,46 @@ impl NodeExecutor for ModelNodeExecutor {
 
         let duration_ms = start.elapsed().as_millis() as u64;
 
-        // Build output — structured or plain text.
+        // Serialize tool_calls to JSON values.  These are small (id/name/arguments
+        // only) and are intentionally placed in state_patch so they NEVER get
+        // spilled to the artifact store (state_patch stays inline per the 2i
+        // spill comment in worker.rs:430-434).
+        let tool_calls_json: Vec<serde_json::Value> = response
+            .tool_calls
+            .iter()
+            .map(|tc| {
+                serde_json::json!({
+                    "id": tc.id,
+                    "name": tc.name,
+                    "arguments": tc.arguments,
+                })
+            })
+            .collect();
+
+        // Build output — carries content + tool_calls + finish_reason.
+        // Note: if content is large, the output blob may be spilled to the
+        // artifact store (2i).  tool_calls and finish_reason are ALSO written to
+        // state_patch (see below) so the condition gate and tool nodes always
+        // find them inline in current_state, even if the output was spilled.
         let output: Value = json!({
             "content": response.content,
             "model": response.model,
             "finish_reason": response.finish_reason,
+            "tool_calls": tool_calls_json,
         });
 
-        // State patch: write content to `last_model_output` in workflow state.
+        // State patch: write model outputs inline into workflow state.
+        // Convention for 2j-3's condition gate and tool-dispatch nodes:
+        //   state["last_model_finish_reason"] — "tool_calls", "stop", etc.
+        //   state["last_model_tool_calls"]    — [{id, name, arguments}, ...]
+        //   state["last_model_output"]        — content text (last model turn)
+        // These keys are safe to overwrite per turn because the static unroll
+        // executes model nodes sequentially; the condition gate for turn N always
+        // reads after that turn's model node completes.
         let state_patch = json!({
             "last_model_output": response.content,
+            "last_model_finish_reason": response.finish_reason,
+            "last_model_tool_calls": tool_calls_json,
         });
 
         Ok(ExecutionResult {
@@ -170,15 +211,19 @@ impl NodeExecutor for ModelNodeExecutor {
 mod tests {
     use super::*;
     use crate::executor::ExecutorError;
+    use jamjet_models::adapter::ToolCall;
     use jamjet_models::{ModelAdapter, ModelError, ModelRequest, ModelResponse, StructuredRequest};
     use jamjet_state::backend::WorkItem;
     use std::sync::Arc;
 
     // ── Fake adapter ──────────────────────────────────────────────────────────
 
+    #[allow(dead_code)]
     enum FakeKind {
         RateLimited { retry_after_secs: u64 },
         ApiError,
+        ToolCallResponse,
+        TextResponse,
     }
 
     struct FakeAdapter {
@@ -202,6 +247,28 @@ mod tests {
                     status: 500,
                     body: "internal server error".into(),
                 }),
+                FakeKind::ToolCallResponse => Ok(ModelResponse {
+                    content: "".to_string(),
+                    model: "fake-model".to_string(),
+                    finish_reason: "tool_calls".to_string(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    structured: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_abc123".to_string(),
+                        name: "get_weather".to_string(),
+                        arguments: serde_json::json!({"location": "London"}),
+                    }],
+                }),
+                FakeKind::TextResponse => Ok(ModelResponse {
+                    content: "Hello, world!".to_string(),
+                    model: "fake-model".to_string(),
+                    finish_reason: "stop".to_string(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    structured: None,
+                    tool_calls: vec![],
+                }),
             }
         }
         async fn structured_output(
@@ -221,6 +288,29 @@ mod tests {
             payload: serde_json::json!({
                 "model": "fake-model",
                 "prompt": "hello",
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        }
+    }
+
+    fn make_item_with_tools() -> WorkItem {
+        WorkItem {
+            id: uuid::Uuid::new_v4(),
+            execution_id: jamjet_core::workflow::ExecutionId::new(),
+            node_id: "test-node".into(),
+            queue_type: "model".into(),
+            payload: serde_json::json!({
+                "model": "fake-model",
+                "prompt": "What is the weather in London?",
+                "tools": [
+                    {"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {}}}
+                ]
             }),
             attempt: 0,
             max_attempts: 3,
@@ -271,6 +361,84 @@ mod tests {
             matches!(result, Err(ExecutorError::Fatal(_))),
             "expected Fatal, got: {:?}",
             result
+        );
+    }
+
+    /// When the model returns tool_calls, the output and state_patch must carry
+    /// the serialized tool calls and the finish_reason "tool_calls".
+    #[tokio::test]
+    async fn tool_calls_response_lands_in_output_and_state_patch() {
+        let executor = make_executor(FakeKind::ToolCallResponse);
+        let result = executor
+            .execute(&make_item_with_tools())
+            .await
+            .expect("ToolCallResponse must not error");
+
+        // output["tool_calls"] must be an array with one entry.
+        let tool_calls = result.output["tool_calls"]
+            .as_array()
+            .expect("output.tool_calls must be an array");
+        assert_eq!(tool_calls.len(), 1, "expected exactly one tool call");
+        assert_eq!(tool_calls[0]["id"], "call_abc123");
+        assert_eq!(tool_calls[0]["name"], "get_weather");
+        assert_eq!(tool_calls[0]["arguments"]["location"], "London");
+
+        // output["finish_reason"] must be "tool_calls".
+        assert_eq!(
+            result.output["finish_reason"], "tool_calls",
+            "output.finish_reason must be 'tool_calls'"
+        );
+
+        // state_patch must carry finish_reason and tool_calls inline.
+        assert_eq!(
+            result.state_patch["last_model_finish_reason"], "tool_calls",
+            "state_patch.last_model_finish_reason must be 'tool_calls'"
+        );
+        let sp_tool_calls = result.state_patch["last_model_tool_calls"]
+            .as_array()
+            .expect("state_patch.last_model_tool_calls must be an array");
+        assert_eq!(
+            sp_tool_calls.len(),
+            1,
+            "expected exactly one tool call in state_patch"
+        );
+        assert_eq!(sp_tool_calls[0]["name"], "get_weather");
+    }
+
+    /// When the model returns a plain text response with no tool_calls, the
+    /// output and state_patch must contain empty tool_calls arrays and
+    /// finish_reason "stop".
+    #[tokio::test]
+    async fn no_tool_calls_response_has_empty_tool_calls() {
+        let executor = make_executor(FakeKind::TextResponse);
+        let result = executor
+            .execute(&make_item())
+            .await
+            .expect("TextResponse must not error");
+
+        // output["tool_calls"] must be an empty array.
+        let tool_calls = result.output["tool_calls"]
+            .as_array()
+            .expect("output.tool_calls must be an array");
+        assert!(tool_calls.is_empty(), "expected empty tool_calls array");
+
+        // output["finish_reason"] must be "stop".
+        assert_eq!(
+            result.output["finish_reason"], "stop",
+            "output.finish_reason must be 'stop'"
+        );
+
+        // state_patch must carry finish_reason "stop" and empty tool_calls.
+        assert_eq!(
+            result.state_patch["last_model_finish_reason"], "stop",
+            "state_patch.last_model_finish_reason must be 'stop'"
+        );
+        let sp_tool_calls = result.state_patch["last_model_tool_calls"]
+            .as_array()
+            .expect("state_patch.last_model_tool_calls must be an array");
+        assert!(
+            sp_tool_calls.is_empty(),
+            "expected empty tool_calls in state_patch"
         );
     }
 }

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -29,6 +29,8 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import json
+import time
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -38,6 +40,11 @@ from jamjet.tools.decorators import ToolDefinition
 
 if TYPE_CHECKING:
     from jamjet.spec import AgentSpec
+
+# Terminal execution statuses (WorkflowStatus, snake_case) the durable poll stops on.
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "limit_exceeded"})
+# How often run_durable polls get_execution while waiting for a terminal state.
+_POLL_INTERVAL_SECONDS = 0.5
 
 
 class Agent:
@@ -140,6 +147,187 @@ class Agent:
     def run_sync(self, prompt: str) -> AgentResult:
         """Synchronous wrapper around :meth:`run` for scripts and notebooks."""
         return asyncio.run(self.run(prompt))
+
+    async def run_durable(
+        self,
+        prompt: str,
+        *,
+        max_turns: int = 8,
+        runtime_url: str = "http://127.0.0.1:8080",
+    ) -> AgentResult:
+        """Run the agent durably on the JamJet engine, mirroring :meth:`run`.
+
+        Compiles the agent to an agent-loop IR (``model -> tools -> model``,
+        statically unrolled and bounded by *max_turns*), registers it, then
+        starts an execution seeded with the system+user ``messages`` and the
+        ``{name: "module:function"}`` tool-resolver map. It polls the execution
+        to a terminal state and extracts an :class:`AgentResult` with the SAME
+        fields as the in-process :meth:`run` (final content, the tool calls made,
+        the IR, and the wall-clock duration).
+
+        Unlike :meth:`run` (a pure in-process loop), this routes every model call
+        and tool dispatch through the durable event-sourced engine, so the run
+        gets the event log, replay, idempotency, park-on-429, and artifacts for
+        free. It requires a running engine at *runtime_url* and a running
+        ``jamjet worker`` (the python_tool worker) to execute the ``@tool``
+        functions.
+
+        Raises
+        ------
+        RuntimeError
+            If the execution reaches a non-``completed`` terminal state
+            (``failed`` / ``cancelled`` / ``limit_exceeded``).
+        TimeoutError
+            If no terminal state is reached within the agent's
+            ``timeout_seconds`` limit.
+        """
+        from jamjet.client import JamjetClient  # noqa: PLC0415 - patch point / avoid import cycle
+        from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir  # noqa: PLC0415
+
+        ir = compile_agent_to_ir(self, prompt, max_turns)
+        initial_input = build_initial_state(self, prompt)
+        workflow_id: str = ir["workflow_id"]
+        workflow_version: str | None = ir.get("version")
+
+        t0 = time.monotonic()
+        async with JamjetClient(runtime_url) as client:
+            # Register the compiled IR, then start an execution seeded with the
+            # running messages + tool-resolver map (build_initial_state).
+            await client.create_workflow(ir)
+            started = await client.start_execution(workflow_id, initial_input, workflow_version=workflow_version)
+            exec_id = started.get("execution_id")
+            if not exec_id:
+                raise RuntimeError(f"start_execution returned no execution_id: {started!r}")
+
+            execution = await self._poll_to_terminal(client, exec_id)
+            # Events carry artifact-resolved NodeCompleted outputs (server-side),
+            # used only as a fallback if a spilled answer sentinel slips through.
+            try:
+                events = (await client.get_events(exec_id)).get("events", [])
+            except Exception:  # noqa: BLE001 - events are a best-effort fallback
+                events = []
+
+        duration_us = int((time.monotonic() - t0) * 1_000_000)
+        return self._extract_result(execution, events, ir, duration_us)
+
+    async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:
+        """Poll ``get_execution`` until the execution reaches a terminal state."""
+        elapsed = 0.0
+        timeout_s = self.limits.timeout_seconds
+        while True:
+            execution = await client.get_execution(exec_id)
+            status = execution.get("status", "unknown")
+            if status in _TERMINAL_STATUSES:
+                return execution
+            if elapsed >= timeout_s:
+                raise TimeoutError(
+                    f"durable agent run {exec_id} did not reach a terminal state "
+                    f"within {timeout_s}s (last status: {status!r})"
+                )
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
+
+    def _extract_result(
+        self,
+        execution: dict[str, Any],
+        events: list[dict[str, Any]],
+        ir: dict[str, Any],
+        duration_us: int,
+    ) -> AgentResult:
+        """Build an :class:`AgentResult` from a terminal durable execution.
+
+        The final answer is the last model turn's content
+        (``current_state["last_model_output"]``, written inline by the Model
+        executor; falls back to the last assistant message). The tool-call trace
+        is reconstructed from the accumulated ``messages``. Field shape matches
+        the in-process :meth:`run` result exactly.
+        """
+        status = execution.get("status")
+        if status != "completed":
+            detail = execution.get("detail") or status
+            raise RuntimeError(f"durable agent run ended in non-completed state: {detail}")
+
+        state = execution.get("current_state") or {}
+        messages = state.get("messages") or []
+
+        output = state.get("last_model_output")
+        if output is None:
+            output = self._last_assistant_content(messages)
+        output = self._resolve_artifact_sentinel(output, events)
+
+        return AgentResult(
+            output=output if isinstance(output, str) else ("" if output is None else str(output)),
+            tool_calls=self._tool_calls_from_messages(messages),
+            ir=ir,
+            duration_us=duration_us,
+        )
+
+    @staticmethod
+    def _last_assistant_content(messages: list[dict[str, Any]]) -> str | None:
+        """The content of the last assistant message that carried text."""
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("content"):
+                return msg["content"]
+        return None
+
+    @staticmethod
+    def _tool_calls_from_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Reconstruct the in-process tool-call trace from the message history.
+
+        Pairs each ``role: tool`` result with the arguments from the assistant
+        ``tool_calls`` that requested it (matched by ``tool_call_id``), yielding
+        dicts with the same keys as the in-process ``ToolCallRecord.model_dump()``
+        (``tool`` / ``input`` / ``output`` / ``duration_us``). Per-call durations
+        are not carried in the message history, so ``duration_us`` is ``0``.
+        """
+        args_by_id: dict[str, Any] = {}
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            for call in msg.get("tool_calls") or []:
+                fn = call.get("function") or {}
+                raw = fn.get("arguments")
+                try:
+                    parsed = json.loads(raw) if isinstance(raw, str) else (raw or {})
+                except (TypeError, ValueError):
+                    parsed = {}
+                if call.get("id") is not None:
+                    args_by_id[call["id"]] = parsed
+
+        calls: list[dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") != "tool":
+                continue
+            calls.append(
+                {
+                    "tool": msg.get("name"),
+                    "input": args_by_id.get(msg.get("tool_call_id"), {}),
+                    "output": msg.get("content"),
+                    "duration_us": 0,
+                }
+            )
+        return calls
+
+    @staticmethod
+    def _resolve_artifact_sentinel(value: Any, events: list[dict[str, Any]]) -> Any:
+        """Recover the answer if it surfaced as a 2i artifact spill sentinel.
+
+        ``last_model_output`` is written inline (never spilled to the artifact
+        store), so it is normally already the answer text. As a guard, if a
+        ``{"$artifact": ...}`` sentinel slips through, recover the resolved text
+        from the most recent NodeCompleted event's ``output.content`` (the
+        ``get_events`` endpoint resolves sentinels server-side).
+        """
+        if not (isinstance(value, dict) and "$artifact" in value):
+            return value
+        for ev in reversed(events):
+            kind = ev.get("kind") or {}
+            if kind.get("type") != "node_completed":
+                continue
+            out = kind.get("output")
+            if isinstance(out, dict) and "content" in out and "$artifact" not in out:
+                return out["content"]
+        return value
 
     async def stream(
         self,

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -153,7 +153,7 @@ class Agent:
         prompt: str,
         *,
         max_turns: int = 8,
-        runtime_url: str = "http://127.0.0.1:8080",
+        runtime_url: str = "http://127.0.0.1:7700",
     ) -> AgentResult:
         """Run the agent durably on the JamJet engine, mirroring :meth:`run`.
 
@@ -168,9 +168,23 @@ class Agent:
         Unlike :meth:`run` (a pure in-process loop), this routes every model call
         and tool dispatch through the durable event-sourced engine, so the run
         gets the event log, replay, idempotency, park-on-429, and artifacts for
-        free. It requires a running engine at *runtime_url* and a running
-        ``jamjet worker`` (the python_tool worker) to execute the ``@tool``
-        functions.
+        free.
+
+        v1 limitations
+        --------------
+        - **Static unroll, no early exit.** The loop runs up to *max_turns* model
+          turns and currently does NOT short-circuit when the model returns a
+          final answer; the engine has no edge-condition evaluator yet
+          (F-2j-dynamic-loop). A real model is re-invoked on every remaining
+          turn, so cost scales with *max_turns* and the answer can drift across
+          turns. Size *max_turns* to the conversation depth you actually expect.
+        - **Requires running services.** A live engine at *runtime_url*, a
+          ``jamjet worker`` draining the ``python_tool`` queue (to execute the
+          ``@tool`` functions), and the model sidecar (``JAMJET_MODEL_SEAM_URL``,
+          which forwards tools to the provider) must all be running.
+        - **The read is the final state.** The returned answer is the durable
+          execution's final state (the last model turn's output), not a
+          per-turn early-stop result.
 
         Raises
         ------

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -172,19 +172,20 @@ class Agent:
 
         v1 limitations
         --------------
-        - **Static unroll, no early exit.** The loop runs up to *max_turns* model
-          turns and currently does NOT short-circuit when the model returns a
-          final answer; the engine has no edge-condition evaluator yet
-          (F-2j-dynamic-loop). A real model is re-invoked on every remaining
-          turn, so cost scales with *max_turns* and the answer can drift across
-          turns. Size *max_turns* to the conversation depth you actually expect.
+        - **Static unroll, no early exit.** The loop runs up to *max_turns* tool
+          turns plus a final answer-only model turn, and currently does NOT
+          short-circuit when the model returns a final answer early; the engine has
+          no edge-condition evaluator yet (F-2j-dynamic-loop). A real model is
+          re-invoked on every remaining turn, so cost scales with *max_turns* and
+          the answer can drift across turns. Size *max_turns* to the conversation
+          depth you actually expect.
         - **Requires running services.** A live engine at *runtime_url*, a
           ``jamjet worker`` draining the ``python_tool`` queue (to execute the
           ``@tool`` functions), and the model sidecar (``JAMJET_MODEL_SEAM_URL``,
           which forwards tools to the provider) must all be running.
         - **The read is the final state.** The returned answer is the durable
-          execution's final state (the last model turn's output), not a
-          per-turn early-stop result.
+          execution's final state — the final model turn's output, which consumes
+          the last tool results — not a per-turn early-stop result.
 
         Raises
         ------
@@ -226,20 +227,21 @@ class Agent:
 
     async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:
         """Poll ``get_execution`` until the execution reaches a terminal state."""
-        elapsed = 0.0
         timeout_s = self.limits.timeout_seconds
+        # Monotonic deadline: time spent inside slow get_execution() calls counts
+        # toward the timeout, so a stalled run can't blow past timeout_seconds.
+        deadline = time.monotonic() + timeout_s
         while True:
             execution = await client.get_execution(exec_id)
             status = execution.get("status", "unknown")
             if status in _TERMINAL_STATUSES:
                 return execution
-            if elapsed >= timeout_s:
+            if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"durable agent run {exec_id} did not reach a terminal state "
                     f"within {timeout_s}s (last status: {status!r})"
                 )
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-            elapsed += _POLL_INTERVAL_SECONDS
 
     def _extract_result(
         self,

--- a/sdk/python/jamjet/agents/tool_runtime.py
+++ b/sdk/python/jamjet/agents/tool_runtime.py
@@ -119,16 +119,22 @@ def _coerce_arguments(arguments: Any) -> Any:
 def _resolve_tool(name: str | None, tools: dict[str, str]) -> Callable[..., Any]:
     """Resolve a tool name to a callable via the ``module:function`` map.
 
-    Falls back to the in-process ``@tool`` registry when the name is not in the
-    map (useful for in-process tests and dev).
+    Falls back to the in-process ``@tool`` registry both when the name is absent
+    from the map AND when a present-but-stale ref fails to import/resolve (useful
+    for in-process tests and dev, and resilient to a renamed/moved tool module).
     """
     ref = tools.get(name) if (name and isinstance(tools, dict)) else None
     if ref:
-        module_path, _, fn_path = ref.partition(":")
-        obj: Any = importlib.import_module(module_path)
-        for part in fn_path.split("."):
-            obj = getattr(obj, part)
-        return obj
+        try:
+            module_path, _, fn_path = ref.partition(":")
+            obj: Any = importlib.import_module(module_path)
+            for part in fn_path.split("."):
+                obj = getattr(obj, part)
+            return obj
+        except (ImportError, AttributeError):
+            # A stale/non-importable map ref must not mask the @tool registry
+            # fallback below — fall through and try the registry before raising.
+            pass
 
     from jamjet.tools.decorators import get_tool  # noqa: PLC0415 - avoid import cycle
 

--- a/sdk/python/jamjet/agents/tool_runtime.py
+++ b/sdk/python/jamjet/agents/tool_runtime.py
@@ -1,0 +1,151 @@
+"""Runtime helper for the durable agent loop — dispatch a model turn's tool calls.
+
+This is the function the ``__tools_<turn>__`` PythonFn nodes emitted by
+:func:`jamjet.compiler.agent_ir.compile_agent_to_ir` point at. On the durable
+engine it runs on the ``python_tool`` worker (Track 2d): the worker resolves
+``payload["module"]`` / ``payload["function"]`` to this coroutine and calls it
+with ``payload["input"]`` — the **full accumulated workflow state** (the
+scheduler passes ``progress.final_state`` as the PythonFn input; PythonFn nodes
+have no per-node input mapping).
+
+Message accumulation lives ENTIRELY here so the generic Model executor stays
+generic: we append the assistant message that requested the tools plus one
+``role: tool`` message per call to the running ``messages`` list, and return the
+**full updated list**. The engine replaces ``state["messages"]`` with it
+(merge-patch, top-level key replace).
+
+Input keys (read with fallbacks so this is unit-testable without the engine):
+
+* ``messages``              — the running message list (default ``[]``)
+* ``tool_calls`` | ``last_model_tool_calls`` — ``[{id, name, arguments}, ...]``
+  (the Model executor / Track 2j-2 writes ``last_model_tool_calls`` to state)
+* ``assistant_content`` | ``last_model_output`` — the assistant content text
+* ``tools``                 — ``{name: "module:function"}`` resolver map
+
+Each tool is resolved through the ``module:function`` map (imported on demand,
+mirroring the worker's own handler resolution) so the dispatch worker does not
+need the user's tool module pre-imported; the in-process ``@tool`` registry is a
+secondary fallback.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from collections.abc import Callable
+from typing import Any
+
+
+async def dispatch_tool_calls(input: dict[str, Any]) -> dict[str, Any]:  # noqa: A002 - matches worker payload key
+    """Run the tool calls from one model turn and return the updated messages.
+
+    Returns ``{"messages": <full updated list>}`` which replaces
+    ``state["messages"]`` for the next turn's model node.
+    """
+    messages: list[dict[str, Any]] = list(input.get("messages") or [])
+
+    tool_calls = input.get("tool_calls")
+    if tool_calls is None:
+        tool_calls = input.get("last_model_tool_calls") or []
+
+    assistant_content = input.get("assistant_content")
+    if assistant_content is None:
+        assistant_content = input.get("last_model_output")
+
+    tools: dict[str, str] = input.get("tools") or {}
+
+    # 1. The assistant message that requested these tool calls (OpenAI shape so
+    #    the message history replays cleanly into the next model turn).
+    messages.append(
+        {
+            "role": "assistant",
+            "content": assistant_content or "",
+            "tool_calls": [_assistant_tool_call(call) for call in tool_calls],
+        }
+    )
+
+    # 2. Execute each requested tool, append its result as a tool message.
+    for call in tool_calls:
+        name = call.get("name")
+        call_id = call.get("id")
+        arguments = _coerce_arguments(call.get("arguments"))
+
+        fn = _resolve_tool(name, tools)
+        result = fn(**arguments) if isinstance(arguments, dict) else fn(arguments)
+        if inspect.isawaitable(result):
+            result = await result
+
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "name": name,
+                "content": _stringify(result),
+            }
+        )
+
+    # 3. Return the FULL updated list — replaces state["messages"].
+    return {"messages": messages}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _assistant_tool_call(call: dict[str, Any]) -> dict[str, Any]:
+    """Render a ``{id, name, arguments}`` call into the OpenAI assistant shape."""
+    arguments = call.get("arguments")
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments if arguments is not None else {})
+    return {
+        "id": call.get("id"),
+        "type": "function",
+        "function": {"name": call.get("name"), "arguments": arguments},
+    }
+
+
+def _coerce_arguments(arguments: Any) -> Any:
+    """Tool arguments arrive as a dict or a JSON string — normalise to a dict."""
+    if isinstance(arguments, str):
+        if not arguments.strip():
+            return {}
+        try:
+            return json.loads(arguments)
+        except json.JSONDecodeError:
+            return {}
+    return arguments if arguments is not None else {}
+
+
+def _resolve_tool(name: str | None, tools: dict[str, str]) -> Callable[..., Any]:
+    """Resolve a tool name to a callable via the ``module:function`` map.
+
+    Falls back to the in-process ``@tool`` registry when the name is not in the
+    map (useful for in-process tests and dev).
+    """
+    ref = tools.get(name) if (name and isinstance(tools, dict)) else None
+    if ref:
+        module_path, _, fn_path = ref.partition(":")
+        obj: Any = importlib.import_module(module_path)
+        for part in fn_path.split("."):
+            obj = getattr(obj, part)
+        return obj
+
+    from jamjet.tools.decorators import get_tool  # noqa: PLC0415 - avoid import cycle
+
+    defn = get_tool(name) if name else None
+    if defn is None:
+        raise KeyError(f"tool {name!r} not found in tools map or @tool registry")
+    return defn.fn
+
+
+def _stringify(result: Any) -> str:
+    """Coerce a tool result to the string content a ``role: tool`` message needs."""
+    if isinstance(result, str):
+        return result
+    model_dump_json = getattr(result, "model_dump_json", None)  # pydantic BaseModel
+    if callable(model_dump_json):
+        return model_dump_json()
+    try:
+        return json.dumps(result)
+    except (TypeError, ValueError):
+        return str(result)

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1682,6 +1682,13 @@ async def _worker_loop(
                 # A non-dict return is coerced to {"result": <value>} above, so a
                 # plain tool additively records {"result": ...}; nodes that mean
                 # to leave state untouched simply return {}.
+                #
+                # This is a deliberate semantic (return-as-state_patch), NOT a bug.
+                # Caveat (F-2j-statepatch-namespace): because top-level keys are
+                # replaced, a plain @tool that returns a dict must avoid the loop's
+                # reserved keys (e.g. "messages", "last_model_output") or it will
+                # clobber loop state. There is no key namespacing yet; that is a
+                # tracked follow-up, not handled here.
                 state_patch: dict[str, Any] = output
 
                 # Forward optional GenAI telemetry if the tool surfaced it.

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1674,6 +1674,16 @@ async def _worker_loop(
                 duration_ms = int((time.monotonic() - t_start) * 1000)
                 output: Any = result if isinstance(result, dict) else {"result": result}
 
+                # The node mutates workflow state with its return value: a
+                # PythonFn node's return dict IS its `state_patch` (merge-patched
+                # into state, top-level keys replaced). This is what carries the
+                # agent loop's `dispatch_tool_calls` return — {"messages": [...]}
+                # — into state["messages"] for the next turn's model node.
+                # A non-dict return is coerced to {"result": <value>} above, so a
+                # plain tool additively records {"result": ...}; nodes that mean
+                # to leave state untouched simply return {}.
+                state_patch: dict[str, Any] = output
+
                 # Forward optional GenAI telemetry if the tool surfaced it.
                 gen_ai_model_field: str | None = None
                 finish_reason_field: str | None = None
@@ -1686,7 +1696,7 @@ async def _worker_loop(
                     exec_id,
                     node_id,
                     output,
-                    {},
+                    state_patch,
                     duration_ms,
                     gen_ai_model=gen_ai_model_field,
                     finish_reason=finish_reason_field,

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -1,0 +1,238 @@
+"""Compile a :class:`jamjet.Agent` to a durable agent-loop ``WorkflowIr`` dict.
+
+Track 2j-3. Authoring an agent (model + ``@tool`` functions + instructions) and
+calling the durable path compiles to an event-sourced IR the Rust engine runs as
+a ``model -> tools -> model`` loop. Because the model picks tools *dynamically*,
+we cannot emit one node per actual call at compile time — instead we **statically
+unroll** the loop into ``max_turns`` turns, each turn being three nodes:
+
+1. ``__model_{t}__``     — a Model node carrying the agent's OpenAI tool schemas
+   (Track 2j-2 threads them into the model call) and reading the running
+   ``messages`` from state. It writes ``last_model_output`` /
+   ``last_model_finish_reason`` / ``last_model_tool_calls`` to state.
+2. ``__tool_gate_{t}__`` — a Condition node on
+   ``state.last_model_finish_reason == "tool_calls"``:
+     * true  -> the turn's tool-dispatch node;
+     * false -> the terminal ``end`` (the final answer is ``last_model_output``).
+3. ``__tools_{t}__``     — a single PythonFn node running
+   :func:`jamjet.agents.tool_runtime.dispatch_tool_calls`, which executes every
+   requested call and accumulates the messages, then loops to ``__model_{t+1}__``
+   (or, on the last turn, to ``end`` — the loop is bounded).
+
+The IR dict shape mirrors ``jamjet.workflow.ir_compiler`` exactly (the canonical
+``WorkflowIr`` the engine deserializes); node-kind shapes mirror
+``runtime/core/src/node.rs``: ``Model { ..., tools }``,
+``Condition { branches }``, ``PythonFn { module, function, output_schema }``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from jamjet.model.types import parse_model_ref
+
+if TYPE_CHECKING:
+    from jamjet.agents.agent import Agent
+    from jamjet.tools.decorators import ToolDefinition
+
+# The tool-dispatch PythonFn node points at this coroutine.
+_DISPATCH_MODULE = "jamjet.agents.tool_runtime"
+_DISPATCH_FUNCTION = "dispatch_tool_calls"
+
+# The condition gate branches on the finish reason the Model executor records.
+_TOOL_CALLS_EXPR = 'state.last_model_finish_reason == "tool_calls"'
+
+# Graph terminal sentinel (matches the strategy compiler's edge-to-"end").
+_END = "end"
+
+
+def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[str, Any]:
+    """Compile *agent* + *prompt* into a durable agent-loop ``WorkflowIr`` dict.
+
+    Parameters
+    ----------
+    agent:
+        A constructed :class:`jamjet.Agent` (model + ``@tool`` functions +
+        instructions).
+    prompt:
+        The user prompt; seeds the initial ``user`` message (see
+        :func:`build_initial_state`, which the durable run entrypoint passes as
+        the execution ``initial_input``).
+    max_turns:
+        Static unroll bound — the maximum number of ``model -> tools`` turns.
+        Must be ``>= 1``.
+
+    Returns
+    -------
+    dict
+        A ``WorkflowIr`` dict ready to ``POST /workflows`` (matches the shape
+        produced by ``jamjet.workflow.ir_compiler``).
+    """
+    if max_turns < 1:
+        raise ValueError("max_turns must be >= 1")
+
+    model_ref = parse_model_ref(agent.model).litellm_model
+    tool_schemas = [_tool_schema(td) for td in agent._tools]
+    tools_map = _tools_map(agent)
+
+    nodes: dict[str, Any] = {}
+    edges: list[dict[str, Any]] = []
+
+    for t in range(max_turns):
+        model_id = f"__model_{t}__"
+        gate_id = f"__tool_gate_{t}__"
+        tools_id = f"__tools_{t}__"
+        is_last = t == max_turns - 1
+        next_target = _END if is_last else f"__model_{t + 1}__"
+
+        # ── Model node: carries tool schemas, reads messages from state. ──────
+        nodes[model_id] = _node(
+            model_id,
+            {
+                "type": "model",
+                "model_ref": model_ref,
+                # Empty prompt_ref => the executor uses the `messages` list from
+                # state rather than a single templated user prompt.
+                "prompt_ref": "",
+                "output_schema": "",
+                "system_prompt": agent.instructions or None,
+                "tools": tool_schemas,
+            },
+            retry_policy="llm_default",
+            description=f"agent turn {t} — model call",
+            labels={"jamjet.agent.loop": "model", "jamjet.agent.turn": str(t)},
+        )
+        edges.append(_edge(model_id, gate_id))
+
+        # ── Condition gate: tool_calls -> dispatch, else -> final answer. ─────
+        nodes[gate_id] = _node(
+            gate_id,
+            {
+                "type": "condition",
+                "branches": [
+                    {"condition": _TOOL_CALLS_EXPR, "target": tools_id},
+                    {"condition": None, "target": _END},
+                ],
+                # Extra metadata mirroring the strategy compiler's condition
+                # nodes; the engine reads `branches` and ignores `expression`.
+                "expression": _TOOL_CALLS_EXPR,
+            },
+            description=f"agent turn {t} — tool-call gate",
+            labels={"jamjet.agent.loop": "gate", "jamjet.agent.turn": str(t)},
+        )
+        edges.append(_edge(gate_id, tools_id, _TOOL_CALLS_EXPR))
+        edges.append(_edge(gate_id, _END, None))
+
+        # ── Tool-dispatch node: one PythonFn runs every requested call. ───────
+        nodes[tools_id] = _node(
+            tools_id,
+            {
+                "type": "python_fn",
+                "module": _DISPATCH_MODULE,
+                "function": _DISPATCH_FUNCTION,
+                "output_schema": "",
+                # Descriptor of the data the dispatch coroutine consumes. The
+                # engine passes the full accumulated state to PythonFn nodes
+                # (no per-node input mapping), so `dispatch_tool_calls` reads
+                # these keys from state at runtime; this records intent + carries
+                # the {name: "module:function"} resolver map.
+                "input": {
+                    "messages": "$state.messages",
+                    "assistant_content": "$state.last_model_output",
+                    "tool_calls": "$state.last_model_tool_calls",
+                    "tools": tools_map,
+                },
+            },
+            description=f"agent turn {t} — dispatch tool calls",
+            labels={"jamjet.agent.loop": "tools", "jamjet.agent.turn": str(t)},
+        )
+        edges.append(_edge(tools_id, next_target))
+
+    return {
+        "workflow_id": agent.name,
+        "version": "0.1.0",
+        "name": agent.name,
+        "description": agent.instructions or prompt,
+        "state_schema": "",
+        "start_node": "__model_0__",
+        "nodes": nodes,
+        "edges": edges,
+        "retry_policies": {},
+        "timeouts": {
+            "workflow_timeout": agent.limits.timeout_seconds,
+            "heartbeat_interval": 30,
+        },
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {},
+        "labels": {
+            "jamjet.agent.id": agent.name,
+            "jamjet.agent.loop": "true",
+            "jamjet.agent.max_turns": str(max_turns),
+        },
+    }
+
+
+def build_initial_state(agent: Agent, prompt: str) -> dict[str, Any]:
+    """The execution ``initial_input`` for a compiled agent-loop IR.
+
+    Seeds the running ``messages`` (system + user) and the
+    ``{name: "module:function"}`` tool resolver map into workflow state, so the
+    first model node and every ``dispatch_tool_calls`` node find them. The
+    durable run entrypoint (Track 2j-4) passes this to ``start_execution``.
+    """
+    return {
+        "messages": [
+            {"role": "system", "content": agent.instructions or "You are a helpful assistant."},
+            {"role": "user", "content": prompt},
+        ],
+        "tools": _tools_map(agent),
+    }
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _tools_map(agent: Agent) -> dict[str, str]:
+    """``{tool_name: "module:qualname"}`` — mirrors ``Agent.compile`` handler_ref."""
+    return {td.name: f"{td.fn.__module__}:{td.fn.__qualname__}" for td in agent._tools}
+
+
+def _tool_schema(td: ToolDefinition) -> dict[str, Any]:
+    """An OpenAI function schema for a ``@tool`` definition.
+
+    Mirrors ``LocalRuntime._tool_to_openai_schema`` so the durable and
+    in-process paths offer the model identical tool schemas.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": td.name,
+            "description": td.description,
+            "parameters": td.input_schema,
+        },
+    }
+
+
+def _node(
+    node_id: str,
+    kind: dict[str, Any],
+    *,
+    retry_policy: str | None = None,
+    description: str | None = None,
+    labels: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Normalise a node into the IR node shape the engine expects."""
+    return {
+        "id": node_id,
+        "kind": kind,
+        "retry_policy": retry_policy,
+        "node_timeout_secs": None,
+        "description": description,
+        "labels": labels or {},
+    }
+
+
+def _edge(from_: str, to: str, condition: str | None = None) -> dict[str, Any]:
+    return {"from": from_, "to": to, "condition": condition}

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -16,8 +16,16 @@ unroll** the loop into ``max_turns`` turns, each turn being three nodes:
      * false -> the terminal ``end`` (the final answer is ``last_model_output``).
 3. ``__tools_{t}__``     — a single PythonFn node running
    :func:`jamjet.agents.tool_runtime.dispatch_tool_calls`, which executes every
-   requested call and accumulates the messages, then loops to ``__model_{t+1}__``
-   (or, on the last turn, to ``end`` — the loop is bounded).
+   requested call and accumulates the messages, then loops to ``__model_{t+1}__``.
+   It carries the ``no_retry`` policy: the dispatch runs user ``@tool`` functions
+   (possible non-idempotent external writes), so the scheduler must NOT re-run an
+   already-succeeded dispatch on a retry.
+
+A **final** Model node ``__model_{max_turns}__`` (no tool schemas, so it must
+return a text answer) consumes the last tool results and produces the answer,
+then routes to ``end``. The terminal is therefore ALWAYS reached via a model node
+— never directly from a tool-dispatch node — so the extracted answer is a real
+model turn that saw the tool results, not a stale tool-requesting message.
 
 The IR dict shape mirrors ``jamjet.workflow.ir_compiler`` exactly (the canonical
 ``WorkflowIr`` the engine deserializes); node-kind shapes mirror
@@ -27,6 +35,8 @@ The IR dict shape mirrors ``jamjet.workflow.ir_compiler`` exactly (the canonical
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import TYPE_CHECKING, Any
 
 from jamjet.model.types import parse_model_ref
@@ -45,6 +55,18 @@ _TOOL_CALLS_EXPR = 'state.last_model_finish_reason == "tool_calls"'
 # Graph terminal sentinel (matches the strategy compiler's edge-to-"end").
 _END = "end"
 
+# Retry-policy names the scheduler resolves to a max_attempts (runner.rs):
+# llm_default -> 3 (model calls retry on rate-limit/timeout); no_retry -> 1
+# (the tool-dispatch node runs non-idempotent user @tool functions, so a retry
+# must NOT re-run already-succeeded calls).
+_MODEL_RETRY_POLICY = "llm_default"
+_TOOLS_RETRY_POLICY = "no_retry"
+
+# Base of the workflow version. The real cache key is suffixed with a hash of the
+# IR content (see :func:`_content_version`) so a changed agent never reuses a
+# stale immutably-cached graph.
+_VERSION_BASE = "0.1.0"
+
 
 def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[str, Any]:
     """Compile *agent* + *prompt* into a durable agent-loop ``WorkflowIr`` dict.
@@ -55,12 +77,15 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
         A constructed :class:`jamjet.Agent` (model + ``@tool`` functions +
         instructions).
     prompt:
-        The user prompt; seeds the initial ``user`` message (see
-        :func:`build_initial_state`, which the durable run entrypoint passes as
-        the execution ``initial_input``).
+        The user prompt. It is deliberately NOT embedded in the workflow
+        definition (the prompt is per-run and private); it seeds the initial
+        ``user`` message via :func:`build_initial_state`, which the durable run
+        entrypoint passes as the execution ``initial_input``. Accepted here to
+        keep the call symmetric with ``build_initial_state``.
     max_turns:
         Static unroll bound — the maximum number of ``model -> tools`` turns.
-        Must be ``>= 1``.
+        Must be ``>= 1``. The compiled graph has ``max_turns`` tool turns plus a
+        final model node that produces the answer.
 
     Returns
     -------
@@ -78,27 +103,18 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
     nodes: dict[str, Any] = {}
     edges: list[dict[str, Any]] = []
 
+    system_prompt = agent.instructions or None
+
     for t in range(max_turns):
         model_id = f"__model_{t}__"
         gate_id = f"__tool_gate_{t}__"
         tools_id = f"__tools_{t}__"
-        is_last = t == max_turns - 1
-        next_target = _END if is_last else f"__model_{t + 1}__"
 
         # ── Model node: carries tool schemas, reads messages from state. ──────
         nodes[model_id] = _node(
             model_id,
-            {
-                "type": "model",
-                "model_ref": model_ref,
-                # Empty prompt_ref => the executor uses the `messages` list from
-                # state rather than a single templated user prompt.
-                "prompt_ref": "",
-                "output_schema": "",
-                "system_prompt": agent.instructions or None,
-                "tools": tool_schemas,
-            },
-            retry_policy="llm_default",
+            _model_kind(model_ref, system_prompt, tool_schemas),
+            retry_policy=_MODEL_RETRY_POLICY,
             description=f"agent turn {t} — model call",
             labels={"jamjet.agent.loop": "model", "jamjet.agent.turn": str(t)},
         )
@@ -124,6 +140,9 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
         edges.append(_edge(gate_id, _END, None))
 
         # ── Tool-dispatch node: one PythonFn runs every requested call. ───────
+        # no_retry: the dispatch runs user @tool functions (possible
+        # non-idempotent external writes), so the scheduler must not re-run an
+        # already-succeeded dispatch on a retry (runner.rs no_retry -> 1 attempt).
         nodes[tools_id] = _node(
             tools_id,
             {
@@ -143,16 +162,42 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
                     "tools": tools_map,
                 },
             },
+            retry_policy=_TOOLS_RETRY_POLICY,
             description=f"agent turn {t} — dispatch tool calls",
             labels={"jamjet.agent.loop": "tools", "jamjet.agent.turn": str(t)},
         )
-        edges.append(_edge(tools_id, next_target))
+        # Always route forward to the NEXT model node — including the last turn,
+        # whose tool-dispatch flows into the final model node below. A
+        # tool-dispatch node never routes directly to `end`.
+        edges.append(_edge(tools_id, f"__model_{t + 1}__"))
 
-    return {
+    # ── Final model node: consume the last tool results, produce the answer. ──
+    # Reached when every turn requested tools (the unroll hit its bound). It
+    # carries NO tool schemas, so the model must return a text answer rather than
+    # request more tools, and routes straight to `end`. This guarantees the
+    # terminal is always reached via a model turn that saw the tool results —
+    # never a tool-dispatch node whose state holds a stale tool-requesting message.
+    final_id = f"__model_{max_turns}__"
+    nodes[final_id] = _node(
+        final_id,
+        _model_kind(model_ref, system_prompt, []),
+        retry_policy=_MODEL_RETRY_POLICY,
+        description=f"agent turn {max_turns} — final answer (no tools)",
+        labels={
+            "jamjet.agent.loop": "model",
+            "jamjet.agent.turn": str(max_turns),
+            "jamjet.agent.final": "true",
+        },
+    )
+    edges.append(_edge(final_id, _END))
+
+    ir = {
         "workflow_id": agent.name,
-        "version": "0.1.0",
+        "version": _VERSION_BASE,  # replaced with a content hash below
         "name": agent.name,
-        "description": agent.instructions or prompt,
+        # A STABLE description (never the per-run prompt — the prompt is private
+        # and belongs only in the execution input seeded by build_initial_state).
+        "description": agent.instructions or f"Durable agent: {agent.name}",
         "state_schema": "",
         "start_node": "__model_0__",
         "nodes": nodes,
@@ -172,6 +217,12 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
             "jamjet.agent.max_turns": str(max_turns),
         },
     }
+    # Content-version the IR: the runtime caches by (workflow_id, version)
+    # immutably, so a changed agent (tools / instructions / max_turns / timeout)
+    # must yield a new key or a stale graph could run. The prompt is excluded
+    # (it is not in the IR), so re-running the SAME agent reuses the cached graph.
+    ir["version"] = _content_version(ir)
+    return ir
 
 
 def build_initial_state(agent: Agent, prompt: str) -> dict[str, Any]:
@@ -213,6 +264,39 @@ def _tool_schema(td: ToolDefinition) -> dict[str, Any]:
             "parameters": td.input_schema,
         },
     }
+
+
+def _model_kind(model_ref: str, system_prompt: str | None, tool_schemas: list[dict[str, Any]]) -> dict[str, Any]:
+    """A Model node kind. ``tool_schemas=[]`` offers the model no tools.
+
+    Empty ``prompt_ref`` => the executor reads the running ``messages`` list from
+    state rather than a single templated user prompt.
+    """
+    return {
+        "type": "model",
+        "model_ref": model_ref,
+        "prompt_ref": "",
+        "output_schema": "",
+        "system_prompt": system_prompt,
+        "tools": tool_schemas,
+    }
+
+
+def _content_version(ir: dict[str, Any]) -> str:
+    """Derive an immutable cache key from the IR content (sans ``version``).
+
+    Returns ``"{_VERSION_BASE}+{sha256(canonical_ir)[:12]}"`` so two compiles of
+    the same agent share a version (and the runtime's immutable cache) while any
+    change to tools / instructions / max_turns / timeout yields a fresh key.
+    """
+    canonical = json.dumps(
+        {k: v for k, v in ir.items() if k != "version"},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{_VERSION_BASE}+{digest}"
 
 
 def _node(

--- a/sdk/python/jamjet/model/sidecar_server.py
+++ b/sdk/python/jamjet/model/sidecar_server.py
@@ -10,6 +10,7 @@ Run with:
 
 from __future__ import annotations
 
+import json as _json
 from typing import Any
 
 from starlette.applications import Starlette
@@ -65,26 +66,58 @@ def _get_model() -> Model:
     return _model
 
 
+def _extract_tool_calls(message: Any) -> list[dict[str, Any]]:
+    """Extract and normalise tool_calls from an OpenAI-shaped message.
+
+    litellm returns tool_calls as a list of objects with:
+      tc.id, tc.function.name, tc.function.arguments (JSON-serialised string)
+
+    We normalise arguments to a JSON object when possible; the Rust side stores
+    whatever Value arrives so no information is lost.
+    """
+    raw = getattr(message, "tool_calls", None)
+    if not raw:
+        return []
+    out: list[dict[str, Any]] = []
+    for tc in raw:
+        fn = getattr(tc, "function", None)
+        name = getattr(fn, "name", None) if fn else getattr(tc, "name", None)
+        raw_args = getattr(fn, "arguments", None) if fn else getattr(tc, "arguments", None)
+        if isinstance(raw_args, str):
+            try:
+                raw_args = _json.loads(raw_args)
+            except Exception:
+                pass  # keep as string if the provider emits malformed JSON
+        out.append({"id": getattr(tc, "id", ""), "name": name or "", "arguments": raw_args})
+    return out
+
+
 async def _complete(body: dict[str, Any], model: Model) -> dict[str, Any]:
     """Core completion handler; injectable for testing without Starlette."""
     ref = parse_model_ref(body["model"])
     req = ModelRequest(
         ref=ref,
         messages=body["messages"],
+        tools=body.get("tools") or None,
         temperature=body.get("temperature"),
         max_tokens=body.get("max_tokens"),
     )
     resp = await model.complete(req)
+
+    tool_calls = _extract_tool_calls(resp.message)
+    finish_reason = getattr(resp.message, "finish_reason", None) or ("tool_calls" if tool_calls else None) or "stop"
+
     return {
         "message": {
-            "content": resp.message.content,
+            "content": resp.message.content or "",
             "role": "assistant",
         },
+        "tool_calls": tool_calls,
         "input_tokens": resp.input_tokens,
         "output_tokens": resp.output_tokens,
         "cost_usd": resp.cost_usd,
         "model": ref.litellm_model,
-        "finish_reason": getattr(resp.message, "finish_reason", None) or "stop",
+        "finish_reason": finish_reason,
     }
 
 

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -18,12 +18,36 @@ from jamjet.model.sidecar_server import (
 from jamjet.model.types import ModelResponse
 
 
+class _FakeFunction:
+    """Minimal function-call descriptor on a tool call (mirrors litellm shape)."""
+
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeToolCall:
+    """Minimal tool-call descriptor returned by litellm on a message."""
+
+    def __init__(self, id: str, name: str, arguments: object) -> None:
+        self.id = id
+        # Mimic litellm: store under .function.name / .function.arguments
+        args_str = arguments if isinstance(arguments, str) else __import__("json").dumps(arguments)
+        self.function = _FakeFunction(name=name, arguments=args_str)
+
+
 class FakeMessage:
     """Minimal OpenAI-shaped message object returned by the fake backend."""
 
-    def __init__(self, content: str = "hi", finish_reason: str | None = None) -> None:
+    def __init__(
+        self,
+        content: str = "hi",
+        finish_reason: str | None = None,
+        tool_calls: list | None = None,
+    ) -> None:
         self.content = content
         self.finish_reason = finish_reason
+        self.tool_calls = tool_calls
 
 
 class FakeModel:
@@ -109,6 +133,80 @@ async def test_complete_core_optional_params_forwarded() -> None:
     req = received_reqs[0]
     assert req.temperature == pytest.approx(0.7)
     assert req.max_tokens == 512
+
+
+# --------------------------------------------------------------------------- #
+# 2j-1: tool-call round-trip and tools forwarded through the governed seam
+# --------------------------------------------------------------------------- #
+
+
+async def test_complete_core_tools_forwarded_to_model() -> None:
+    """tools in the request body are passed through to ModelRequest.tools (governed path)."""
+    received_reqs = []
+
+    class CapturingModel:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            received_reqs.append(request)
+            return ModelResponse(message=FakeMessage(content="ok"), input_tokens=0, output_tokens=0, cost_usd=0.0)
+
+    tool_schema = {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+    await _complete(
+        {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [tool_schema],
+        },
+        CapturingModel(),  # type: ignore[arg-type]
+    )
+
+    assert len(received_reqs) == 1
+    assert received_reqs[0].tools == [tool_schema], "tools must be threaded into ModelRequest (governed path)"
+
+
+async def test_complete_core_tool_calls_returned() -> None:
+    """When the model returns tool_calls, they appear in the response with finish_reason='tool_calls'."""
+
+    class FakeToolCallModel:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            tc = _FakeToolCall(id="c1", name="get_weather", arguments={"city": "SF"})
+            return ModelResponse(
+                message=FakeMessage(content=None, finish_reason="tool_calls", tool_calls=[tc]),
+                input_tokens=5,
+                output_tokens=3,
+                cost_usd=0.001,
+            )
+
+    result = await _complete(
+        {"model": "anthropic/claude-sonnet-4-6", "messages": [{"role": "user", "content": "weather?"}]},
+        FakeToolCallModel(),  # type: ignore[arg-type]
+    )
+
+    assert result["finish_reason"] == "tool_calls"
+    assert result["tool_calls"] == [{"id": "c1", "name": "get_weather", "arguments": {"city": "SF"}}]
+    # content is empty string when the model is making tool calls, not producing text
+    assert result["message"]["content"] == ""
+
+
+async def test_complete_core_tool_calls_infer_finish_reason() -> None:
+    """finish_reason is inferred as 'tool_calls' when tool_calls are present but finish_reason is None."""
+
+    class FakeToolCallModelNoReason:
+        async def complete(self, request):  # noqa: ANN001, ANN201
+            tc = _FakeToolCall(id="c2", name="search", arguments={"q": "hello"})
+            return ModelResponse(
+                message=FakeMessage(content=None, finish_reason=None, tool_calls=[tc]),
+                input_tokens=2,
+                output_tokens=1,
+                cost_usd=0.0,
+            )
+
+    result = await _complete(
+        {"model": "openai/gpt-4o", "messages": []},
+        FakeToolCallModelNoReason(),  # type: ignore[arg-type]
+    )
+
+    assert result["finish_reason"] == "tool_calls", "must infer tool_calls finish_reason when tool_calls present"
+    assert len(result["tool_calls"]) == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/sdk/python/tests/test_agent_durable_loop_parity.py
+++ b/sdk/python/tests/test_agent_durable_loop_parity.py
@@ -1,0 +1,301 @@
+"""Track 2j-5 — the agent loop runs end to end, and in-process == durable.
+
+This is the final 2j test: it proves authoring one ``Agent`` runs the same
+``model -> tool -> model`` loop two ways and reaches the same answer.
+
+Why a loop-logic driver instead of a full in-process engine run
+---------------------------------------------------------------
+A live durable run of the agent loop spans TWO processes that CI does not stand
+up: the Rust engine (HTTP API) AND a separate ``jamjet worker`` that executes the
+Python ``@tool`` functions. The tool-dispatch node lands in the ``python_tool``
+queue, and the engine's default worker pool spawns ZERO internal workers for that
+queue on purpose (``runtime/workers/src/pool.rs``) — only an external
+``jamjet worker`` claims it. So the loop cannot complete inside one in-process
+test; the README is the true full-stack demonstration.
+
+Instead we drive the **real** compiled IR (:func:`compile_agent_to_ir`) and the
+**real** tool-dispatch helper (:func:`dispatch_tool_calls`) through a faithful
+re-implementation of the engine's control flow (:func:`drive_agent_loop`), with a
+deterministic mock model. The driver mirrors the engine exactly:
+
+* the scheduler dispatches a node once all its predecessors completed
+  (``runner.rs::is_runnable``); it does NOT evaluate edge conditions — the
+  condition node is a no-op stub and ``NodeSkipped`` is never emitted today, so
+  the static unroll runs to its ``max_turns`` bound (the per-turn gate's
+  short-circuit is the F-2j-dynamic-loop follow-up);
+* a Model node reads ``state['messages']`` and writes
+  ``last_model_output`` / ``last_model_finish_reason`` / ``last_model_tool_calls``
+  (``model_node.rs`` state_patch);
+* a PythonFn (``__tools__``) node receives the full state as input
+  (``runner.rs`` passes ``progress.final_state``) and its return dict IS the
+  state_patch (the worker posts the return AS state_patch, top-level merge), so
+  ``dispatch_tool_calls``' ``{'messages': [...]}`` replaces ``state['messages']``.
+
+The per-leg Rust/Python contracts (payload threading, message mapping, state_patch
+fold, tool-call fidelity) are unit-tested in 2j-1..2j-4; this file proves the legs
+compose into a terminating loop with the right answer, and that the in-process
+``Agent.run`` reaches the same answer with the same scripted model.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from jamjet.agents.tool_runtime import dispatch_tool_calls
+from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir
+
+# The shipped example IS the agent under test: import its module (tools + factory)
+# so this test exercises exactly what the README demonstrates.
+_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "react-agent-durable"
+if str(_EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_DIR))
+import weather_agent  # noqa: E402  (path inserted just above)
+
+_PROMPT = "What's the weather in Paris?"
+_LOOP_NODES = [
+    "__model_0__",
+    "__tool_gate_0__",
+    "__tools_0__",
+    "__model_1__",
+    "__tool_gate_1__",
+    "__tools_1__",
+]
+
+
+# ── Deterministic mock model (single source of truth for both paths) ──────────
+
+
+class ScriptedModel:
+    """A deterministic two-turn model, shared by the durable loop and the
+    in-process run so the parity assertion compares like for like.
+
+    Turn 0 -> one tool call: ``get_weather(city="Paris")`` (finish ``tool_calls``).
+    Turn 1 -> a final answer with no tool calls (finish ``stop``).
+    """
+
+    FINAL_ANSWER = "It is sunny in Paris."
+    TOOL_NAME = "get_weather"
+    TOOL_ARGS = {"city": "Paris"}
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def next_turn(self) -> dict[str, Any]:
+        """Return the next turn in engine-state shape (content/finish/tool_calls)."""
+        turn = self.calls
+        self.calls += 1
+        if turn == 0:
+            return {
+                "content": "",
+                "finish_reason": "tool_calls",
+                "tool_calls": [{"id": "call_0", "name": self.TOOL_NAME, "arguments": dict(self.TOOL_ARGS)}],
+            }
+        return {"content": self.FINAL_ANSWER, "finish_reason": "stop", "tool_calls": []}
+
+
+# ── In-process adapter shim over the same ScriptedModel (OpenAI message shape) ──
+
+
+class _OAIFunction:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _OAIToolCall:
+    def __init__(self, call: dict[str, Any]) -> None:
+        self.id = call["id"]
+        self.type = "function"
+        self.function = _OAIFunction(call["name"], json.dumps(call["arguments"]))
+
+
+class _OAIMessage:
+    def __init__(self, content: str | None, tool_calls: list[_OAIToolCall]) -> None:
+        self.role = "assistant"
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class ScriptedAdapter:
+    """``LLMAdapter`` over a :class:`ScriptedModel` for the in-process react runner.
+
+    The react strategy calls ``generate(messages, tools=...)`` and reads
+    ``msg.content`` / ``msg.tool_calls``; we render the scripted turn into that
+    OpenAI-message shape.
+    """
+
+    def __init__(self, script: ScriptedModel) -> None:
+        self.script = script
+
+    async def generate(self, messages: list[Any], *, tools: list[Any] | None = None) -> _OAIMessage:
+        turn = self.script.next_turn()
+        return _OAIMessage(
+            content=turn["content"] or None,
+            tool_calls=[_OAIToolCall(c) for c in turn["tool_calls"]],
+        )
+
+
+# ── Faithful in-process re-implementation of the engine's control flow ────────
+
+
+async def drive_agent_loop(ir: dict[str, Any], state: dict[str, Any], model: ScriptedModel) -> list[str]:
+    """Drive the compiled agent-loop IR exactly as the JamJet engine would.
+
+    Returns the visit order of node ids (for the ``model -> tool -> model``
+    assertion). Mutates *state* in place to the terminal state.
+    """
+    nodes = ir["nodes"]
+    edges = ir["edges"]
+    preds = {nid: [e["from"] for e in edges if e["to"] == nid] for nid in nodes}
+
+    completed: set[str] = set()
+    visited: list[str] = []
+    while True:
+        runnable = [nid for nid in nodes if nid not in completed and all(p in completed for p in preds[nid])]
+        if not runnable:
+            break
+        # The v1 static unroll is a linear chain: exactly one node runs per step.
+        assert len(runnable) == 1, f"static-unroll loop must be linear; runnable={runnable}"
+        node_id = runnable[0]
+        kind = nodes[node_id]["kind"]["type"]
+
+        if kind == "model":
+            # model_node.rs: read messages, call the model, write the last_model_* keys.
+            turn = model.next_turn()
+            state["last_model_output"] = turn["content"]
+            state["last_model_finish_reason"] = turn["finish_reason"]
+            state["last_model_tool_calls"] = turn["tool_calls"]
+        elif kind == "python_fn":
+            # Worker passes the FULL state as input; the return dict is the
+            # state_patch (top-level merge -> replaces state["messages"]).
+            patch = await dispatch_tool_calls(dict(state))
+            for key, value in patch.items():
+                state[key] = value
+        elif kind == "condition":
+            pass  # no-op stub: the engine does not evaluate edge conditions today
+        else:  # pragma: no cover - the compiler only emits these three kinds
+            raise AssertionError(f"unexpected node kind {kind!r}")
+
+        completed.add(node_id)
+        visited.append(node_id)
+    return visited
+
+
+# ── Authored gate semantics (what F-2j-dynamic-loop will wire into the engine) ─
+
+
+def _eval_branch_condition(condition: str | None, state: dict[str, Any]) -> bool:
+    """Evaluate a ``state.<key> == "<literal>"`` condition. ``None`` is the else."""
+    if condition is None:
+        return True
+    match = re.fullmatch(r'\s*state\.(\w+)\s*==\s*"([^"]*)"\s*', condition)
+    assert match, f"unexpected condition form: {condition!r}"
+    key, literal = match.group(1), match.group(2)
+    return state.get(key) == literal
+
+
+def _route_gate(branches: list[dict[str, Any]], state: dict[str, Any]) -> str | None:
+    for branch in branches:
+        if _eval_branch_condition(branch["condition"], state):
+            return branch["target"]
+    return None
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+async def test_agent_loop_ir_runs_model_tool_model_and_terminates() -> None:
+    """The compiled IR drives a model -> tool -> model loop that terminates with
+    the final answer, invoking the tool once and accumulating the messages."""
+    agent = weather_agent.build_agent()
+    ir = compile_agent_to_ir(agent, _PROMPT, max_turns=2)
+
+    # The model node carries the agent's tool schemas (2j-2/2j-3 wiring) so the
+    # model can emit tool_calls; the dispatch node points at the loop helper.
+    assert ir["nodes"]["__model_0__"]["kind"]["tools"], "model node must carry tool schemas"
+    disp = ir["nodes"]["__tools_0__"]["kind"]
+    assert (disp["module"], disp["function"]) == ("jamjet.agents.tool_runtime", "dispatch_tool_calls")
+
+    state = build_initial_state(agent, _PROMPT)
+    model = ScriptedModel()
+    visited = await drive_agent_loop(ir, state, model)
+
+    # The loop ran model -> tool -> model and terminated at the unroll bound.
+    assert visited == _LOOP_NODES
+    assert model.calls == 2  # exactly two model turns
+
+    # The tool was actually invoked once, with the model's arguments, and its
+    # result was appended to the running messages (message accumulation).
+    expected_tool_output = await weather_agent.get_weather(city="Paris")
+    tool_msgs = [m for m in state["messages"] if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0]["name"] == "get_weather"
+    assert tool_msgs[0]["content"] == expected_tool_output
+
+    assistant_calls = [m for m in state["messages"] if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert json.loads(assistant_calls[0]["tool_calls"][0]["function"]["arguments"]) == {"city": "Paris"}
+
+    # Terminates with the turn-1 answer (last_model_output, what run_durable extracts).
+    assert state["last_model_output"] == ScriptedModel.FINAL_ANSWER
+
+
+def test_compiled_gate_routes_tool_calls_to_dispatch_and_stop_to_end() -> None:
+    """The authored gate routes tool_calls -> dispatch and a final answer -> end.
+
+    The engine does not yet act on these edge conditions (F-2j-dynamic-loop), but
+    the IR encodes the correct branch logic, ready for when it does.
+    """
+    ir = compile_agent_to_ir(weather_agent.build_agent(), _PROMPT, max_turns=2)
+    gate = ir["nodes"]["__tool_gate_0__"]["kind"]
+    assert gate["type"] == "condition"
+
+    branches = gate["branches"]
+    assert _route_gate(branches, {"last_model_finish_reason": "tool_calls"}) == "__tools_0__"
+    assert _route_gate(branches, {"last_model_finish_reason": "stop"}) == "end"
+
+
+async def test_inprocess_run_matches_durable_loop_answer(monkeypatch: Any) -> None:
+    """Parity: the SAME agent + prompt reaches the SAME answer in process and via
+    the durable loop, and both actually invoke the tool."""
+    agent = weather_agent.build_agent()
+
+    # Durable loop path: real IR + real dispatch_tool_calls + scripted model.
+    ir = compile_agent_to_ir(agent, _PROMPT, max_turns=2)
+    state = build_initial_state(agent, _PROMPT)
+    visited = await drive_agent_loop(ir, state, ScriptedModel())
+    durable_output = state["last_model_output"]
+
+    # In-process path: Agent.run() with the same scripted model injected at the
+    # adapter seam (so neither litellm nor the network is touched).
+    monkeypatch.setattr(
+        "jamjet.runtime.local.executor.get_adapter",
+        lambda _cfg: ScriptedAdapter(ScriptedModel()),
+    )
+    inproc = await agent.run(_PROMPT)
+
+    # Shape parity: identical final answer.
+    assert durable_output == inproc.output == ScriptedModel.FINAL_ANSWER
+
+    # Both paths invoked the tool exactly once.
+    assert [c["tool"] for c in inproc.tool_calls] == ["get_weather"]
+    assert [m["name"] for m in state["messages"] if m.get("role") == "tool"] == ["get_weather"]
+    # And the durable path ran the full model -> tool -> model loop.
+    assert visited == _LOOP_NODES
+
+
+def test_example_react_agent_durable_compiles() -> None:
+    """The shipped example imports, compiles to a valid agent-loop IR, and its
+    tools resolve to importable ``module:function`` refs the worker can load."""
+    agent = weather_agent.build_agent()
+    ir = compile_agent_to_ir(agent, "hi", max_turns=2)
+
+    assert ir["labels"]["jamjet.agent.loop"] == "true"
+    assert ir["start_node"] == "__model_0__"
+
+    tools = build_initial_state(agent, "hi")["tools"]
+    assert tools["get_weather"] == "weather_agent:get_weather"
+    assert tools["add"] == "weather_agent:add"

--- a/sdk/python/tests/test_agent_durable_loop_parity.py
+++ b/sdk/python/tests/test_agent_durable_loop_parity.py
@@ -56,6 +56,9 @@ if str(_EXAMPLE_DIR) not in sys.path:
 import weather_agent  # noqa: E402  (path inserted just above)
 
 _PROMPT = "What's the weather in Paris?"
+# max_turns=2 -> two tool turns plus the final model node (__model_2__); the engine
+# does not yet evaluate gate conditions, so the static unroll visits the full chain
+# and terminates at the final model node (never at a tool-dispatch node).
 _LOOP_NODES = [
     "__model_0__",
     "__tool_gate_0__",
@@ -63,6 +66,7 @@ _LOOP_NODES = [
     "__model_1__",
     "__tool_gate_1__",
     "__tools_1__",
+    "__model_2__",
 ]
 
 
@@ -70,11 +74,12 @@ _LOOP_NODES = [
 
 
 class ScriptedModel:
-    """A deterministic two-turn model, shared by the durable loop and the
-    in-process run so the parity assertion compares like for like.
+    """A deterministic model, shared by the durable loop and the in-process run so
+    the parity assertion compares like for like.
 
-    Turn 0 -> one tool call: ``get_weather(city="Paris")`` (finish ``tool_calls``).
-    Turn 1 -> a final answer with no tool calls (finish ``stop``).
+    Turn 0     -> one tool call: ``get_weather(city="Paris")`` (finish ``tool_calls``).
+    Turn 1 on  -> a final answer with no tool calls (finish ``stop``); this also
+                  covers the bounded final model node the durable unroll appends.
     """
 
     FINAL_ANSWER = "It is sunny in Paris."
@@ -224,9 +229,9 @@ async def test_agent_loop_ir_runs_model_tool_model_and_terminates() -> None:
     model = ScriptedModel()
     visited = await drive_agent_loop(ir, state, model)
 
-    # The loop ran model -> tool -> model and terminated at the unroll bound.
+    # The loop ran model -> tool -> model and terminated at the final model node.
     assert visited == _LOOP_NODES
-    assert model.calls == 2  # exactly two model turns
+    assert model.calls == 3  # two turn-models + the final answer model
 
     # The tool was actually invoked once, with the model's arguments, and its
     # result was appended to the running messages (message accumulation).

--- a/sdk/python/tests/test_agent_ir.py
+++ b/sdk/python/tests/test_agent_ir.py
@@ -83,8 +83,9 @@ def test_node_and_edge_invariants():
 # ── Model nodes ───────────────────────────────────────────────────────────────
 
 
-def test_three_model_nodes_each_carry_both_tool_schemas():
+def test_turn_model_nodes_each_carry_both_tool_schemas():
     ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    # The per-turn model nodes (0..max_turns-1) carry the tool schemas.
     model_ids = [f"__model_{t}__" for t in range(3)]
     assert all(mid in ir["nodes"] for mid in model_ids)
     for mid in model_ids:
@@ -103,6 +104,21 @@ def test_three_model_nodes_each_carry_both_tool_schemas():
         assert params["type"] == "object"
         assert params["properties"]["city"] == "string"
         assert params["required"] == ["city"]
+
+
+def test_final_model_node_carries_no_tools_and_ends():
+    """The final model node (index == max_turns) consumes the last tool results and
+    must answer (no tool schemas), and is the only node routing to `end` besides the
+    per-turn gates — the terminal is always reached via a model node."""
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    final = ir["nodes"]["__model_3__"]
+    assert final["kind"]["type"] == "model"
+    assert final["kind"]["tools"] == [], "final model must offer no tools so it answers"
+    assert final["labels"].get("jamjet.agent.final") == "true"
+    assert ("__model_3__", "end") in _edge_set(ir)
+    # No node with a tool-dispatch kind routes directly to `end`.
+    tool_ids = {nid for nid, n in ir["nodes"].items() if n["kind"]["type"] == "python_fn"}
+    assert not any(frm in tool_ids and to == "end" for frm, to in _edge_set(ir))
 
 
 # ── Condition gates ───────────────────────────────────────────────────────────
@@ -157,13 +173,16 @@ def test_loop_edges_route_model_gate_tools_next():
         assert (f"__model_{t}__", f"__tool_gate_{t}__") in edges
         assert (f"__tool_gate_{t}__", f"__tools_{t}__") in edges
         assert (f"__tool_gate_{t}__", "end") in edges
-    # tools loop forward to the next model node...
+    # Every tools node loops forward to the NEXT model node — including the last
+    # turn, whose dispatch flows into the final model node (never directly to end).
     assert (f"__tools_{0}__", "__model_1__") in edges
     assert (f"__tools_{1}__", "__model_2__") in edges
-    # ...except the last turn, which is bounded -> end.
-    assert (f"__tools_{2}__", "end") in edges
-    assert ("__tools_2__", "__model_3__") not in edges
-    assert "__model_3__" not in ir["nodes"]
+    assert ("__tools_2__", "__model_3__") in edges
+    assert ("__tools_2__", "end") not in edges
+    # The final model node is the bounded terminal model -> end, and has no gate.
+    assert "__model_3__" in ir["nodes"]
+    assert ("__model_3__", "end") in edges
+    assert "__tool_gate_3__" not in ir["nodes"]
 
 
 def test_terminal_is_reachable_end_sentinel():
@@ -176,7 +195,8 @@ def test_terminal_is_reachable_end_sentinel():
 def test_node_counts_scale_with_max_turns():
     ir = compile_agent_to_ir(_agent(), "hi", max_turns=4)
     kinds = [n["kind"]["type"] for n in ir["nodes"].values()]
-    assert kinds.count("model") == 4
+    # max_turns turn-models + 1 final model; one gate and one dispatch per turn.
+    assert kinds.count("model") == 5
     assert kinds.count("condition") == 4
     assert kinds.count("python_fn") == 4
 
@@ -184,10 +204,15 @@ def test_node_counts_scale_with_max_turns():
 # ── max_turns=1 + validation ──────────────────────────────────────────────────
 
 
-def test_single_turn_dispatch_routes_to_end():
+def test_single_turn_dispatch_routes_to_final_model_then_end():
     ir = compile_agent_to_ir(_agent(), "hi", max_turns=1)
-    assert set(ir["nodes"]) == {"__model_0__", "__tool_gate_0__", "__tools_0__"}
-    assert ("__tools_0__", "end") in _edge_set(ir)
+    # One turn (model_0/gate_0/tools_0) plus the final model node (model_1).
+    assert set(ir["nodes"]) == {"__model_0__", "__tool_gate_0__", "__tools_0__", "__model_1__"}
+    edges = _edge_set(ir)
+    # The single dispatch routes into the final model, which routes to end.
+    assert ("__tools_0__", "__model_1__") in edges
+    assert ("__model_1__", "end") in edges
+    assert ("__tools_0__", "end") not in edges
 
 
 def test_max_turns_must_be_positive():
@@ -204,3 +229,50 @@ def test_build_initial_state_seeds_messages_and_tools():
     assert state["messages"][1] == {"role": "user", "content": "what's the weather?"}
     assert set(state["tools"]) == {"get_weather", "search_web"}
     assert state["tools"]["get_weather"].endswith(":get_weather")
+
+
+# ── Retry policy (tool-dispatch nodes must not auto-retry) ─────────────────────
+
+
+def test_tool_dispatch_nodes_disable_retry():
+    """The __tools__ nodes run non-idempotent @tool functions, so they must carry a
+    no-retry policy (scheduler resolves no_retry -> max_attempts 1); model nodes keep
+    the rate-limit-friendly llm_default."""
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    for t in range(3):
+        assert ir["nodes"][f"__tools_{t}__"]["retry_policy"] == "no_retry"
+        assert ir["nodes"][f"__model_{t}__"]["retry_policy"] == "llm_default"
+    assert ir["nodes"]["__model_3__"]["retry_policy"] == "llm_default"
+
+
+# ── Content-derived version + stable description (cache key + privacy) ─────────
+
+
+def test_version_is_content_derived_and_prompt_independent():
+    base = compile_agent_to_ir(_agent(), "prompt A", max_turns=3)["version"]
+    assert base.startswith("0.1.0+")
+    # Same agent + same max_turns => same cache key, regardless of the prompt.
+    assert compile_agent_to_ir(_agent(), "a different prompt", max_turns=3)["version"] == base
+    # A changed max_turns changes the cache key (a different graph).
+    assert compile_agent_to_ir(_agent(), "prompt A", max_turns=4)["version"] != base
+    # Changed instructions => changed key.
+    other = Agent(
+        "research",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather, search_web],
+        instructions="You are a DIFFERENT assistant.",
+    )
+    assert compile_agent_to_ir(other, "prompt A", max_turns=3)["version"] != base
+
+
+def test_description_is_stable_and_never_the_prompt():
+    prompt = "this prompt must not leak into the workflow definition"
+    ir = compile_agent_to_ir(_agent(), prompt, max_turns=2)
+    # Instructions are set, so the description is the instructions (stable) — never the prompt.
+    assert ir["description"] == "You are a research assistant."
+    assert prompt not in ir["description"]
+    # With empty instructions, the description is a stable agent-name string, not the prompt.
+    bare = Agent("bare", model="anthropic/claude-sonnet-4-6", tools=[get_weather])
+    ir_bare = compile_agent_to_ir(bare, prompt, max_turns=2)
+    assert ir_bare["description"] == "Durable agent: bare"
+    assert prompt not in ir_bare["description"]

--- a/sdk/python/tests/test_agent_ir.py
+++ b/sdk/python/tests/test_agent_ir.py
@@ -1,0 +1,206 @@
+"""Structural tests for the agent-loop IR builder (Track 2j-3).
+
+No engine: assert the compiled ``WorkflowIr`` dict has the model/condition/
+tool-dispatch nodes, the correct edges (model -> gate -> (tools -> next | end)),
+and the canonical top-level shape the Rust engine deserializes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.agents.agent import Agent
+from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir
+from jamjet.tools.decorators import tool
+
+
+@tool
+async def get_weather(city: str) -> str:
+    """Return the weather for a city."""
+    return f"sunny in {city}"
+
+
+@tool
+async def search_web(query: str, limit: int = 5) -> str:
+    """Search the web."""
+    return f"results for {query} (limit {limit})"
+
+
+def _agent() -> Agent:
+    return Agent(
+        "research",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather, search_web],
+        instructions="You are a research assistant.",
+    )
+
+
+# ── Top-level shape ───────────────────────────────────────────────────────────
+
+# The canonical WorkflowIr keys produced by jamjet.workflow.ir_compiler — the
+# shape the Rust engine deserializes (there is no Python validator for the
+# kind-based IR, so we assert required keys + node/edge invariants).
+_REQUIRED_KEYS = {
+    "workflow_id",
+    "version",
+    "name",
+    "description",
+    "state_schema",
+    "start_node",
+    "nodes",
+    "edges",
+    "retry_policies",
+    "timeouts",
+    "models",
+    "tools",
+    "mcp_servers",
+    "remote_agents",
+    "labels",
+}
+
+
+def test_ir_has_required_top_level_keys():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    assert _REQUIRED_KEYS <= set(ir), f"missing: {_REQUIRED_KEYS - set(ir)}"
+    assert ir["start_node"] == "__model_0__"
+    assert ir["start_node"] in ir["nodes"]
+    assert ir["workflow_id"] == "research"
+
+
+def test_node_and_edge_invariants():
+    """Every node is normalised; every edge target is a known node or `end`."""
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    node_ids = set(ir["nodes"]) | {"end"}
+    for node_id, node in ir["nodes"].items():
+        assert node["id"] == node_id
+        assert "kind" in node and "type" in node["kind"]
+        assert {"retry_policy", "node_timeout_secs", "description", "labels"} <= set(node)
+    for e in ir["edges"]:
+        assert e["from"] in ir["nodes"], f"edge from unknown node: {e['from']}"
+        assert e["to"] in node_ids, f"edge to unknown node: {e['to']}"
+
+
+# ── Model nodes ───────────────────────────────────────────────────────────────
+
+
+def test_three_model_nodes_each_carry_both_tool_schemas():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    model_ids = [f"__model_{t}__" for t in range(3)]
+    assert all(mid in ir["nodes"] for mid in model_ids)
+    for mid in model_ids:
+        kind = ir["nodes"][mid]["kind"]
+        assert kind["type"] == "model"
+        assert kind["model_ref"] == "anthropic/claude-sonnet-4-6"
+        assert kind["system_prompt"] == "You are a research assistant."
+        # Empty prompt_ref => the executor reads `messages` from state.
+        assert kind["prompt_ref"] == ""
+        names = [s["function"]["name"] for s in kind["tools"]]
+        assert names == ["get_weather", "search_web"]
+        # OpenAI function-schema shape; parameters are the tool's input_schema
+        # verbatim (this SDK's @tool maps a str param to the bare token "string").
+        assert kind["tools"][0]["type"] == "function"
+        params = kind["tools"][0]["function"]["parameters"]
+        assert params["type"] == "object"
+        assert params["properties"]["city"] == "string"
+        assert params["required"] == ["city"]
+
+
+# ── Condition gates ───────────────────────────────────────────────────────────
+
+
+def test_three_condition_gates_branch_on_tool_calls():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    expr = 'state.last_model_finish_reason == "tool_calls"'
+    for t in range(3):
+        kind = ir["nodes"][f"__tool_gate_{t}__"]["kind"]
+        assert kind["type"] == "condition"
+        branches = kind["branches"]
+        # true branch -> the turn's tool node; default branch -> terminal.
+        assert branches[0] == {"condition": expr, "target": f"__tools_{t}__"}
+        assert branches[1] == {"condition": None, "target": "end"}
+
+
+# ── Tool-dispatch PythonFn nodes ──────────────────────────────────────────────
+
+
+def test_three_tool_dispatch_nodes_with_resolver_map():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    for t in range(3):
+        kind = ir["nodes"][f"__tools_{t}__"]["kind"]
+        assert kind["type"] == "python_fn"
+        assert kind["module"] == "jamjet.agents.tool_runtime"
+        assert kind["function"] == "dispatch_tool_calls"
+        tools_map = kind["input"]["tools"]
+        assert set(tools_map) == {"get_weather", "search_web"}
+        # name -> "module:qualname" (mirrors Agent.compile handler_ref).
+        assert tools_map["get_weather"].endswith(":get_weather")
+        assert tools_map["search_web"].endswith(":search_web")
+        assert ":" in tools_map["get_weather"]
+        # The dispatch input references the 2j-2 state keys.
+        assert kind["input"]["tool_calls"] == "$state.last_model_tool_calls"
+        assert kind["input"]["assistant_content"] == "$state.last_model_output"
+        assert kind["input"]["messages"] == "$state.messages"
+
+
+# ── Edges / loop topology ─────────────────────────────────────────────────────
+
+
+def _edge_set(ir: dict) -> set[tuple[str, str]]:
+    return {(e["from"], e["to"]) for e in ir["edges"]}
+
+
+def test_loop_edges_route_model_gate_tools_next():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    edges = _edge_set(ir)
+    # model -> gate, gate -> tools, gate -> end for every turn.
+    for t in range(3):
+        assert (f"__model_{t}__", f"__tool_gate_{t}__") in edges
+        assert (f"__tool_gate_{t}__", f"__tools_{t}__") in edges
+        assert (f"__tool_gate_{t}__", "end") in edges
+    # tools loop forward to the next model node...
+    assert (f"__tools_{0}__", "__model_1__") in edges
+    assert (f"__tools_{1}__", "__model_2__") in edges
+    # ...except the last turn, which is bounded -> end.
+    assert (f"__tools_{2}__", "end") in edges
+    assert ("__tools_2__", "__model_3__") not in edges
+    assert "__model_3__" not in ir["nodes"]
+
+
+def test_terminal_is_reachable_end_sentinel():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=2)
+    targets = {e["to"] for e in ir["edges"]}
+    assert "end" in targets
+    assert "end" not in ir["nodes"]  # `end` is the graph terminal sentinel
+
+
+def test_node_counts_scale_with_max_turns():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=4)
+    kinds = [n["kind"]["type"] for n in ir["nodes"].values()]
+    assert kinds.count("model") == 4
+    assert kinds.count("condition") == 4
+    assert kinds.count("python_fn") == 4
+
+
+# ── max_turns=1 + validation ──────────────────────────────────────────────────
+
+
+def test_single_turn_dispatch_routes_to_end():
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=1)
+    assert set(ir["nodes"]) == {"__model_0__", "__tool_gate_0__", "__tools_0__"}
+    assert ("__tools_0__", "end") in _edge_set(ir)
+
+
+def test_max_turns_must_be_positive():
+    with pytest.raises(ValueError, match="max_turns"):
+        compile_agent_to_ir(_agent(), "hi", max_turns=0)
+
+
+# ── Initial state ─────────────────────────────────────────────────────────────
+
+
+def test_build_initial_state_seeds_messages_and_tools():
+    state = build_initial_state(_agent(), "what's the weather?")
+    assert state["messages"][0] == {"role": "system", "content": "You are a research assistant."}
+    assert state["messages"][1] == {"role": "user", "content": "what's the weather?"}
+    assert set(state["tools"]) == {"get_weather", "search_web"}
+    assert state["tools"]["get_weather"].endswith(":get_weather")

--- a/sdk/python/tests/test_agent_run_durable.py
+++ b/sdk/python/tests/test_agent_run_durable.py
@@ -1,0 +1,192 @@
+"""Tests for ``Agent.run_durable`` (Track 2j-4) — the durable run entrypoint.
+
+No real engine: a ``_FakeDurableClient`` stands in for ``JamjetClient`` and
+returns a terminal execution with a known final ``current_state``. We assert that
+``run_durable`` compiles + registers + starts an execution seeded with the
+messages/tools, polls to terminal, and extracts an ``AgentResult`` whose fields
+(final content, tool-call trace, ir) match the in-process ``Agent.run`` shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jamjet.agents.agent import Agent, AgentResult
+from jamjet.tools.decorators import tool
+
+
+@tool
+async def get_weather(city: str) -> str:
+    """Return the weather for a city."""
+    return f"sunny in {city}"
+
+
+def _agent() -> Agent:
+    return Agent(
+        "weatherbot",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather],
+        instructions="You are a weather assistant.",
+    )
+
+
+# A terminal execution whose final state is a tool-using turn followed by the
+# model's final answer (the answer lives in last_model_output, NOT appended to
+# messages — only tool turns append to messages in the loop).
+def _completed_execution() -> dict[str, Any]:
+    return {
+        "execution_id": "exec_test",
+        "status": "completed",
+        "current_state": {
+            "messages": [
+                {"role": "system", "content": "You are a weather assistant."},
+                {"role": "user", "content": "weather in London?"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "London"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "name": "get_weather",
+                    "content": "sunny in London",
+                },
+            ],
+            "last_model_output": "It is sunny in London.",
+            "last_model_finish_reason": "stop",
+            "tools": {"get_weather": "tests.test_agent_run_durable:get_weather"},
+        },
+    }
+
+
+class _FakeDurableClient:
+    """Async-context-manager fake of JamjetClient for run_durable unit tests."""
+
+    def __init__(self, execution: dict[str, Any], events: list[dict[str, Any]] | None = None) -> None:
+        self._execution = execution
+        self._events = events or []
+        self.created: list[dict[str, Any]] = []
+        self.started: list[tuple[str, dict[str, Any]]] = []
+
+    async def __aenter__(self) -> _FakeDurableClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        self.created.append(ir)
+        return {"workflow_id": ir["workflow_id"]}
+
+    async def start_execution(
+        self, workflow_id: str, input: dict[str, Any], workflow_version: str | None = None
+    ) -> dict[str, Any]:
+        self.started.append((workflow_id, input))
+        return {"execution_id": "exec_test"}
+
+    async def get_execution(self, execution_id: str) -> dict[str, Any]:
+        return self._execution
+
+    async def get_events(self, execution_id: str) -> dict[str, Any]:
+        return {"events": self._events}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeDurableClient) -> None:
+    # run_durable does `from jamjet.client import JamjetClient` at call time, so
+    # patching the module attribute swaps in our fake.
+    monkeypatch.setattr("jamjet.client.JamjetClient", lambda *a, **k: fake)
+
+
+async def test_run_durable_extracts_final_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_durable returns an AgentResult whose final content is last_model_output."""
+    fake = _FakeDurableClient(_completed_execution())
+    _patch_client(monkeypatch, fake)
+
+    result = await _agent().run_durable("weather in London?", max_turns=3)
+
+    assert isinstance(result, AgentResult)
+    assert result.output == "It is sunny in London."
+
+
+async def test_run_durable_reconstructs_tool_call_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tool calls made during the loop are reconstructed with in-process shape."""
+    fake = _FakeDurableClient(_completed_execution())
+    _patch_client(monkeypatch, fake)
+
+    result = await _agent().run_durable("weather in London?", max_turns=3)
+
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    # Same keys as the in-process ToolCallRecord.model_dump().
+    assert set(call) == {"tool", "input", "output", "duration_us"}
+    assert call["tool"] == "get_weather"
+    assert call["input"] == {"city": "London"}
+    assert call["output"] == "sunny in London"
+
+
+async def test_run_durable_seeds_messages_and_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_durable registers the IR and starts an execution seeded with the
+    system+user messages and the tool-resolver map."""
+    fake = _FakeDurableClient(_completed_execution())
+    _patch_client(monkeypatch, fake)
+
+    result = await _agent().run_durable("weather in London?", max_turns=3)
+
+    # Registered exactly one workflow; the result.ir is the compiled agent-loop IR.
+    assert len(fake.created) == 1
+    assert result.ir["labels"]["jamjet.agent.loop"] == "true"
+    assert result.ir["workflow_id"] == "weatherbot"
+
+    # Started exactly one execution, seeded with messages + tools.
+    assert len(fake.started) == 1
+    workflow_id, initial_input = fake.started[0]
+    assert workflow_id == "weatherbot"
+    assert [m["role"] for m in initial_input["messages"]] == ["system", "user"]
+    assert initial_input["messages"][1]["content"] == "weather in London?"
+    assert initial_input["tools"]["get_weather"].endswith(":get_weather")
+
+
+async def test_run_durable_no_tool_turns_uses_last_model_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run that answers directly (no tool turns) still returns the answer with
+    an empty tool-call trace."""
+    execution = {
+        "execution_id": "exec_direct",
+        "status": "completed",
+        "current_state": {
+            "messages": [
+                {"role": "system", "content": "You are a weather assistant."},
+                {"role": "user", "content": "hello"},
+            ],
+            "last_model_output": "Hi there!",
+            "last_model_finish_reason": "stop",
+        },
+    }
+    fake = _FakeDurableClient(execution)
+    _patch_client(monkeypatch, fake)
+
+    result = await _agent().run_durable("hello", max_turns=3)
+
+    assert result.output == "Hi there!"
+    assert result.tool_calls == []
+
+
+async def test_run_durable_raises_on_failed_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed terminal state raises RuntimeError rather than returning a result."""
+    execution = {"execution_id": "exec_fail", "status": "failed", "current_state": {}}
+    fake = _FakeDurableClient(execution)
+    _patch_client(monkeypatch, fake)
+
+    with pytest.raises(RuntimeError, match="non-completed"):
+        await _agent().run_durable("weather?", max_turns=3)

--- a/sdk/python/tests/test_tool_runtime.py
+++ b/sdk/python/tests/test_tool_runtime.py
@@ -123,6 +123,20 @@ async def test_registry_fallback_when_not_in_map():
     assert result["messages"][1]["content"] == "registry: v"
 
 
+async def test_registry_fallback_when_map_ref_is_stale():
+    """A present-but-non-importable map ref must not mask the @tool registry: the
+    bad ref fails to import, then the name resolves via the registry."""
+    result = await dispatch_tool_calls(
+        {
+            "messages": [],
+            "tool_calls": [{"id": "c1", "name": "registry_tool", "arguments": {"value": "v"}}],
+            # Stale ref: the module/attr no longer exists, but the @tool is registered.
+            "tools": {"registry_tool": "jamjet._gone_module:registry_tool"},
+        }
+    )
+    assert result["messages"][1]["content"] == "registry: v"
+
+
 async def test_unknown_tool_raises():
     with pytest.raises(KeyError, match="nope"):
         await dispatch_tool_calls(

--- a/sdk/python/tests/test_tool_runtime.py
+++ b/sdk/python/tests/test_tool_runtime.py
@@ -1,0 +1,145 @@
+"""Unit tests for the agent-loop tool-dispatch helper (Track 2j-3).
+
+Drives :func:`jamjet.agents.tool_runtime.dispatch_tool_calls` with a fake tool
+registry (a ``module:function`` map pointing at this test module) and asserts the
+returned messages carry the appended assistant + tool messages.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from jamjet.agents.tool_runtime import dispatch_tool_calls
+from jamjet.tools.decorators import tool
+
+
+# Fake tools resolved via the {name: "module:function"} map. `__name__` is the
+# live, importable name of this test module (already in sys.modules).
+async def echo_tool(text: str) -> str:
+    return f"echo: {text}"
+
+
+async def add_tool(a: int, b: int) -> int:
+    return a + b
+
+
+# A @tool-decorated function exercises the registry fallback (resolved by name).
+@tool
+async def registry_tool(value: str) -> str:
+    """Registered via @tool."""
+    return f"registry: {value}"
+
+
+_ECHO_REF = f"{__name__}:echo_tool"
+_ADD_REF = f"{__name__}:add_tool"
+
+
+async def test_appends_assistant_then_tool_message():
+    result = await dispatch_tool_calls(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "assistant_content": "let me check",
+            "tool_calls": [{"id": "c1", "name": "echo", "arguments": {"text": "hello"}}],
+            "tools": {"echo": _ECHO_REF},
+        }
+    )
+    msgs = result["messages"]
+    assert len(msgs) == 3  # original user + assistant + tool
+
+    assistant = msgs[1]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == "let me check"
+    assert assistant["tool_calls"][0]["id"] == "c1"
+    assert assistant["tool_calls"][0]["type"] == "function"
+    assert assistant["tool_calls"][0]["function"]["name"] == "echo"
+    # Arguments are serialised to a JSON string (OpenAI shape).
+    assert json.loads(assistant["tool_calls"][0]["function"]["arguments"]) == {"text": "hello"}
+
+    tool_msg = msgs[2]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == "c1"
+    assert tool_msg["name"] == "echo"
+    assert tool_msg["content"] == "echo: hello"
+
+
+async def test_reads_2j2_state_keys_as_fallback():
+    """When called with the engine's full state, read last_model_* keys."""
+    result = await dispatch_tool_calls(
+        {
+            "messages": [],
+            "last_model_output": "thinking",
+            "last_model_tool_calls": [{"id": "c9", "name": "echo", "arguments": {"text": "x"}}],
+            "tools": {"echo": _ECHO_REF},
+        }
+    )
+    msgs = result["messages"]
+    assert msgs[0]["role"] == "assistant"
+    assert msgs[0]["content"] == "thinking"
+    assert msgs[1]["role"] == "tool"
+    assert msgs[1]["content"] == "echo: x"
+
+
+async def test_multiple_tool_calls_in_one_turn():
+    result = await dispatch_tool_calls(
+        {
+            "messages": [],
+            "tool_calls": [
+                {"id": "a", "name": "echo", "arguments": {"text": "one"}},
+                {"id": "b", "name": "add", "arguments": {"a": 2, "b": 3}},
+            ],
+            "tools": {"echo": _ECHO_REF, "add": _ADD_REF},
+        }
+    )
+    msgs = result["messages"]
+    # assistant (with 2 tool_calls) + 2 tool messages
+    assert len(msgs) == 3
+    assert len(msgs[0]["tool_calls"]) == 2
+    assert msgs[1]["content"] == "echo: one"
+    assert msgs[2]["content"] == "5"  # add result stringified
+
+
+async def test_json_string_arguments_are_parsed():
+    result = await dispatch_tool_calls(
+        {
+            "messages": [],
+            "tool_calls": [{"id": "c1", "name": "echo", "arguments": '{"text": "parsed"}'}],
+            "tools": {"echo": _ECHO_REF},
+        }
+    )
+    assert result["messages"][1]["content"] == "echo: parsed"
+
+
+async def test_registry_fallback_when_not_in_map():
+    """A tool absent from the map resolves via the in-process @tool registry."""
+    result = await dispatch_tool_calls(
+        {
+            "messages": [],
+            "tool_calls": [{"id": "c1", "name": "registry_tool", "arguments": {"value": "v"}}],
+            "tools": {},
+        }
+    )
+    assert result["messages"][1]["content"] == "registry: v"
+
+
+async def test_unknown_tool_raises():
+    with pytest.raises(KeyError, match="nope"):
+        await dispatch_tool_calls(
+            {
+                "messages": [],
+                "tool_calls": [{"id": "c1", "name": "nope", "arguments": {}}],
+                "tools": {},
+            }
+        )
+
+
+async def test_no_tool_calls_returns_assistant_only():
+    result = await dispatch_tool_calls(
+        {"messages": [{"role": "user", "content": "hi"}], "last_model_output": "done", "tools": {}}
+    )
+    msgs = result["messages"]
+    assert len(msgs) == 2
+    assert msgs[1]["role"] == "assistant"
+    assert msgs[1]["content"] == "done"
+    assert msgs[1]["tool_calls"] == []

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -45,6 +45,11 @@ async def _with_genai(input: dict) -> dict:
     }
 
 
+def _echo_tool(text: str) -> str:
+    """A plain @tool-style handler resolved by dispatch_tool_calls' tools map."""
+    return f"echo:{text}"
+
+
 # ── Stub client ───────────────────────────────────────────────────────────────
 
 
@@ -77,6 +82,7 @@ class _StubClient:
                 "execution_id": execution_id,
                 "node_id": node_id,
                 "output": output,
+                "state_patch": state_patch,
                 "gen_ai_model": gen_ai_model,
                 "finish_reason": finish_reason,
             }
@@ -158,6 +164,9 @@ async def test_worker_runs_handler_and_posts_complete() -> None:
     assert call["execution_id"] == "exec_abc"
     assert call["node_id"] == "add_step"
     assert call["output"] == {"sum": 7}
+    # 2j-4 G2: a PythonFn node's return dict IS its state_patch (it mutates
+    # state with its return), so the dict reaches state via the merge-patch.
+    assert call["state_patch"] == {"sum": 7}, "the handler's return dict must be the state_patch"
     assert len(stub.fail_calls) == 0, "fail must not be called on success"
 
 
@@ -208,3 +217,55 @@ async def test_worker_forwards_gen_ai_fields() -> None:
     assert call["finish_reason"] == "stop"
     # The full output dict (including GenAI fields) is still forwarded as-is.
     assert call["output"]["result"] == "answer"
+
+
+_DISPATCH_ITEM: dict = {
+    "id": "wi-005",
+    "execution_id": "exec_dispatch",
+    "node_id": "__tools_0__",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "jamjet.agents.tool_runtime",
+        "function": "dispatch_tool_calls",
+        # input == the full accumulated state the scheduler passes to a PythonFn
+        # node (messages + the model turn's tool_calls + the resolver map).
+        "input": {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "echo hi"},
+            ],
+            "last_model_output": "",
+            "last_model_tool_calls": [
+                {"id": "call_1", "name": "echo", "arguments": {"text": "hi"}},
+            ],
+            "tools": {"echo": "tests.test_worker:_echo_tool"},
+        },
+    },
+    "lease_fence": 0,
+}
+
+
+async def test_worker_dispatch_tool_calls_return_reaches_state() -> None:
+    """2j-4 G2: the agent loop's dispatch_tool_calls runs on the worker and its
+    {"messages": [...]} return is posted as the state_patch — so the accumulated
+    conversation (assistant tool-call turn + tool result) reaches state["messages"]
+    for the next turn's model node, instead of being silently dropped."""
+    stub = _StubClient(claimed_item=_DISPATCH_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    call = stub.complete_calls[0]
+
+    # The dispatch return must be threaded into the state_patch as `messages`.
+    patch = call["state_patch"]
+    assert "messages" in patch, "dispatch_tool_calls' {messages} return must be the state_patch"
+    msgs = patch["messages"]
+    # original system + user, then the assistant tool-call turn and the tool result.
+    assert len(msgs) == 4, f"expected 4 accumulated messages, got {len(msgs)}"
+    assert msgs[2]["role"] == "assistant"
+    assert msgs[2]["tool_calls"][0]["function"]["name"] == "echo"
+    assert msgs[3]["role"] == "tool"
+    assert msgs[3]["tool_call_id"] == "call_1"
+    assert msgs[3]["content"] == "echo:hi", "the resolved tool's result must be carried forward"
+    # output mirrors the same dict (the worker coerces a dict return as-is).
+    assert call["output"]["messages"] == msgs

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -238,7 +238,7 @@ _DISPATCH_ITEM: dict = {
             "last_model_tool_calls": [
                 {"id": "call_1", "name": "echo", "arguments": {"text": "hi"}},
             ],
-            "tools": {"echo": "tests.test_worker:_echo_tool"},
+            "tools": {"echo": f"{__name__}:_echo_tool"},
         },
     },
     "lease_fence": 0,


### PR DESCRIPTION
## What

The final track of the durable-loop build. A user-authored `jamjet.Agent` (model + `@tool` functions + instructions) can now run on the durable event-sourced engine via `Agent.run_durable(prompt)`, so authoring an agent gets durability (event log, replay, idempotency, park-on-429, continue-as-new, artifacts) instead of a separate in-process loop.

## How

- **Model seam tool calls** (the crux): the Rust `ModelRequest`/`ModelResponse` now carry `tools` and `tool_calls`, and the Python model-seam sidecar forwards the tools into the governed `Model.complete` (allowlist, PII, metering still run) and surfaces the tool calls back. Native adapters warn when given tools they cannot forward (use the sidecar for tool calls).
- **Agent-loop IR**: `compile_agent_to_ir` builds a static-unroll workflow — per turn, a model node carrying the tool schemas, a condition on `last_model_finish_reason == "tool_calls"`, and a tool-dispatch node that runs the requested `@tool` functions and appends their results to the conversation.
- **Run + result**: `Agent.run_durable` compiles the agent, starts a durable execution seeded with the conversation, polls to completion, and extracts a result with the same shape as the in-process `Agent.run()`.
- **Example**: `examples/react-agent-durable/` is a runnable ReAct agent with a README showing the engine + worker + sidecar commands.

## Review

Subagent-driven, with a whole-branch adversarial review. The review confirmed: the loop works on the real engine (terminates, returns the right answer with a deterministic or sidecar model), the model call still goes through the governed seam with tools, replay is deterministic, and the two engine-wide wiring changes are sound (one is a scheduler/materializer consistency fix; the other makes a python tool node's return merge-patch state, with tests updated). Full workspace tests plus the Python suite are green.

## v1 limitations (documented, tracked)

This is a working v1, not the final shape:

- The engine does not yet evaluate edge conditions, so the loop runs the full `max_turns` rather than exiting early when the model is done. Size `max_turns` to the expected conversation. F-2j-dynamic-loop adds a real condition evaluator for early exit.
- The Rust `ChatMessage` is role and content only, so a rebuilt conversation flattens tool and assistant-tool-call structure across turns. F-2j-chatmessage-fidelity adds structured tool messages.
- A python tool node's return value now merge-patches execution state. Avoid returning reserved keys (`messages`, `last_model_output`). F-2j-statepatch-namespace adds a guard.
- The parity test drives the real compiled IR and the real tool dispatch through a faithful control-flow driver; a live full-stack run needs the engine plus a `jamjet worker` plus the sidecar (documented in the example). F-2j-engine-smoke adds a real-engine integration smoke.

## Completes the build

With this track, the durable-loop ADK build (tracks 2a through 2j) is feature-complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable agent execution with tool-calling support.
  * Added a Python tool-dispatch runtime and updated the worker loop to carry state changes through execution.
  * Expanded the sidecar and model integrations to surface tool calls and related outputs.

* **Bug Fixes**
  * Improved handling of tool-related model requests and responses across supported providers.
  * Ensured durable runs preserve final outputs, tool traces, and execution state more reliably.

* **Documentation**
  * Updated example READMEs with new durable agent guidance and runnable examples.

* **Tests**
  * Added coverage for durable runs, tool dispatch, IR compilation, and sidecar/model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->