### PR TITLE
feat(fdl): edge-condition evaluator so the durable agent loop early-exits

### DIFF
--- a/runtime/api/src/main.rs
+++ b/runtime/api/src/main.rs
@@ -187,6 +187,10 @@ async fn main() -> anyhow::Result<()> {
             .with_executor(
                 "eval",
                 Arc::new(jamjet_worker::EvalExecutor::new(model_registry.clone())),
+            )
+            .with_executor(
+                "condition",
+                Arc::new(jamjet_worker::ConditionNodeExecutor::new()),
             );
         // Detaching the handles lets the workers run for the lifetime of the process
         // (same pattern as the scheduler above).

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -14,6 +14,7 @@ categories.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 

--- a/runtime/core/src/condition.rs
+++ b/runtime/core/src/condition.rs
@@ -1,0 +1,394 @@
+//! Pure, total evaluator for `Condition`-node branch expressions.
+//!
+//! # Expression grammar
+//!
+//! Only three forms are authored in practice (grounding §1c):
+//!
+//! ```text
+//! expr    := path                        # truthiness
+//!          | path "==" literal           # equality
+//!          | path "!=" literal           # inequality
+//! path    := "state" ("." ident)+        # always rooted at `state`, dotted segments
+//! literal := '"' … '"'                   # double-quoted JSON string
+//!          | "true" | "false" | "null"   # JSON keywords (bare, lowercase)
+//!          | number                       # JSON number
+//! ```
+//!
+//! # Truthiness rule
+//!
+//! For the bare-path form a value is **falsy** iff it is:
+//! - absent (path does not resolve),
+//! - JSON `null`,
+//! - `false`,
+//! - the number `0` (or `0.0`),
+//! - the empty string `""`,
+//! - an empty array `[]`, or
+//! - an empty object `{}`.
+//!
+//! Everything else is truthy. This mirrors JS/Python truthiness and matches the
+//! budget code that sets `__cost_exceeded__` as a bool.
+//!
+//! # Total / never-panics contract
+//!
+//! A malformed or unsupported expression always returns `false` — no panic.
+//! Unrecognised forms emit a `tracing::warn!` to aid debugging.
+//!
+//! # Path resolution
+//!
+//! The path after `state.` is split on `.` and each segment descends into the
+//! JSON object (or an array by zero-based numeric index when the segment is all
+//! digits). A missing or non-traversable segment resolves to absent (treated as
+//! `null` for comparisons and as falsy for truthiness).
+
+use serde_json::Value;
+
+/// Evaluate a Condition-node branch expression against committed workflow state.
+///
+/// Pure + total: never panics; a malformed or unsupported expression returns `false`.
+///
+/// # Truthiness rule (bare-path form)
+///
+/// Falsy: absent path, `null`, `false`, `0`/`0.0`, `""`, `[]`, `{}`.
+/// Everything else is truthy.
+///
+/// # Literal parsing (comparison form)
+///
+/// The RHS is parsed with `serde_json::from_str`, which handles `"..."`,
+/// `true`, `false`, `null`, and numbers. If parsing fails the raw trimmed
+/// text is treated as a bare string.
+///
+/// Comparison uses typed `serde_json::Value` equality: `"5" != 5`.
+pub fn eval_condition(expr: &str, state: &Value) -> bool {
+    let expr = expr.trim();
+    if expr.is_empty() {
+        return false;
+    }
+
+    match find_first_op(expr) {
+        Some((op_pos, op)) => eval_comparison(expr, state, op_pos, op),
+        None => eval_truthiness(expr, state),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Scan left-to-right for the first `!=` or `==` operator.
+///
+/// Returns `(byte_position_of_operator, operator_str)`.
+fn find_first_op(expr: &str) -> Option<(usize, &'static str)> {
+    let b = expr.as_bytes();
+    let len = b.len();
+    if len < 2 {
+        return None;
+    }
+    for i in 0..len - 1 {
+        match (b[i], b[i + 1]) {
+            (b'!', b'=') => return Some((i, "!=")),
+            (b'=', b'=') => return Some((i, "==")),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Evaluate a comparison expression: `lhs OP rhs`.
+fn eval_comparison(expr: &str, state: &Value, op_pos: usize, op: &str) -> bool {
+    let lhs = expr[..op_pos].trim();
+    // op_pos + 2 is safe: find_first_op only returns positions where i+1 < len,
+    // so i+2 <= len is guaranteed.
+    let rhs = expr[op_pos + 2..].trim();
+
+    let path = match lhs.strip_prefix("state.") {
+        Some(p) if !p.is_empty() => p,
+        _ => {
+            tracing::warn!(
+                "eval_condition: lhs `{}` does not start with `state.<path>`; returning false",
+                lhs
+            );
+            return false;
+        }
+    };
+
+    let resolved = resolve_path(state, path);
+    let rhs_val = parse_literal(rhs);
+    let equal = values_equal(resolved, &rhs_val);
+
+    match op {
+        "==" => equal,
+        "!=" => !equal,
+        _ => false, // unreachable guard; keeps the function total
+    }
+}
+
+/// Evaluate a truthiness expression: the whole expr is a `state.<path>`.
+fn eval_truthiness(expr: &str, state: &Value) -> bool {
+    let path = match expr.strip_prefix("state.") {
+        Some(p) if !p.is_empty() => p,
+        _ => {
+            tracing::warn!(
+                "eval_condition: expr `{}` does not start with `state.<path>`; returning false",
+                expr
+            );
+            return false;
+        }
+    };
+    is_truthy(resolve_path(state, path))
+}
+
+/// Walk a dotted path (e.g. `"a.b.c"`) through a JSON value.
+///
+/// Returns `None` for any missing or non-traversable segment.
+/// Array indexing by zero-based numeric segment is supported: `"arr.0"` reads index 0.
+fn resolve_path<'a>(root: &'a Value, dotted_path: &str) -> Option<&'a Value> {
+    let mut current = root;
+    for segment in dotted_path.split('.') {
+        if segment.is_empty() {
+            return None;
+        }
+        match current {
+            Value::Object(map) => {
+                current = map.get(segment)?;
+            }
+            Value::Array(arr) => {
+                let idx: usize = segment.parse().ok()?;
+                current = arr.get(idx)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+/// JSON truthiness: falsy = absent | null | false | 0 | "" | [] | {}.
+/// Everything else is truthy.
+fn is_truthy(v: Option<&Value>) -> bool {
+    match v {
+        None => false,
+        Some(Value::Null) => false,
+        Some(Value::Bool(b)) => *b,
+        Some(Value::Number(n)) => n.as_f64().is_some_and(|f| f != 0.0),
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(Value::Array(a)) => !a.is_empty(),
+        Some(Value::Object(o)) => !o.is_empty(),
+    }
+}
+
+/// Parse an RHS literal string into a `serde_json::Value`.
+///
+/// `serde_json::from_str` handles `"..."`, `true`, `false`, `null`, and numbers.
+/// If parsing fails the raw trimmed text is treated as a bare `Value::String`.
+fn parse_literal(s: &str) -> Value {
+    match serde_json::from_str::<Value>(s) {
+        Ok(v) => v,
+        Err(_) => Value::String(s.to_string()),
+    }
+}
+
+/// Compare a resolved path value to an RHS literal.
+///
+/// A missing path (`None`) is treated as `null`: it equals `Value::Null` and
+/// nothing else.
+fn values_equal(resolved: Option<&Value>, rhs: &Value) -> bool {
+    match resolved {
+        None => rhs == &Value::Null,
+        Some(v) => v == rhs,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---- string equality ----
+
+    #[test]
+    fn string_eq_match() {
+        assert!(eval_condition(
+            r#"state.last_model_finish_reason == "tool_calls""#,
+            &json!({"last_model_finish_reason": "tool_calls"}),
+        ));
+    }
+
+    #[test]
+    fn string_eq_mismatch() {
+        assert!(!eval_condition(
+            r#"state.last_model_finish_reason == "tool_calls""#,
+            &json!({"last_model_finish_reason": "stop"}),
+        ));
+    }
+
+    #[test]
+    fn string_eq_missing_key() {
+        assert!(!eval_condition(
+            r#"state.last_model_finish_reason == "tool_calls""#,
+            &json!({}),
+        ));
+    }
+
+    // ---- string inequality ----
+
+    #[test]
+    fn string_neq_true() {
+        assert!(eval_condition(r#"state.x != "a""#, &json!({"x": "b"}),));
+    }
+
+    #[test]
+    fn string_neq_false() {
+        assert!(!eval_condition(r#"state.x != "a""#, &json!({"x": "a"}),));
+    }
+
+    // ---- truthiness ----
+
+    #[test]
+    fn truthiness_bool_true() {
+        assert!(eval_condition(
+            "state.__cost_exceeded__",
+            &json!({"__cost_exceeded__": true}),
+        ));
+    }
+
+    #[test]
+    fn truthiness_bool_false() {
+        assert!(!eval_condition(
+            "state.__cost_exceeded__",
+            &json!({"__cost_exceeded__": false}),
+        ));
+    }
+
+    #[test]
+    fn truthiness_absent_key() {
+        assert!(!eval_condition("state.__cost_exceeded__", &json!({})));
+    }
+
+    #[test]
+    fn truthiness_non_empty_string() {
+        assert!(eval_condition(
+            "state.__cost_exceeded__",
+            &json!({"__cost_exceeded__": "yes"}),
+        ));
+    }
+
+    #[test]
+    fn truthiness_zero_is_falsy() {
+        assert!(!eval_condition("state.count", &json!({"count": 0})));
+    }
+
+    #[test]
+    fn truthiness_empty_string_is_falsy() {
+        assert!(!eval_condition("state.s", &json!({"s": ""})));
+    }
+
+    #[test]
+    fn truthiness_empty_array_is_falsy() {
+        assert!(!eval_condition("state.arr", &json!({"arr": []})));
+    }
+
+    #[test]
+    fn truthiness_empty_object_is_falsy() {
+        assert!(!eval_condition("state.obj", &json!({"obj": {}})));
+    }
+
+    // ---- nested paths ----
+
+    #[test]
+    fn nested_bool_eq_true() {
+        assert!(eval_condition(
+            "state.__critic_0_verdict__.passed == true",
+            &json!({"__critic_0_verdict__": {"passed": true}}),
+        ));
+    }
+
+    #[test]
+    fn nested_bool_eq_false_value() {
+        assert!(!eval_condition(
+            "state.__critic_0_verdict__.passed == true",
+            &json!({"__critic_0_verdict__": {"passed": false}}),
+        ));
+    }
+
+    #[test]
+    fn nested_missing_parent() {
+        assert!(!eval_condition(
+            "state.__critic_0_verdict__.passed == true",
+            &json!({}),
+        ));
+    }
+
+    // ---- null literal ----
+
+    #[test]
+    fn null_eq_missing_path() {
+        // A missing path is treated as null.
+        assert!(eval_condition("state.missing_key == null", &json!({})));
+    }
+
+    #[test]
+    fn null_eq_explicit_null() {
+        assert!(eval_condition("state.x == null", &json!({"x": null}),));
+    }
+
+    #[test]
+    fn null_eq_non_null_is_false() {
+        assert!(!eval_condition(
+            "state.x == null",
+            &json!({"x": "something"}),
+        ));
+    }
+
+    // ---- number literal ----
+
+    #[test]
+    fn number_eq_true() {
+        assert!(eval_condition("state.count == 5", &json!({"count": 5})));
+    }
+
+    #[test]
+    fn number_eq_string_is_false() {
+        // Typed equality: "5" (string) != 5 (number).
+        assert!(!eval_condition("state.count == 5", &json!({"count": "5"}),));
+    }
+
+    // ---- bool literal ----
+
+    #[test]
+    fn bool_false_literal_match() {
+        assert!(eval_condition(
+            "state.flag == false",
+            &json!({"flag": false}),
+        ));
+    }
+
+    // ---- malformed inputs — must return false, never panic ----
+
+    #[test]
+    fn malformed_garbage() {
+        assert!(!eval_condition("garbage", &json!({})));
+    }
+
+    #[test]
+    fn malformed_lhs_not_state() {
+        assert!(!eval_condition(r#"x == "y""#, &json!({"x": "y"})));
+    }
+
+    #[test]
+    fn malformed_empty_expr() {
+        assert!(!eval_condition("", &json!({})));
+    }
+
+    #[test]
+    fn malformed_just_state_dot() {
+        assert!(!eval_condition("state.", &json!({})));
+    }
+
+    #[test]
+    fn malformed_whitespace_only() {
+        assert!(!eval_condition("   ", &json!({})));
+    }
+}

--- a/runtime/core/src/condition.rs
+++ b/runtime/core/src/condition.rs
@@ -53,11 +53,11 @@ use serde_json::Value;
 ///
 /// # Literal parsing (comparison form)
 ///
-/// The RHS is parsed with `serde_json::from_str`, which handles `"..."`,
-/// `true`, `false`, `null`, and numbers. If parsing fails the raw trimmed
-/// text is treated as a bare string.
-///
-/// Comparison uses typed `serde_json::Value` equality: `"5" != 5`.
+/// The RHS must be a valid JSON literal: a double-quoted string (`"x"`),
+/// `true`, `false`, `null`, or a JSON number. Bare words (e.g. `done`) are NOT
+/// valid literals; an unparseable RHS causes the whole comparison to return
+/// `false` (fail-closed). Comparison uses typed `serde_json::Value` equality:
+/// `"5" != 5`.
 pub fn eval_condition(expr: &str, state: &Value) -> bool {
     let expr = expr.trim();
     if expr.is_empty() {
@@ -111,8 +111,21 @@ fn eval_comparison(expr: &str, state: &Value, op_pos: usize, op: &str) -> bool {
         }
     };
 
+    // Fail closed: an unparseable RHS literal (e.g. bare word `done`) is an
+    // invalid expression — return false rather than silently coercing to a string.
+    let rhs_val = match parse_literal(rhs) {
+        Some(v) => v,
+        None => {
+            tracing::warn!(
+                "eval_condition: RHS `{}` is not a valid literal \
+                 (must be a quoted string, true, false, null, or a number); returning false",
+                rhs
+            );
+            return false;
+        }
+    };
+
     let resolved = resolve_path(state, path);
-    let rhs_val = parse_literal(rhs);
     let equal = values_equal(resolved, &rhs_val);
 
     match op {
@@ -177,13 +190,12 @@ fn is_truthy(v: Option<&Value>) -> bool {
 
 /// Parse an RHS literal string into a `serde_json::Value`.
 ///
-/// `serde_json::from_str` handles `"..."`, `true`, `false`, `null`, and numbers.
-/// If parsing fails the raw trimmed text is treated as a bare `Value::String`.
-fn parse_literal(s: &str) -> Value {
-    match serde_json::from_str::<Value>(s) {
-        Ok(v) => v,
-        Err(_) => Value::String(s.to_string()),
-    }
+/// Valid forms: double-quoted JSON string (`"x"`), `true`, `false`, `null`,
+/// or a JSON number. Returns `None` for any other input (e.g. bare words),
+/// which the caller must treat as an invalid expression (fail-closed: return
+/// `false`).
+fn parse_literal(s: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(s).ok()
 }
 
 /// Compare a resolved path value to an RHS literal.
@@ -390,5 +402,27 @@ mod tests {
     #[test]
     fn malformed_whitespace_only() {
         assert!(!eval_condition("   ", &json!({})));
+    }
+
+    // ---- fail-closed: invalid (unquoted) RHS literal ----
+
+    #[test]
+    fn unquoted_rhs_bareword_fail_closed() {
+        // `done` is a bare word, not a valid JSON literal.
+        // Even though state.status == "done" would be true, the malformed
+        // expression must return false (fail-closed contract).
+        assert!(!eval_condition(
+            "state.status == done",
+            &json!({"status": "done"}),
+        ));
+    }
+
+    #[test]
+    fn quoted_rhs_string_still_works() {
+        // The quoted form must continue to work correctly.
+        assert!(eval_condition(
+            r#"state.status == "done""#,
+            &json!({"status": "done"}),
+        ));
     }
 }

--- a/runtime/core/src/lib.rs
+++ b/runtime/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent_tool;
+pub mod condition;
 pub mod coordinator;
 pub mod error;
 pub mod node;
@@ -6,6 +7,7 @@ pub mod retry;
 pub mod timeout;
 pub mod workflow;
 
+pub use condition::eval_condition;
 pub use error::Error;
 pub use node::{NodeId, NodeKind, NodeStatus};
 pub use retry::{BackoffStrategy, RetryPolicy};

--- a/runtime/ir/src/error.rs
+++ b/runtime/ir/src/error.rs
@@ -20,6 +20,9 @@ pub enum IrError {
     #[error("edge from '{from}' to '{to}': target node does not exist")]
     UnknownEdgeTarget { from: String, to: String },
 
+    #[error("condition node '{node}' branch targets unknown node '{target}'")]
+    UnknownBranchTarget { node: String, target: String },
+
     #[error("node '{0}' is unreachable from the start node")]
     UnreachableNode(String),
 

--- a/runtime/ir/src/error.rs
+++ b/runtime/ir/src/error.rs
@@ -23,6 +23,9 @@ pub enum IrError {
     #[error("condition node '{node}' branch targets unknown node '{target}'")]
     UnknownBranchTarget { node: String, target: String },
 
+    #[error("condition node '{node}' branch target '{target}' has no matching out-edge")]
+    BranchTargetMissingOutEdge { node: String, target: String },
+
     #[error("node '{0}' is unreachable from the start node")]
     UnreachableNode(String),
 

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -78,14 +78,31 @@ fn validate_edges(ir: &WorkflowIr) -> IrResult<()> {
 // node that never runs, silently stranding the branch. This mirrors
 // `validate_edges` but checks the branch list the routing executor reads, which a
 // hand-built or miscompiled IR could leave inconsistent with the edges.
+//
+// Additionally, each branch target must appear as a `to` in the Condition node's
+// out-edges. The compiler emits branches and edges 1:1; a mismatch means the
+// executor would resolve a target that the scheduler's edge graph can never
+// traverse, silently dropping the branch at runtime.
 fn validate_branch_targets(ir: &WorkflowIr) -> IrResult<()> {
     use jamjet_core::node::NodeKind;
 
     for (node_id, node) in &ir.nodes {
         if let NodeKind::Condition { branches } = &node.kind {
+            let out_targets: HashSet<&str> = ir
+                .edges_from(node_id)
+                .into_iter()
+                .map(|e| e.to.as_str())
+                .collect();
+
             for branch in branches {
                 if branch.target != "end" && !ir.nodes.contains_key(&branch.target) {
                     return Err(IrError::UnknownBranchTarget {
+                        node: node_id.clone(),
+                        target: branch.target.clone(),
+                    });
+                }
+                if !out_targets.contains(branch.target.as_str()) {
+                    return Err(IrError::BranchTargetMissingOutEdge {
                         node: node_id.clone(),
                         target: branch.target.clone(),
                     });
@@ -305,6 +322,36 @@ mod tests {
         assert!(
             validate_workflow(&ir).is_ok(),
             "branch targets that are real nodes or `end` must validate"
+        );
+    }
+
+    #[test]
+    fn branch_target_missing_out_edge() {
+        // Branch declares target "b" (a known node), but no edge a->b exists.
+        // The cross-check must catch the mismatch before reachability does.
+        let cond = NodeKind::Condition {
+            branches: vec![
+                ConditionalBranch {
+                    condition: Some("state.x == \"go\"".into()),
+                    target: "b".into(),
+                },
+                ConditionalBranch {
+                    condition: None,
+                    target: "end".into(),
+                },
+            ],
+        };
+        let b = NodeKind::Condition { branches: vec![] };
+        // Edge a->b intentionally absent; only a->end and b->end present.
+        let ir = make_ir(
+            "a",
+            vec![("a", cond), ("b", b)],
+            vec![("a", "end"), ("b", "end")],
+        );
+        let err = validate_workflow(&ir);
+        assert!(
+            matches!(&err, Err(IrError::BranchTargetMissingOutEdge { node, target }) if node == "a" && target == "b"),
+            "a branch target with no matching out-edge must fail with BranchTargetMissingOutEdge, got {err:?}"
         );
     }
 

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -10,16 +10,18 @@ use std::collections::{HashSet, VecDeque};
 /// 2. No duplicate node ids
 /// 3. start_node exists in nodes
 /// 4. All edge targets exist
-/// 5. All nodes are reachable from start_node
-/// 6. All paths from start lead to a terminal node ("end" or a terminal kind)
-/// 7. All tool_ref, model_ref, agent_ref resolve to known definitions
-/// 8. All MCP servers referenced by mcp_tool nodes are configured
-/// 9. All remote agents referenced by a2a_task nodes are configured
+/// 5. Every Condition node's branch targets exist
+/// 6. All nodes are reachable from start_node
+/// 7. All paths from start lead to a terminal node ("end" or a terminal kind)
+/// 8. All tool_ref, model_ref, agent_ref resolve to known definitions
+/// 9. All MCP servers referenced by mcp_tool nodes are configured
+/// 10. All remote agents referenced by a2a_task nodes are configured
 pub fn validate_workflow(ir: &WorkflowIr) -> IrResult<()> {
     validate_metadata(ir)?;
     validate_no_duplicate_nodes(ir)?;
     validate_start_node(ir)?;
     validate_edges(ir)?;
+    validate_branch_targets(ir)?;
     validate_reachability(ir)?;
     validate_refs(ir)?;
     Ok(())
@@ -65,6 +67,30 @@ fn validate_edges(ir: &WorkflowIr) -> IrResult<()> {
                 from: edge.from.clone(),
                 to: edge.to.clone(),
             });
+        }
+    }
+    Ok(())
+}
+
+// FDL-5: every `ConditionalBranch.target` of a Condition node must reference an
+// existing node id (or the terminal sentinel `"end"`, like an edge target). A
+// dangling branch target is a validation error: the scheduler would route to a
+// node that never runs, silently stranding the branch. This mirrors
+// `validate_edges` but checks the branch list the routing executor reads, which a
+// hand-built or miscompiled IR could leave inconsistent with the edges.
+fn validate_branch_targets(ir: &WorkflowIr) -> IrResult<()> {
+    use jamjet_core::node::NodeKind;
+
+    for (node_id, node) in &ir.nodes {
+        if let NodeKind::Condition { branches } = &node.kind {
+            for branch in branches {
+                if branch.target != "end" && !ir.nodes.contains_key(&branch.target) {
+                    return Err(IrError::UnknownBranchTarget {
+                        node: node_id.clone(),
+                        target: branch.target.clone(),
+                    });
+                }
+            }
         }
     }
     Ok(())
@@ -138,7 +164,7 @@ fn validate_refs(ir: &WorkflowIr) -> IrResult<()> {
 mod tests {
     use super::*;
     use crate::workflow::*;
-    use jamjet_core::node::NodeKind;
+    use jamjet_core::node::{ConditionalBranch, NodeKind};
     use jamjet_core::timeout::TimeoutConfig;
     use std::collections::HashMap;
 
@@ -222,6 +248,64 @@ mod tests {
         );
         let err = validate_workflow(&ir);
         assert!(matches!(err, Err(IrError::UnreachableNode(_))));
+    }
+
+    #[test]
+    fn unknown_branch_target() {
+        // A Condition whose branch points at a node that doesn't exist. The edges
+        // are all valid (validate_edges passes), so the dangling BRANCH target is
+        // what gets caught — a clear, branch-specific error.
+        let cond = NodeKind::Condition {
+            branches: vec![
+                ConditionalBranch {
+                    condition: Some("state.x == \"go\"".into()),
+                    target: "ghost".into(),
+                },
+                ConditionalBranch {
+                    condition: None,
+                    target: "b".into(),
+                },
+            ],
+        };
+        let b = NodeKind::Condition { branches: vec![] };
+        let ir = make_ir(
+            "a",
+            vec![("a", cond), ("b", b)],
+            vec![("a", "b"), ("b", "end")],
+        );
+        let err = validate_workflow(&ir);
+        assert!(
+            matches!(&err, Err(IrError::UnknownBranchTarget { node, target }) if node == "a" && target == "ghost"),
+            "a dangling branch target must fail with UnknownBranchTarget, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn valid_branch_targets_pass() {
+        // Branches targeting a real node and the `end` sentinel both validate
+        // (the agent-loop gate's `{tool_calls -> tools, else -> end}` shape).
+        let cond = NodeKind::Condition {
+            branches: vec![
+                ConditionalBranch {
+                    condition: Some("state.x == \"go\"".into()),
+                    target: "b".into(),
+                },
+                ConditionalBranch {
+                    condition: None,
+                    target: "end".into(),
+                },
+            ],
+        };
+        let b = NodeKind::Condition { branches: vec![] };
+        let ir = make_ir(
+            "a",
+            vec![("a", cond), ("b", b)],
+            vec![("a", "b"), ("a", "end"), ("b", "end")],
+        );
+        assert!(
+            validate_workflow(&ir).is_ok(),
+            "branch targets that are real nodes or `end` must validate"
+        );
     }
 
     #[test]

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -2225,4 +2225,219 @@ mod tests {
             "the run must still terminate when no branch matched (no hang)"
         );
     }
+
+    // ── FDL-4: determinism / replay of the route + skip set ─────────────────────
+
+    /// Re-fold an event log into a FRESH `ExecProgress` — exactly what a recovery
+    /// or replay does (rebuild scheduling state purely from the durable log).
+    fn replay(events: &[Event]) -> ExecProgress {
+        let mut progress = ExecProgress::default();
+        for ev in events {
+            progress.apply(ev);
+        }
+        progress
+    }
+
+    /// The sorted set of nodes the dispatcher would consider runnable against a
+    /// folded progress — the pure routing decision `is_runnable` makes each tick.
+    fn runnable_set(ir: &WorkflowIr, p: &ExecProgress) -> Vec<String> {
+        let mut v: Vec<String> = ir
+            .nodes
+            .keys()
+            .filter(|nid| is_runnable(nid, ir, &p.completed, &p.scheduled, &p.skipped, &p.routes))
+            .cloned()
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// REPLAY DETERMINISM (headline): drive the agent-loop early-exit to
+    /// completion, then re-fold the durable event log from scratch. The recorded
+    /// `chosen_target` + the emitted `NodeSkipped` events reproduce the EXACT same
+    /// route + skip set + completed set on every replay — no re-evaluation drift.
+    #[tokio::test]
+    async fn early_exit_route_and_skips_replay_deterministically() {
+        let (s, b, e) = setup(agent_loop_ir()).await;
+
+        // Run the early-exit (gate_0 -> end) all the way to terminal.
+        tick(&s, &e).await; // model_0
+        append(
+            &b,
+            &e,
+            node_completed(
+                "model_0",
+                serde_json::json!({"last_model_finish_reason": "stop"}),
+            ),
+        )
+        .await;
+        tick(&s, &e).await; // gate_0
+        append(
+            &b,
+            &e,
+            condition_completed("gate_0", Some("end"), &["tools_0", "end"]),
+        )
+        .await;
+        tick(&s, &e).await; // cascade skips the dead branch, dispatches `end`
+        append(&b, &e, node_completed("end", serde_json::json!({}))).await;
+        tick(&s, &e).await; // completes
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Completed);
+
+        // Re-fold the SAME durable log twice (two independent replays).
+        let evs = b.get_events(&e).await.unwrap();
+        let r1 = replay(&evs);
+        let r2 = replay(&evs);
+
+        // The fold is a pure function of the log: replay == replay (no drift).
+        assert_eq!(
+            r1.routes, r2.routes,
+            "re-folding the log is deterministic (routes)"
+        );
+        assert_eq!(
+            r1.skipped, r2.skipped,
+            "re-folding the log is deterministic (skips)"
+        );
+        assert_eq!(
+            r1.completed, r2.completed,
+            "re-folding the log is deterministic (completed)"
+        );
+
+        // ...and reproduces the exact recorded route + dead-branch skip set.
+        assert_eq!(
+            r1.routes.get("gate_0").map(String::as_str),
+            Some("end"),
+            "the recorded route is reproduced verbatim on replay"
+        );
+        for n in ["tools_0", "model_1", "gate_1", "tools_1", "model_2"] {
+            assert!(
+                r1.skipped.contains(n),
+                "{n} must be skipped on replay (dead branch)"
+            );
+        }
+        assert!(
+            !r1.skipped.contains("end"),
+            "end (shared join, live in-edge) must never be skipped on replay"
+        );
+
+        // A completed run replays to NO runnable node — replay never resurrects a
+        // skipped node nor strands the terminal.
+        let ir: WorkflowIr = serde_json::from_value(agent_loop_ir()).unwrap();
+        assert!(
+            runnable_set(&ir, &r1).is_empty(),
+            "a completed run replays with an empty runnable set"
+        );
+    }
+
+    /// DETERMINISM — the route is the RECORDED `chosen_target`, never recomputed.
+    /// Fold a durable record whose gate routed to `end` even though the committed
+    /// state (`finish_reason == "tool_calls"`) would, if re-evaluated, route to
+    /// `tools_0`. The recorded route + `NodeSkipped` events ALONE determine the
+    /// runnable set: `end` runs, the dead branch never does — identical on replay.
+    #[test]
+    fn recorded_route_and_skips_determine_runnable_node() {
+        let ir: WorkflowIr = serde_json::from_value(agent_loop_ir()).unwrap();
+
+        // The committed state says "tool_calls" (re-evaluation would pick tools_0)
+        // but the RECORDED route is `end`; the durable skips fold the dead branch.
+        let skip = |n: &str| EventKind::NodeSkipped {
+            node_id: n.into(),
+            reason: "branch not taken".into(),
+        };
+        let log = vec![
+            node_completed(
+                "model_0",
+                serde_json::json!({"last_model_finish_reason": "tool_calls"}),
+            ),
+            condition_completed("gate_0", Some("end"), &["tools_0", "end"]),
+            skip("tools_0"),
+            skip("model_1"),
+            skip("gate_1"),
+            skip("tools_1"),
+            skip("model_2"),
+        ];
+        let p1 = fold_events(log.clone());
+        let p2 = fold_events(log);
+
+        // The recorded route is honored, NOT recomputed from the (tool_calls) state.
+        assert_eq!(
+            p1.routes.get("gate_0").map(String::as_str),
+            Some("end"),
+            "the recorded route stands even when live state would evaluate otherwise"
+        );
+        assert_eq!(
+            p1.routes, p2.routes,
+            "route fold is deterministic across replays"
+        );
+        assert_eq!(
+            p1.skipped, p2.skipped,
+            "skip fold is deterministic across replays"
+        );
+
+        // The route + skips alone make `end` the sole runnable node; the dead
+        // branch's `tools_0` is never runnable — identical on every replay.
+        assert_eq!(
+            runnable_set(&ir, &p1),
+            vec!["end".to_string()],
+            "the recorded route + skips determine `end` as the only runnable node"
+        );
+        assert_eq!(
+            runnable_set(&ir, &p1),
+            runnable_set(&ir, &p2),
+            "the runnable decision is deterministic across replays"
+        );
+    }
+
+    /// NULL-ROUTE replay determinism: a Condition that matched no branch and had no
+    /// default records NO route, and that absence replays deterministically — every
+    /// branch target is skipped on every re-fold and the run still terminates.
+    /// (`no_matching_branch_skips_all_targets_and_terminates` covers the live run;
+    /// this locks the REPLAY of that null-route decision.)
+    #[tokio::test]
+    async fn null_route_skips_replay_deterministically() {
+        let ir = build_ir(
+            "start",
+            serde_json::json!({
+                "start": cond_node("start", serde_json::json!([])),
+                "gate": cond_node("gate", serde_json::json!([
+                    {"condition": "state.x == \"1\"", "target": "A"},
+                    {"condition": "state.y == \"2\"", "target": "B"}
+                ])),
+                "A": cond_node("A", serde_json::json!([])),
+                "B": cond_node("B", serde_json::json!([]))
+            }),
+            serde_json::json!([
+                {"from": "start", "to": "gate", "condition": null},
+                {"from": "gate", "to": "A", "condition": "state.x == \"1\""},
+                {"from": "gate", "to": "B", "condition": "state.y == \"2\""}
+            ]),
+        );
+        let (s, b, e) = setup(ir).await;
+
+        tick(&s, &e).await; // start
+        append(&b, &e, node_completed("start", serde_json::json!({}))).await;
+        tick(&s, &e).await; // gate
+        append(&b, &e, condition_completed("gate", None, &["A", "B"])).await;
+        tick(&s, &e).await; // cascade skips A + B
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Completed);
+
+        // Re-fold the durable log twice: the null route records NO entry and both
+        // targets are skipped — deterministically, on every replay.
+        let evs = b.get_events(&e).await.unwrap();
+        let r1 = replay(&evs);
+        let r2 = replay(&evs);
+        assert!(
+            !r1.routes.contains_key("gate"),
+            "a null route records no entry — reproduced on replay"
+        );
+        assert_eq!(r1.routes, r2.routes, "null-route fold is deterministic");
+        assert_eq!(
+            r1.skipped, r2.skipped,
+            "null-route skip fold is deterministic"
+        );
+        for n in ["A", "B"] {
+            assert!(
+                r1.skipped.contains(n),
+                "{n} must be skipped on replay (null route)"
+            );
+        }
+    }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -430,6 +430,28 @@ impl Scheduler {
                     }
                 }
 
+                // For Condition nodes, enrich the payload with the branch list
+                // and the current workflow state so the condition executor is
+                // self-contained.  The executor evaluates each branch's expression
+                // against `state` and records the routing decision on NodeCompleted.
+                // `progress.final_state` is the accumulated state from all
+                // completed nodes so far — exactly what the condition gate reads.
+                if let NodeKind::Condition { branches } = &node.kind {
+                    if !branches.is_empty() {
+                        let obj = payload
+                            .as_object_mut()
+                            .expect("payload is always a JSON object");
+                        obj.insert(
+                            "branches".into(),
+                            serde_json::to_value(branches).unwrap_or(serde_json::json!([])),
+                        );
+                        obj.insert(
+                            "state".into(),
+                            serde_json::Value::Object(progress.final_state.clone()),
+                        );
+                    }
+                }
+
                 let item = WorkItem {
                     id: Uuid::new_v4(),
                     execution_id: execution_id.clone(),
@@ -1451,5 +1473,129 @@ mod tests {
         );
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[1]["content"], "What is the weather in London?");
+    }
+
+    /// Condition node work-item payload carries `branches` and committed `state`.
+    ///
+    /// A Condition node with non-empty branches must have both:
+    ///   - `payload["branches"]`: the serialized branch list from the IR
+    ///   - `payload["state"]`: the accumulated workflow state at dispatch time
+    ///
+    /// This is the payload the condition executor (FDL-2) reads to evaluate the route.
+    #[tokio::test]
+    async fn condition_node_payload_carries_branches_and_state() {
+        // Build a 2-node IR:
+        //   start (empty-branches Condition — used as a simple pass-through) -> gate
+        //   gate  (Condition with non-empty branches)                         -> a | b
+        let ir = serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": "start",
+            "nodes": {
+                "start": {
+                    "id": "start",
+                    "kind": { "type": "condition", "branches": [] },
+                    "retry_policy": null,
+                    "node_timeout_secs": null,
+                    "description": null,
+                    "labels": {}
+                },
+                "gate": {
+                    "id": "gate",
+                    "kind": {
+                        "type": "condition",
+                        "branches": [
+                            {"condition": "state.x == \"stop\"", "target": "end"},
+                            {"condition": null, "target": "tools"}
+                        ]
+                    },
+                    "retry_policy": null,
+                    "node_timeout_secs": null,
+                    "description": null,
+                    "labels": {}
+                }
+            },
+            "edges": [
+                {"from": "start", "to": "gate", "condition": null},
+                {"from": "gate", "to": "end",   "condition": "state.x == \"stop\""},
+                {"from": "gate", "to": "tools", "condition": null}
+            ],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        });
+        let (s, b, e) = setup(ir).await;
+
+        // Tick 1: schedules `start` (no predecessors).
+        tick(&s, &e).await;
+
+        // Drain the `start` work item so it is no longer in the queue.
+        // Without this the next claim_work_item would return `start` instead of
+        // `gate` (work items are returned in FIFO order).
+        let _start_item = b
+            .claim_work_item("test-worker-a", &["general"])
+            .await
+            .expect("claim start must not error")
+            .expect("start work item must be present");
+
+        // Simulate `start` completing with some workflow state.
+        let patch = serde_json::json!({ "x": "stop", "other": 42 });
+        append(&b, &e, node_completed("start", patch)).await;
+
+        // Tick 2: `gate` is now runnable; the scheduler must enrich its payload.
+        tick(&s, &e).await;
+
+        // Claim from the general queue (Condition nodes use QueueType::General).
+        let item = b
+            .claim_work_item("test-worker-b", &["general"])
+            .await
+            .expect("backend claim must not error")
+            .expect("gate Condition node must produce exactly one work item");
+
+        // The claimed item is for `gate`, not `start` (which has no branches).
+        assert_eq!(
+            item.node_id, "gate",
+            "claimed item must be for the gate node"
+        );
+
+        // payload["branches"] must carry the two branches from the IR.
+        let branches = item.payload["branches"]
+            .as_array()
+            .expect("payload.branches must be a JSON array");
+        assert_eq!(branches.len(), 2, "both branches must be in the payload");
+        assert_eq!(
+            branches[0]["target"], "end",
+            "first branch target must be 'end'"
+        );
+        assert!(
+            !branches[0]["condition"].is_null(),
+            "first branch must have a condition expression"
+        );
+        assert_eq!(
+            branches[1]["target"], "tools",
+            "second branch target must be 'tools'"
+        );
+        assert!(
+            branches[1]["condition"].is_null(),
+            "second branch must be the default (condition: null)"
+        );
+
+        // payload["state"] must carry the accumulated workflow state.
+        let state = &item.payload["state"];
+        assert_eq!(
+            state["x"], "stop",
+            "payload.state must carry the state_patch from 'start'"
+        );
+        assert_eq!(
+            state["other"], 42,
+            "payload.state must carry all state keys"
+        );
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -273,8 +273,90 @@ impl Scheduler {
             info!(execution_id = %execution_id, node_id = %node_id, "Approval rejected — node failed");
         }
 
+        // FDL-3 skip cascade (the dead-edge fixpoint). A node whose EVERY
+        // in-edge is dead can never run, so emit `NodeSkipped` for it. The skip
+        // folds into `completed` (satisfying downstream AND-joins without it) and
+        // into `skipped` (making this node's OUT-edges dead), which can make MORE
+        // nodes skippable — so iterate to a fixpoint. A node reachable via ANY
+        // live in-edge is never all-dead, so shared joins (the agent loop's
+        // `end`, a `__finalize__` join) survive; only a dead branch's exclusive
+        // tail is skipped. Capped at node-count passes defensively — each pass
+        // skips >= 1 new node or stops, so it converges well within the cap.
+        let max_passes = ir.nodes.len() + 1;
+        for _ in 0..max_passes {
+            // Collect the nodes that become skippable in this pass against the
+            // current progress, then emit + fold them. A node is skippable iff
+            // it is not already resolved, has >= 1 in-edge, and ALL its in-edges
+            // are dead. (Roots — no in-edges — are never skipped here.)
+            let mut newly_skippable: Vec<NodeId> = Vec::new();
+            for node_id in ir.nodes.keys() {
+                let n = node_id.as_str();
+                if progress.completed.contains(n)
+                    || progress.scheduled.contains(n)
+                    || progress.skipped.contains(n)
+                    || progress.terminal_failed.contains(n)
+                {
+                    continue;
+                }
+                let mut has_in_edge = false;
+                let mut all_dead = true;
+                for e in ir.edges.iter().filter(|e| e.to == *node_id) {
+                    has_in_edge = true;
+                    if !edge_dead(
+                        &e.from,
+                        n,
+                        &ir,
+                        &progress.completed,
+                        &progress.skipped,
+                        &progress.routes,
+                    ) {
+                        all_dead = false;
+                        break;
+                    }
+                }
+                if has_in_edge && all_dead {
+                    newly_skippable.push(node_id.clone());
+                }
+            }
+            if newly_skippable.is_empty() {
+                break;
+            }
+            // Sort for deterministic event sequencing (ir.nodes is a HashMap).
+            newly_skippable.sort();
+            for node_id in newly_skippable {
+                let seq = self.backend.latest_sequence(execution_id).await? + 1;
+                let skip_event = jamjet_state::Event::new(
+                    execution_id.clone(),
+                    seq,
+                    EventKind::NodeSkipped {
+                        node_id: node_id.clone(),
+                        reason: "branch not taken".to_string(),
+                    },
+                );
+                self.backend.append_event(skip_event.clone()).await?;
+                // Fold the skip into LOCAL progress immediately so the next pass
+                // (and this tick's dispatch) sees it — reaching the fixpoint
+                // within one tick rather than one skip per tick.
+                progress.apply(&skip_event);
+                info!(
+                    execution_id = %execution_id,
+                    node_id = %node_id,
+                    "Skipped node (dead branch — all in-edges dead)"
+                );
+            }
+        }
+
+        // Persist the cascade's advance (skips + last_sequence) so an early
+        // return below (e.g. the concurrency cap) doesn't replay the same delta.
+        self.progress
+            .lock()
+            .unwrap()
+            .insert(execution_id.clone(), progress.clone());
+
         let completed = &progress.completed;
         let scheduled = &progress.scheduled;
+        let skipped = &progress.skipped;
+        let routes = &progress.routes;
         let terminal_failed = &progress.terminal_failed;
 
         debug!(
@@ -316,7 +398,7 @@ impl Scheduler {
             if terminal_failed.contains(node_id.as_str()) {
                 continue; // permanently failed
             }
-            if is_runnable(node_id, &ir, completed, scheduled) {
+            if is_runnable(node_id, &ir, completed, scheduled, skipped, routes) {
                 // Serialize the QueueType variant name to snake_case string.
                 let queue_type = serde_json::to_value(node.kind.queue_type())
                     .ok()
@@ -552,6 +634,23 @@ struct ExecProgress {
     /// Note: a rejected node stays in `scheduled` (consuming a concurrency slot)
     /// until the follow-up `NodeFailed` emission clears it.
     rejected: HashMap<NodeId, String>,
+    /// FDL-3: a Condition node's recorded route — condition node id -> the single
+    /// chosen branch target. Populated when a Condition `NodeCompleted` carries a
+    /// non-null `chosen_target` (the condition executor's routing decision). The
+    /// route is a deterministic function of committed state recorded once at the
+    /// condition's completion, so replay reproduces the exact route.
+    ///
+    /// A routing Condition that completed with a NULL `chosen_target` (no branch
+    /// matched and no default) records NO entry here; the dead-edge predicate
+    /// then reads `routes.get(cond) == None` for a completed routing Condition as
+    /// "every out-edge is dead" — so all its branch targets are skipped.
+    routes: HashMap<NodeId, NodeId>,
+    /// FDL-3: nodes that were emitted as `NodeSkipped` (the dead-branch tails).
+    /// A skipped node also folds into `completed` (so a downstream AND-join is
+    /// satisfied without it), but is tracked separately here so the dead-edge
+    /// predicate can treat a skipped node's OUT-edges as dead — which is what
+    /// cascades a skip down a fully-dead branch to its exclusive tail.
+    skipped: HashSet<NodeId>,
 }
 
 impl ExecProgress {
@@ -560,6 +659,7 @@ impl ExecProgress {
         match &event.kind {
             EventKind::NodeCompleted {
                 node_id,
+                output,
                 state_patch,
                 ..
             } => {
@@ -567,6 +667,18 @@ impl ExecProgress {
                 self.scheduled.remove(node_id);
                 // Stale-hold cleanup: a completed node no longer awaits approval.
                 self.held.remove(node_id);
+                // FDL-3: record a Condition node's routing decision. The condition
+                // executor (FDL-2) records `chosen_target` on its `output`: a
+                // non-null string is the single live out-edge; a null/absent
+                // target (no branch matched, no default) records no route so the
+                // dead-edge predicate treats every out-edge of this completed
+                // Condition as dead. A spurious `chosen_target` on a NON-Condition
+                // node's output is harmless: the dead-edge predicate only consults
+                // `routes` for nodes the IR confirms are Condition nodes with
+                // non-empty branches.
+                if let Some(target) = output.get("chosen_target").and_then(|v| v.as_str()) {
+                    self.routes.insert(node_id.clone(), target.to_string());
+                }
                 if let serde_json::Value::Object(patch) = state_patch {
                     for (k, v) in patch {
                         self.final_state.insert(k.clone(), v.clone());
@@ -574,7 +686,11 @@ impl ExecProgress {
                 }
             }
             EventKind::NodeSkipped { node_id, .. } => {
+                // A skipped node folds into `completed` (satisfying downstream
+                // AND-joins) AND into `skipped` (so its OUT-edges read as dead in
+                // the dead-edge predicate, cascading the skip down the branch).
                 self.completed.insert(node_id.clone());
+                self.skipped.insert(node_id.clone());
                 self.scheduled.remove(node_id);
                 // Stale-hold cleanup: a skipped node no longer awaits approval.
                 self.held.remove(node_id);
@@ -675,22 +791,88 @@ impl ExecProgress {
     }
 }
 
-/// Check if a node is runnable: all its predecessors are completed and
-/// it hasn't been scheduled yet.
+/// FDL-3: is the edge `src -> dst` DEAD (i.e. it must never enable `dst`)?
+///
+/// An edge is dead iff EITHER:
+///   - `src` was skipped — a skipped node's out-edges cannot enable anything
+///     (this is what cascades a skip down a fully-dead branch); OR
+///   - `src` is a routing Condition (a `Condition` node with NON-EMPTY
+///     `branches`) that has COMPLETED and routed somewhere other than `dst`.
+///     A completed routing Condition routes to exactly one target — the live
+///     out-edge — so every other out-edge is dead. The null-route case (no
+///     branch matched, no default) records no entry in `routes`, so
+///     `routes.get(src)` is `None`, which differs from `Some(dst)` for every
+///     `dst`: ALL its out-edges are dead.
+///
+/// Edges that are LIVE (this returns false):
+///   - a routing Condition that has NOT YET completed — its out-edges are
+///     pending, not dead (the route is unknown until it runs);
+///   - an empty-`branches` Condition (a generic pass-through) — never routes,
+///     so its out-edges are governed only by the skip rule (backward-compat);
+///   - any non-Condition source that has not been skipped.
+fn edge_dead(
+    src: &str,
+    dst: &str,
+    ir: &WorkflowIr,
+    completed: &HashSet<NodeId>,
+    skipped: &HashSet<NodeId>,
+    routes: &HashMap<NodeId, NodeId>,
+) -> bool {
+    if skipped.contains(src) {
+        return true;
+    }
+    if let Some(node) = ir.nodes.get(src) {
+        if let NodeKind::Condition { branches } = &node.kind {
+            if !branches.is_empty() && completed.contains(src) {
+                // Completed routing Condition: live edge is `routes[src]` only.
+                return routes.get(src).map(String::as_str) != Some(dst);
+            }
+        }
+    }
+    false
+}
+
+/// Check if a node is runnable. Route-aware AND-join over LIVE edges only.
+///
+/// A node runs iff it is not already completed/scheduled/skipped, it has at
+/// least one LIVE in-edge (an in-edge `src -> node` that is not [`edge_dead`]),
+/// and EVERY live in-edge's source has COMPLETED. A node with NO in-edges is a
+/// root — runnable until it has run (matches the original topology behaviour).
+///
+/// A node whose every in-edge is dead is NOT runnable here (it is a skip
+/// candidate the cascade marks `NodeSkipped`); a node reachable via any live
+/// in-edge is never skipped, so the dead branch's exclusive tail is skipped
+/// while shared joins (the agent loop's `end`, a `__finalize__` join) survive.
 fn is_runnable(
     node_id: &str,
     ir: &WorkflowIr,
     completed: &HashSet<NodeId>,
     scheduled: &HashSet<NodeId>,
+    skipped: &HashSet<NodeId>,
+    routes: &HashMap<NodeId, NodeId>,
 ) -> bool {
-    if scheduled.contains(node_id) || completed.contains(node_id) {
+    if scheduled.contains(node_id) || completed.contains(node_id) || skipped.contains(node_id) {
         return false;
     }
-    // All predecessors (nodes with an edge TO this node) must be completed.
-    ir.edges
-        .iter()
-        .filter(|e| e.to == node_id)
-        .all(|e| completed.contains(&e.from))
+    let mut has_in_edge = false;
+    let mut has_live_edge = false;
+    let mut all_live_sources_done = true;
+    for e in ir.edges.iter().filter(|e| e.to == node_id) {
+        has_in_edge = true;
+        if !edge_dead(&e.from, node_id, ir, completed, skipped, routes) {
+            has_live_edge = true;
+            if !completed.contains(&e.from) {
+                all_live_sources_done = false;
+            }
+        }
+    }
+    // A node with no in-edges is a root — runnable (subject to the already-run
+    // guards above). A node with in-edges runs iff it has a live in-edge AND
+    // every live in-edge's source has completed.
+    if !has_in_edge {
+        return true;
+    }
+    has_live_edge && all_live_sources_done
 }
 
 #[cfg(test)]
@@ -1596,6 +1778,451 @@ mod tests {
         assert_eq!(
             state["other"], 42,
             "payload.state must carry all state keys"
+        );
+    }
+
+    // ── FDL-3: route-aware is_runnable + NodeSkipped skip cascade ───────────────
+
+    /// Assemble a workflow IR JSON value from a start node, a `nodes` object and
+    /// an `edges` array — the empty config maps are boilerplate every IR needs.
+    fn build_ir(
+        start: &str,
+        nodes: serde_json::Value,
+        edges: serde_json::Value,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": start,
+            "nodes": nodes,
+            "edges": edges,
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        })
+    }
+
+    /// A `condition`-kind node. Non-empty `branches` make it a routing gate;
+    /// empty `branches` make it a generic pass-through (the scheduler dispatches
+    /// off edges, so the concrete kind doesn't matter for non-gate nodes).
+    fn cond_node(id: &str, branches: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "kind": { "type": "condition", "branches": branches },
+            "retry_policy": null,
+            "node_timeout_secs": null,
+            "description": null,
+            "labels": {}
+        })
+    }
+
+    /// A `NodeCompleted` the way the FDL-2 condition executor emits it: the
+    /// routing decision recorded on BOTH `output` and `state_patch`.
+    /// `chosen_target = None` is the null-route case (no branch matched, no
+    /// default) — the scheduler records no route, so every branch target dies.
+    fn condition_completed(
+        node_id: &str,
+        chosen_target: Option<&str>,
+        branch_targets: &[&str],
+    ) -> EventKind {
+        let chosen = match chosen_target {
+            Some(t) => serde_json::Value::String(t.to_string()),
+            None => serde_json::Value::Null,
+        };
+        let targets: Vec<serde_json::Value> = branch_targets
+            .iter()
+            .map(|t| serde_json::Value::String(t.to_string()))
+            .collect();
+        let routing = serde_json::json!({
+            "chosen_target": chosen,
+            "branch_targets": targets,
+        });
+        EventKind::NodeCompleted {
+            node_id: node_id.into(),
+            output: routing.clone(),
+            state_patch: routing,
+            duration_ms: 1,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+            cost_usd: None,
+            provenance: None,
+            idempotency_key: None,
+        }
+    }
+
+    fn skipped_nodes(events: &[Event]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|ev| match &ev.kind {
+                EventKind::NodeSkipped { node_id, .. } => Some(node_id.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A static agent-loop unroll (turns 0,1 + a final model_2):
+    /// `model_0 -> gate_0`; `gate_0` branches `{tool_calls -> tools_0 | else -> end}`;
+    /// `tools_0 -> model_1 -> gate_1 -> {tools_1 | end}`; `tools_1 -> model_2 -> end`.
+    /// `end` is a shared JOIN: both gates' `else` edges and the final model feed it.
+    fn agent_loop_ir() -> serde_json::Value {
+        let tool_calls = "state.last_model_finish_reason == \"tool_calls\"";
+        build_ir(
+            "model_0",
+            serde_json::json!({
+                "model_0": cond_node("model_0", serde_json::json!([])),
+                "gate_0": cond_node("gate_0", serde_json::json!([
+                    {"condition": tool_calls, "target": "tools_0"},
+                    {"condition": null, "target": "end"}
+                ])),
+                "tools_0": cond_node("tools_0", serde_json::json!([])),
+                "model_1": cond_node("model_1", serde_json::json!([])),
+                "gate_1": cond_node("gate_1", serde_json::json!([
+                    {"condition": tool_calls, "target": "tools_1"},
+                    {"condition": null, "target": "end"}
+                ])),
+                "tools_1": cond_node("tools_1", serde_json::json!([])),
+                "model_2": cond_node("model_2", serde_json::json!([])),
+                "end": cond_node("end", serde_json::json!([]))
+            }),
+            serde_json::json!([
+                {"from": "model_0", "to": "gate_0", "condition": null},
+                {"from": "gate_0", "to": "tools_0", "condition": tool_calls},
+                {"from": "gate_0", "to": "end", "condition": null},
+                {"from": "tools_0", "to": "model_1", "condition": null},
+                {"from": "model_1", "to": "gate_1", "condition": null},
+                {"from": "gate_1", "to": "tools_1", "condition": tool_calls},
+                {"from": "gate_1", "to": "end", "condition": null},
+                {"from": "tools_1", "to": "model_2", "condition": null},
+                {"from": "model_2", "to": "end", "condition": null}
+            ]),
+        )
+    }
+
+    /// FOLD: a Condition `NodeCompleted` with a non-null `chosen_target` records
+    /// the route; the node also folds into `completed`.
+    #[test]
+    fn condition_completion_records_route() {
+        let progress = fold_events(vec![condition_completed(
+            "gate",
+            Some("end"),
+            &["tools", "end"],
+        )]);
+        assert_eq!(
+            progress.routes.get("gate").map(String::as_str),
+            Some("end"),
+            "non-null chosen_target must be recorded as the route"
+        );
+        assert!(progress.completed.contains("gate"));
+    }
+
+    /// FOLD: a null `chosen_target` records NO route entry (the dead-edge
+    /// predicate reads a completed routing Condition with no route as
+    /// "every out-edge dead").
+    #[test]
+    fn null_route_records_no_route_entry() {
+        let progress = fold_events(vec![condition_completed("gate", None, &["A", "B"])]);
+        assert!(
+            !progress.routes.contains_key("gate"),
+            "null chosen_target must record no route"
+        );
+        assert!(progress.completed.contains("gate"));
+    }
+
+    /// FOLD: `NodeSkipped` folds into BOTH `completed` (satisfies AND-joins) and
+    /// `skipped` (so its out-edges read as dead, cascading the skip).
+    #[test]
+    fn skipped_event_folds_into_completed_and_skipped() {
+        let progress = fold_events(vec![EventKind::NodeSkipped {
+            node_id: "x".into(),
+            reason: "branch not taken".into(),
+        }]);
+        assert!(
+            progress.completed.contains("x"),
+            "skipped folds into completed"
+        );
+        assert!(
+            progress.skipped.contains("x"),
+            "skipped is tracked for the dead-edge predicate"
+        );
+    }
+
+    /// HEADLINE — agent-loop early-exit. With `gate_0` routing to `end`
+    /// (model_0 returned finish_reason "stop"), the ENTIRE remaining loop is
+    /// skipped, `end` is reached via its live in-edge from `gate_0`, and the
+    /// workflow completes WITHOUT ever scheduling `model_1`.
+    #[tokio::test]
+    async fn agent_loop_early_exit_skips_unused_turns() {
+        let (s, b, e) = setup(agent_loop_ir()).await;
+
+        // Tick 1: model_0 (start, no in-edges) is scheduled.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(scheduled_nodes(&evs).contains(&"model_0".to_string()));
+
+        // model_0 completes — the model is done (finish_reason "stop").
+        append(
+            &b,
+            &e,
+            node_completed(
+                "model_0",
+                serde_json::json!({"last_model_finish_reason": "stop"}),
+            ),
+        )
+        .await;
+
+        // Tick 2: gate_0 becomes runnable.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(scheduled_nodes(&evs).contains(&"gate_0".to_string()));
+
+        // gate_0 routes to `end` (the FDL-2 executor records chosen_target="end").
+        append(
+            &b,
+            &e,
+            condition_completed("gate_0", Some("end"), &["tools_0", "end"]),
+        )
+        .await;
+
+        // Tick 3: the cascade skips the whole dead branch and dispatches `end`.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        let skipped = skipped_nodes(&evs);
+        for n in ["tools_0", "model_1", "gate_1", "tools_1", "model_2"] {
+            assert!(
+                skipped.contains(&n.to_string()),
+                "{n} must be skipped (dead branch tail)"
+            );
+        }
+        // `end` survives (live in-edge from gate_0) and is reached.
+        assert!(
+            scheduled_nodes(&evs).contains(&"end".to_string()),
+            "end must be reached via its live in-edge from gate_0"
+        );
+        // The early-exit: model_1 must NEVER be scheduled.
+        assert!(
+            !scheduled_nodes(&evs).contains(&"model_1".to_string()),
+            "model_1 must never be scheduled (early exit)"
+        );
+        // `end` is not skipped.
+        assert!(
+            !skipped.contains(&"end".to_string()),
+            "end must NOT be skipped — it has a live in-edge"
+        );
+
+        // end completes -> workflow completes.
+        append(&b, &e, node_completed("end", serde_json::json!({}))).await;
+        tick(&s, &e).await;
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Completed);
+    }
+
+    /// Inverse — when `gate_0` routes to `tools_0` (the model asked for a tool),
+    /// the loop proceeds and NOTHING is wrongly skipped.
+    #[tokio::test]
+    async fn agent_loop_route_to_tools_proceeds_without_skipping() {
+        let (s, b, e) = setup(agent_loop_ir()).await;
+
+        tick(&s, &e).await; // model_0
+        append(
+            &b,
+            &e,
+            node_completed(
+                "model_0",
+                serde_json::json!({"last_model_finish_reason": "tool_calls"}),
+            ),
+        )
+        .await;
+        tick(&s, &e).await; // gate_0
+        append(
+            &b,
+            &e,
+            condition_completed("gate_0", Some("tools_0"), &["tools_0", "end"]),
+        )
+        .await;
+        tick(&s, &e).await;
+
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"tools_0".to_string()),
+            "tools_0 must proceed when gate_0 routes to it"
+        );
+        assert!(
+            skipped_nodes(&evs).is_empty(),
+            "no node may be skipped while the loop continues"
+        );
+        assert!(
+            !scheduled_nodes(&evs).contains(&"end".to_string()),
+            "end must not be reached yet (later gates/model still pending)"
+        );
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
+    }
+
+    /// A diamond AND-join: `C -> {L, R}`, `L -> J`, `R -> J`, `J -> end`.
+    /// `C` routes to `L`. The dead branch `R` is skipped, but `J` STILL RUNS
+    /// (live in-edge from L) once L completes — neither premature completion
+    /// (J skipped) nor hang (J waiting on the skipped R).
+    fn diamond_ir() -> serde_json::Value {
+        build_ir(
+            "C",
+            serde_json::json!({
+                "C": cond_node("C", serde_json::json!([
+                    {"condition": "state.go == \"L\"", "target": "L"},
+                    {"condition": null, "target": "R"}
+                ])),
+                "L": cond_node("L", serde_json::json!([])),
+                "R": cond_node("R", serde_json::json!([])),
+                "J": cond_node("J", serde_json::json!([])),
+                "end": cond_node("end", serde_json::json!([]))
+            }),
+            serde_json::json!([
+                {"from": "C", "to": "L", "condition": "state.go == \"L\""},
+                {"from": "C", "to": "R", "condition": null},
+                {"from": "L", "to": "J", "condition": null},
+                {"from": "R", "to": "J", "condition": null},
+                {"from": "J", "to": "end", "condition": null}
+            ]),
+        )
+    }
+
+    #[tokio::test]
+    async fn diamond_join_skips_dead_branch_but_join_survives() {
+        let (s, b, e) = setup(diamond_ir()).await;
+
+        tick(&s, &e).await; // C
+        append(&b, &e, condition_completed("C", Some("L"), &["L", "R"])).await;
+        tick(&s, &e).await;
+
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            skipped_nodes(&evs).contains(&"R".to_string()),
+            "R (dead branch) must be skipped"
+        );
+        assert!(
+            !skipped_nodes(&evs).contains(&"J".to_string()),
+            "J must NOT be skipped — it has a live in-edge from L"
+        );
+        assert!(
+            scheduled_nodes(&evs).contains(&"L".to_string()),
+            "L (taken branch) must be scheduled"
+        );
+        assert!(
+            !scheduled_nodes(&evs).contains(&"J".to_string()),
+            "J must not run until L completes"
+        );
+
+        // L completes -> J becomes runnable via the AND-join over LIVE edges only.
+        append(&b, &e, node_completed("L", serde_json::json!({}))).await;
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"J".to_string()),
+            "J must run once L completes — it must not wait on the skipped R"
+        );
+
+        // J -> end -> complete.
+        append(&b, &e, node_completed("J", serde_json::json!({}))).await;
+        tick(&s, &e).await; // schedules end
+        append(&b, &e, node_completed("end", serde_json::json!({}))).await;
+        tick(&s, &e).await; // completes
+        assert_eq!(
+            status(&b, &e).await,
+            WorkflowStatus::Completed,
+            "workflow completes via J (no premature completion, no hang)"
+        );
+    }
+
+    /// BACKWARD-COMPAT: an empty-`branches` Condition is a pass-through — both
+    /// successors run, nothing is skipped (a workflow with no routing gates is
+    /// entirely unaffected by FDL-3).
+    #[tokio::test]
+    async fn empty_branches_condition_runs_all_successors() {
+        let ir = build_ir(
+            "start",
+            serde_json::json!({
+                "start": cond_node("start", serde_json::json!([])),
+                "a": cond_node("a", serde_json::json!([])),
+                "b": cond_node("b", serde_json::json!([]))
+            }),
+            serde_json::json!([
+                {"from": "start", "to": "a", "condition": null},
+                {"from": "start", "to": "b", "condition": null}
+            ]),
+        );
+        let (s, b, e) = setup(ir).await;
+
+        tick(&s, &e).await; // start
+        append(&b, &e, node_completed("start", serde_json::json!({}))).await;
+        tick(&s, &e).await;
+
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"a".to_string()),
+            "both successors of an empty-branches condition must run (a)"
+        );
+        assert!(
+            scheduled_nodes(&evs).contains(&"b".to_string()),
+            "both successors of an empty-branches condition must run (b)"
+        );
+        assert!(
+            skipped_nodes(&evs).is_empty(),
+            "an empty-branches condition must never skip a successor"
+        );
+    }
+
+    /// NO-ROUTE: a Condition that matched no branch and had no default
+    /// (`chosen_target = null`) skips ALL its branch targets' exclusive tails,
+    /// and the run still TERMINATES (no hang).
+    #[tokio::test]
+    async fn no_matching_branch_skips_all_targets_and_terminates() {
+        let ir = build_ir(
+            "start",
+            serde_json::json!({
+                "start": cond_node("start", serde_json::json!([])),
+                "gate": cond_node("gate", serde_json::json!([
+                    {"condition": "state.x == \"1\"", "target": "A"},
+                    {"condition": "state.y == \"2\"", "target": "B"}
+                ])),
+                "A": cond_node("A", serde_json::json!([])),
+                "B": cond_node("B", serde_json::json!([]))
+            }),
+            serde_json::json!([
+                {"from": "start", "to": "gate", "condition": null},
+                {"from": "gate", "to": "A", "condition": "state.x == \"1\""},
+                {"from": "gate", "to": "B", "condition": "state.y == \"2\""}
+            ]),
+        );
+        let (s, b, e) = setup(ir).await;
+
+        tick(&s, &e).await; // start
+        append(&b, &e, node_completed("start", serde_json::json!({}))).await;
+        tick(&s, &e).await; // gate
+                            // gate matched no branch and has no default -> chosen_target null.
+        append(&b, &e, condition_completed("gate", None, &["A", "B"])).await;
+        tick(&s, &e).await;
+
+        let evs = b.get_events(&e).await.unwrap();
+        let skipped = skipped_nodes(&evs);
+        assert!(
+            skipped.contains(&"A".to_string()),
+            "A must be skipped (null route -> every target dead)"
+        );
+        assert!(
+            skipped.contains(&"B".to_string()),
+            "B must be skipped (null route -> every target dead)"
+        );
+        assert_eq!(
+            status(&b, &e).await,
+            WorkflowStatus::Completed,
+            "the run must still terminate when no branch matched (no hang)"
         );
     }
 }

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -1824,7 +1824,8 @@ mod tests {
     }
 
     /// A `NodeCompleted` the way the FDL-2 condition executor emits it: the
-    /// routing decision recorded on BOTH `output` and `state_patch`.
+    /// routing decision recorded on `output` only; `state_patch` is empty so
+    /// routing metadata never bleeds into workflow state.
     /// `chosen_target = None` is the null-route case (no branch matched, no
     /// default) — the scheduler records no route, so every branch target dies.
     fn condition_completed(
@@ -1846,8 +1847,8 @@ mod tests {
         });
         EventKind::NodeCompleted {
             node_id: node_id.into(),
-            output: routing.clone(),
-            state_patch: routing,
+            output: routing,
+            state_patch: serde_json::json!({}),
             duration_ms: 1,
             gen_ai_system: None,
             gen_ai_model: None,

--- a/runtime/workers/src/executors/condition_node.rs
+++ b/runtime/workers/src/executors/condition_node.rs
@@ -1,0 +1,299 @@
+//! Executor for `Condition` workflow nodes.
+//!
+//! Reads the node's `branches` from the work-item payload, evaluates each
+//! branch expression against the committed workflow state (also in the payload),
+//! picks the first matching branch, and records the routing decision on the
+//! `NodeCompleted` output so the scheduler (FDL-3) can honor it.
+//!
+//! # Routing logic (ordered evaluation)
+//!
+//! 1. For each branch in order: if `condition` is `Some(expr)` and
+//!    `eval_condition(expr, &state)` is true, that branch wins.
+//! 2. If no conditional branch matched, use the first branch with
+//!    `condition: None` (the default/else branch).
+//! 3. If neither — no match and no default — `chosen_target` is `null`.
+//!    The scheduler (FDL-3) will treat every branch target as dead and emit
+//!    `NodeSkipped` for them.
+//!
+//! # Output shape
+//!
+//! Both `output` and `state_patch` carry:
+//! ```json
+//! { "chosen_target": "<NodeId>" | null, "branch_targets": ["<NodeId>", ...] }
+//! ```
+//!
+//! FDL-3 reads `chosen_target` and `branch_targets` off the `NodeCompleted`
+//! event to build the dead-edge set and emit `NodeSkipped` for dominated tails.
+//!
+//! # Backward compatibility
+//!
+//! An empty `branches` list (used as a generic pass-through in scheduler tests)
+//! returns empty `output` and `state_patch` — identical to the old no-op stub.
+
+use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
+use async_trait::async_trait;
+use jamjet_core::eval_condition;
+use jamjet_state::backend::WorkItem;
+use serde_json::{json, Value};
+
+/// Executor for `condition` workflow nodes.
+#[derive(Debug, Default)]
+pub struct ConditionNodeExecutor;
+
+impl ConditionNodeExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Local mirror of `jamjet_core::node::ConditionalBranch`.
+///
+/// We deserialize from the payload rather than importing the core struct so
+/// this crate does not need to reach into `jamjet_core::node` internals.
+#[derive(Debug, serde::Deserialize)]
+struct BranchDef {
+    /// `None` marks the default/else branch.
+    condition: Option<String>,
+    /// The NodeId this branch routes to.
+    target: String,
+}
+
+#[async_trait]
+impl NodeExecutor for ConditionNodeExecutor {
+    async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
+        let start = std::time::Instant::now();
+
+        // Deserialize the branches array from the payload (scheduler-enriched).
+        // An absent or empty branches list falls through to the no-op path.
+        let branches: Vec<BranchDef> = item
+            .payload
+            .get("branches")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        // No-op path: empty branches = pass-through (backward-compat with
+        // the old stub and with condition nodes used as generic topology nodes
+        // in tests — e.g. runner.rs `linear_ir`).
+        if branches.is_empty() {
+            return Ok(ExecutionResult {
+                output: json!({}),
+                state_patch: json!({}),
+                duration_ms: start.elapsed().as_millis() as u64,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+            });
+        }
+
+        // Committed workflow state injected by the scheduler into the payload.
+        let state: Value = item.payload.get("state").cloned().unwrap_or(json!({}));
+
+        // All branch targets — written into the output so FDL-3 can identify
+        // every branch target to potentially skip.
+        let branch_targets: Vec<Value> = branches
+            .iter()
+            .map(|b| Value::String(b.target.clone()))
+            .collect();
+
+        // Evaluate branches in order:
+        //   first Some(expr) that evals true -> chosen
+        //   else first None (default/else)   -> chosen
+        //   else null                        -> no-match
+        let mut chosen: Option<String> = None;
+        let mut default_branch: Option<String> = None;
+
+        for branch in &branches {
+            match &branch.condition {
+                Some(expr) => {
+                    if chosen.is_none() && eval_condition(expr, &state) {
+                        chosen = Some(branch.target.clone());
+                    }
+                }
+                None => {
+                    if default_branch.is_none() {
+                        default_branch = Some(branch.target.clone());
+                    }
+                }
+            }
+        }
+
+        let resolved = chosen.or(default_branch);
+
+        let chosen_json: Value = match &resolved {
+            Some(t) => Value::String(t.clone()),
+            None => {
+                tracing::warn!(
+                    node_id = %item.node_id,
+                    "condition: no branch matched and no default; all targets will be skipped"
+                );
+                Value::Null
+            }
+        };
+
+        // Record the routing decision on both output and state_patch so the
+        // scheduler (FDL-3) can read it off the NodeCompleted event.
+        // Kept small + inline (NOT spilled): these are short strings.
+        let routing = json!({
+            "chosen_target": chosen_json,
+            "branch_targets": branch_targets,
+        });
+
+        Ok(ExecutionResult {
+            output: routing.clone(),
+            state_patch: routing,
+            duration_ms: start.elapsed().as_millis() as u64,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jamjet_state::backend::WorkItem;
+
+    fn make_item(branches: serde_json::Value, state: serde_json::Value) -> WorkItem {
+        WorkItem {
+            id: uuid::Uuid::new_v4(),
+            execution_id: jamjet_core::workflow::ExecutionId::new(),
+            node_id: "gate".into(),
+            queue_type: "general".into(),
+            payload: json!({
+                "workflow_id": "wf",
+                "workflow_version": "0.1.0",
+                "node_id": "gate",
+                "branches": branches,
+                "state": state,
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        }
+    }
+
+    /// G1: first conditional branch matches (state.x == "go") -> chosen_target "A".
+    #[tokio::test]
+    async fn first_branch_matches() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item(
+            json!([
+                {"condition": "state.x == \"go\"", "target": "A"},
+                {"condition": null, "target": "B"}
+            ]),
+            json!({"x": "go"}),
+        );
+        let result = executor.execute(&item).await.expect("must not error");
+
+        assert_eq!(
+            result.output["chosen_target"], "A",
+            "first branch condition matches -> chosen_target A"
+        );
+        assert_eq!(
+            result.state_patch["chosen_target"], "A",
+            "state_patch must also carry chosen_target"
+        );
+        let targets = result.output["branch_targets"]
+            .as_array()
+            .expect("branch_targets must be an array");
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0], "A");
+        assert_eq!(targets[1], "B");
+    }
+
+    /// G2: first conditional branch does NOT match -> falls back to the default (None) branch B.
+    #[tokio::test]
+    async fn falls_back_to_default_branch() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item(
+            json!([
+                {"condition": "state.x == \"go\"", "target": "A"},
+                {"condition": null, "target": "B"}
+            ]),
+            json!({"x": "no"}),
+        );
+        let result = executor.execute(&item).await.expect("must not error");
+
+        assert_eq!(
+            result.output["chosen_target"], "B",
+            "no conditional match -> falls back to default branch B"
+        );
+    }
+
+    /// G3: no conditional branch matches and no default branch -> chosen_target null.
+    #[tokio::test]
+    async fn no_match_no_default_returns_null() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item(
+            json!([
+                {"condition": "state.x == \"go\"", "target": "A"},
+                {"condition": "state.x == \"maybe\"", "target": "C"}
+            ]),
+            json!({"x": "never"}),
+        );
+        let result = executor.execute(&item).await.expect("must not error");
+
+        assert!(
+            result.output["chosen_target"].is_null(),
+            "no match and no default -> chosen_target must be null"
+        );
+        let targets = result.output["branch_targets"]
+            .as_array()
+            .expect("branch_targets must be an array");
+        assert_eq!(targets.len(), 2);
+    }
+
+    /// G4: empty branches -> no-op (empty output/state_patch, backward-compat).
+    #[tokio::test]
+    async fn empty_branches_is_noop() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item(json!([]), json!({"x": "go"}));
+        let result = executor.execute(&item).await.expect("must not error");
+
+        // Neither chosen_target nor branch_targets should be present.
+        assert!(
+            result.output["chosen_target"].is_null(),
+            "empty branches -> output must not carry routing keys"
+        );
+        assert_eq!(
+            result.output,
+            json!({}),
+            "empty branches -> output must be empty object (no-op)"
+        );
+        assert_eq!(
+            result.state_patch,
+            json!({}),
+            "empty branches -> state_patch must be empty (no-op)"
+        );
+    }
+
+    /// G5: absent state key -> the missing-path rule (eval_condition returns false)
+    ///     so the default branch is taken.
+    #[tokio::test]
+    async fn absent_state_key_falls_back_to_default() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item(
+            json!([
+                {"condition": "state.finish_reason == \"stop\"", "target": "END"},
+                {"condition": null, "target": "TOOLS"}
+            ]),
+            json!({}),
+        );
+        let result = executor.execute(&item).await.expect("must not error");
+        assert_eq!(
+            result.output["chosen_target"], "TOOLS",
+            "absent state key -> condition false -> default branch taken"
+        );
+    }
+}

--- a/runtime/workers/src/executors/condition_node.rs
+++ b/runtime/workers/src/executors/condition_node.rs
@@ -17,13 +17,14 @@
 //!
 //! # Output shape
 //!
-//! Both `output` and `state_patch` carry:
+//! Only `output` carries the routing dict:
 //! ```json
 //! { "chosen_target": "<NodeId>" | null, "branch_targets": ["<NodeId>", ...] }
 //! ```
+//! `state_patch` is always `{}` — routing metadata must not enter workflow state.
 //!
 //! FDL-3 reads `chosen_target` and `branch_targets` off the `NodeCompleted`
-//! event to build the dead-edge set and emit `NodeSkipped` for dominated tails.
+//! `output` to build the dead-edge set and emit `NodeSkipped` for dominated tails.
 //!
 //! # Backward compatibility
 //!
@@ -132,17 +133,17 @@ impl NodeExecutor for ConditionNodeExecutor {
             }
         };
 
-        // Record the routing decision on both output and state_patch so the
-        // scheduler (FDL-3) can read it off the NodeCompleted event.
-        // Kept small + inline (NOT spilled): these are short strings.
+        // Record the routing decision on output only so the scheduler (FDL-3)
+        // can read it off the NodeCompleted event. state_patch stays empty so
+        // routing metadata never bleeds into workflow state or final_state.
         let routing = json!({
             "chosen_target": chosen_json,
             "branch_targets": branch_targets,
         });
 
         Ok(ExecutionResult {
-            output: routing.clone(),
-            state_patch: routing,
+            output: routing,
+            state_patch: json!({}),
             duration_ms: start.elapsed().as_millis() as u64,
             gen_ai_system: None,
             gen_ai_model: None,
@@ -201,8 +202,9 @@ mod tests {
             "first branch condition matches -> chosen_target A"
         );
         assert_eq!(
-            result.state_patch["chosen_target"], "A",
-            "state_patch must also carry chosen_target"
+            result.state_patch,
+            json!({}),
+            "routing is output-only; state_patch must be empty"
         );
         let targets = result.output["branch_targets"]
             .as_array()

--- a/runtime/workers/src/executors/condition_node.rs
+++ b/runtime/workers/src/executors/condition_node.rs
@@ -64,28 +64,42 @@ impl NodeExecutor for ConditionNodeExecutor {
     async fn execute(&self, item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
         let start = std::time::Instant::now();
 
-        // Deserialize the branches array from the payload (scheduler-enriched).
-        // An absent or empty branches list falls through to the no-op path.
-        let branches: Vec<BranchDef> = item
-            .payload
-            .get("branches")
-            .and_then(|v| serde_json::from_value(v.clone()).ok())
-            .unwrap_or_default();
+        // Three-case handling for the `branches` payload field:
+        //
+        //   1. Missing key  -> no-op (backward-compat: a non-Condition or
+        //      unenriched node; the scheduler didn't inject branches).
+        //   2. Present + explicitly empty array `[]` -> no-op (backward-compat:
+        //      empty-branches Condition used as a pass-through in topology tests).
+        //   3. Present but malformed (wrong type, or objects missing required
+        //      fields) -> Fatal error. Silently dropping routing is worse than
+        //      failing loudly; the scheduler must not run all branches.
+        let noop_result = || ExecutionResult {
+            output: json!({}),
+            state_patch: json!({}),
+            duration_ms: start.elapsed().as_millis() as u64,
+            gen_ai_system: None,
+            gen_ai_model: None,
+            input_tokens: None,
+            output_tokens: None,
+            finish_reason: None,
+        };
 
-        // No-op path: empty branches = pass-through (backward-compat with
-        // the old stub and with condition nodes used as generic topology nodes
-        // in tests — e.g. runner.rs `linear_ir`).
+        let branches_raw = match item.payload.get("branches") {
+            None => return Ok(noop_result()), // case 1: key absent
+            Some(v) => v.clone(),
+        };
+
+        let branches: Vec<BranchDef> = serde_json::from_value(branches_raw).map_err(|e| {
+            ExecutorError::Fatal(format!(
+                "condition node `{}`: malformed `branches` payload — \
+                     expected an array of {{condition, target}} objects; {e}",
+                item.node_id
+            ))
+        })?; // case 3: present but malformed -> propagate Fatal
+
+        // Case 2: present but explicitly empty -> no-op pass-through.
         if branches.is_empty() {
-            return Ok(ExecutionResult {
-                output: json!({}),
-                state_patch: json!({}),
-                duration_ms: start.elapsed().as_millis() as u64,
-                gen_ai_system: None,
-                gen_ai_model: None,
-                input_tokens: None,
-                output_tokens: None,
-                finish_reason: None,
-            });
+            return Ok(noop_result());
         }
 
         // Committed workflow state injected by the scheduler into the payload.
@@ -174,6 +188,24 @@ mod tests {
                 "branches": branches,
                 "state": state,
             }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "default".into(),
+        }
+    }
+
+    /// Build a WorkItem with a fully-custom payload (no implicit `branches` key).
+    fn make_item_raw(payload: serde_json::Value) -> WorkItem {
+        WorkItem {
+            id: uuid::Uuid::new_v4(),
+            execution_id: jamjet_core::workflow::ExecutionId::new(),
+            node_id: "gate".into(),
+            queue_type: "general".into(),
+            payload,
             attempt: 0,
             max_attempts: 3,
             created_at: chrono::Utc::now(),
@@ -297,5 +329,66 @@ mod tests {
             result.output["chosen_target"], "TOOLS",
             "absent state key -> condition false -> default branch taken"
         );
+    }
+
+    /// G6: `branches` is present but malformed (not an array) -> Fatal error.
+    ///
+    /// Regression: the old code silently fell through to the no-op path, which
+    /// would disable routing without any signal.
+    #[tokio::test]
+    async fn malformed_branches_string_returns_fatal_error() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item_raw(json!({
+            "workflow_id": "wf",
+            "workflow_version": "0.1.0",
+            "node_id": "gate",
+            "branches": "not an array",
+            "state": {},
+        }));
+        let result = executor.execute(&item).await;
+        assert!(
+            matches!(result, Err(ExecutorError::Fatal(_))),
+            "malformed branches must return ExecutorError::Fatal, got: {:?}",
+            result
+        );
+    }
+
+    /// G7: `branches` is present but contains objects missing required fields -> Fatal error.
+    #[tokio::test]
+    async fn malformed_branches_missing_target_returns_fatal_error() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item_raw(json!({
+            "workflow_id": "wf",
+            "workflow_version": "0.1.0",
+            "node_id": "gate",
+            "branches": [{"no_target": true}],
+            "state": {},
+        }));
+        let result = executor.execute(&item).await;
+        assert!(
+            matches!(result, Err(ExecutorError::Fatal(_))),
+            "branches array with objects missing `target` must return ExecutorError::Fatal, got: {:?}",
+            result
+        );
+    }
+
+    /// G8: `branches` key is absent entirely -> no-op success (backward-compat).
+    #[tokio::test]
+    async fn missing_branches_key_is_noop() {
+        let executor = ConditionNodeExecutor::new();
+        let item = make_item_raw(json!({
+            "workflow_id": "wf",
+            "workflow_version": "0.1.0",
+            "node_id": "gate",
+            // no "branches" key
+            "state": {"x": "go"},
+        }));
+        let result = executor.execute(&item).await.expect("must not error");
+        assert_eq!(
+            result.output,
+            json!({}),
+            "missing branches key -> no-op empty output"
+        );
+        assert_eq!(result.state_patch, json!({}));
     }
 }

--- a/runtime/workers/src/executors/mod.rs
+++ b/runtime/workers/src/executors/mod.rs
@@ -1,6 +1,7 @@
 pub mod a2a_task;
 pub mod agent_discovery;
 pub mod agent_tool;
+pub mod condition_node;
 pub mod coordinator;
 pub mod eval;
 pub mod mcp_tool;
@@ -9,6 +10,7 @@ pub mod model_node;
 pub use a2a_task::A2aTaskExecutor;
 pub use agent_discovery::AgentDiscoveryExecutor;
 pub use agent_tool::AgentToolExecutor;
+pub use condition_node::ConditionNodeExecutor;
 pub use coordinator::CoordinatorExecutor;
 pub use eval::EvalExecutor;
 pub use mcp_tool::McpToolExecutor;

--- a/runtime/workers/src/lib.rs
+++ b/runtime/workers/src/lib.rs
@@ -15,7 +15,8 @@ pub mod worker;
 
 pub use executor::{ExecutionResult, ExecutorError, NodeExecutor};
 pub use executors::{
-    A2aTaskExecutor, AgentDiscoveryExecutor, EvalExecutor, McpToolExecutor, ModelNodeExecutor,
+    A2aTaskExecutor, AgentDiscoveryExecutor, ConditionNodeExecutor, EvalExecutor, McpToolExecutor,
+    ModelNodeExecutor,
 };
 pub use pool::{default_pool, WorkerGroupConfig, WorkerPool};
 pub use worker::Worker;

--- a/sdk/python/tests/test_agent_durable_loop_parity.py
+++ b/sdk/python/tests/test_agent_durable_loop_parity.py
@@ -18,11 +18,13 @@ Instead we drive the **real** compiled IR (:func:`compile_agent_to_ir`) and the
 re-implementation of the engine's control flow (:func:`drive_agent_loop`), with a
 deterministic mock model. The driver mirrors the engine exactly:
 
-* the scheduler dispatches a node once all its predecessors completed
-  (``runner.rs::is_runnable``); it does NOT evaluate edge conditions — the
-  condition node is a no-op stub and ``NodeSkipped`` is never emitted today, so
-  the static unroll runs to its ``max_turns`` bound (the per-turn gate's
-  short-circuit is the F-2j-dynamic-loop follow-up);
+* the scheduler dispatches a node once its LIVE predecessors completed
+  (``runner.rs::is_runnable``); it NOW evaluates the per-turn gate (F-2j-dynamic-loop /
+  FDL): a Condition gate records the branch it routes to, the dead branch's
+  exclusive tail is marked ``NodeSkipped`` via a dead-edge fixpoint, and the loop
+  EARLY-EXITS the moment a gate routes to ``end`` — the remaining turns are
+  skipped, never run (so a model that finishes at turn 0 makes exactly ONE model
+  call, not ``max_turns + 1``);
 * a Model node reads ``state['messages']`` and writes
   ``last_model_output`` / ``last_model_finish_reason`` / ``last_model_tool_calls``
   (``model_node.rs`` state_patch);
@@ -56,17 +58,26 @@ if str(_EXAMPLE_DIR) not in sys.path:
 import weather_agent  # noqa: E402  (path inserted just above)
 
 _PROMPT = "What's the weather in Paris?"
-# max_turns=2 -> two tool turns plus the final model node (__model_2__); the engine
-# does not yet evaluate gate conditions, so the static unroll visits the full chain
-# and terminates at the final model node (never at a tool-dispatch node).
-_LOOP_NODES = [
+# The engine NOW evaluates the per-turn gate (FDL), so the durable loop EARLY-EXITS
+# instead of running the full max_turns unroll: a turn whose model returns a tool
+# call routes gate -> dispatch and proceeds; a turn whose model returns a final
+# answer (finish_reason "stop") routes gate -> end, and the scheduler skips the
+# remaining turns. The visit order is therefore the LIVE path only.
+#
+# tool-then-stop (turn 0 asks for a tool, turn 1 answers): the turn-1 gate routes
+# to `end`, so __tools_1__ / __model_2__ are skipped — two model calls, not three.
+_EARLY_EXIT_TOOL_THEN_STOP = [
     "__model_0__",
     "__tool_gate_0__",
     "__tools_0__",
     "__model_1__",
     "__tool_gate_1__",
-    "__tools_1__",
-    "__model_2__",
+]
+# stop-at-turn-0 (the model answers immediately): the turn-0 gate routes to `end`,
+# so EVERY tool turn is skipped — exactly ONE model call.
+_EARLY_EXIT_STOP_AT_0 = [
+    "__model_0__",
+    "__tool_gate_0__",
 ]
 
 
@@ -77,27 +88,31 @@ class ScriptedModel:
     """A deterministic model, shared by the durable loop and the in-process run so
     the parity assertion compares like for like.
 
-    Turn 0     -> one tool call: ``get_weather(city="Paris")`` (finish ``tool_calls``).
-    Turn 1 on  -> a final answer with no tool calls (finish ``stop``); this also
-                  covers the bounded final model node the durable unroll appends.
+    ``tool_turns`` leading turns ask for ``get_weather(city="Paris")`` (finish
+    ``tool_calls``); every turn after that returns a final answer with no tool
+    calls (finish ``stop``). The default (``tool_turns=1``) is the canonical
+    react case: turn 0 asks for the tool, turn 1 answers. ``tool_turns=0`` makes
+    the model answer immediately at turn 0 (so the gate routes straight to ``end``
+    and the loop early-exits after a single model call).
     """
 
     FINAL_ANSWER = "It is sunny in Paris."
     TOOL_NAME = "get_weather"
     TOOL_ARGS = {"city": "Paris"}
 
-    def __init__(self) -> None:
+    def __init__(self, tool_turns: int = 1) -> None:
         self.calls = 0
+        self._tool_turns = tool_turns
 
     def next_turn(self) -> dict[str, Any]:
         """Return the next turn in engine-state shape (content/finish/tool_calls)."""
         turn = self.calls
         self.calls += 1
-        if turn == 0:
+        if turn < self._tool_turns:
             return {
                 "content": "",
                 "finish_reason": "tool_calls",
-                "tool_calls": [{"id": "call_0", "name": self.TOOL_NAME, "arguments": dict(self.TOOL_ARGS)}],
+                "tool_calls": [{"id": f"call_{turn}", "name": self.TOOL_NAME, "arguments": dict(self.TOOL_ARGS)}],
             }
         return {"content": self.FINAL_ANSWER, "finish_reason": "stop", "tool_calls": []}
 
@@ -148,23 +163,83 @@ class ScriptedAdapter:
 
 
 async def drive_agent_loop(ir: dict[str, Any], state: dict[str, Any], model: ScriptedModel) -> list[str]:
-    """Drive the compiled agent-loop IR exactly as the JamJet engine would.
+    """Drive the compiled agent-loop IR exactly as the JamJet engine now does.
 
-    Returns the visit order of node ids (for the ``model -> tool -> model``
-    assertion). Mutates *state* in place to the terminal state.
+    Mirrors the FDL scheduler (``runner.rs``): a Condition gate evaluates its
+    branches against committed state and records the chosen route; the dead
+    branch's exclusive tail is marked ``NodeSkipped`` via a dead-edge fixpoint
+    (``edge_dead``); a node is runnable iff it has a LIVE in-edge whose every live
+    source has completed (``is_runnable``, the AND-join over live edges only). The
+    loop therefore EARLY-EXITS the moment a gate routes to ``end``: the remaining
+    turns are skipped, never run.
+
+    ``end`` is the graph's terminal sentinel (``agent_ir._END``), not a node, so it
+    is never runnable — routing to it simply leaves no runnable node and the loop
+    stops. Returns the visit order of node ids; mutates *state* in place to the
+    terminal state.
     """
     nodes = ir["nodes"]
     edges = ir["edges"]
-    preds = {nid: [e["from"] for e in edges if e["to"] == nid] for nid in nodes}
+    in_edges = {nid: [e for e in edges if e["to"] == nid] for nid in nodes}
 
     completed: set[str] = set()
+    skipped: set[str] = set()
+    routes: dict[str, str | None] = {}  # condition node id -> chosen branch target
     visited: list[str] = []
+
+    def edge_dead(src: str, dst: str) -> bool:
+        # A skipped source kills its out-edges (cascades a skip down the branch).
+        if src in skipped:
+            return True
+        # A COMPLETED routing Condition's only live out-edge is its recorded route;
+        # every other out-edge is dead (a null route makes ALL of them dead).
+        node = nodes.get(src)
+        if node is not None and node["kind"]["type"] == "condition":
+            branches = node["kind"].get("branches") or []
+            if branches and src in completed:
+                return routes.get(src) != dst
+        return False
+
+    def is_runnable(nid: str) -> bool:
+        if nid in completed or nid in skipped:
+            return False
+        ins = in_edges[nid]
+        if not ins:
+            return True  # root
+        has_live = False
+        all_live_sources_done = True
+        for e in ins:
+            if not edge_dead(e["from"], nid):
+                has_live = True
+                if e["from"] not in completed:
+                    all_live_sources_done = False
+        return has_live and all_live_sources_done
+
+    def skip_cascade() -> None:
+        # Fixpoint: a node whose EVERY in-edge is dead can never run, so skip it.
+        # The skip folds into `completed` (satisfying a downstream AND-join without
+        # it) AND into `skipped` (so its out-edges die, which may make more nodes
+        # skippable). Roots (no in-edges) are never skipped here.
+        changed = True
+        while changed:
+            changed = False
+            for nid in nodes:
+                if nid in completed or nid in skipped:
+                    continue
+                ins = in_edges[nid]
+                if ins and all(edge_dead(e["from"], nid) for e in ins):
+                    skipped.add(nid)
+                    completed.add(nid)
+                    changed = True
+
     while True:
-        runnable = [nid for nid in nodes if nid not in completed and all(p in completed for p in preds[nid])]
+        skip_cascade()
+        runnable = [nid for nid in nodes if is_runnable(nid)]
         if not runnable:
             break
-        # The v1 static unroll is a linear chain: exactly one node runs per step.
-        assert len(runnable) == 1, f"static-unroll loop must be linear; runnable={runnable}"
+        # The live path of the static unroll is linear: the gate's route makes
+        # exactly one successor live, so exactly one node runs per step.
+        assert len(runnable) == 1, f"agent-loop unroll must be linear; runnable={runnable}"
         node_id = runnable[0]
         kind = nodes[node_id]["kind"]["type"]
 
@@ -181,7 +256,12 @@ async def drive_agent_loop(ir: dict[str, Any], state: dict[str, Any], model: Scr
             for key, value in patch.items():
                 state[key] = value
         elif kind == "condition":
-            pass  # no-op stub: the engine does not evaluate edge conditions today
+            # FDL: honor the gate. Evaluate the branches against committed state
+            # and record the chosen route (empty branches = pass-through, no
+            # route). The next skip_cascade()/is_runnable() act on it.
+            branches = nodes[node_id]["kind"].get("branches") or []
+            if branches:
+                routes[node_id] = _route_gate(branches, state)
         else:  # pragma: no cover - the compiler only emits these three kinds
             raise AssertionError(f"unexpected node kind {kind!r}")
 
@@ -190,7 +270,7 @@ async def drive_agent_loop(ir: dict[str, Any], state: dict[str, Any], model: Scr
     return visited
 
 
-# ── Authored gate semantics (what F-2j-dynamic-loop will wire into the engine) ─
+# ── Authored gate semantics (wired into drive_agent_loop above) ───────────────
 
 
 def _eval_branch_condition(condition: str | None, state: dict[str, Any]) -> bool:
@@ -214,8 +294,9 @@ def _route_gate(branches: list[dict[str, Any]], state: dict[str, Any]) -> str | 
 
 
 async def test_agent_loop_ir_runs_model_tool_model_and_terminates() -> None:
-    """The compiled IR drives a model -> tool -> model loop that terminates with
-    the final answer, invoking the tool once and accumulating the messages."""
+    """The compiled IR drives a model -> tool -> model loop that EARLY-EXITS at the
+    turn the model answers: the tool is invoked once, the messages accumulate, and
+    the gate routes the final turn to `end` so the remaining unroll is skipped."""
     agent = weather_agent.build_agent()
     ir = compile_agent_to_ir(agent, _PROMPT, max_turns=2)
 
@@ -229,9 +310,11 @@ async def test_agent_loop_ir_runs_model_tool_model_and_terminates() -> None:
     model = ScriptedModel()
     visited = await drive_agent_loop(ir, state, model)
 
-    # The loop ran model -> tool -> model and terminated at the final model node.
-    assert visited == _LOOP_NODES
-    assert model.calls == 3  # two turn-models + the final answer model
+    # The model asked for a tool at turn 0 then answered at turn 1, so the turn-1
+    # gate routes to `end`: the loop runs model -> tool -> model and EARLY-EXITS,
+    # skipping __tools_1__/__model_2__ (NOT the full max_turns unroll).
+    assert visited == _EARLY_EXIT_TOOL_THEN_STOP
+    assert model.calls == 2  # turn 0 (tool) + turn 1 (final answer); NOT max_turns + 1
 
     # The tool was actually invoked once, with the model's arguments, and its
     # result was appended to the running messages (message accumulation).
@@ -248,11 +331,32 @@ async def test_agent_loop_ir_runs_model_tool_model_and_terminates() -> None:
     assert state["last_model_output"] == ScriptedModel.FINAL_ANSWER
 
 
+async def test_durable_loop_early_exits_on_immediate_stop() -> None:
+    """EARLY-EXIT headline: a model that answers at turn 0 (finish_reason "stop")
+    makes EXACTLY ONE model call — the turn-0 gate routes to `end`, every tool turn
+    is skipped, and the loop never reaches __model_1__ (NOT the max_turns unroll)."""
+    agent = weather_agent.build_agent()
+    ir = compile_agent_to_ir(agent, _PROMPT, max_turns=2)
+
+    state = build_initial_state(agent, _PROMPT)
+    model = ScriptedModel(tool_turns=0)  # answer immediately, no tool call
+    visited = await drive_agent_loop(ir, state, model)
+
+    # One model call, the gate, then `end` — the rest of the unroll is skipped.
+    assert visited == _EARLY_EXIT_STOP_AT_0
+    assert model.calls == 1, "stop at turn 0 must make exactly ONE model call"
+    # The dispatch node never ran, so no tool was invoked.
+    assert [m for m in state["messages"] if m.get("role") == "tool"] == []
+    # The answer is turn 0's output.
+    assert state["last_model_output"] == ScriptedModel.FINAL_ANSWER
+
+
 def test_compiled_gate_routes_tool_calls_to_dispatch_and_stop_to_end() -> None:
     """The authored gate routes tool_calls -> dispatch and a final answer -> end.
 
-    The engine does not yet act on these edge conditions (F-2j-dynamic-loop), but
-    the IR encodes the correct branch logic, ready for when it does.
+    The engine NOW acts on these edge conditions (F-2j-dynamic-loop / FDL): the
+    same branch logic that ``drive_agent_loop`` honors above is what the scheduler
+    evaluates to early-exit the durable run.
     """
     ir = compile_agent_to_ir(weather_agent.build_agent(), _PROMPT, max_turns=2)
     gate = ir["nodes"]["__tool_gate_0__"]["kind"]
@@ -271,7 +375,8 @@ async def test_inprocess_run_matches_durable_loop_answer(monkeypatch: Any) -> No
     # Durable loop path: real IR + real dispatch_tool_calls + scripted model.
     ir = compile_agent_to_ir(agent, _PROMPT, max_turns=2)
     state = build_initial_state(agent, _PROMPT)
-    visited = await drive_agent_loop(ir, state, ScriptedModel())
+    durable_model = ScriptedModel()
+    visited = await drive_agent_loop(ir, state, durable_model)
     durable_output = state["last_model_output"]
 
     # In-process path: Agent.run() with the same scripted model injected at the
@@ -288,8 +393,10 @@ async def test_inprocess_run_matches_durable_loop_answer(monkeypatch: Any) -> No
     # Both paths invoked the tool exactly once.
     assert [c["tool"] for c in inproc.tool_calls] == ["get_weather"]
     assert [m["name"] for m in state["messages"] if m.get("role") == "tool"] == ["get_weather"]
-    # And the durable path ran the full model -> tool -> model loop.
-    assert visited == _LOOP_NODES
+    # And the durable path ran the model -> tool -> model loop, EARLY-EXITING at
+    # the turn the model answered (exactly two model calls, not the full unroll).
+    assert visited == _EARLY_EXIT_TOOL_THEN_STOP
+    assert durable_model.calls == 2
 
 
 def test_example_react_agent_durable_compiles() -> None:


### PR DESCRIPTION
## What

Implements F-2j-dynamic-loop: a real edge-condition evaluator so a workflow's `Condition` nodes actually route, taking the matching branch and skipping the others. This makes the durable agent loop early-exit when the model is done, instead of running the full `max_turns`. It also makes the strategy compiler's existing conditions (cost guards, critic gates) branch correctly.

## How

- **Evaluator** (`runtime/core/src/condition.rs`): a pure, total `eval_condition(expr, &state)` over the authored forms — `state.<path>` truthiness and `state.<path> == | != <literal>`. Never panics; a malformed expression returns false.
- **Condition executor** (`runtime/workers/src/executors/condition_node.rs`): evaluates the branches in order against committed state and records the chosen route on its `NodeCompleted` output. The decision is made once and recorded, so replay reproduces it exactly.
- **Scheduler** (`runtime/scheduler/src/runner.rs`): `is_runnable` is now route-aware (an AND-join over live edges only), and a skip-cascade emits `NodeSkipped` for any node whose every in-edge is dead, to a fixpoint. `NodeSkipped` already existed and was folded into the materializer; it was just never emitted.

## Result

The agent loop early-exits: a model that returns `stop` at turn 0 makes exactly one model call (not `max_turns + 1`); the rest of the unroll is skipped and the workflow completes via the taken branch.

## Safety

A whole-branch adversarial review confirmed the skip-cascade fixpoint is correct across the agent-loop early-exit, a diamond join, and a condition chain: a node reachable via any live edge is never skipped (no lost terminal), every dead-branch node is skipped (no hang or premature completion), and a join with one live and one dead predecessor runs on the live source. Routing is deterministic (recorded, never re-evaluated at schedule time). Backward-compat holds: an empty-branches condition and any workflow with no conditions behave exactly as before. The review's polish items are addressed (routing kept off workflow state; branch targets validated against out-edges).

## Tests

`eval_condition` (28), the condition executor, the scheduler routing + skip-cascade + replay-determinism (the headline agent-loop early-exit, the diamond join, backward-compat, no-route), the agent-loop parity driver updated to honor routes with early-exit call-count assertions, and branch-target validation. Full workspace plus the Python suite green.

## Follow-ups

- F-fdl-exprlang: a richer expression language (AND/OR, ordered comparisons) if workflows need it.
- F-fdl-backedge: true loop back-edges once continue-as-new (2g) is wired to the agent loop for unbounded conversations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conditional workflow branching, including ordered branch evaluation and default-path handling.
  * Improved workflow routing so completed branches are tracked more reliably and skipped paths are resolved earlier.

* **Bug Fixes**
  * Fixed branch execution to prevent invalid or missing targets from routing incorrectly.
  * Improved scheduler behavior for faster, more deterministic execution when a branch is no longer reachable.

* **Tests**
  * Expanded automated coverage for branching, skip behavior, and early-exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->