### PR TITLE
feat(track-3): governance on by default (policy/approval/budget knobs, PII, signed audit, receipts)

### DIFF
--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -45,6 +45,7 @@ rust-embed = { workspace = true }
 mime_guess = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
 tracing-subscriber = { workspace = true }

--- a/runtime/api/src/approvals.rs
+++ b/runtime/api/src/approvals.rs
@@ -56,12 +56,15 @@ impl std::fmt::Display for SubmitError {
 }
 
 /// Validate against derived pending state, then append `ApprovalReceived`.
-/// Returns the resolved `node_id`.
+///
+/// Returns the resolved `node_id` and the `ApprovalReceived` event that was
+/// appended, so callers can seal it into the signed, hash-chained audit log
+/// (via `AuditEnricher::enrich_and_append`) after the durable event write.
 pub async fn submit_approval(
     backend: &Arc<dyn StateBackend>,
     execution_id: &ExecutionId,
     submission: ApprovalSubmission,
-) -> Result<String, SubmitError> {
+) -> Result<(String, Event), SubmitError> {
     // Refuse decisions on terminal executions up front. The event-derived
     // pending list can still show an undecided request after a cancellation
     // (the fold intentionally ignores decisions for unheld nodes), so without
@@ -117,18 +120,19 @@ pub async fn submit_approval(
         + 1;
     // TOCTOU: a concurrent approve may have already appended a decision; the
     // scheduler fold's held.remove gate makes the second event a no-op.
+    let event = Event::new(
+        execution_id.clone(),
+        seq,
+        EventKind::ApprovalReceived {
+            node_id: node_id.clone(),
+            user_id: submission.user_id,
+            decision: submission.decision,
+            comment: submission.comment,
+            state_patch: submission.state_patch,
+        },
+    );
     backend
-        .append_event(Event::new(
-            execution_id.clone(),
-            seq,
-            EventKind::ApprovalReceived {
-                node_id: node_id.clone(),
-                user_id: submission.user_id,
-                decision: submission.decision,
-                comment: submission.comment,
-                state_patch: submission.state_patch,
-            },
-        ))
+        .append_event(event.clone())
         .await
         .map_err(|e| SubmitError::Backend(e.to_string()))?;
 
@@ -141,7 +145,7 @@ pub async fn submit_approval(
             .map_err(|e| SubmitError::Backend(e.to_string()))?;
     }
 
-    Ok(node_id)
+    Ok((node_id, event))
 }
 
 /// Pending + decided approval view for `GET /executions/:id/approvals`.

--- a/runtime/api/src/mcp_bridge.rs
+++ b/runtime/api/src/mcp_bridge.rs
@@ -449,7 +449,7 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                 let eid = parse_execution_id(id_str)?;
                 let backend = s.backend_for(&tenant_id);
 
-                let resolved_node = crate::approvals::submit_approval(
+                let (resolved_node, event) = crate::approvals::submit_approval(
                     &backend,
                     &eid,
                     crate::approvals::ApprovalSubmission {
@@ -466,6 +466,18 @@ pub fn build_mcp_bridge(state: AppState) -> Router {
                 )
                 .await
                 .map_err(|e| e.to_string())?;
+
+                // Seal the approval into the signed, hash-chained audit log,
+                // mirroring the REST approve path: best-effort, after the
+                // durable event write, off the worker's fenced commit path.
+                let ctx = jamjet_audit::RequestContext {
+                    actor_type: jamjet_audit::ActorType::Human,
+                    tenant_id: tenant_id.0.clone(),
+                    method: Some("POST".to_string()),
+                    path: Some("/mcp/tools/jamjet_approve".to_string()),
+                    ..Default::default()
+                };
+                s.enricher.enrich_and_append(&event, Some(&ctx)).await;
 
                 Ok(vec![McpContent::Text {
                     text: json!({"execution_id": id_str, "node_id": resolved_node, "accepted": true})

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -441,7 +441,7 @@ async fn approve_execution(
         other => return Err(ApiError::BadRequest(format!("unknown decision: {other}"))),
     };
 
-    let node_id = crate::approvals::submit_approval(
+    let (node_id, event) = crate::approvals::submit_approval(
         &backend,
         &execution_id,
         crate::approvals::ApprovalSubmission {
@@ -460,6 +460,23 @@ async fn approve_execution(
         | crate::approvals::SubmitError::ExecutionTerminal(_) => ApiError::Conflict(e.to_string()),
         crate::approvals::SubmitError::Backend(msg) => ApiError::Internal(msg),
     })?;
+
+    // Seal this approval into the signed, hash-chained audit log. This runs
+    // *after* the event is durably appended, never fails the request
+    // (`enrich_and_append` warns-and-continues on a write error), and is off
+    // the worker's fenced commit hot path — so it adds tamper-evident audit
+    // without touching the durability invariant. The per-tool-call / per-node
+    // worker events emitted through the fenced `commit_turn` path are not yet
+    // routed through the enricher (that needs the enricher threaded into the
+    // worker pool); tracked as F-t3-audit-emit.
+    let ctx = jamjet_audit::RequestContext {
+        actor_type: jamjet_audit::ActorType::Human,
+        tenant_id: tenant_id.0.clone(),
+        method: Some("POST".to_string()),
+        path: Some(format!("/executions/{id}/approve")),
+        ..Default::default()
+    };
+    state.enricher.enrich_and_append(&event, Some(&ctx)).await;
 
     Ok(Json(
         json!({ "execution_id": id, "node_id": node_id, "accepted": true }),

--- a/runtime/api/src/state.rs
+++ b/runtime/api/src/state.rs
@@ -20,7 +20,10 @@ pub struct AppState {
     pub agents: Arc<dyn AgentRegistry>,
     /// Audit log backend — append-only, immutable.
     pub audit: Arc<dyn AuditBackend>,
-    /// Audit enricher — wraps all `append_event` calls with audit metadata.
+    /// Audit enricher — seals events into the signed, hash-chained audit log.
+    /// Live on the approval append path (`POST /executions/:id/approve` + the
+    /// MCP `jamjet_approve` tool); extending it to the worker's per-node fenced
+    /// `commit_turn` events is tracked as F-t3-audit-emit.
     pub enricher: Arc<AuditEnricher>,
     /// Protocol adapter registry — pre-loaded with MCP, A2A, and ANP adapters.
     pub protocols: ProtocolRegistry,

--- a/runtime/api/tests/audit_emit.rs
+++ b/runtime/api/tests/audit_emit.rs
@@ -1,0 +1,210 @@
+//! The live approval append path emits signed, hash-chained audit entries.
+//!
+//! T3-4 Part A added the `AuditEnricher` (sign + hash-chain) but left it
+//! dormant — plumbed onto `AppState`, never called. This test drives a real
+//! `POST /executions/:id/approve` through the HTTP router with a recording
+//! audit backend behind the enricher and asserts the entries the live path
+//! wrote are sealed (entry_hash + signature), linked into a chain, and verify
+//! under the signer — plus the adversarial dual that tampering a live-written
+//! entry breaks `verify_chain`.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+use async_trait::async_trait;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{
+    verify_chain, ActorType, AuditBackend, AuditEnricher, AuditError, AuditLogEntry, AuditQuery,
+    AuditSigner, ChainError,
+};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::StateBackend;
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, InMemoryBackend};
+
+// ── Recording audit backend ─────────────────────────────────────────────────
+
+/// Keeps every appended entry (in append/chain order) so the test can verify
+/// the chain the enricher wrote. `query` returns newest-first to match the
+/// `SqliteAuditBackend` ordering the enricher relies on for chain seeding.
+#[derive(Default)]
+struct CapturingAuditBackend {
+    entries: tokio::sync::Mutex<Vec<AuditLogEntry>>,
+}
+
+#[async_trait]
+impl AuditBackend for CapturingAuditBackend {
+    async fn append(&self, entry: AuditLogEntry) -> Result<(), AuditError> {
+        self.entries.lock().await.push(entry);
+        Ok(())
+    }
+
+    async fn query(&self, _q: &AuditQuery) -> Result<Vec<AuditLogEntry>, AuditError> {
+        Ok(self.entries.lock().await.iter().rev().cloned().collect())
+    }
+
+    async fn count(&self, _q: &AuditQuery) -> Result<u64, AuditError> {
+        Ok(self.entries.lock().await.len() as u64)
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Build an `AppState` whose enricher signs with `signer` and writes to `audit`.
+fn make_state(audit: Arc<dyn AuditBackend>, signer: AuditSigner) -> AppState {
+    let backend = Arc::new(InMemoryBackend::new());
+    let backend_clone = backend.clone();
+    let enricher = Arc::new(AuditEnricher::with_signer(audit.clone(), signer));
+    AppState {
+        backend: backend.clone() as Arc<dyn StateBackend>,
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| {
+            backend_clone.clone() as Arc<dyn StateBackend>
+        }),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+async fn create_execution(backend: &Arc<dyn StateBackend>) -> ExecutionId {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "test-wf".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "test-wf".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+    execution_id
+}
+
+async fn seed_approval_required(
+    backend: &Arc<dyn StateBackend>,
+    execution_id: &ExecutionId,
+    node_id: &str,
+) {
+    let seq = backend
+        .latest_sequence(execution_id)
+        .await
+        .expect("latest_sequence")
+        + 1;
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            seq,
+            EventKind::ToolApprovalRequired {
+                node_id: node_id.into(),
+                tool_name: format!("tool_{node_id}"),
+                approver: "human".into(),
+                context: serde_json::json!({ "action": node_id }),
+            },
+        ))
+        .await
+        .expect("append ToolApprovalRequired");
+}
+
+fn approve_body(node_id: &str, user_id: &str) -> Body {
+    Body::from(
+        serde_json::to_vec(&serde_json::json!({
+            "decision": "approved",
+            "node_id": node_id,
+            "user_id": user_id,
+        }))
+        .unwrap(),
+    )
+}
+
+// ── Test ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn approve_path_writes_signed_chained_audit_entries() {
+    let signer = AuditSigner::new(b"audit-emit-test-key".to_vec());
+    let audit = Arc::new(CapturingAuditBackend::default());
+    let audit_dyn: Arc<dyn AuditBackend> = audit.clone();
+    let state = make_state(audit_dyn, signer.clone());
+    let backend = state.backend.clone();
+    let router = build_router_with_opts(state, true);
+
+    // One execution with two pending approvals.
+    let execution_id = create_execution(&backend).await;
+    seed_approval_required(&backend, &execution_id, "a").await;
+    seed_approval_required(&backend, &execution_id, "b").await;
+    let id_str = execution_id.to_string();
+
+    // Drive two real approvals through the HTTP write path.
+    for (node, user) in [("a", "alice"), ("b", "bob")] {
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::post(format!("/executions/{id_str}/approve"))
+                    .header("content-type", "application/json")
+                    .body(approve_body(node, user))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "approve {node} must 200");
+    }
+
+    // The enricher must have written one sealed audit entry per approval.
+    let entries = audit.entries.lock().await.clone();
+    assert_eq!(entries.len(), 2, "one audit entry per approval");
+
+    for (entry, user) in entries.iter().zip(["alice", "bob"]) {
+        assert_eq!(entry.event_type, "approval_received");
+        assert_eq!(entry.actor_type, ActorType::Human, "approver is a human");
+        assert_eq!(
+            entry.actor_id, user,
+            "approver id flows into the audit entry"
+        );
+        assert!(entry.entry_hash.is_some(), "live entry must be sealed");
+        assert!(entry.signature.is_some(), "live entry must be signed");
+    }
+
+    // It is a real chain: genesis has no predecessor, the next links to it.
+    assert!(entries[0].prev_hash.is_none(), "first entry is the genesis");
+    assert_eq!(
+        entries[1].prev_hash, entries[0].entry_hash,
+        "second entry links to the first"
+    );
+
+    // The chain the live path wrote verifies under the same signer.
+    verify_chain(&entries, &signer).expect("live audit entries must form a verifiable chain");
+
+    // Adversarial dual: tampering a live-written entry breaks verification.
+    let mut tampered = entries.clone();
+    tampered[0].actor_id = "mallory".to_string();
+    assert_eq!(
+        verify_chain(&tampered, &signer).unwrap_err(),
+        ChainError::HashMismatch { index: 0 },
+        "mutating a sealed entry must fail verification"
+    );
+}

--- a/runtime/audit/Cargo.toml
+++ b/runtime/audit/Cargo.toml
@@ -23,6 +23,9 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 sqlx = { workspace = true }
 sha2 = { workspace = true }
+hmac = "0.12"
+hex = "0.4"
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/runtime/audit/src/chain.rs
+++ b/runtime/audit/src/chain.rs
@@ -1,0 +1,83 @@
+//! Tamper-evidence verification for a sealed audit-log chain.
+//!
+//! [`verify_chain`] re-walks an ordered slice of entries and, for each one:
+//! recomputes its content hash, checks the recomputed hash equals the stored
+//! `entry_hash`, checks `prev_hash` links to the previous entry's hash, and
+//! checks the signature over `entry_hash` with the signer's key. Any deviation
+//! — a mutated field, a re-linked chain, a forged or stripped signature — is
+//! reported as an error naming the offending index.
+
+use crate::entry::AuditLogEntry;
+use crate::signer::AuditSigner;
+use thiserror::Error;
+
+/// Why a chain failed verification. The `index` is the position in the slice
+/// passed to [`verify_chain`] (0-based).
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ChainError {
+    #[error("entry {index} has no entry_hash (never sealed)")]
+    Unsealed { index: usize },
+    #[error("entry {index} has no signature (never sealed)")]
+    Unsigned { index: usize },
+    #[error("entry {index} prev_hash does not link to the previous entry's hash")]
+    BrokenLink { index: usize },
+    #[error("entry {index} content hash does not match its recorded entry_hash (tampered)")]
+    HashMismatch { index: usize },
+    #[error("entry {index} signature is invalid for its entry_hash (forged or wrong key)")]
+    BadSignature { index: usize },
+}
+
+impl ChainError {
+    /// The index of the entry at which verification failed.
+    pub fn index(&self) -> usize {
+        match self {
+            ChainError::Unsealed { index }
+            | ChainError::Unsigned { index }
+            | ChainError::BrokenLink { index }
+            | ChainError::HashMismatch { index }
+            | ChainError::BadSignature { index } => *index,
+        }
+    }
+}
+
+/// Verify a contiguous, ordered slice of sealed audit entries.
+///
+/// `entries` must be in chain order (oldest first); the first entry is treated
+/// as the chain segment's genesis (its `prev_hash` must be `None`). Returns
+/// `Ok(())` only when every entry's hash, linkage, and signature check out.
+pub fn verify_chain(entries: &[AuditLogEntry], signer: &AuditSigner) -> Result<(), ChainError> {
+    let mut prev: Option<&str> = None;
+    for (index, entry) in entries.iter().enumerate() {
+        let entry_hash = entry
+            .entry_hash
+            .as_deref()
+            .ok_or(ChainError::Unsealed { index })?;
+        let signature = entry
+            .signature
+            .as_deref()
+            .ok_or(ChainError::Unsigned { index })?;
+
+        // 1. Linkage: this entry's prev_hash must equal the previous entry's
+        //    entry_hash (and None at the genesis).
+        if entry.prev_hash.as_deref() != prev {
+            return Err(ChainError::BrokenLink { index });
+        }
+
+        // 2. Integrity: recomputing the content hash over the stored fields +
+        //    the stored prev_hash must reproduce the recorded entry_hash. A
+        //    tampered field changes the recomputed hash.
+        if entry.content_hash(entry.prev_hash.as_deref()) != entry_hash {
+            return Err(ChainError::HashMismatch { index });
+        }
+
+        // 3. Authenticity: the signature must verify against entry_hash. An
+        //    attacker who recomputes the hash to match tampered content still
+        //    cannot produce a valid signature without the key.
+        if !signer.verify(entry_hash.as_bytes(), signature) {
+            return Err(ChainError::BadSignature { index });
+        }
+
+        prev = Some(entry_hash);
+    }
+    Ok(())
+}

--- a/runtime/audit/src/enricher.rs
+++ b/runtime/audit/src/enricher.rs
@@ -1,7 +1,8 @@
 //! `AuditEnricher` — derives audit metadata from events and writes to the audit log.
 
-use crate::backend::AuditBackend;
+use crate::backend::{AuditBackend, AuditQuery};
 use crate::entry::{ActorType, AuditLogEntry};
+use crate::signer::AuditSigner;
 use chrono::Duration;
 use jamjet_ir::workflow::DataPolicyIr;
 use jamjet_policy::redaction::PiiRedactor;
@@ -49,14 +50,53 @@ impl RequestContext {
     }
 }
 
-/// Enriches events with audit metadata and appends them to the audit log.
+/// In-memory head of the tamper-evident audit chain for this enricher.
+#[derive(Default)]
+struct ChainHead {
+    /// Whether `head` has been seeded from the backend yet.
+    seeded: bool,
+    /// `entry_hash` of the most recently appended entry (`None` at genesis).
+    head: Option<String>,
+}
+
+/// Enriches events with audit metadata, seals them into the tamper-evident
+/// chain, and appends them to the audit log.
 pub struct AuditEnricher {
     backend: Arc<dyn AuditBackend>,
+    /// Signs each entry's content hash. Sourced from the environment by
+    /// default (`AuditSigner::from_env`); see [`AuditSigner`] for the key.
+    signer: AuditSigner,
+    /// Serializes the read-head -> seal -> append -> advance-head sequence so
+    /// concurrent appends form a single linear chain.
+    chain: tokio::sync::Mutex<ChainHead>,
 }
 
 impl AuditEnricher {
+    /// Build an enricher that signs with the key from the environment
+    /// (`JAMJET_AUDIT_SIGNING_KEY`, or the insecure dev key with a warning).
     pub fn new(backend: Arc<dyn AuditBackend>) -> Self {
-        Self { backend }
+        Self::with_signer(backend, AuditSigner::from_env())
+    }
+
+    /// Build an enricher with an explicit signer (tests / callers that load the
+    /// signing key from their own secret store).
+    pub fn with_signer(backend: Arc<dyn AuditBackend>, signer: AuditSigner) -> Self {
+        Self {
+            backend,
+            signer,
+            chain: tokio::sync::Mutex::new(ChainHead::default()),
+        }
+    }
+
+    /// The `entry_hash` of the most recent entry already in the log, used to
+    /// resume the chain across process restarts. `None` for an empty log.
+    async fn latest_entry_hash(&self) -> Option<String> {
+        let q = AuditQuery {
+            limit: 1,
+            ..Default::default()
+        };
+        let latest = self.backend.query(&q).await.ok()?.into_iter().next()?;
+        latest.entry_hash
     }
 
     /// Derive audit metadata from an event and append it to the audit log.
@@ -131,8 +171,23 @@ impl AuditEnricher {
             }
         }
 
-        if let Err(e) = self.backend.append(entry).await {
-            warn!("Failed to write audit log entry: {e}");
+        // Seal the entry into the tamper-evident chain: link it to the
+        // previous entry's hash, then sign. Held under the chain lock for the
+        // whole read-head -> seal -> append -> advance-head sequence so that
+        // concurrent appends produce one linear chain.
+        let mut chain = self.chain.lock().await;
+        if !chain.seeded {
+            chain.head = self.latest_entry_hash().await;
+            chain.seeded = true;
+        }
+        entry.seal(chain.head.clone(), &self.signer);
+        let sealed_hash = entry.entry_hash.clone();
+
+        match self.backend.append(entry).await {
+            // Advance the head only after a durable append, so a failed write
+            // never leaves a gap that the next entry would link straight past.
+            Ok(()) => chain.head = sealed_hash,
+            Err(e) => warn!("Failed to write audit log entry: {e}"),
         }
     }
 }

--- a/runtime/audit/src/enricher.rs
+++ b/runtime/audit/src/enricher.rs
@@ -64,7 +64,10 @@ struct ChainHead {
 pub struct AuditEnricher {
     backend: Arc<dyn AuditBackend>,
     /// Signs each entry's content hash. Sourced from the environment by
-    /// default (`AuditSigner::from_env`); see [`AuditSigner`] for the key.
+    /// default (`AuditSigner::from_env`). With no `JAMJET_AUDIT_SIGNING_KEY`
+    /// and no `JAMJET_AUDIT_ALLOW_INSECURE_KEY` opt-in this signer is
+    /// unsigned/refused, so entries are chained but left unsigned (never signed
+    /// with a forgeable dev key by default); see [`AuditSigner`].
     signer: AuditSigner,
     /// Serializes the read-head -> seal -> append -> advance-head sequence so
     /// concurrent appends form a single linear chain.
@@ -73,7 +76,8 @@ pub struct AuditEnricher {
 
 impl AuditEnricher {
     /// Build an enricher that signs with the key from the environment
-    /// (`JAMJET_AUDIT_SIGNING_KEY`, or the insecure dev key with a warning).
+    /// (`JAMJET_AUDIT_SIGNING_KEY`; the insecure dev key only behind the
+    /// explicit `JAMJET_AUDIT_ALLOW_INSECURE_KEY` opt-in; otherwise unsigned).
     pub fn new(backend: Arc<dyn AuditBackend>) -> Self {
         Self::with_signer(backend, AuditSigner::from_env())
     }

--- a/runtime/audit/src/entry.rs
+++ b/runtime/audit/src/entry.rs
@@ -169,9 +169,15 @@ impl AuditLogEntry {
     /// Call this once, after all enrichment/redaction is applied, immediately
     /// before persisting the entry. The `prev_hash` is the `entry_hash` of the
     /// previous sealed entry in the log (`None` for the genesis entry).
+    ///
+    /// When `signer` has no key (the unsigned/refused signer — no
+    /// `JAMJET_AUDIT_SIGNING_KEY` and no insecure opt-in), `signature` is left
+    /// `None`: the entry is still hash-chained but honestly unsigned, and
+    /// [`crate::verify_chain`] reports it as `Unsigned` rather than trusting a
+    /// forgeable dev-key signature.
     pub fn seal(&mut self, prev_hash: Option<String>, signer: &AuditSigner) {
         let hash = self.content_hash(prev_hash.as_deref());
-        self.signature = Some(signer.sign(hash.as_bytes()));
+        self.signature = signer.sign(hash.as_bytes());
         self.entry_hash = Some(hash);
         self.prev_hash = prev_hash;
     }

--- a/runtime/audit/src/entry.rs
+++ b/runtime/audit/src/entry.rs
@@ -1,8 +1,16 @@
 //! `AuditLogEntry` — the canonical immutable record written to the audit log.
 
+use crate::signer::AuditSigner;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
+
+/// Field separator used when building the canonical content of an entry for
+/// hashing. A control character that never appears in our field values, so
+/// concatenation is unambiguous (`"a" || "bc"` cannot collide with
+/// `"ab" || "c"`).
+const FIELD_SEP: u8 = 0x1f;
 
 /// A single immutable audit log entry.
 ///
@@ -51,6 +59,22 @@ pub struct AuditLogEntry {
     /// Whether PII redaction was applied to raw_event.
     #[serde(default)]
     pub redacted: bool,
+    /// Hash of the *previous* sealed entry in the log (its `entry_hash`).
+    ///
+    /// `None` for the genesis entry of a chain. Each entry's `entry_hash`
+    /// covers this field, so the entries form a tamper-evident chain: altering
+    /// any past entry's content (or re-linking the chain) breaks verification
+    /// from that point forward.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev_hash: Option<String>,
+    /// SHA-256 hex digest of this entry's canonical content **plus**
+    /// `prev_hash`. Set by [`AuditLogEntry::seal`]. `None` until sealed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_hash: Option<String>,
+    /// Keyed HMAC-SHA256 (hex) over `entry_hash`. Set by
+    /// [`AuditLogEntry::seal`]. A verifier without the key cannot forge it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
 }
 
 fn default_tenant() -> String {
@@ -86,7 +110,70 @@ impl AuditLogEntry {
             tenant_id: "default".to_string(),
             expires_at: None,
             redacted: false,
+            prev_hash: None,
+            entry_hash: None,
+            signature: None,
         }
+    }
+
+    /// Compute this entry's content hash, chained onto `prev_hash`.
+    ///
+    /// The hash covers every immutable, security-relevant field (everything
+    /// except `entry_hash`/`signature`, which are derived) plus the supplied
+    /// `prev_hash`. The serialization is deterministic and round-trips through
+    /// SQLite storage: scalars are hashed as their stored textual form,
+    /// `raw_event` via canonical (sorted-key) JSON, fields separated by
+    /// [`FIELD_SEP`].
+    pub fn content_hash(&self, prev_hash: Option<&str>) -> String {
+        let mut hasher = Sha256::new();
+        let mut field = |bytes: &[u8]| {
+            hasher.update(bytes);
+            hasher.update([FIELD_SEP]);
+        };
+
+        field(self.id.as_bytes());
+        field(self.event_id.as_bytes());
+        field(self.execution_id.as_bytes());
+        field(&self.sequence.to_le_bytes());
+        field(self.event_type.as_bytes());
+        field(self.actor_id.as_bytes());
+        field(self.actor_type.as_str().as_bytes());
+        field(self.tool_call_hash.as_deref().unwrap_or("").as_bytes());
+        field(self.policy_decision.as_deref().unwrap_or("").as_bytes());
+        field(self.http_request_id.as_deref().unwrap_or("").as_bytes());
+        field(self.http_method.as_deref().unwrap_or("").as_bytes());
+        field(self.http_path.as_deref().unwrap_or("").as_bytes());
+        field(self.ip_address.as_deref().unwrap_or("").as_bytes());
+        field(self.created_at.to_rfc3339().as_bytes());
+        field(
+            serde_json::to_string(&self.raw_event)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        field(self.tenant_id.as_bytes());
+        field(
+            self.expires_at
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        field(&[u8::from(self.redacted)]);
+        field(prev_hash.unwrap_or("").as_bytes());
+
+        hex::encode(hasher.finalize())
+    }
+
+    /// Seal this entry into the chain: record `prev_hash`, compute `entry_hash`
+    /// over the content + `prev_hash`, then sign `entry_hash` with `signer`.
+    ///
+    /// Call this once, after all enrichment/redaction is applied, immediately
+    /// before persisting the entry. The `prev_hash` is the `entry_hash` of the
+    /// previous sealed entry in the log (`None` for the genesis entry).
+    pub fn seal(&mut self, prev_hash: Option<String>, signer: &AuditSigner) {
+        let hash = self.content_hash(prev_hash.as_deref());
+        self.signature = Some(signer.sign(hash.as_bytes()));
+        self.entry_hash = Some(hash);
+        self.prev_hash = prev_hash;
     }
 }
 
@@ -101,4 +188,15 @@ pub enum ActorType {
     Agent,
     /// The JamJet runtime itself (scheduler, worker, heartbeat).
     System,
+}
+
+impl ActorType {
+    /// The stable lowercase wire/storage form (matches the SQLite encoding).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ActorType::Human => "human",
+            ActorType::Agent => "agent",
+            ActorType::System => "system",
+        }
+    }
 }

--- a/runtime/audit/src/lib.rs
+++ b/runtime/audit/src/lib.rs
@@ -9,13 +9,17 @@
 //! without touching the workflow execution tables.
 
 pub mod backend;
+pub mod chain;
 pub mod enricher;
 pub mod entry;
 pub mod noop;
+pub mod signer;
 pub mod sqlite;
 
 pub use backend::{AuditBackend, AuditError, AuditQuery};
+pub use chain::{verify_chain, ChainError};
 pub use enricher::{AuditEnricher, RequestContext};
 pub use entry::{ActorType, AuditLogEntry};
 pub use noop::NoopAuditBackend;
+pub use signer::AuditSigner;
 pub use sqlite::SqliteAuditBackend;

--- a/runtime/audit/src/signer.rs
+++ b/runtime/audit/src/signer.rs
@@ -9,16 +9,25 @@
 //! and verifies. Per-tenant keys / rotation / an asymmetric upgrade are a
 //! documented follow-up (`F-t3-key-mgmt`).
 //!
-//! ## Key source
+//! ## Key source (honest, fail-closed — no silent insecure default)
 //!
 //! The signing key is read once from the `JAMJET_AUDIT_SIGNING_KEY`
-//! environment variable (its raw UTF-8 bytes are the HMAC key). When the
-//! variable is absent or empty the signer falls back to a **built-in,
-//! publicly-known dev key** and logs loudly at `warn`. This keeps local
-//! development and tests verifiable (a fixed key round-trips across process
-//! restarts, unlike an ephemeral random key) while making it unmistakable
-//! that the signatures are NOT secure until a real key is provisioned. The
-//! engine never hard-fails for a missing key.
+//! environment variable (its raw UTF-8 bytes are the HMAC key). The fallback
+//! when it is absent/empty is a **deliberate opt-in**, never silent:
+//!
+//! * `JAMJET_AUDIT_SIGNING_KEY` set (non-empty) -> sign with it (secure).
+//! * else `JAMJET_AUDIT_ALLOW_INSECURE_KEY` set -> sign with the **built-in,
+//!   publicly-known dev key**, logging loudly at `warn`. This keeps local
+//!   development and tests verifiable behind an explicit, intentional opt-in.
+//! * else (no key, no opt-in) -> the signer is **unsigned/refused**: it does
+//!   NOT sign (entries are left unsigned and [`crate::verify_chain`] reports
+//!   them as `Unsigned`) and [`AuditSigner::verify`] always returns `false`.
+//!   It logs loudly at `warn`. The audit log never *pretends* to be securely
+//!   signed with a forgeable, publicly-known key.
+//!
+//! The engine never hard-fails at startup for a missing key (audit may be off);
+//! instead the signed-audit path refuses to produce a trustworthy-looking
+//! signature unless a real key — or the explicit insecure opt-in — is present.
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -29,18 +38,24 @@ type HmacSha256 = Hmac<Sha256>;
 /// The environment variable holding the raw audit signing key.
 pub const SIGNING_KEY_ENV: &str = "JAMJET_AUDIT_SIGNING_KEY";
 
-/// Built-in dev key used when `JAMJET_AUDIT_SIGNING_KEY` is unset.
+/// Opt-in flag to use the insecure built-in dev key when no real key is set.
+pub const ALLOW_INSECURE_KEY_ENV: &str = "JAMJET_AUDIT_ALLOW_INSECURE_KEY";
+
+/// Built-in dev key, used ONLY behind the explicit `JAMJET_AUDIT_ALLOW_INSECURE_KEY`
+/// opt-in.
 ///
-/// This value is public by design; signatures produced with it are
-/// reproducible but provide NO security. Production deployments MUST set
-/// `JAMJET_AUDIT_SIGNING_KEY`.
+/// This value is public by design; signatures produced with it provide NO
+/// security. Production deployments MUST set `JAMJET_AUDIT_SIGNING_KEY`.
 pub const DEV_DEFAULT_KEY: &str =
     "jamjet-insecure-dev-audit-signing-key-set-JAMJET_AUDIT_SIGNING_KEY-in-prod";
 
 /// Signs and verifies audit entries with a keyed HMAC-SHA256.
+///
+/// A signer with no key (`key: None`) is the *unsigned/refused* signer: it
+/// cannot sign or verify, so it can never masquerade as secure.
 #[derive(Clone)]
 pub struct AuditSigner {
-    key: Vec<u8>,
+    key: Option<Vec<u8>>,
     /// True when the built-in insecure dev key is in use.
     is_dev_key: bool,
 }
@@ -50,29 +65,61 @@ impl AuditSigner {
     /// that load the key from their own config/secret store).
     pub fn new(key: impl Into<Vec<u8>>) -> Self {
         Self {
-            key: key.into(),
+            key: Some(key.into()),
             is_dev_key: false,
         }
     }
 
-    /// Build a signer from `JAMJET_AUDIT_SIGNING_KEY`, falling back to the
-    /// built-in dev key (with a loud `warn`) when the variable is unset/empty.
+    /// Build an *unsigned/refused* signer: no key, so it cannot sign or verify.
+    /// Used when no key is configured and the insecure dev key was not opted in.
+    pub fn unsigned() -> Self {
+        Self {
+            key: None,
+            is_dev_key: false,
+        }
+    }
+
+    /// Build a signer from the environment with the honest, fail-closed policy
+    /// documented at the module level: real key -> secure; explicit insecure
+    /// opt-in -> dev key (loud warn); otherwise -> unsigned (loud warn).
     pub fn from_env() -> Self {
         match std::env::var(SIGNING_KEY_ENV) {
             Ok(key) if !key.is_empty() => Self::new(key.into_bytes()),
             _ => {
-                warn!(
-                    env = SIGNING_KEY_ENV,
-                    "{SIGNING_KEY_ENV} is not set; signing the audit log with the BUILT-IN \
-                     INSECURE DEV KEY. Audit signatures provide NO tamper-resistance against \
-                     an attacker until {SIGNING_KEY_ENV} is provisioned with a real secret."
-                );
-                Self {
-                    key: DEV_DEFAULT_KEY.as_bytes().to_vec(),
-                    is_dev_key: true,
+                let opted_in = std::env::var(ALLOW_INSECURE_KEY_ENV)
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false);
+                if opted_in {
+                    warn!(
+                        env = SIGNING_KEY_ENV,
+                        opt_in = ALLOW_INSECURE_KEY_ENV,
+                        "{SIGNING_KEY_ENV} is not set; signing the audit log with the \
+                         BUILT-IN INSECURE DEV KEY because {ALLOW_INSECURE_KEY_ENV} is set. \
+                         Audit signatures provide NO tamper-resistance against an attacker. \
+                         Provision {SIGNING_KEY_ENV} with a real secret in production."
+                    );
+                    Self {
+                        key: Some(DEV_DEFAULT_KEY.as_bytes().to_vec()),
+                        is_dev_key: true,
+                    }
+                } else {
+                    warn!(
+                        env = SIGNING_KEY_ENV,
+                        opt_in = ALLOW_INSECURE_KEY_ENV,
+                        "{SIGNING_KEY_ENV} is not set; audit entries will be hash-chained \
+                         but left UNSIGNED (verification reports them as unsigned). Set \
+                         {SIGNING_KEY_ENV} to a real secret, or {ALLOW_INSECURE_KEY_ENV}=1 \
+                         to explicitly opt into the insecure built-in dev key."
+                    );
+                    Self::unsigned()
                 }
             }
         }
+    }
+
+    /// True when this signer holds a key and can therefore sign/verify.
+    pub fn can_sign(&self) -> bool {
+        self.key.is_some()
     }
 
     /// True when this signer is using the insecure built-in dev key.
@@ -80,23 +127,27 @@ impl AuditSigner {
         self.is_dev_key
     }
 
-    /// Sign `data`, returning the lowercase-hex HMAC-SHA256 tag.
-    pub fn sign(&self, data: &[u8]) -> String {
-        let mut mac =
-            HmacSha256::new_from_slice(&self.key).expect("HMAC accepts a key of any length");
+    /// Sign `data`, returning the lowercase-hex HMAC-SHA256 tag, or `None` when
+    /// this signer has no key (the unsigned/refused signer).
+    pub fn sign(&self, data: &[u8]) -> Option<String> {
+        let key = self.key.as_ref()?;
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts a key of any length");
         mac.update(data);
-        hex::encode(mac.finalize().into_bytes())
+        Some(hex::encode(mac.finalize().into_bytes()))
     }
 
     /// Verify a hex-encoded signature over `data` in constant time.
     ///
-    /// Returns `false` for a malformed (non-hex) signature or any mismatch.
+    /// Returns `false` for an unsigned/refused signer (no key), a malformed
+    /// (non-hex) signature, or any mismatch.
     pub fn verify(&self, data: &[u8], signature_hex: &str) -> bool {
+        let Some(key) = self.key.as_ref() else {
+            return false;
+        };
         let Ok(expected) = hex::decode(signature_hex) else {
             return false;
         };
-        let mut mac =
-            HmacSha256::new_from_slice(&self.key).expect("HMAC accepts a key of any length");
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts a key of any length");
         mac.update(data);
         // `verify_slice` is a constant-time comparison (no timing oracle).
         mac.verify_slice(&expected).is_ok()
@@ -106,11 +157,15 @@ impl AuditSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-var mutation across the (parallel) tests in this module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn sign_then_verify_roundtrips() {
         let signer = AuditSigner::new(b"unit-test-key".to_vec());
-        let sig = signer.sign(b"hello");
+        let sig = signer.sign(b"hello").expect("real signer signs");
         assert!(signer.verify(b"hello", &sig));
     }
 
@@ -123,7 +178,7 @@ mod tests {
     #[test]
     fn verify_fails_for_tampered_data() {
         let signer = AuditSigner::new(b"k".to_vec());
-        let sig = signer.sign(b"hello");
+        let sig = signer.sign(b"hello").expect("real signer signs");
         assert!(!signer.verify(b"hell0", &sig));
     }
 
@@ -131,7 +186,7 @@ mod tests {
     fn verify_fails_under_a_different_key() {
         let signer = AuditSigner::new(b"key-a".to_vec());
         let attacker = AuditSigner::new(b"key-b".to_vec());
-        let sig = signer.sign(b"payload");
+        let sig = signer.sign(b"payload").expect("real signer signs");
         assert!(!attacker.verify(b"payload", &sig));
     }
 
@@ -139,5 +194,65 @@ mod tests {
     fn verify_rejects_non_hex_signature() {
         let signer = AuditSigner::new(b"k".to_vec());
         assert!(!signer.verify(b"data", "not-hex-zzzz"));
+    }
+
+    #[test]
+    fn unsigned_signer_cannot_sign_or_verify() {
+        let signer = AuditSigner::unsigned();
+        assert!(!signer.can_sign());
+        assert!(signer.sign(b"x").is_none(), "unsigned signer must not sign");
+        // Even a structurally valid hex signature must not verify under no key.
+        let real = AuditSigner::new(b"k".to_vec());
+        let sig = real.sign(b"x").expect("real signer signs");
+        assert!(
+            !signer.verify(b"x", &sig),
+            "unsigned signer must never verify-as-signed"
+        );
+    }
+
+    #[test]
+    fn from_env_uses_real_key_when_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // Safety: guarded by ENV_LOCK; cleaned up before unlock.
+        unsafe {
+            std::env::set_var(SIGNING_KEY_ENV, "a-real-secret");
+            std::env::remove_var(ALLOW_INSECURE_KEY_ENV);
+        }
+        let signer = AuditSigner::from_env();
+        unsafe {
+            std::env::remove_var(SIGNING_KEY_ENV);
+        }
+        assert!(signer.can_sign());
+        assert!(!signer.is_dev_key());
+    }
+
+    #[test]
+    fn from_env_refuses_without_key_or_opt_in() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(SIGNING_KEY_ENV);
+            std::env::remove_var(ALLOW_INSECURE_KEY_ENV);
+        }
+        let signer = AuditSigner::from_env();
+        assert!(
+            !signer.can_sign(),
+            "no key + no opt-in must be unsigned/refused, not the dev key"
+        );
+        assert!(signer.sign(b"x").is_none());
+    }
+
+    #[test]
+    fn from_env_uses_dev_key_only_with_explicit_opt_in() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(SIGNING_KEY_ENV);
+            std::env::set_var(ALLOW_INSECURE_KEY_ENV, "1");
+        }
+        let signer = AuditSigner::from_env();
+        unsafe {
+            std::env::remove_var(ALLOW_INSECURE_KEY_ENV);
+        }
+        assert!(signer.can_sign());
+        assert!(signer.is_dev_key(), "explicit opt-in selects the dev key");
     }
 }

--- a/runtime/audit/src/signer.rs
+++ b/runtime/audit/src/signer.rs
@@ -1,0 +1,143 @@
+//! `AuditSigner` — keyed HMAC-SHA256 signatures over audit-log entries.
+//!
+//! The signature authenticates each entry's content hash so that a tampered
+//! entry (or a forged one written by an attacker who does not hold the key)
+//! fails verification. HMAC-SHA256 is used because it is the strongest signer
+//! available from the already-vendored crypto crates (`hmac` + `sha2`); the
+//! workspace carries no asymmetric signer (`ed25519-dalek`/`ring` is not a
+//! direct dependency). The signature is a symmetric MAC: the same key signs
+//! and verifies. Per-tenant keys / rotation / an asymmetric upgrade are a
+//! documented follow-up (`F-t3-key-mgmt`).
+//!
+//! ## Key source
+//!
+//! The signing key is read once from the `JAMJET_AUDIT_SIGNING_KEY`
+//! environment variable (its raw UTF-8 bytes are the HMAC key). When the
+//! variable is absent or empty the signer falls back to a **built-in,
+//! publicly-known dev key** and logs loudly at `warn`. This keeps local
+//! development and tests verifiable (a fixed key round-trips across process
+//! restarts, unlike an ephemeral random key) while making it unmistakable
+//! that the signatures are NOT secure until a real key is provisioned. The
+//! engine never hard-fails for a missing key.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use tracing::warn;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The environment variable holding the raw audit signing key.
+pub const SIGNING_KEY_ENV: &str = "JAMJET_AUDIT_SIGNING_KEY";
+
+/// Built-in dev key used when `JAMJET_AUDIT_SIGNING_KEY` is unset.
+///
+/// This value is public by design; signatures produced with it are
+/// reproducible but provide NO security. Production deployments MUST set
+/// `JAMJET_AUDIT_SIGNING_KEY`.
+pub const DEV_DEFAULT_KEY: &str =
+    "jamjet-insecure-dev-audit-signing-key-set-JAMJET_AUDIT_SIGNING_KEY-in-prod";
+
+/// Signs and verifies audit entries with a keyed HMAC-SHA256.
+#[derive(Clone)]
+pub struct AuditSigner {
+    key: Vec<u8>,
+    /// True when the built-in insecure dev key is in use.
+    is_dev_key: bool,
+}
+
+impl AuditSigner {
+    /// Build a signer from explicit key bytes (used in tests and by callers
+    /// that load the key from their own config/secret store).
+    pub fn new(key: impl Into<Vec<u8>>) -> Self {
+        Self {
+            key: key.into(),
+            is_dev_key: false,
+        }
+    }
+
+    /// Build a signer from `JAMJET_AUDIT_SIGNING_KEY`, falling back to the
+    /// built-in dev key (with a loud `warn`) when the variable is unset/empty.
+    pub fn from_env() -> Self {
+        match std::env::var(SIGNING_KEY_ENV) {
+            Ok(key) if !key.is_empty() => Self::new(key.into_bytes()),
+            _ => {
+                warn!(
+                    env = SIGNING_KEY_ENV,
+                    "{SIGNING_KEY_ENV} is not set; signing the audit log with the BUILT-IN \
+                     INSECURE DEV KEY. Audit signatures provide NO tamper-resistance against \
+                     an attacker until {SIGNING_KEY_ENV} is provisioned with a real secret."
+                );
+                Self {
+                    key: DEV_DEFAULT_KEY.as_bytes().to_vec(),
+                    is_dev_key: true,
+                }
+            }
+        }
+    }
+
+    /// True when this signer is using the insecure built-in dev key.
+    pub fn is_dev_key(&self) -> bool {
+        self.is_dev_key
+    }
+
+    /// Sign `data`, returning the lowercase-hex HMAC-SHA256 tag.
+    pub fn sign(&self, data: &[u8]) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(&self.key).expect("HMAC accepts a key of any length");
+        mac.update(data);
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    /// Verify a hex-encoded signature over `data` in constant time.
+    ///
+    /// Returns `false` for a malformed (non-hex) signature or any mismatch.
+    pub fn verify(&self, data: &[u8], signature_hex: &str) -> bool {
+        let Ok(expected) = hex::decode(signature_hex) else {
+            return false;
+        };
+        let mut mac =
+            HmacSha256::new_from_slice(&self.key).expect("HMAC accepts a key of any length");
+        mac.update(data);
+        // `verify_slice` is a constant-time comparison (no timing oracle).
+        mac.verify_slice(&expected).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let signer = AuditSigner::new(b"unit-test-key".to_vec());
+        let sig = signer.sign(b"hello");
+        assert!(signer.verify(b"hello", &sig));
+    }
+
+    #[test]
+    fn signature_is_deterministic_for_same_key_and_data() {
+        let signer = AuditSigner::new(b"k".to_vec());
+        assert_eq!(signer.sign(b"abc"), signer.sign(b"abc"));
+    }
+
+    #[test]
+    fn verify_fails_for_tampered_data() {
+        let signer = AuditSigner::new(b"k".to_vec());
+        let sig = signer.sign(b"hello");
+        assert!(!signer.verify(b"hell0", &sig));
+    }
+
+    #[test]
+    fn verify_fails_under_a_different_key() {
+        let signer = AuditSigner::new(b"key-a".to_vec());
+        let attacker = AuditSigner::new(b"key-b".to_vec());
+        let sig = signer.sign(b"payload");
+        assert!(!attacker.verify(b"payload", &sig));
+    }
+
+    #[test]
+    fn verify_rejects_non_hex_signature() {
+        let signer = AuditSigner::new(b"k".to_vec());
+        assert!(!signer.verify(b"data", "not-hex-zzzz"));
+    }
+}

--- a/runtime/audit/src/sqlite.rs
+++ b/runtime/audit/src/sqlite.rs
@@ -32,7 +32,10 @@ CREATE TABLE IF NOT EXISTS audit_log (
     raw_event       TEXT NOT NULL,
     tenant_id       TEXT NOT NULL DEFAULT 'default',
     expires_at      TEXT,
-    redacted        INTEGER NOT NULL DEFAULT 0
+    redacted        INTEGER NOT NULL DEFAULT 0,
+    prev_hash       TEXT,
+    entry_hash      TEXT,
+    signature       TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_audit_execution_id ON audit_log (execution_id);
 CREATE INDEX IF NOT EXISTS idx_audit_actor_id     ON audit_log (actor_id);
@@ -81,6 +84,18 @@ impl SqliteAuditBackend {
             }
             sqlx::query(stmt).execute(&self.pool).await?;
         }
+        // Forward-migrate audit_log tables created before the tamper-evidence
+        // columns existed (the CREATE above is `IF NOT EXISTS`, so a pre-existing
+        // table is left untouched). Adding a column that is already present is a
+        // benign "duplicate column name" error we deliberately ignore.
+        for col in ["prev_hash", "entry_hash", "signature"] {
+            let sql = format!("ALTER TABLE audit_log ADD COLUMN {col} TEXT");
+            if let Err(e) = sqlx::query(&sql).execute(&self.pool).await {
+                if !e.to_string().to_lowercase().contains("duplicate column") {
+                    return Err(e);
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -99,8 +114,9 @@ impl AuditBackend for SqliteAuditBackend {
                 (id, event_id, execution_id, sequence, event_type,
                  actor_id, actor_type, tool_call_hash, policy_decision,
                  http_request_id, http_method, http_path, ip_address,
-                 created_at, raw_event, tenant_id, expires_at, redacted)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 created_at, raw_event, tenant_id, expires_at, redacted,
+                 prev_hash, entry_hash, signature)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(entry.id.to_string())
@@ -121,6 +137,9 @@ impl AuditBackend for SqliteAuditBackend {
         .bind(&entry.tenant_id)
         .bind(expires_at.as_deref())
         .bind(entry.redacted as i32)
+        .bind(&entry.prev_hash)
+        .bind(&entry.entry_hash)
+        .bind(&entry.signature)
         .execute(&self.pool)
         .await
         .map_err(|e| AuditError::Database(e.to_string()))?;
@@ -223,6 +242,9 @@ struct AuditRow {
     tenant_id: String,
     expires_at: Option<String>,
     redacted: i32,
+    prev_hash: Option<String>,
+    entry_hash: Option<String>,
+    signature: Option<String>,
 }
 
 fn row_to_entry(row: AuditRow) -> Result<AuditLogEntry, AuditError> {
@@ -256,6 +278,9 @@ fn row_to_entry(row: AuditRow) -> Result<AuditLogEntry, AuditError> {
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc)),
         redacted: row.redacted != 0,
+        prev_hash: row.prev_hash,
+        entry_hash: row.entry_hash,
+        signature: row.signature,
     })
 }
 

--- a/runtime/audit/tests/chain.rs
+++ b/runtime/audit/tests/chain.rs
@@ -1,0 +1,188 @@
+//! Tamper-evidence tests for the signed, hash-chained audit log.
+//!
+//! Covers the chain invariants directly on `AuditLogEntry`/`verify_chain`, the
+//! adversarial duals (tampered content, forged signature, wrong key, broken
+//! downstream link), and the `AuditEnricher` write path (every appended entry
+//! is sealed into a verifiable chain).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jamjet_audit::{
+    verify_chain, ActorType, AuditBackend, AuditEnricher, AuditError, AuditLogEntry, AuditQuery,
+    AuditSigner, ChainError,
+};
+use jamjet_core::workflow::ExecutionId;
+use jamjet_state::event::{Event, EventKind};
+use uuid::Uuid;
+
+fn make_entry(seq: i64, actor: &str) -> AuditLogEntry {
+    AuditLogEntry::new(
+        Uuid::new_v4(),
+        "exec-1".to_string(),
+        seq,
+        "node_completed".to_string(),
+        actor.to_string(),
+        ActorType::System,
+        serde_json::json!({ "type": "node_completed", "seq": seq }),
+    )
+}
+
+/// Seal a slice of entries into a single chain (genesis prev_hash = None).
+fn seal_chain(entries: &mut [AuditLogEntry], signer: &AuditSigner) {
+    let mut prev: Option<String> = None;
+    for entry in entries.iter_mut() {
+        entry.seal(prev.clone(), signer);
+        prev = entry.entry_hash.clone();
+    }
+}
+
+#[test]
+fn three_entry_chain_verifies() {
+    let signer = AuditSigner::new(b"test-key".to_vec());
+    let mut entries = vec![make_entry(0, "a"), make_entry(1, "b"), make_entry(2, "c")];
+    seal_chain(&mut entries, &signer);
+
+    assert!(verify_chain(&entries, &signer).is_ok());
+
+    // Genesis has no predecessor; each later entry links to the one before it.
+    assert!(entries[0].prev_hash.is_none());
+    assert_eq!(entries[1].prev_hash, entries[0].entry_hash);
+    assert_eq!(entries[2].prev_hash, entries[1].entry_hash);
+    // Every entry is sealed (hash + signature present).
+    assert!(entries
+        .iter()
+        .all(|e| e.entry_hash.is_some() && e.signature.is_some()));
+}
+
+#[test]
+fn tampering_entry_content_breaks_verification_from_that_point() {
+    let signer = AuditSigner::new(b"test-key".to_vec());
+    let mut entries = vec![make_entry(0, "a"), make_entry(1, "b"), make_entry(2, "c")];
+    seal_chain(&mut entries, &signer);
+
+    // Mutate entry 2's (index 1) content but leave its hash + signature intact —
+    // exactly what an attacker editing the stored row would do.
+    entries[1].actor_id = "tampered".to_string();
+
+    let err = verify_chain(&entries, &signer).unwrap_err();
+    assert_eq!(err, ChainError::HashMismatch { index: 1 });
+
+    // The untampered prefix (entry 1 alone) still verifies; the break is at 2..n.
+    assert!(verify_chain(&entries[..1], &signer).is_ok());
+}
+
+#[test]
+fn forged_signature_fails() {
+    let signer = AuditSigner::new(b"test-key".to_vec());
+    let mut entries = vec![make_entry(0, "a"), make_entry(1, "b"), make_entry(2, "c")];
+    seal_chain(&mut entries, &signer);
+
+    // Swap in a well-formed but wrong signature (64 hex chars).
+    entries[1].signature = Some("ab".repeat(32));
+
+    let err = verify_chain(&entries, &signer).unwrap_err();
+    assert_eq!(err, ChainError::BadSignature { index: 1 });
+}
+
+#[test]
+fn rehashed_tamper_without_the_key_fails_on_signature() {
+    let signer = AuditSigner::new(b"real-key".to_vec());
+    let mut entries = vec![make_entry(0, "a"), make_entry(1, "b"), make_entry(2, "c")];
+    seal_chain(&mut entries, &signer);
+
+    // Attacker tampers content and recomputes the hash so the integrity check
+    // would pass — but can only sign with their OWN key.
+    let attacker = AuditSigner::new(b"attacker-key".to_vec());
+    let prev = entries[0].entry_hash.clone();
+    entries[1].actor_id = "tampered".to_string();
+    entries[1].seal(prev, &attacker);
+
+    let err = verify_chain(&entries, &signer).unwrap_err();
+    assert_eq!(err, ChainError::BadSignature { index: 1 });
+}
+
+#[test]
+fn relinking_a_single_entry_breaks_the_downstream_link() {
+    let signer = AuditSigner::new(b"real-key".to_vec());
+    let mut entries = vec![make_entry(0, "a"), make_entry(1, "b"), make_entry(2, "c")];
+    seal_chain(&mut entries, &signer);
+
+    // Even WITH the key, rewriting entry 2 in place changes its hash; entry 3
+    // still points at the original hash, so the chain breaks downstream.
+    let prev = entries[0].entry_hash.clone();
+    entries[1].actor_id = "rewritten".to_string();
+    entries[1].seal(prev, &signer);
+
+    let err = verify_chain(&entries, &signer).unwrap_err();
+    assert_eq!(err, ChainError::BrokenLink { index: 2 });
+}
+
+#[test]
+fn unsealed_entry_is_rejected() {
+    let signer = AuditSigner::new(b"k".to_vec());
+    let entries = vec![make_entry(0, "a")]; // never sealed
+    assert_eq!(
+        verify_chain(&entries, &signer).unwrap_err(),
+        ChainError::Unsealed { index: 0 }
+    );
+}
+
+// ── Enricher write-path: appended entries are sealed + chained ──────────────
+
+/// In-memory backend that keeps every appended entry so the test can verify
+/// the chain the enricher produced. `query` returns newest-first to match the
+/// SqliteAuditBackend ordering the enricher relies on for chain seeding.
+#[derive(Default)]
+struct CapturingBackend {
+    entries: tokio::sync::Mutex<Vec<AuditLogEntry>>,
+}
+
+#[async_trait]
+impl AuditBackend for CapturingBackend {
+    async fn append(&self, entry: AuditLogEntry) -> Result<(), AuditError> {
+        self.entries.lock().await.push(entry);
+        Ok(())
+    }
+
+    async fn query(&self, _q: &AuditQuery) -> Result<Vec<AuditLogEntry>, AuditError> {
+        Ok(self.entries.lock().await.iter().rev().cloned().collect())
+    }
+
+    async fn count(&self, _q: &AuditQuery) -> Result<u64, AuditError> {
+        Ok(self.entries.lock().await.len() as u64)
+    }
+}
+
+fn workflow_event(exec: ExecutionId, seq: i64) -> Event {
+    Event::new(
+        exec,
+        seq,
+        EventKind::WorkflowCompleted {
+            final_state: serde_json::json!({ "seq": seq }),
+        },
+    )
+}
+
+#[tokio::test]
+async fn enricher_seals_and_chains_appended_entries() {
+    let backend = Arc::new(CapturingBackend::default());
+    let signer = AuditSigner::new(b"enricher-key".to_vec());
+    let enricher = AuditEnricher::with_signer(backend.clone(), signer.clone());
+
+    let exec = ExecutionId(Uuid::new_v4());
+    for seq in 0..3 {
+        enricher
+            .enrich_and_append(&workflow_event(exec.clone(), seq), None)
+            .await;
+    }
+
+    let captured = backend.entries.lock().await.clone();
+    assert_eq!(captured.len(), 3);
+    // The whole written chain verifies under the same signer.
+    verify_chain(&captured, &signer).expect("enricher must produce a verifiable chain");
+    // And it is a real chain: genesis None, then linked.
+    assert!(captured[0].prev_hash.is_none());
+    assert_eq!(captured[1].prev_hash, captured[0].entry_hash);
+    assert_eq!(captured[2].prev_hash, captured[1].entry_hash);
+}

--- a/runtime/ir/src/workflow.rs
+++ b/runtime/ir/src/workflow.rs
@@ -333,4 +333,97 @@ mod tests {
         let parsed = WorkflowIr::from_json(&json).unwrap();
         assert_eq!(parsed.workflow_id, ir.workflow_id);
     }
+
+    /// T3-5: verify that a WorkflowIr JSON carrying all governance fields emitted
+    /// by compile_agent_to_ir (Python) deserializes correctly into the Rust struct.
+    /// Field names, types, and nesting must match exactly — a mismatch here means
+    /// the Python emitter and the Rust deserializer are out of sync.
+    #[test]
+    fn governance_fields_deserialize_from_python_shape() {
+        // This JSON mirrors the exact output of _compile_governance_ir() in
+        // sdk/python/jamjet/compiler/agent_ir.py (T3-5).
+        let json = r#"{
+            "workflow_id": "governed_agent",
+            "version": "0.1.0+abc123456789",
+            "name": "governed_agent",
+            "description": "Durable agent: governed_agent",
+            "state_schema": "",
+            "start_node": "start",
+            "nodes": {},
+            "edges": [],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {},
+            "policy": {
+                "blocked_tools": [],
+                "require_approval_for": ["delete_*"],
+                "model_allowlist": []
+            },
+            "token_budget": {
+                "total_tokens": 1000
+            },
+            "cost_budget_usd": 0.5,
+            "data_policy": {
+                "pii_fields": [],
+                "pii_detectors": ["email", "ssn", "credit_card", "phone", "ip_address"],
+                "redaction_mode": "mask",
+                "retain_prompts": false,
+                "retain_outputs": true
+            }
+        }"#;
+
+        let ir = WorkflowIr::from_json(json)
+            .expect("governance fields emitted by Python must deserialize into WorkflowIr");
+
+        // Policy / approval
+        let policy = ir.policy.expect("policy must be Some");
+        assert_eq!(policy.require_approval_for, vec!["delete_*"]);
+        assert!(policy.blocked_tools.is_empty());
+        assert!(policy.model_allowlist.is_empty());
+
+        // Token budget
+        let token_budget = ir.token_budget.expect("token_budget must be Some");
+        assert_eq!(token_budget.total_tokens, Some(1000));
+        assert!(token_budget.input_tokens.is_none());
+        assert!(token_budget.output_tokens.is_none());
+
+        // Cost budget
+        let cost = ir.cost_budget_usd.expect("cost_budget_usd must be Some");
+        assert!((cost - 0.5_f64).abs() < f64::EPSILON);
+
+        // Data policy / PII
+        let dp = ir.data_policy.expect("data_policy must be Some");
+        assert!(dp.pii_detectors.contains(&"email".to_string()));
+        assert!(dp.pii_detectors.contains(&"ssn".to_string()));
+        assert!(dp.pii_detectors.contains(&"credit_card".to_string()));
+        assert!(dp.pii_detectors.contains(&"phone".to_string()));
+        assert!(dp.pii_detectors.contains(&"ip_address".to_string()));
+        assert_eq!(dp.redaction_mode, "mask");
+        assert!(!dp.retain_prompts);
+        assert!(dp.retain_outputs);
+    }
+
+    /// approval_required=True (all tools) compiles to require_approval_for=["*"].
+    /// This shape must deserialize and the wildcard must be preserved.
+    #[test]
+    fn approval_wildcard_deserializes() {
+        let json = r#"{
+            "workflow_id": "w", "version": "0.1.0", "state_schema": "",
+            "start_node": "s", "nodes": {}, "edges": [], "retry_policies": {},
+            "timeouts": {}, "models": {}, "tools": {}, "mcp_servers": {},
+            "remote_agents": {}, "labels": {},
+            "policy": {
+                "blocked_tools": [],
+                "require_approval_for": ["*"],
+                "model_allowlist": []
+            }
+        }"#;
+        let ir = WorkflowIr::from_json(json).expect("must deserialize");
+        let policy = ir.policy.unwrap();
+        assert_eq!(policy.require_approval_for, vec!["*"]);
+    }
 }

--- a/sdk/python/jamjet/agents/__init__.py
+++ b/sdk/python/jamjet/agents/__init__.py
@@ -1,5 +1,6 @@
 # Agent management Python API
 from jamjet.agents.agent import Agent, AgentResult
+from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
 from jamjet.agents.task import task
 
-__all__ = ["Agent", "AgentResult", "task"]
+__all__ = ["Agent", "AgentResult", "Budget", "GovernanceConfig", "normalize_governance", "task"]

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -188,6 +188,40 @@ class Agent:
             emitter=self._receipt_emitter,
         )
 
+    # ── Governance: per-action signed audit on by default (C1) ─────────────
+
+    def _maybe_emit_audit(
+        self,
+        prompt: str,
+        result: AgentResult,
+        *,
+        execution_id: str,
+    ) -> list[Any] | None:
+        """Emit a signed, hash-chained audit record for this run's actions.
+
+        Audit is ON by default (``GovernanceConfig.audit``): a plain governed
+        ``Agent`` produces one :class:`~jamjet.agents.audit.AuditAction` per tool
+        call plus one for the model turn, sealed into a tamper-evident chain and
+        signed with the keyed HMAC (``JAMJET_AUDIT_SIGNING_KEY``; unsigned-but-
+        chained with a loud warning until a key is provisioned). Returns the list
+        of sealed actions (also attached to :class:`AgentResult.audit`), or
+        ``None`` when ``audit=False``. This is the in-process / SDK audit path;
+        the durable engine additionally signs approval-decision events, and
+        per-node engine-internal audit emission is tracked as F-t3-audit-emit.
+        """
+        if not self.governance.audit:
+            return None
+        from jamjet.agents.audit import build_action_chain  # noqa: PLC0415
+
+        return build_action_chain(
+            agent_name=self.name,
+            model=self.model,
+            execution_id=execution_id,
+            prompt=prompt,
+            output=result.output,
+            tool_calls=result.tool_calls,
+        )
+
     # ── Public run interface ───────────────────────────────────────────────
 
     async def run(self, prompt: str) -> AgentResult:
@@ -224,13 +258,15 @@ class Agent:
         # (the gap deferred from T3-2).
         result = await rt.execute(spec, prompt, governance=self.governance)
         receipt = self._maybe_mint_receipt(prompt, result.output)
-        return AgentResult(
+        agent_result = AgentResult(
             output=result.output,
             tool_calls=[tc.model_dump() for tc in result.tool_calls],
             ir=spec.model_dump(),
             duration_us=result.duration_ms * 1000,
             receipt=receipt,
         )
+        agent_result.audit = self._maybe_emit_audit(prompt, agent_result, execution_id=result.execution_id)
+        return agent_result
 
     def run_sync(self, prompt: str) -> AgentResult:
         """Synchronous wrapper around :meth:`run` for scripts and notebooks."""
@@ -312,9 +348,10 @@ class Agent:
 
         duration_us = int((time.monotonic() - t0) * 1_000_000)
         result = self._extract_result(execution, events, ir, duration_us)
-        # Mint the turn receipt from the durable run's extracted result (on by
-        # default), mirroring the in-process run().
+        # Mint the turn receipt + emit the per-action signed audit chain from the
+        # durable run's extracted result (both on by default), mirroring run().
         result.receipt = self._maybe_mint_receipt(prompt, result.output)
+        result.audit = self._maybe_emit_audit(prompt, result, execution_id=exec_id)
         return result
 
     async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:
@@ -448,7 +485,27 @@ class Agent:
         Streaming is a view; durability records the completed turn (resume
         returns the checkpoint, it does not re-stream). The looped, durable
         stream over the full agent run lands in Track 2.
+
+        Governance on streams (M6 parity)
+        ---------------------------------
+        The seam ``before`` chain still runs, so the **policy/model allowlist and
+        PII redaction ENFORCE** on streamed turns exactly as on ``run()``. What a
+        stream cannot do is run the ``after`` chain (budget accumulation /
+        metering / per-action audit) — a streamed turn carries no usage-bearing
+        finalizer (the streaming ``after`` hook was deferred in Track 1). Rather
+        than silently drop budget enforcement, a ``budget``-capped agent FAILS
+        LOUD here: use :meth:`run` / :meth:`run_durable` for budget-enforced runs,
+        or drop the budget to stream. Audit/metering are likewise not accumulated
+        for the streamed view (documented, never claimed).
         """
+        if self.governance.budget is not None:
+            raise RuntimeError(
+                f"Agent {self.name!r}: stream() cannot enforce a budget cap — streamed "
+                "turns have no usage-bearing finalizer, so token/cost is never "
+                "accumulated and the budget would silently not apply. Use agent.run() "
+                "or agent.run_durable() for budget-enforced runs, or remove the budget "
+                "to stream. (Policy/allowlist and PII redaction DO enforce on streams.)"
+            )
         from jamjet.model.defaults import default_model_middleware  # noqa: PLC0415
         from jamjet.model.seam import Model  # noqa: PLC0415
         from jamjet.model.types import ModelRequest, parse_model_ref  # noqa: PLC0415
@@ -489,12 +546,17 @@ class AgentResult:
         ir: Any,
         duration_us: float = 0.0,
         receipt: dict[str, Any] | None = None,
+        audit: list[Any] | None = None,
     ) -> None:
         self.output = output
         self.tool_calls = tool_calls
         self.ir = ir
         self.duration_us = duration_us
         self.receipt = receipt
+        # ``audit`` is the per-action signed, hash-chained audit record for the
+        # run (a list of jamjet.agents.audit.AuditAction), on by default; None
+        # when ``audit=False``. ``jamjet.agents.audit.verify_chain`` accepts it.
+        self.audit = audit
 
     def __str__(self) -> str:
         return self.output

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -394,7 +394,7 @@ class Agent:
         from jamjet.model.types import ModelRequest, parse_model_ref  # noqa: PLC0415
 
         spec = self.compile()
-        seam = model or Model(middleware=default_model_middleware())
+        seam = model or Model(middleware=default_model_middleware(self.governance))
         request = ModelRequest(
             ref=parse_model_ref(spec.llm.model),
             messages=[

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -78,12 +78,18 @@ class Agent:
         pii: bool = True,
         audit: bool = True,
         receipts: bool = True,
+        # Optional sink for AgentBoundary receipts (T3-4).  When set, every
+        # minted receipt is also shipped here (e.g. a JSONL writer); the receipt
+        # is always attached to the run result regardless.  Defaults to None so
+        # receipts ship nowhere noisy by default while still being produced.
+        receipt_emitter: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self.name = name
         self.model = model
         self.instructions = instructions
         self.strategy = strategy
         self._on_limit_exceeded = on_limit_exceeded
+        self._receipt_emitter = receipt_emitter
         self.limits = StrategyLimits(
             max_iterations=max_iterations,
             max_cost_usd=max_cost_usd,
@@ -157,6 +163,30 @@ class Agent:
             },
         )
 
+    # ── Governance: receipts on by default (T3-4) ──────────────────────────
+
+    def _maybe_mint_receipt(self, prompt: str, output: Any) -> dict[str, Any] | None:
+        """Mint an AgentBoundary receipt for this turn when receipts are enabled.
+
+        Receipts are ON by default (``GovernanceConfig.receipts``); a plain
+        ``Agent()`` produces one without the developer opting in. Returns the
+        receipt dict (also attached to the :class:`AgentResult` and shipped to
+        ``receipt_emitter`` if set), or ``None`` when ``receipts=False``. Reuses
+        the exact mint path :func:`jamjet.gate` uses, so agent receipts and
+        gated-tool receipts are consistent.
+        """
+        if not self.governance.receipts:
+            return None
+        from jamjet.agents.receipts import mint_agent_receipt  # noqa: PLC0415
+
+        return mint_agent_receipt(
+            agent_name=self.name,
+            model=self.model,
+            prompt=prompt,
+            output="" if output is None else str(output),
+            emitter=self._receipt_emitter,
+        )
+
     # ── Public run interface ───────────────────────────────────────────────
 
     async def run(self, prompt: str) -> AgentResult:
@@ -164,16 +194,19 @@ class Agent:
         Run the agent on a single prompt via LocalRuntime.
 
         Compiles to AgentSpec, hands off to LocalRuntime which dispatches to
-        the appropriate strategy runner.
+        the appropriate strategy runner. Emits a signed-audit-aligned
+        AgentBoundary receipt for the turn (on by default).
         """
         spec = self.compile()
         rt = LocalRuntime()
         result = await rt.execute(spec, prompt)
+        receipt = self._maybe_mint_receipt(prompt, result.output)
         return AgentResult(
             output=result.output,
             tool_calls=[tc.model_dump() for tc in result.tool_calls],
             ir=spec.model_dump(),
             duration_us=result.duration_ms * 1000,
+            receipt=receipt,
         )
 
     def run_sync(self, prompt: str) -> AgentResult:
@@ -255,7 +288,11 @@ class Agent:
                 events = []
 
         duration_us = int((time.monotonic() - t0) * 1_000_000)
-        return self._extract_result(execution, events, ir, duration_us)
+        result = self._extract_result(execution, events, ir, duration_us)
+        # Mint the turn receipt from the durable run's extracted result (on by
+        # default), mirroring the in-process run().
+        result.receipt = self._maybe_mint_receipt(prompt, result.output)
+        return result
 
     async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:
         """Poll ``get_execution`` until the execution reaches a terminal state."""
@@ -413,7 +450,14 @@ class Agent:
 
 
 class AgentResult:
-    """Result returned by Agent.run()."""
+    """Result returned by Agent.run().
+
+    ``receipt`` is the AgentBoundary Action Receipt minted for the turn (on by
+    default), or ``None`` when ``receipts=False``. It is a portable, validatable
+    proof of the action -- ``agentboundary.validate_receipt`` /
+    ``check_conformance`` accept it, and its ``arguments_hash`` binds it to this
+    prompt/agent/model.
+    """
 
     def __init__(
         self,
@@ -421,11 +465,13 @@ class AgentResult:
         tool_calls: list[dict[str, Any]],
         ir: Any,
         duration_us: float = 0.0,
+        receipt: dict[str, Any] | None = None,
     ) -> None:
         self.output = output
         self.tool_calls = tool_calls
         self.ir = ir
         self.duration_us = duration_us
+        self.receipt = receipt
 
     def __str__(self) -> str:
         return self.output

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -217,7 +217,12 @@ class Agent:
             )
         spec = self.compile()
         rt = LocalRuntime()
-        result = await rt.execute(spec, prompt)
+        # T3-7: thread governance into the in-process seam so budget / allowlist
+        # / PII enforce on agent.run() (in-process) at parity with run_durable()
+        # (the durable IR).  Without this the seam was built allow-all / no-budget
+        # and the budget + policy knobs silently no-opped on the in-process path
+        # (the gap deferred from T3-2).
+        result = await rt.execute(spec, prompt, governance=self.governance)
         receipt = self._maybe_mint_receipt(prompt, result.output)
         return AgentResult(
             output=result.output,

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+import warnings
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -197,6 +198,23 @@ class Agent:
         the appropriate strategy runner. Emits a signed-audit-aligned
         AgentBoundary receipt for the turn (on by default).
         """
+        # T3-6: approval_required parity — the in-process path cannot enforce
+        # tool-level approval gates (the @gate mechanism is opt-in per function;
+        # the durable Rust engine enforces require_approval_for via the IR).
+        # Fail LOUD rather than silently no-op so the developer knows approval
+        # won't fire here.  See follow-up F-t3-inprocess-approval for full
+        # in-process enforcement.
+        ar = self.governance.approval_required
+        if ar is not False and ar != []:
+            warnings.warn(
+                f"Agent {self.name!r}: approval_required is set but agent.run() uses "
+                "the in-process path, which does not enforce approval gates. "
+                "Use agent.run_durable() — the durable IR carries "
+                "require_approval_for and the Rust engine enforces it fail-closed. "
+                "Follow-up: F-t3-inprocess-approval.",
+                UserWarning,
+                stacklevel=2,
+            )
         spec = self.compile()
         rt = LocalRuntime()
         result = await rt.execute(spec, prompt)

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -34,6 +34,7 @@ import time
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
+from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
 from jamjet.compiler.strategies import StrategyLimits
 from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
@@ -70,6 +71,13 @@ class Agent:
         max_cost_usd: float = 1.0,
         timeout_seconds: int = 300,
         on_limit_exceeded: Callable[[str | None, str, Any, Any], str | None] | None = None,
+        # Governance knobs (T3-1).  T3-2..6 read self.governance to enforce.
+        policy: str | dict | None = None,
+        approval_required: bool | list[str] = False,
+        budget: Budget | float | int | dict | None = None,
+        pii: bool = True,
+        audit: bool = True,
+        receipts: bool = True,
     ) -> None:
         self.name = name
         self.model = model
@@ -80,6 +88,30 @@ class Agent:
             max_iterations=max_iterations,
             max_cost_usd=max_cost_usd,
             timeout_seconds=timeout_seconds,
+        )
+
+        # Build the immutable governance config.
+        #
+        # budget vs max_cost_usd reconciliation: max_cost_usd is the legacy
+        # StrategyLimits cap (used by strategy runners for iteration budgets).
+        # budget= is the new governance-layer cap read by the seam middleware
+        # (T3-2) and compiled into the durable IR (T3-5).  When budget= is not
+        # set but max_cost_usd is explicitly provided, we fold the legacy value
+        # into GovernanceConfig.budget.cost_usd so the governance layer inherits
+        # the same ceiling without requiring callers to set both.  T3-2 will
+        # reconcile and document the authoritative enforcement point.
+        _effective_budget: Budget | float | int | dict | None = budget
+        if _effective_budget is None and max_cost_usd != 1.0:
+            # Non-default max_cost_usd -> carry it forward as the budget cap.
+            _effective_budget = max_cost_usd
+
+        self.governance: GovernanceConfig = normalize_governance(
+            policy=policy,
+            approval_required=approval_required,
+            budget=_effective_budget,
+            pii=pii,
+            audit=audit,
+            receipts=receipts,
         )
 
         # Resolve tool definitions from decorated functions

--- a/sdk/python/jamjet/agents/audit.py
+++ b/sdk/python/jamjet/agents/audit.py
@@ -1,0 +1,305 @@
+"""Per-action signed, hash-chained audit for governed agent runs (T3 / C1).
+
+A governed ``Agent`` produces a tamper-evident audit record for *every action*
+it takes (each tool call plus the model turn), not just for approvals. Each
+:class:`AuditAction` is sealed into a hash chain (``prev_hash`` -> ``entry_hash``)
+and signed with a keyed HMAC-SHA256, mirroring the Rust ``AuditLogEntry`` /
+``verify_chain`` primitive (``runtime/audit/src``) so the SDK and engine layers
+use the same construction.
+
+This is the in-process, SDK-side audit emitted by ``Agent.run`` /
+``Agent.run_durable`` (off any fenced commit path — there is no durability
+transaction here, so emission is always best-effort safe). It is ON by default
+(``GovernanceConfig.audit``); ``audit=False`` emits nothing. The chain is
+attached to :class:`~jamjet.agents.agent.AgentResult.audit` and accepted by
+:func:`verify_chain` under the same signing key.
+
+Signing key (honest, fail-closed posture — mirrors the Rust signer, I4)
+----------------------------------------------------------------------
+The HMAC key is resolved at emission time:
+
+* ``JAMJET_AUDIT_SIGNING_KEY`` set (non-empty)  -> sign with it (secure).
+* else ``JAMJET_AUDIT_ALLOW_INSECURE_KEY`` set  -> sign with the *public*
+  built-in dev key, with a loud warning. A deliberate, explicit opt-in to an
+  insecure key — never a silent default.
+* else (no key, no opt-in)                      -> entries are still chained
+  (tamper-evident linkage) but left **UNSIGNED** (``signature is None``) with a
+  one-time loud warning. :func:`verify_chain` reports such entries as
+  ``Unsigned`` — the audit log never *pretends* to be securely signed.
+
+So a signed-audit path with no real key fails loud rather than forging a
+trustworthy-looking signature with a publicly-known key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import uuid
+import warnings
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+# Field separator for canonical content hashing — a control byte that never
+# appears in our textual field values, so concatenation is unambiguous (matches
+# the Rust entry's FIELD_SEP = 0x1f).
+_FIELD_SEP = "\x1f"
+
+# The environment variables that govern audit signing.
+SIGNING_KEY_ENV = "JAMJET_AUDIT_SIGNING_KEY"
+ALLOW_INSECURE_KEY_ENV = "JAMJET_AUDIT_ALLOW_INSECURE_KEY"
+
+# Public-by-design dev key. Signatures produced with it provide NO security and
+# are only usable behind the explicit JAMJET_AUDIT_ALLOW_INSECURE_KEY opt-in.
+_DEV_DEFAULT_KEY = b"jamjet-insecure-dev-audit-signing-key-set-JAMJET_AUDIT_SIGNING_KEY-in-prod"
+
+# One-time warning guards so a long run / the whole test suite does not spam.
+_warned_unsigned = False
+_warned_insecure = False
+
+
+class ChainError(Exception):
+    """A sealed audit chain failed verification.
+
+    ``index`` is the 0-based position of the offending entry; ``reason`` is one
+    of ``"unsealed" | "unsigned" | "broken_link" | "hash_mismatch" |
+    "bad_signature"`` (mirrors the Rust ``ChainError`` variants).
+    """
+
+    def __init__(self, index: int, reason: str) -> None:
+        self.index = index
+        self.reason = reason
+        super().__init__(f"audit chain entry {index} failed: {reason}")
+
+
+class AuditSigner:
+    """Keyed HMAC-SHA256 signer for audit entries.
+
+    Use :func:`resolve_signer` to build one from the environment with the honest
+    key-source policy; construct directly with explicit ``key`` bytes in tests
+    or callers that hold their own secret. ``key=None`` is the *unsigned* signer:
+    :meth:`sign` returns ``None`` and :meth:`verify` returns ``False`` so it can
+    never masquerade as secure.
+    """
+
+    def __init__(self, key: bytes | None, *, is_dev_key: bool = False) -> None:
+        self._key = key
+        self.is_dev_key = is_dev_key
+
+    @property
+    def can_sign(self) -> bool:
+        return self._key is not None
+
+    def sign(self, data: bytes) -> str | None:
+        if self._key is None:
+            return None
+        return hmac.new(self._key, data, hashlib.sha256).hexdigest()
+
+    def verify(self, data: bytes, signature_hex: str | None) -> bool:
+        if self._key is None or signature_hex is None:
+            return False
+        expected = self.sign(data)
+        if expected is None:
+            return False
+        return hmac.compare_digest(expected, signature_hex)
+
+
+def resolve_signer() -> AuditSigner:
+    """Resolve the audit signer from the environment (honest, fail-closed)."""
+    global _warned_unsigned, _warned_insecure
+    key = os.environ.get(SIGNING_KEY_ENV)
+    if key:
+        return AuditSigner(key.encode("utf-8"))
+    if os.environ.get(ALLOW_INSECURE_KEY_ENV):
+        if not _warned_insecure:
+            _warned_insecure = True
+            warnings.warn(
+                f"{SIGNING_KEY_ENV} is not set; signing the agent audit log with the "
+                f"BUILT-IN INSECURE DEV KEY because {ALLOW_INSECURE_KEY_ENV} is set. "
+                "These signatures provide NO tamper-resistance against an attacker. "
+                f"Provision {SIGNING_KEY_ENV} with a real secret in production.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return AuditSigner(_DEV_DEFAULT_KEY, is_dev_key=True)
+    if not _warned_unsigned:
+        _warned_unsigned = True
+        warnings.warn(
+            f"{SIGNING_KEY_ENV} is not set; agent audit entries will be hash-chained "
+            "but left UNSIGNED (verification reports them as unsigned). Set "
+            f"{SIGNING_KEY_ENV} to a real secret, or {ALLOW_INSECURE_KEY_ENV}=1 to "
+            "explicitly opt into the insecure built-in dev key.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return AuditSigner(None)
+
+
+@dataclass
+class AuditAction:
+    """One immutable, sealed audit record for a single governed action."""
+
+    execution_id: str
+    sequence: int
+    action_type: str  # "tool_call" | "agent_turn"
+    actor_id: str
+    agent: str
+    model: str
+    decision: str = "allow"
+    actor_type: str = "agent"
+    tool: str | None = None
+    arguments_hash: str | None = None
+    result_hash: str | None = None
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    prev_hash: str | None = None
+    entry_hash: str | None = None
+    signature: str | None = None
+
+    def content_hash(self, prev_hash: str | None) -> str:
+        """SHA-256 over the immutable content fields chained onto ``prev_hash``.
+
+        Covers every field except the derived ``entry_hash`` / ``signature``,
+        plus ``prev_hash`` so altering any past entry (or re-linking the chain)
+        breaks verification from that point forward.
+        """
+        parts = [
+            self.id,
+            self.execution_id,
+            str(self.sequence),
+            self.action_type,
+            self.actor_id,
+            self.actor_type,
+            self.agent,
+            self.model,
+            self.decision,
+            self.tool or "",
+            self.arguments_hash or "",
+            self.result_hash or "",
+            self.created_at,
+            prev_hash or "",
+        ]
+        # Coerce defensively to str so a stray non-string field (e.g. a mocked
+        # execution_id) hashes deterministically instead of raising.
+        digest = hashlib.sha256(_FIELD_SEP.join(str(p) for p in parts).encode("utf-8")).hexdigest()
+        return digest
+
+    def seal(self, prev_hash: str | None, signer: AuditSigner) -> None:
+        """Record ``prev_hash``, compute ``entry_hash``, then sign it.
+
+        With an unsigned signer (no key configured) ``signature`` stays ``None``
+        — the entry is chained but honestly marked unsigned.
+        """
+        h = self.content_hash(prev_hash)
+        self.entry_hash = h
+        self.prev_hash = prev_hash
+        self.signature = signer.sign(h.encode("utf-8"))
+
+
+def _hash_value(value: Any) -> str:
+    """A stable SHA-256 of an arbitrary JSON-able value (for args/result refs)."""
+    try:
+        blob = json.dumps(value, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        blob = repr(value)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build_action_chain(
+    *,
+    agent_name: str,
+    model: str,
+    execution_id: str,
+    prompt: str,
+    output: Any,
+    tool_calls: Iterable[dict[str, Any]],
+    signer: AuditSigner | None = None,
+) -> list[AuditAction]:
+    """Build a sealed, chained audit record for one governed agent run.
+
+    Emits one ``tool_call`` action per tool the run invoked, in order, followed
+    by one ``agent_turn`` action for the model turn that produced ``output`` —
+    so every action the agent took is audited, not just approvals. The chain is
+    sealed and signed with ``signer`` (defaults to :func:`resolve_signer`).
+    """
+    if signer is None:
+        signer = resolve_signer()
+
+    actor_id = _default_actor_id()
+    actions: list[AuditAction] = []
+    seq = 0
+    for tc in tool_calls:
+        actions.append(
+            AuditAction(
+                execution_id=execution_id,
+                sequence=seq,
+                action_type="tool_call",
+                actor_id=actor_id,
+                agent=agent_name,
+                model=model,
+                tool=tc.get("tool"),
+                arguments_hash=_hash_value(tc.get("input")),
+                result_hash=_hash_value(tc.get("output")),
+            )
+        )
+        seq += 1
+    actions.append(
+        AuditAction(
+            execution_id=execution_id,
+            sequence=seq,
+            action_type="agent_turn",
+            actor_id=actor_id,
+            agent=agent_name,
+            model=model,
+            arguments_hash=_hash_value(prompt),
+            result_hash=_hash_value("" if output is None else output),
+        )
+    )
+
+    prev: str | None = None
+    for action in actions:
+        action.seal(prev, signer)
+        prev = action.entry_hash
+    return actions
+
+
+def verify_chain(entries: list[AuditAction], signer: AuditSigner) -> None:
+    """Re-walk a sealed audit chain; raise :class:`ChainError` on any deviation.
+
+    Checks, for each entry in order: it is sealed + signed, its ``prev_hash``
+    links to the previous entry's ``entry_hash`` (``None`` at genesis), its
+    recomputed content hash matches the recorded ``entry_hash`` (tamper check),
+    and its signature verifies under ``signer`` (forgery check). Mirrors the
+    Rust ``verify_chain``.
+    """
+    prev: str | None = None
+    for index, entry in enumerate(entries):
+        if entry.entry_hash is None:
+            raise ChainError(index, "unsealed")
+        if entry.signature is None:
+            raise ChainError(index, "unsigned")
+        if entry.prev_hash != prev:
+            raise ChainError(index, "broken_link")
+        if entry.content_hash(entry.prev_hash) != entry.entry_hash:
+            raise ChainError(index, "hash_mismatch")
+        if not signer.verify(entry.entry_hash.encode("utf-8"), entry.signature):
+            raise ChainError(index, "bad_signature")
+        prev = entry.entry_hash
+
+
+def _default_actor_id() -> str:
+    return f"agent:jamjet:pid/{os.getpid()}"
+
+
+__all__ = [
+    "AuditAction",
+    "AuditSigner",
+    "ChainError",
+    "build_action_chain",
+    "resolve_signer",
+    "verify_chain",
+]

--- a/sdk/python/jamjet/agents/governance.py
+++ b/sdk/python/jamjet/agents/governance.py
@@ -61,9 +61,23 @@ class GovernanceConfig:
     budget
         Optional per-run spending cap.  ``None`` when uncapped.
     pii
-        Redact PII from prompts/outputs at the seam.  ON by default.
+        Redact PII from outbound prompts at the model seam.  ON by default.
+        Enforced on the in-process ``agent.run()`` path by the seam middleware
+        (``PiiRedactionMiddleware``) and on the durable path by the model-seam
+        SIDECAR (made prod-mandatory by 2e's fail-loud coverage guard).  The
+        compiled ``data_policy`` IR is emitted as metadata for the audit-log
+        redactor, but the native Rust model adapters do NOT perform outbound PII
+        redaction without the sidecar (dev/fallback path) — see
+        :mod:`jamjet.compiler.agent_ir` and F-t3-durable-data-policy.
     audit
-        Emit signed audit records for every governed action.  ON by default.
+        Emit a signed, hash-chained audit record per governed ACTION (each tool
+        call + the model turn) on the in-process / SDK path (``agent.run`` /
+        ``agent.run_durable``), attached to ``AgentResult.audit`` and verifiable
+        with :func:`jamjet.agents.audit.verify_chain`.  ON by default; ``audit=
+        False`` emits none.  Signed with ``JAMJET_AUDIT_SIGNING_KEY`` (unsigned-
+        but-chained, with a loud warning, until a key is provisioned).  The
+        durable engine additionally signs approval-decision events; per-node
+        engine-internal audit emission is tracked as F-t3-audit-emit.
     receipts
         Mint AgentBoundary receipts per turn.  ON by default.
     """
@@ -138,9 +152,7 @@ def _parse_budget(value: Budget | float | int | dict | None) -> Budget | None:
             tokens=value.get("tokens"),
             cost_usd=value.get("cost_usd"),
         )
-    raise TypeError(
-        f"budget must be a Budget, number, dict, or None — got {type(value).__name__!r}"
-    )
+    raise TypeError(f"budget must be a Budget, number, dict, or None — got {type(value).__name__!r}")
 
 
 def _parse_approval_required(value: ApprovalRequired) -> ApprovalRequired:
@@ -150,6 +162,4 @@ def _parse_approval_required(value: ApprovalRequired) -> ApprovalRequired:
         if not all(isinstance(item, str) for item in value):
             raise TypeError("approval_required list entries must be strings (tool-name globs)")
         return list(value)
-    raise TypeError(
-        f"approval_required must be bool or list[str] — got {type(value).__name__!r}"
-    )
+    raise TypeError(f"approval_required must be bool or list[str] — got {type(value).__name__!r}")

--- a/sdk/python/jamjet/agents/governance.py
+++ b/sdk/python/jamjet/agents/governance.py
@@ -1,0 +1,155 @@
+"""Governance configuration for JamJet agents.
+
+``GovernanceConfig`` is the single, frozen source of truth that the seam-
+middleware factory (T3-2..4) and the IR compiler (T3-5) read.  It is built
+once in ``Agent.__init__`` via :func:`normalize_governance` and stored as
+``agent.governance``.
+
+This module is deliberately side-effect free — it carries typed config only.
+No enforcement happens here; enforcement is added in later tasks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Budget:
+    """Per-run spending cap.  Either or both fields may be set.
+
+    ``tokens``    – total token cap (input + output combined).
+    ``cost_usd``  – wall-cost cap in US dollars.
+    """
+
+    tokens: int | None = None
+    cost_usd: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.tokens is not None and self.tokens <= 0:
+            raise ValueError("Budget.tokens must be positive")
+        if self.cost_usd is not None and self.cost_usd <= 0:
+            raise ValueError("Budget.cost_usd must be positive")
+
+
+# PolicyRef: for now any str / dict is accepted as a policy reference or
+# inline spec.  T3-5 / T3-6 will type-narrow this as the DSL matures.
+PolicyRef = str | dict | None
+
+# approval_required can be True (all tools) or a list of tool-name globs.
+ApprovalRequired = bool | list[str]
+
+
+@dataclass(frozen=True)
+class GovernanceConfig:
+    """Immutable governance configuration attached to every Agent.
+
+    Fields
+    ------
+    policy
+        A policy reference or inline spec (str YAML path / dict IR block /
+        None).  ``None`` means no explicit policy; defaults apply.
+    approval_required
+        ``False``  – no approval gate (default).
+        ``True``   – every tool call requires approval.
+        ``list``   – tool-name globs that require approval (e.g.
+                     ``["delete_*", "send_*"]``).
+    budget
+        Optional per-run spending cap.  ``None`` when uncapped.
+    pii
+        Redact PII from prompts/outputs at the seam.  ON by default.
+    audit
+        Emit signed audit records for every governed action.  ON by default.
+    receipts
+        Mint AgentBoundary receipts per turn.  ON by default.
+    """
+
+    policy: PolicyRef = None
+    approval_required: ApprovalRequired = False
+    budget: Budget | None = None
+    pii: bool = True
+    audit: bool = True
+    receipts: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Normaliser
+# ---------------------------------------------------------------------------
+
+
+def normalize_governance(
+    *,
+    policy: PolicyRef = None,
+    approval_required: ApprovalRequired = False,
+    budget: Budget | float | int | dict | None = None,
+    pii: bool = True,
+    audit: bool = True,
+    receipts: bool = True,
+) -> GovernanceConfig:
+    """Parse and validate governance kwargs into a frozen :class:`GovernanceConfig`.
+
+    ``budget`` coercions
+    --------------------
+    * ``None``                         -> ``None`` (uncapped)
+    * ``int`` or ``float``             -> ``Budget(cost_usd=value)``
+    * ``Budget``                       -> returned as-is
+    * ``dict`` with ``tokens``/``cost_usd`` keys -> ``Budget(**dict)``
+
+    ``approval_required`` coercions
+    --------------------------------
+    * ``bool``        -> stored directly
+    * ``list[str]``   -> stored directly (each entry is a tool-name glob)
+    """
+    resolved_budget = _parse_budget(budget)
+    resolved_approval = _parse_approval_required(approval_required)
+
+    return GovernanceConfig(
+        policy=policy,
+        approval_required=resolved_approval,
+        budget=resolved_budget,
+        pii=pii,
+        audit=audit,
+        receipts=receipts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_budget(value: Budget | float | int | dict | None) -> Budget | None:
+    if value is None:
+        return None
+    if isinstance(value, Budget):
+        return value
+    if isinstance(value, (int, float)):
+        return Budget(cost_usd=float(value))
+    if isinstance(value, dict):
+        known_keys = {"tokens", "cost_usd"}
+        unknown = set(value) - known_keys
+        if unknown:
+            raise ValueError(f"Unknown budget keys: {unknown!r}.  Expected subset of {known_keys!r}.")
+        return Budget(
+            tokens=value.get("tokens"),
+            cost_usd=value.get("cost_usd"),
+        )
+    raise TypeError(
+        f"budget must be a Budget, number, dict, or None — got {type(value).__name__!r}"
+    )
+
+
+def _parse_approval_required(value: ApprovalRequired) -> ApprovalRequired:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, list):
+        if not all(isinstance(item, str) for item in value):
+            raise TypeError("approval_required list entries must be strings (tool-name globs)")
+        return list(value)
+    raise TypeError(
+        f"approval_required must be bool or list[str] — got {type(value).__name__!r}"
+    )

--- a/sdk/python/jamjet/agents/receipts.py
+++ b/sdk/python/jamjet/agents/receipts.py
@@ -1,0 +1,89 @@
+"""Mint AgentBoundary Action Receipts for governed agent turns.
+
+Receipts are ON by default (``GovernanceConfig.receipts``). A receipt is the
+portable, tamper-evident proof that *this* agent took *this* action under a
+policy decision -- the "Prove" pillar of governance-on-by-default.
+
+This module reuses the **exact** mint path the opt-in :func:`jamjet.gate`
+decorator uses (:func:`jamjet.gate._build_receipt` plus ``agentboundary``'s
+canonical-hash helpers), so an agent-turn receipt is byte-for-byte the same
+shape as a gated tool-call receipt and passes ``validate_receipt`` +
+``check_conformance`` for the same reasons.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+ReceiptEmitter = Callable[[dict[str, Any]], None]
+
+
+def agent_action_arguments(*, agent_name: str, model: str, prompt: str) -> dict[str, Any]:
+    """The canonical ``arguments`` object a governed agent turn is hashed over.
+
+    Exposed (and stable) so callers and tests can recompute the
+    ``arguments_hash`` and prove the receipt is bound to *this* action -- the
+    provenance link between the receipt and the agent run.
+    """
+    return {"agent": agent_name, "model": model, "prompt": prompt}
+
+
+def mint_agent_receipt(
+    *,
+    agent_name: str,
+    model: str,
+    prompt: str,
+    output: str,
+    target_system: str = "local",
+    target_environment: str = "prod",
+    emitter: ReceiptEmitter | None = None,
+) -> dict[str, Any]:
+    """Mint a v0.1 Action Receipt for one governed agent turn.
+
+    Reuses :func:`jamjet.gate._build_receipt` so the receipt is identical in
+    shape to a ``@gate`` receipt. The turn is recorded as an ``allow`` decision
+    (the agent ran to completion). Returns the receipt dict; when ``emitter`` is
+    supplied the receipt is also shipped there (the dict is always returned so
+    the caller can attach it to the run result regardless).
+    """
+    # Imported lazily to keep ``import jamjet`` light and avoid any import cycle
+    # through the gate module.
+    from agentboundary.hashing import compute_arguments_hash  # noqa: PLC0415
+
+    from jamjet.gate import (  # noqa: PLC0415
+        _AgentMeta,
+        _build_receipt,
+        _default_actor_id,
+        _result_ref,
+    )
+    from jamjet.policies.decider import PolicyOutcome  # noqa: PLC0415
+
+    arguments = agent_action_arguments(agent_name=agent_name, model=model, prompt=prompt)
+    outcome = PolicyOutcome(
+        decision="allow",
+        name="jamjet.agent.governance",
+        version="1",
+        reason="governed agent turn (receipts on by default)",
+    )
+    receipt = _build_receipt(
+        action_id=f"agent.{agent_name}",
+        outcome=outcome,
+        approval=None,
+        execution="success",
+        result_ref=_result_ref(output),
+        bound=arguments,
+        args_hash=compute_arguments_hash(arguments),
+        actor_id=_default_actor_id(),
+        actor_type="agent",
+        actor_display_name=agent_name,
+        target_system=target_system,
+        target_environment=target_environment,
+        meta=_AgentMeta(model=model),
+    )
+    if emitter is not None:
+        emitter(receipt)
+    return receipt
+
+
+__all__ = ["ReceiptEmitter", "agent_action_arguments", "mint_agent_receipt"]

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -87,11 +87,11 @@ _DEFAULT_PII_DETECTORS: list[str] = [
 # DataPolicyIr dict emitted when GovernanceConfig.pii is True (the default).
 # Field names match the serde snake_case fields in DataPolicyIr (workflow.rs:231-258).
 _DEFAULT_DATA_POLICY_IR: dict[str, Any] = {
-    "pii_fields": [],                  # no extra JSON-path patterns beyond the detectors
+    "pii_fields": [],  # no extra JSON-path patterns beyond the detectors
     "pii_detectors": _DEFAULT_PII_DETECTORS,
-    "redaction_mode": "mask",          # replace PII with [REDACTED]
-    "retain_prompts": False,           # do not persist raw prompts in the audit log
-    "retain_outputs": True,            # model outputs ARE retained for audit/debug
+    "redaction_mode": "mask",  # replace PII with [REDACTED]
+    "retain_prompts": False,  # do not persist raw prompts in the audit log
+    "retain_outputs": True,  # model outputs ARE retained for audit/debug
     # retention_days omitted -> indefinite (matches serde skip_serializing_if = "Option::is_none")
 }
 
@@ -173,9 +173,14 @@ def _compile_governance_ir(agent: Agent) -> dict[str, Any]:
     budget.cost_usd  ->  cost_budget_usd: f64          (only when set)
     budget.tokens    ->  token_budget.total_tokens: u32 (only when set)
     policy / approval_required  ->  policy: PolicySetIr (only when rules exist)
-    pii=True         ->  data_policy: DataPolicyIr      (always for pii-on agents)
-    pii=False        ->  (omitted — no Rust-side PII redaction)
+    pii=True         ->  data_policy: DataPolicyIr      (metadata; see below)
+    pii=False        ->  (omitted)
     =========================================================
+
+    ``data_policy`` is emitted as METADATA, not a durable enforcement point:
+    durable outbound PII redaction is the model-seam sidecar's job
+    (F-t3-durable-data-policy).  See :func:`_compile_governance_ir` for the
+    precise honest scope.
     """
     gov = agent.governance
     out: dict[str, Any] = {}
@@ -198,9 +203,18 @@ def _compile_governance_ir(agent: Agent) -> dict[str, Any]:
         out["policy"] = policy_ir
 
     # ── Data policy / PII (workflow.rs:63-64) ───────────────────────────────
-    # pii=True (the default) -> emit the standard DataPolicyIr so the Rust
-    # audit enricher redacts PII from raw_event before persisting.
-    # pii=False -> omit the field entirely (no Rust-side redaction).
+    # pii=True (the default) -> emit the standard DataPolicyIr as METADATA.
+    #
+    # HONEST SCOPE (F-t3-durable-data-policy): on the durable path, outbound PII
+    # redaction is performed by the model-seam SIDECAR (made prod-mandatory by
+    # 2e's fail-loud coverage guard), NOT by this IR field.  The native Rust
+    # model adapters send UNREDACTED prompts when JAMJET_MODEL_SEAM_URL is unset
+    # (the dev/fallback path).  This `data_policy` block is consumed by the audit
+    # enricher's log redactor only when a RequestContext carries it
+    # (enricher.rs:153) — which the current API request contexts do not yet set,
+    # so it is metadata, not an active Rust enforcement point.  Do not read this
+    # field as a guarantee that durable model calls are PII-redacted.
+    # pii=False -> omit the field entirely.
     if gov.pii:
         out["data_policy"] = _DEFAULT_DATA_POLICY_IR
 

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -43,6 +43,7 @@ from jamjet.model.types import parse_model_ref
 
 if TYPE_CHECKING:
     from jamjet.agents.agent import Agent
+    from jamjet.agents.governance import GovernanceConfig
     from jamjet.tools.decorators import ToolDefinition
 
 # The tool-dispatch PythonFn node points at this coroutine.
@@ -66,6 +67,135 @@ _TOOLS_RETRY_POLICY = "no_retry"
 # IR content (see :func:`_content_version`) so a changed agent never reuses a
 # stale immutably-cached graph.
 _VERSION_BASE = "0.1.0"
+
+# ---------------------------------------------------------------------------
+# Governance IR constants (T3-5)
+# ---------------------------------------------------------------------------
+
+# Standard PII detector names that match the Rust PiiRedactor
+# (runtime/policy/src/redaction.rs) and the Python cloud redactor
+# (cloud/middleware/pii.py). Enabling all five built-in types by default.
+_DEFAULT_PII_DETECTORS: list[str] = [
+    "email",
+    "ssn",
+    "credit_card",
+    "phone",
+    "ip_address",
+]
+
+# DataPolicyIr dict emitted when GovernanceConfig.pii is True (the default).
+# Field names match the serde snake_case fields in DataPolicyIr (workflow.rs:231-258).
+_DEFAULT_DATA_POLICY_IR: dict[str, Any] = {
+    "pii_fields": [],                  # no extra JSON-path patterns beyond the detectors
+    "pii_detectors": _DEFAULT_PII_DETECTORS,
+    "redaction_mode": "mask",          # replace PII with [REDACTED]
+    "retain_prompts": False,           # do not persist raw prompts in the audit log
+    "retain_outputs": True,            # model outputs ARE retained for audit/debug
+    # retention_days omitted -> indefinite (matches serde skip_serializing_if = "Option::is_none")
+}
+
+
+def _compile_agent_policy_ir(gov: GovernanceConfig) -> dict[str, Any] | None:
+    """Build a PolicySetIr dict from *gov*, or ``None`` when no policy rules are needed.
+
+    Mapping (GovernanceConfig -> PolicySetIr — workflow.rs:201-211):
+    - ``policy`` dict  -> base values for ``blocked_tools`` / ``require_approval_for``
+                          / ``model_allowlist``; unknown keys are passed through so the
+                          Rust serde ``deny_unknown_fields``-free schema accepts them.
+    - ``policy`` str   -> empty skeleton now; T3-6 resolves the string to real rules.
+    - ``approval_required=True``   -> ``require_approval_for = ["*"]`` (all tools).
+    - ``approval_required=[...]``  -> ``require_approval_for = [...]`` (those globs).
+
+    Returns ``None`` only when both ``policy`` and ``approval_required`` are unset/empty,
+    which prevents emitting a no-op policy block that wastes bytes and confuses the cache.
+    """
+    approval = gov.approval_required
+    has_policy_ref = gov.policy is not None
+    has_approval = (approval is True) or (isinstance(approval, list) and len(approval) > 0)
+
+    if not has_policy_ref and not has_approval:
+        return None
+
+    # Base from dict-shaped inline policy spec.
+    if isinstance(gov.policy, dict):
+        blocked: list[str] = list(gov.policy.get("blocked_tools") or [])
+        require: list[str] = list(gov.policy.get("require_approval_for") or [])
+        allowlist: list[str] = list(gov.policy.get("model_allowlist") or [])
+    else:
+        # String policy reference (e.g. "strict") — T3-6 will load and expand it
+        # into blocked_tools / model_allowlist; emit an empty skeleton so that any
+        # approval_required rules set below still take effect on the durable path.
+        blocked = []
+        require = []
+        allowlist = []
+
+    # Merge approval_required into require_approval_for.
+    if approval is True:
+        require = ["*"]  # wildcard: every tool requires human approval
+    elif isinstance(approval, list) and approval:
+        # Union the caller-provided globs with any dict-policy require_approval_for,
+        # preserving declaration order and deduplicating.
+        seen: set[str] = set(require)
+        merged: list[str] = list(require)
+        for glob in approval:
+            if glob not in seen:
+                merged.append(glob)
+                seen.add(glob)
+        require = merged
+
+    return {
+        "blocked_tools": blocked,
+        "require_approval_for": require,
+        "model_allowlist": allowlist,
+    }
+
+
+def _compile_governance_ir(agent: Agent) -> dict[str, Any]:
+    """Emit the governance top-level IR fields from ``agent.governance``.
+
+    This is the single T3-5 wiring point: it translates the typed
+    ``GovernanceConfig`` into the exact dict keys the Rust ``WorkflowIr``
+    deserializes (workflow.rs:45-65).  Only fields with *non-trivial* values
+    are emitted to avoid spurious deny-all budget blocks and to keep the IR
+    clean for agents that don't set governance knobs.
+
+    Field mapping (Python -> Rust IR):
+    =========================================================
+    budget.cost_usd  ->  cost_budget_usd: f64          (only when set)
+    budget.tokens    ->  token_budget.total_tokens: u32 (only when set)
+    policy / approval_required  ->  policy: PolicySetIr (only when rules exist)
+    pii=True         ->  data_policy: DataPolicyIr      (always for pii-on agents)
+    pii=False        ->  (omitted — no Rust-side PII redaction)
+    =========================================================
+    """
+    gov = agent.governance
+    out: dict[str, Any] = {}
+
+    # ── Budget (workflow.rs:49-57) ──────────────────────────────────────────
+    # Emit ONLY when the respective field is explicitly set; a zero-value
+    # budget block would immediately exceed the cap and deny all runs.
+    if gov.budget is not None:
+        if gov.budget.cost_usd is not None:
+            # cost_budget_usd: Option<f64> — execution fails when exceeded.
+            out["cost_budget_usd"] = gov.budget.cost_usd
+        if gov.budget.tokens is not None:
+            # token_budget: Option<TokenBudgetIr> — total_tokens cap covers
+            # combined input+output, which is the most useful single-knob limit.
+            out["token_budget"] = {"total_tokens": gov.budget.tokens}
+
+    # ── Policy + Approval (workflow.rs:46-47) ───────────────────────────────
+    policy_ir = _compile_agent_policy_ir(gov)
+    if policy_ir is not None:
+        out["policy"] = policy_ir
+
+    # ── Data policy / PII (workflow.rs:63-64) ───────────────────────────────
+    # pii=True (the default) -> emit the standard DataPolicyIr so the Rust
+    # audit enricher redacts PII from raw_event before persisting.
+    # pii=False -> omit the field entirely (no Rust-side redaction).
+    if gov.pii:
+        out["data_policy"] = _DEFAULT_DATA_POLICY_IR
+
+    return out
 
 
 def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[str, Any]:
@@ -217,10 +347,21 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
             "jamjet.agent.max_turns": str(max_turns),
         },
     }
+
+    # ── Governance IR fields (T3-5) ────────────────────────────────────────────
+    # Emit policy / budget / data_policy from the agent's GovernanceConfig so the
+    # Rust engine enforces them fail-closed (enforcement already exists in
+    # workers/src/worker.rs; this is the compile-side wiring that turns it on).
+    # These are merged BEFORE content-versioning so the cache key changes when
+    # governance config changes (a different budget or policy must NOT reuse a
+    # cached graph compiled without those constraints).
+    ir.update(_compile_governance_ir(agent))
+
     # Content-version the IR: the runtime caches by (workflow_id, version)
-    # immutably, so a changed agent (tools / instructions / max_turns / timeout)
-    # must yield a new key or a stale graph could run. The prompt is excluded
-    # (it is not in the IR), so re-running the SAME agent reuses the cached graph.
+    # immutably, so a changed agent (tools / instructions / max_turns / timeout
+    # / governance) must yield a new key or a stale graph could run. The prompt
+    # is excluded (it is not in the IR), so re-running the SAME agent reuses
+    # the cached graph.
     ir["version"] = _content_version(ir)
     return ir
 

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -39,6 +39,7 @@ import hashlib
 import json
 from typing import TYPE_CHECKING, Any
 
+from jamjet.model.policy_resolver import resolve_named_policy
 from jamjet.model.types import parse_model_ref
 
 if TYPE_CHECKING:
@@ -102,7 +103,9 @@ def _compile_agent_policy_ir(gov: GovernanceConfig) -> dict[str, Any] | None:
     - ``policy`` dict  -> base values for ``blocked_tools`` / ``require_approval_for``
                           / ``model_allowlist``; unknown keys are passed through so the
                           Rust serde ``deny_unknown_fields``-free schema accepts them.
-    - ``policy`` str   -> empty skeleton now; T3-6 resolves the string to real rules.
+    - ``policy`` str   -> resolved via :func:`~jamjet.model.policy_resolver.resolve_named_policy`
+                          to real ``blocked_tools`` / ``require_approval_for`` /
+                          ``model_allowlist``; raises ``ValueError`` for unknown names.
     - ``approval_required=True``   -> ``require_approval_for = ["*"]`` (all tools).
     - ``approval_required=[...]``  -> ``require_approval_for = [...]`` (those globs).
 
@@ -121,10 +124,16 @@ def _compile_agent_policy_ir(gov: GovernanceConfig) -> dict[str, Any] | None:
         blocked: list[str] = list(gov.policy.get("blocked_tools") or [])
         require: list[str] = list(gov.policy.get("require_approval_for") or [])
         allowlist: list[str] = list(gov.policy.get("model_allowlist") or [])
+    elif isinstance(gov.policy, str):
+        # T3-6: resolve the named policy to real rules so the IR carries
+        # the actual allowlist (not an empty skeleton).  Raises ValueError
+        # for unknown names — a misconfigured policy string is a hard error,
+        # never a silent allow-all in the compiled IR.
+        rules = resolve_named_policy(gov.policy)
+        blocked = list(rules.get("blocked_tools") or [])
+        require = list(rules.get("require_approval_for") or [])
+        allowlist = list(rules.get("model_allowlist") or [])
     else:
-        # String policy reference (e.g. "strict") — T3-6 will load and expand it
-        # into blocked_tools / model_allowlist; emit an empty skeleton so that any
-        # approval_required rules set below still take effect on the durable path.
         blocked = []
         require = []
         allowlist = []

--- a/sdk/python/jamjet/entry.py
+++ b/sdk/python/jamjet/entry.py
@@ -59,11 +59,18 @@ async def resume(
     target: Any,
     execution_id: str,
     *,
+    governance: Any | None = None,
     target_runtime: str | None = None,
 ) -> RuntimeResult:
+    """Resume a durable execution, keeping its governance enforced (M6 parity).
+
+    Pass ``governance`` (e.g. ``agent.governance``) so a resumed in-process run
+    keeps the SAME budget / allowlist / PII enforcement as the original run
+    instead of silently resuming ungoverned.
+    """
     spec = _resolve_spec(target)
     rt = _select_runtime(target_runtime)
-    return await rt.resume(spec, execution_id)
+    return await rt.resume(spec, execution_id, governance=governance)
 
 
 async def deploy(target: Any, *, runtime: str = "cloud") -> None:

--- a/sdk/python/jamjet/model/__init__.py
+++ b/sdk/python/jamjet/model/__init__.py
@@ -13,6 +13,7 @@ from jamjet.model.middleware import (
     ModelDeniedError,
     ModelMiddleware,
 )
+from jamjet.model.pii import PiiRedactionMiddleware
 from jamjet.model.seam import Model
 from jamjet.model.types import (
     ModelRef,
@@ -37,6 +38,7 @@ __all__ = [
     "ModelRef",
     "ModelRequest",
     "ModelResponse",
+    "PiiRedactionMiddleware",
     "StreamChunk",
     "api_key_env_for",
     "default_model_middleware",

--- a/sdk/python/jamjet/model/__init__.py
+++ b/sdk/python/jamjet/model/__init__.py
@@ -3,10 +3,12 @@
 No module outside this package may import a provider SDK on the hot path.
 """
 
+from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.defaults import default_model_middleware
 from jamjet.model.metering import MeteringMiddleware, ModelCallRecord
 from jamjet.model.middleware import (
     BaseModelMiddleware,
+    BudgetExceededError,
     ModelAllowlistMiddleware,
     ModelDeniedError,
     ModelMiddleware,
@@ -24,6 +26,8 @@ from jamjet.model.types import (
 
 __all__ = [
     "BaseModelMiddleware",
+    "BudgetExceededError",
+    "BudgetMiddleware",
     "MeteringMiddleware",
     "Model",
     "ModelAllowlistMiddleware",

--- a/sdk/python/jamjet/model/budget.py
+++ b/sdk/python/jamjet/model/budget.py
@@ -4,13 +4,26 @@
 instance) and denies the next model call — before it reaches the provider —
 when the configured ``Budget`` is already met or exceeded.
 
-Enforcement rule
-----------------
+Enforcement rule (post-hoc, ``>=``)
+-----------------------------------
 Check BEFORE the call: if accumulated spend (tokens and/or cost_usd) is
 already >= the configured limit, raise ``BudgetExceededError`` without calling
 the backend.  After a successful provider response, accumulate the response's
 ``cost_usd`` and total tokens (``input_tokens + output_tokens``) for future
 checks.
+
+Precise semantics (M5):
+
+* The check is ``>=`` and POST-HOC.  Accumulation happens in ``after`` (once a
+  call has already completed), and the next call's ``before`` is what denies.
+* The **first** call of a run ALWAYS proceeds (accumulated spend starts at 0,
+  and ``0 >= limit`` is false for any positive cap).
+* The call that BREACHES the cap still completes — its cost is what pushes the
+  accumulator to/over the limit; the *next* call is the one denied.  So a single
+  unavoidable overshoot of one call is expected by design; the cap bounds how
+  far a run can keep going, it does not abort an in-flight call.
+* A zero/negative budget cannot be constructed (``Budget`` rejects it at
+  construction), so ``>=`` can never deny-all a freshly-started run via a 0 cap.
 
 Run-scoped state
 ----------------

--- a/sdk/python/jamjet/model/budget.py
+++ b/sdk/python/jamjet/model/budget.py
@@ -1,0 +1,94 @@
+"""Fail-closed budget-enforcement middleware (T3-2).
+
+``BudgetMiddleware`` tracks cumulative cost and tokens across a run (per
+instance) and denies the next model call — before it reaches the provider —
+when the configured ``Budget`` is already met or exceeded.
+
+Enforcement rule
+----------------
+Check BEFORE the call: if accumulated spend (tokens and/or cost_usd) is
+already >= the configured limit, raise ``BudgetExceededError`` without calling
+the backend.  After a successful provider response, accumulate the response's
+``cost_usd`` and total tokens (``input_tokens + output_tokens``) for future
+checks.
+
+Run-scoped state
+----------------
+Each ``BudgetMiddleware`` instance carries its own accumulator.  For the
+in-process path, ``LocalRuntime`` creates a new ``SeamAdapter`` (and therefore
+a new ``Model`` with fresh middleware) per execution, so instance state gives
+per-run scoping automatically.  For the sidecar (durable path), the Rust
+engine enforces the budget compiled into the IR (T3-5) and is the
+authoritative check; the seam-level ``BudgetMiddleware`` on the sidecar
+singleton has ``budget=None`` by default and is a no-op pass-through there.
+
+A ``budget`` of ``None`` -> no enforcement; all calls pass through (metering
+via ``MeteringMiddleware`` is separate and still records).
+"""
+
+from __future__ import annotations
+
+from jamjet.agents.governance import Budget
+from jamjet.model.middleware import BaseModelMiddleware, BudgetExceededError
+from jamjet.model.types import ModelRequest, ModelResponse
+
+
+class BudgetMiddleware(BaseModelMiddleware):
+    """Per-run budget enforcement at the model seam.
+
+    Parameters
+    ----------
+    budget:
+        The per-run spending cap.  ``None`` disables enforcement (allow-all).
+        ``Budget(cost_usd=...)`` enforces cost only.
+        ``Budget(tokens=...)`` enforces total tokens only.
+        ``Budget(tokens=..., cost_usd=...)`` enforces either — whichever
+        cap is hit first triggers denial.
+    """
+
+    def __init__(self, budget: Budget | None) -> None:
+        self._budget = budget
+        self._consumed_tokens: int = 0
+        self._consumed_cost_usd: float = 0.0
+
+    # -- Read-only introspection ----------------------------------------------
+
+    @property
+    def consumed_tokens(self) -> int:
+        """Total tokens accumulated so far (input + output across all calls)."""
+        return self._consumed_tokens
+
+    @property
+    def consumed_cost_usd(self) -> float:
+        """Total cost_usd accumulated so far across all calls."""
+        return self._consumed_cost_usd
+
+    # -- Middleware hooks ------------------------------------------------------
+
+    async def before(self, request: ModelRequest) -> ModelRequest:
+        """Deny the call if the accumulated budget is already exhausted."""
+        if self._budget is None:
+            return request
+
+        cost_cap = self._budget.cost_usd
+        token_cap = self._budget.tokens
+
+        cost_exceeded = cost_cap is not None and self._consumed_cost_usd >= cost_cap
+        token_exceeded = token_cap is not None and self._consumed_tokens >= token_cap
+
+        if cost_exceeded or token_exceeded:
+            raise BudgetExceededError(
+                limit_usd=cost_cap,
+                limit_tokens=token_cap,
+                consumed_usd=self._consumed_cost_usd,
+                consumed_tokens=self._consumed_tokens,
+            )
+
+        return request
+
+    async def after(self, request: ModelRequest, response: ModelResponse) -> ModelResponse:
+        """Accumulate the cost and tokens from a completed call."""
+        if self._budget is not None:
+            self._consumed_tokens += response.input_tokens + response.output_tokens
+            self._consumed_cost_usd += response.cost_usd
+        return response

--- a/sdk/python/jamjet/model/defaults.py
+++ b/sdk/python/jamjet/model/defaults.py
@@ -2,16 +2,50 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.metering import MeteringMiddleware
 from jamjet.model.middleware import ModelAllowlistMiddleware, ModelMiddleware
 
+if TYPE_CHECKING:
+    from jamjet.agents.governance import GovernanceConfig
 
-def default_model_middleware() -> list[ModelMiddleware]:
-    """The Track-1 default chain: allow-all + metering.
 
-    ``ModelAllowlistMiddleware(None)`` is allow-all by design for Track 1;
-    Track 3 replaces the ``None`` with the agent's policy-derived allowlist
-    (and adds budget + PII middleware) HERE, so every seam call site inherits
-    it from one place.
+def default_model_middleware(
+    governance: GovernanceConfig | None = None,
+) -> list[ModelMiddleware]:
+    """The default seam middleware chain.
+
+    Track 1 default: allow-all allowlist + no-budget + metering.
+    Track 3 (T3-2): passing ``governance`` enables budget enforcement.
+
+    Chain order
+    -----------
+    1. ``ModelAllowlistMiddleware`` — deny disallowed models (allow-all when
+       ``allowed=None``; Track 3 T3-6 wires the real policy-derived list).
+    2. ``BudgetMiddleware`` — fail-closed per-run budget enforcement; no-op
+       when ``governance`` is ``None`` or ``governance.budget`` is ``None``.
+    3. ``MeteringMiddleware`` — passive cost/token recorder; always active.
+
+    Threading the budget
+    --------------------
+    Pass ``agent.governance`` (set by T3-1 in ``Agent.__init__``) so that
+    every seam call site inherits budget enforcement from one place:
+
+    * ``Agent.stream()`` passes ``self.governance`` here.
+    * ``SeamAdapter`` (in-process via ``LocalRuntime``) creates a fresh
+      instance per run via ``default_model_middleware()``.  For the
+      ``Agent.run()`` path, governance threading through ``LocalRuntime`` is a
+      T3-7 follow-up; the sidecar path delegates to the Rust-side budget (T3-5).
+
+    Each call to ``default_model_middleware()`` returns FRESH instances so
+    middleware state (budget accumulator, metering records) never leaks between
+    runs.
     """
-    return [ModelAllowlistMiddleware(None), MeteringMiddleware()]
+    budget = governance.budget if governance is not None else None
+    return [
+        ModelAllowlistMiddleware(None),
+        BudgetMiddleware(budget),
+        MeteringMiddleware(),
+    ]

--- a/sdk/python/jamjet/model/defaults.py
+++ b/sdk/python/jamjet/model/defaults.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.metering import MeteringMiddleware
 from jamjet.model.middleware import ModelAllowlistMiddleware, ModelMiddleware
+from jamjet.model.pii import PiiRedactionMiddleware
 
 if TYPE_CHECKING:
     from jamjet.agents.governance import GovernanceConfig
@@ -19,14 +20,25 @@ def default_model_middleware(
 
     Track 1 default: allow-all allowlist + no-budget + metering.
     Track 3 (T3-2): passing ``governance`` enables budget enforcement.
+    Track 3 (T3-3): PII redaction is ON by default; ``pii=False`` omits it.
 
     Chain order
     -----------
-    1. ``ModelAllowlistMiddleware`` — deny disallowed models (allow-all when
+    1. ``ModelAllowlistMiddleware`` -- deny disallowed models (allow-all when
        ``allowed=None``; Track 3 T3-6 wires the real policy-derived list).
-    2. ``BudgetMiddleware`` — fail-closed per-run budget enforcement; no-op
+    2. ``PiiRedactionMiddleware`` -- redact PII from outbound prompt messages
+       BEFORE the provider or any other middleware sees them; fail-closed
+       (redact-or-deny).  Omitted when ``governance.pii`` is ``False``.
+    3. ``BudgetMiddleware`` -- fail-closed per-run budget enforcement; no-op
        when ``governance`` is ``None`` or ``governance.budget`` is ``None``.
-    3. ``MeteringMiddleware`` — passive cost/token recorder; always active.
+    4. ``MeteringMiddleware`` -- passive cost/token recorder; always active.
+
+    PII is DEFAULT ON
+    -----------------
+    When ``governance`` is ``None`` (no explicit governance config), PII
+    redaction is ENABLED (the safe default).  Pass
+    ``GovernanceConfig(pii=False)`` or ``normalize_governance(pii=False)``
+    to disable it explicitly and receive unredacted prompts at the provider.
 
     Threading the budget
     --------------------
@@ -44,8 +56,11 @@ def default_model_middleware(
     runs.
     """
     budget = governance.budget if governance is not None else None
-    return [
-        ModelAllowlistMiddleware(None),
-        BudgetMiddleware(budget),
-        MeteringMiddleware(),
-    ]
+    pii_on = governance.pii if governance is not None else True
+
+    chain: list[ModelMiddleware] = [ModelAllowlistMiddleware(None)]
+    if pii_on:
+        chain.append(PiiRedactionMiddleware())
+    chain.append(BudgetMiddleware(budget))
+    chain.append(MeteringMiddleware())
+    return chain

--- a/sdk/python/jamjet/model/defaults.py
+++ b/sdk/python/jamjet/model/defaults.py
@@ -8,6 +8,7 @@ from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.metering import MeteringMiddleware
 from jamjet.model.middleware import ModelAllowlistMiddleware, ModelMiddleware
 from jamjet.model.pii import PiiRedactionMiddleware
+from jamjet.model.policy_resolver import resolve_policy_allowlist
 
 if TYPE_CHECKING:
     from jamjet.agents.governance import GovernanceConfig
@@ -24,8 +25,11 @@ def default_model_middleware(
 
     Chain order
     -----------
-    1. ``ModelAllowlistMiddleware`` -- deny disallowed models (allow-all when
-       ``allowed=None``; Track 3 T3-6 wires the real policy-derived list).
+    1. ``ModelAllowlistMiddleware`` -- deny disallowed models.  T3-6 derives the
+       allowlist from ``governance.policy``: ``None`` -> allow-all; dict with
+       ``model_allowlist`` -> use that set; string -> resolved from the built-in
+       named-policy table (unknown string raises ``ValueError``, never silently
+       allows).
     2. ``PiiRedactionMiddleware`` -- redact PII from outbound prompt messages
        BEFORE the provider or any other middleware sees them; fail-closed
        (redact-or-deny).  Omitted when ``governance.pii`` is ``False``.
@@ -57,8 +61,16 @@ def default_model_middleware(
     """
     budget = governance.budget if governance is not None else None
     pii_on = governance.pii if governance is not None else True
+    policy = governance.policy if governance is not None else None
 
-    chain: list[ModelMiddleware] = [ModelAllowlistMiddleware(None)]
+    # T3-6: resolve the policy to a model allowlist.
+    # - None              -> allow-all (ModelAllowlistMiddleware(None))
+    # - dict w/ allowlist -> use that set
+    # - known str         -> built-in named policy's allowlist
+    # - unknown str       -> ValueError raised here (fail loud, never silent-allow)
+    allowlist = resolve_policy_allowlist(policy)
+
+    chain: list[ModelMiddleware] = [ModelAllowlistMiddleware(allowlist)]
     if pii_on:
         chain.append(PiiRedactionMiddleware())
     chain.append(BudgetMiddleware(budget))

--- a/sdk/python/jamjet/model/middleware.py
+++ b/sdk/python/jamjet/model/middleware.py
@@ -20,6 +20,35 @@ class ModelDeniedError(Exception):
         self.code = code
 
 
+class BudgetExceededError(ModelDeniedError):
+    """Raised by ``BudgetMiddleware`` when accumulated spend has reached the budget.
+
+    Fail-closed: the call is denied *before* it reaches the provider.
+    Both the limit and the consumed amount are named in the message so callers
+    can surface the exact figures to the user or an audit log.
+    """
+
+    def __init__(
+        self,
+        *,
+        limit_usd: float | None,
+        limit_tokens: int | None,
+        consumed_usd: float,
+        consumed_tokens: int,
+    ) -> None:
+        parts: list[str] = []
+        if limit_usd is not None:
+            parts.append(f"cost ${consumed_usd:.6f} >= limit ${limit_usd:.6f}")
+        if limit_tokens is not None:
+            parts.append(f"tokens {consumed_tokens} >= limit {limit_tokens}")
+        reason = "budget exceeded: " + "; ".join(parts) if parts else "budget exceeded"
+        super().__init__(reason, code="budget_exceeded")
+        self.limit_usd = limit_usd
+        self.limit_tokens = limit_tokens
+        self.consumed_usd = consumed_usd
+        self.consumed_tokens = consumed_tokens
+
+
 @runtime_checkable
 class ModelMiddleware(Protocol):
     async def before(self, request: ModelRequest) -> ModelRequest: ...

--- a/sdk/python/jamjet/model/pii.py
+++ b/sdk/python/jamjet/model/pii.py
@@ -11,14 +11,21 @@ If the detector genuinely raises while redacting a STRING it was handed
 ``ModelDeniedError(code="pii_redaction_error")`` so the provider is never
 called with unredacted text.
 
-Robust content extraction
--------------------------
-The detector only ever runs on plain-string content.  A message whose shape
-the redactor does not understand — a non-dict message (a provider SDK message
-object or a test mock), ``None`` / non-string content, or a structured content
-block without a string ``text`` field — is PASSED THROUGH unchanged.  An
-unexpected message shape is not a redaction failure and never trips the deny
-path; only a real detector error on real string input does.
+Recursive, fail-closed content traversal
+----------------------------------------
+The redactor RECURSES through the whole message/content structure and runs the
+detector on **every string it can reach**, regardless of key or nesting:
+plain-string content, bare strings inside a content list, text under any key
+(not only ``"text"``), and arbitrarily nested dicts/lists.  A non-dict message
+(a provider SDK message object or a test mock) has its textual ``content``
+surface redacted on a copy.  Genuinely non-textual leaves — ``bytes``, numbers,
+``None``, an image-URL with no PII — pass through.
+
+If a reachable value is an opaque object the redactor cannot traverse but which
+may hold string data, the call is DENIED (``ModelDeniedError`` with code
+``pii_unredactable_content``) rather than forwarded — fail-CLOSED: any reachable
+string is redacted, or the call is denied; nothing unredacted reaches the
+provider.
 
 A prompt that contains no PII passes through unchanged.
 
@@ -56,6 +63,8 @@ tracked as follow-up F-t3-pii-output.
 
 from __future__ import annotations
 
+import copy
+from collections.abc import Mapping
 from typing import Any
 
 from jamjet.cloud.middleware.pii import RegexDetector
@@ -84,11 +93,12 @@ class PiiRedactionMiddleware(BaseModelMiddleware):
 
     Fail-closed
     -----------
-    A genuine exception from ``detector.redact`` on string input raises
-    ``ModelDeniedError(code="pii_redaction_error")`` -- the provider is NEVER
-    called with unredacted text (redact-or-deny posture).  An unexpected
-    message shape (non-dict message, non-string content) is skipped and passed
-    through unchanged rather than denied.
+    Every reachable string is redacted.  A genuine exception from
+    ``detector.redact`` on string input raises
+    ``ModelDeniedError(code="pii_redaction_error")``; an opaque value the
+    redactor cannot traverse (but which may hold strings) raises
+    ``ModelDeniedError(code="pii_unredactable_content")``.  Either way the
+    provider is NEVER called with unredacted text (redact-or-deny posture).
     """
 
     def __init__(
@@ -106,16 +116,13 @@ class PiiRedactionMiddleware(BaseModelMiddleware):
     async def before(self, request: ModelRequest) -> ModelRequest:
         """Redact PII from all message content before it reaches the provider.
 
-        Only plain-string content (and the string ``text`` field of multi-part
-        content blocks) is run through the detector.  Messages whose shape the
-        redactor does not understand — a non-dict message, ``None`` / non-string
-        content, or a block without a string ``text`` field — are passed through
-        unchanged; an unexpected shape is skipped, never denied.
-
-        Fail-closed: the deny path lives in :func:`_redact_text` and triggers
-        ONLY when the detector genuinely raises on string input, raising
-        ``ModelDeniedError(code="pii_redaction_error")`` so the provider is
-        never called with unredacted text.
+        Recurses through every message and content block and runs the detector
+        on every reachable string (regardless of key or nesting).  Fail-closed:
+        a detector error on string input raises
+        ``ModelDeniedError(code="pii_redaction_error")``; an opaque value the
+        redactor cannot traverse raises
+        ``ModelDeniedError(code="pii_unredactable_content")`` — so the provider
+        is never called with unredacted text.
         """
         request.messages = _redact_messages(request.messages, self._detector)
         return request
@@ -147,23 +154,85 @@ def _redact_text(text: str, detector: Any) -> str:
         ) from exc
 
 
+class _UnredactableError(Exception):
+    """Internal sentinel: an opaque value the redactor cannot traverse but which
+    may hold string data.  Caught at the message boundary and turned into a
+    fail-closed ``ModelDeniedError`` (never propagated to callers)."""
+
+
+def _redact_value(value: Any, detector: Any) -> Any:
+    """Recursively redact every string reachable inside ``value``.
+
+    ``str`` -> redacted; ``Mapping`` -> values recursed (keys are field names,
+    left as-is); ``list`` / ``tuple`` -> elements recursed; ``bytes``-like and
+    non-string scalars (``bool`` / ``int`` / ``float`` / ``None``) pass through
+    as genuinely non-textual.  Any other opaque object raises
+    :class:`_UnredactableError` so the caller fails CLOSED rather than forwarding a
+    string it could not reach.  Builds new containers so the caller's structures
+    are never mutated.
+    """
+    if isinstance(value, str):
+        return _redact_text(value, detector)
+    # bool is an int subclass; both (and float / None) are non-textual scalars.
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return value
+    if isinstance(value, Mapping):
+        return {k: _redact_value(v, detector) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(v, detector) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(v, detector) for v in value)
+    # An opaque object that is not provably non-textual -- cannot guarantee no
+    # string slips through, so fail CLOSED.
+    raise _UnredactableError(type(value).__name__)
+
+
+def _redact_message(msg: Any, detector: Any) -> Any:
+    """Redact one message, returning a redacted copy (never mutating ``msg``).
+
+    A mapping message is recursed in full.  A provider/mock message OBJECT (the
+    assistant message the in-process loop appends back into the running list)
+    has its textual ``content`` surface redacted on a shallow copy.  An object
+    with no recognizable textual surface fails CLOSED via :class:`_UnredactableError`.
+    """
+    if isinstance(msg, Mapping):
+        return _redact_value(msg, detector)
+
+    # Message-like object (e.g. a provider SDK message or a test mock): redact
+    # its ``content``.  When there is no PII the original is returned untouched
+    # (no copy, no mutation); only a genuine change forces a redacted copy.
+    if hasattr(msg, "content"):
+        content = msg.content
+        if content is None:
+            return msg
+        redacted = _redact_value(content, detector)  # may raise _UnredactableError
+        if redacted == content:
+            return msg
+        new = copy.copy(msg)
+        try:
+            new.content = redacted
+        except Exception as exc:  # noqa: BLE001 - read-only/frozen -> cannot redact -> deny
+            raise _UnredactableError(type(msg).__name__) from exc
+        return new
+
+    # Opaque, non-mapping message with no content surface -- fail CLOSED.
+    raise _UnredactableError(type(msg).__name__)
+
+
 def _redact_messages(
     messages: list[dict[str, Any]],
     detector: Any,
 ) -> list[dict[str, Any]]:
-    """Return a new message list with PII redacted from all text content.
+    """Return a new message list with PII redacted from every reachable string.
 
-    Robust to unexpected message shapes: only plain-string content (and the
-    string ``text`` field of multi-part content blocks) is run through the
-    detector.  A message that is not a dict, or whose content is ``None`` or a
-    non-string object the redactor does not understand, is passed through
-    unchanged — an unexpected shape is skipped, never denied.  The fail-closed
-    deny path lives in :func:`_redact_text` and fires only on a real detector
-    error against string input.
-
-    Builds a shallow copy of each message dict so the caller's list is never
-    mutated.  Handles both ``"content": "string"`` and
-    ``"content": [{"type": "text", "text": "..."}]`` shapes.
+    Recurses through each message (and arbitrarily nested content) and redacts
+    all strings.  Fail-closed: a detector error on string input raises
+    ``ModelDeniedError(code="pii_redaction_error")`` (in :func:`_redact_text`);
+    an opaque value the redactor cannot traverse raises
+    ``ModelDeniedError(code="pii_unredactable_content")``.  The caller's list and
+    dicts are never mutated.
     """
     # Degenerate / unexpected top-level shape -- nothing to iterate, pass through.
     if not isinstance(messages, list):
@@ -171,24 +240,12 @@ def _redact_messages(
 
     result: list[Any] = []
     for msg in messages:
-        # Unexpected message shape (e.g. a provider SDK message object or a test
-        # mock) -- not a redactable dict, so pass it through untouched.
-        if not isinstance(msg, dict):
-            result.append(msg)
-            continue
-        msg = dict(msg)  # shallow copy -- do not mutate caller's list
-        content = msg.get("content")
-        if isinstance(content, str):
-            msg["content"] = _redact_text(content, detector)
-        elif isinstance(content, list):
-            new_parts: list[Any] = []
-            for part in content:
-                if isinstance(part, dict) and isinstance(part.get("text"), str):
-                    part = dict(part)  # copy before mutating
-                    part["text"] = _redact_text(part["text"], detector)
-                new_parts.append(part)
-            msg["content"] = new_parts
-        # else: content is None or a non-string object the redactor does not
-        # understand -- leave it unchanged (skip, do not deny).
-        result.append(msg)
+        try:
+            result.append(_redact_message(msg, detector))
+        except _UnredactableError as exc:
+            raise ModelDeniedError(
+                f"PII redaction cannot traverse message content of type {exc}; call "
+                "denied to prevent sending unredacted data to the provider.",
+                code="pii_unredactable_content",
+            ) from exc
     return result

--- a/sdk/python/jamjet/model/pii.py
+++ b/sdk/python/jamjet/model/pii.py
@@ -6,10 +6,19 @@ reaches any provider, replacing detected PII with typed placeholder tokens
 
 Fail-closed posture — "redact-or-deny"
 ---------------------------------------
-If the detector raises for any reason (bug in the pattern, an unexpected
-message shape, etc.) the call is DENIED by raising
-``ModelDeniedError(code="pii_redaction_error")``.  The provider is never
+If the detector genuinely raises while redacting a STRING it was handed
+(a real redactor bug) the call is DENIED by raising
+``ModelDeniedError(code="pii_redaction_error")`` so the provider is never
 called with unredacted text.
+
+Robust content extraction
+-------------------------
+The detector only ever runs on plain-string content.  A message whose shape
+the redactor does not understand — a non-dict message (a provider SDK message
+object or a test mock), ``None`` / non-string content, or a structured content
+block without a string ``text`` field — is PASSED THROUGH unchanged.  An
+unexpected message shape is not a redaction failure and never trips the deny
+path; only a real detector error on real string input does.
 
 A prompt that contains no PII passes through unchanged.
 
@@ -75,9 +84,11 @@ class PiiRedactionMiddleware(BaseModelMiddleware):
 
     Fail-closed
     -----------
-    Any exception from ``detector.redact`` raises
+    A genuine exception from ``detector.redact`` on string input raises
     ``ModelDeniedError(code="pii_redaction_error")`` -- the provider is NEVER
-    called with unredacted text (redact-or-deny posture).
+    called with unredacted text (redact-or-deny posture).  An unexpected
+    message shape (non-dict message, non-string content) is skipped and passed
+    through unchanged rather than denied.
     """
 
     def __init__(
@@ -95,21 +106,18 @@ class PiiRedactionMiddleware(BaseModelMiddleware):
     async def before(self, request: ModelRequest) -> ModelRequest:
         """Redact PII from all message content before it reaches the provider.
 
-        Handles both plain-string content and multi-part content lists.
+        Only plain-string content (and the string ``text`` field of multi-part
+        content blocks) is run through the detector.  Messages whose shape the
+        redactor does not understand — a non-dict message, ``None`` / non-string
+        content, or a block without a string ``text`` field — are passed through
+        unchanged; an unexpected shape is skipped, never denied.
 
-        Fail-closed: any exception from the detector raises
+        Fail-closed: the deny path lives in :func:`_redact_text` and triggers
+        ONLY when the detector genuinely raises on string input, raising
         ``ModelDeniedError(code="pii_redaction_error")`` so the provider is
         never called with unredacted text.
         """
-        try:
-            request.messages = _redact_messages(request.messages, self._detector)
-        except ModelDeniedError:
-            raise  # already a deny -- propagate unchanged
-        except Exception as exc:
-            raise ModelDeniedError(
-                f"PII redaction failed; call denied to prevent data leak: {exc!r}",
-                code="pii_redaction_error",
-            ) from exc
+        request.messages = _redact_messages(request.messages, self._detector)
         return request
 
 
@@ -118,29 +126,69 @@ class PiiRedactionMiddleware(BaseModelMiddleware):
 # ---------------------------------------------------------------------------
 
 
+def _redact_text(text: str, detector: Any) -> str:
+    """Redact a single string, denying only on a genuine detector failure.
+
+    This is the *one* place the fail-closed deny path lives: an exception from
+    ``detector.redact`` on real string input becomes a
+    ``ModelDeniedError(code="pii_redaction_error")`` so the provider is never
+    called with text the detector could not clear.  Callers must only pass
+    strings here — unexpected message shapes are filtered out upstream so they
+    never reach (and never trip) this deny path.
+    """
+    try:
+        return detector.redact(text)
+    except ModelDeniedError:
+        raise  # already a deny -- propagate unchanged
+    except Exception as exc:
+        raise ModelDeniedError(
+            f"PII redaction failed; call denied to prevent data leak: {exc!r}",
+            code="pii_redaction_error",
+        ) from exc
+
+
 def _redact_messages(
     messages: list[dict[str, Any]],
     detector: Any,
 ) -> list[dict[str, Any]]:
     """Return a new message list with PII redacted from all text content.
 
+    Robust to unexpected message shapes: only plain-string content (and the
+    string ``text`` field of multi-part content blocks) is run through the
+    detector.  A message that is not a dict, or whose content is ``None`` or a
+    non-string object the redactor does not understand, is passed through
+    unchanged — an unexpected shape is skipped, never denied.  The fail-closed
+    deny path lives in :func:`_redact_text` and fires only on a real detector
+    error against string input.
+
     Builds a shallow copy of each message dict so the caller's list is never
     mutated.  Handles both ``"content": "string"`` and
     ``"content": [{"type": "text", "text": "..."}]`` shapes.
     """
-    result: list[dict[str, Any]] = []
+    # Degenerate / unexpected top-level shape -- nothing to iterate, pass through.
+    if not isinstance(messages, list):
+        return messages
+
+    result: list[Any] = []
     for msg in messages:
+        # Unexpected message shape (e.g. a provider SDK message object or a test
+        # mock) -- not a redactable dict, so pass it through untouched.
+        if not isinstance(msg, dict):
+            result.append(msg)
+            continue
         msg = dict(msg)  # shallow copy -- do not mutate caller's list
         content = msg.get("content")
         if isinstance(content, str):
-            msg["content"] = detector.redact(content)
+            msg["content"] = _redact_text(content, detector)
         elif isinstance(content, list):
             new_parts: list[Any] = []
             for part in content:
                 if isinstance(part, dict) and isinstance(part.get("text"), str):
                     part = dict(part)  # copy before mutating
-                    part["text"] = detector.redact(part["text"])
+                    part["text"] = _redact_text(part["text"], detector)
                 new_parts.append(part)
             msg["content"] = new_parts
+        # else: content is None or a non-string object the redactor does not
+        # understand -- leave it unchanged (skip, do not deny).
         result.append(msg)
     return result

--- a/sdk/python/jamjet/model/pii.py
+++ b/sdk/python/jamjet/model/pii.py
@@ -1,0 +1,146 @@
+"""PII-redaction middleware for the model seam (T3-3).
+
+``PiiRedactionMiddleware`` rewrites ``ModelRequest.messages`` before the call
+reaches any provider, replacing detected PII with typed placeholder tokens
+(``[REDACTED:EMAIL]``, ``[REDACTED:US_SSN]``, etc.).
+
+Fail-closed posture — "redact-or-deny"
+---------------------------------------
+If the detector raises for any reason (bug in the pattern, an unexpected
+message shape, etc.) the call is DENIED by raising
+``ModelDeniedError(code="pii_redaction_error")``.  The provider is never
+called with unredacted text.
+
+A prompt that contains no PII passes through unchanged.
+
+Detector
+--------
+The default detector is a ``RegexDetector`` (from ``jamjet.cloud.middleware.pii``)
+covering four conservative, high-signal types:
+
+  * ``EMAIL``        -- e-mail addresses
+  * ``US_SSN``       -- US social-security numbers (\\d{3}-\\d{2}-\\d{4})
+  * ``CREDIT_CARD``  -- credit/debit card numbers (digit-sequence pattern)
+  * ``PHONE_NUMBER`` -- North-American phone numbers
+
+These mirror the Rust ``PiiRedactor`` types (``runtime/policy/src/redaction.rs``)
+and the cloud ``RegexDetector`` matchers so redaction is consistent across all
+three enforcement layers.
+
+Presidio upgrade path
+---------------------
+Pass a ``CompositeDetector([RegexDetector(...), PresidioDetector(...)])`` from
+``jamjet.cloud.middleware.pii`` for Presidio higher-recall NLP on top:
+
+    from jamjet.cloud.middleware.pii import (
+        CompositeDetector, PresidioDetector, RegexDetector,
+    )
+    detector = CompositeDetector([
+        RegexDetector(types=_DEFAULT_PII_TYPES),
+        PresidioDetector(types=_DEFAULT_PII_TYPES),
+    ])
+    mw = PiiRedactionMiddleware(detector=detector)
+
+Output-PII redaction (the ``after`` hook) is out of scope for v1 and is
+tracked as follow-up F-t3-pii-output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jamjet.cloud.middleware.pii import RegexDetector
+from jamjet.model.middleware import BaseModelMiddleware, ModelDeniedError
+from jamjet.model.types import ModelRequest
+
+# Default PII types -- conservative, high-signal.  Mirrors the Rust redactor
+# types in runtime/policy/src/redaction.rs and the cloud RegexDetector so
+# the three enforcement layers use identical matchers.
+_DEFAULT_PII_TYPES: list[str] = ["EMAIL", "US_SSN", "CREDIT_CARD", "PHONE_NUMBER"]
+
+
+class PiiRedactionMiddleware(BaseModelMiddleware):
+    """Redact PII from outbound prompt messages before the provider sees them.
+
+    Parameters
+    ----------
+    detector:
+        Any object implementing ``redact(text: str) -> str``.  Defaults to a
+        ``RegexDetector`` covering the four default PII types.
+        Inject a custom detector in tests or pass a ``CompositeDetector`` for
+        Presidio-augmented recall (see module docstring for the recipe).
+    pii_types:
+        Override the default type list when using the built-in
+        ``RegexDetector``.  Ignored when ``detector`` is provided explicitly.
+
+    Fail-closed
+    -----------
+    Any exception from ``detector.redact`` raises
+    ``ModelDeniedError(code="pii_redaction_error")`` -- the provider is NEVER
+    called with unredacted text (redact-or-deny posture).
+    """
+
+    def __init__(
+        self,
+        detector: Any | None = None,
+        *,
+        pii_types: list[str] | None = None,
+    ) -> None:
+        if detector is not None:
+            self._detector = detector
+        else:
+            types = pii_types if pii_types is not None else _DEFAULT_PII_TYPES
+            self._detector = RegexDetector(types=types)
+
+    async def before(self, request: ModelRequest) -> ModelRequest:
+        """Redact PII from all message content before it reaches the provider.
+
+        Handles both plain-string content and multi-part content lists.
+
+        Fail-closed: any exception from the detector raises
+        ``ModelDeniedError(code="pii_redaction_error")`` so the provider is
+        never called with unredacted text.
+        """
+        try:
+            request.messages = _redact_messages(request.messages, self._detector)
+        except ModelDeniedError:
+            raise  # already a deny -- propagate unchanged
+        except Exception as exc:
+            raise ModelDeniedError(
+                f"PII redaction failed; call denied to prevent data leak: {exc!r}",
+                code="pii_redaction_error",
+            ) from exc
+        return request
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _redact_messages(
+    messages: list[dict[str, Any]],
+    detector: Any,
+) -> list[dict[str, Any]]:
+    """Return a new message list with PII redacted from all text content.
+
+    Builds a shallow copy of each message dict so the caller's list is never
+    mutated.  Handles both ``"content": "string"`` and
+    ``"content": [{"type": "text", "text": "..."}]`` shapes.
+    """
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        msg = dict(msg)  # shallow copy -- do not mutate caller's list
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = detector.redact(content)
+        elif isinstance(content, list):
+            new_parts: list[Any] = []
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    part = dict(part)  # copy before mutating
+                    part["text"] = detector.redact(part["text"])
+                new_parts.append(part)
+            msg["content"] = new_parts
+        result.append(msg)
+    return result

--- a/sdk/python/jamjet/model/policy_resolver.py
+++ b/sdk/python/jamjet/model/policy_resolver.py
@@ -124,6 +124,4 @@ def resolve_policy_allowlist(policy: str | dict | None) -> set[str] | None:
             return None
         return set(al)
 
-    raise TypeError(
-        f"policy must be str, dict, or None — got {type(policy).__name__!r}"
-    )
+    raise TypeError(f"policy must be str, dict, or None — got {type(policy).__name__!r}")

--- a/sdk/python/jamjet/model/policy_resolver.py
+++ b/sdk/python/jamjet/model/policy_resolver.py
@@ -1,0 +1,129 @@
+"""Policy resolver: map a PolicyRef to the model allowlist (and other rules).
+
+T3-6: replaces the static ``ModelAllowlistMiddleware(None)`` allow-all with a
+real policy-derived set fed into the seam middleware chain.
+
+Design rules
+------------
+* ``policy=None``   -> allow-all (``None`` allowlist).  The documented v1 default.
+  The *other* governance defaults (audit, PII, budget) are still active; the
+  model layer is simply uncapped.
+* ``policy`` is a dict -> read ``model_allowlist`` directly; unknown keys are
+  passed through (the IR compiler validates them separately).
+* ``policy`` is a str -> resolved against :data:`BUILT_IN_POLICIES`.  An
+  **unknown** named policy raises ``ValueError`` — it never silently allows
+  everything, because a misconfigured policy name that degrades to allow-all is
+  worse than the hard error that surfaces the typo immediately.
+
+The full jamjet-policy DSL (YAML/JSON loaded from a registry or URL) is a
+follow-up (F-t3-policy-dsl).  Built-in named policies cover the common cases so
+the string form is immediately useful without that follow-up.
+
+Built-in named policies
+-----------------------
+``"strict"``
+    Anthropic-only model calls.  A conservative starting point for agents that
+    should never route to third-party providers.  The allowlist contains the
+    ``"anthropic"`` provider string so it works for every Anthropic model
+    (checked against ``ModelRef.provider`` in ``ModelAllowlistMiddleware``).
+
+``"open"``
+    Explicit alias for allow-all.  Equivalent to omitting ``policy=`` but makes
+    the intent legible in code.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Built-in named-policy table
+# ---------------------------------------------------------------------------
+
+# Each entry is the *rules dict* for that policy — same shape as the inline
+# dict a developer can pass to ``Agent(policy={...})``.  The IR compiler and the
+# allowlist resolver both read from here so the string and dict forms produce
+# identical results.
+BUILT_IN_POLICIES: dict[str, dict[str, Any]] = {
+    "strict": {
+        # Only Anthropic provider models allowed.  Checked against
+        # ModelRef.provider (e.g. "anthropic") so all Anthropic model names pass.
+        "model_allowlist": ["anthropic"],
+        "blocked_tools": [],
+        "require_approval_for": [],
+    },
+    "open": {
+        # Explicit allow-all — every model allowed, no tools blocked.
+        "model_allowlist": [],
+        "blocked_tools": [],
+        "require_approval_for": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_named_policy(name: str) -> dict[str, Any]:
+    """Resolve a named policy string to its rules dict.
+
+    Raises ``ValueError`` for unknown names — never silently falls back to
+    allow-all, because a mis-typed policy name degrades to no governance.
+    """
+    try:
+        return BUILT_IN_POLICIES[name]
+    except KeyError:
+        known = sorted(BUILT_IN_POLICIES)
+        raise ValueError(
+            f"Unknown named policy {name!r}. "
+            f"Built-in policies: {known!r}. "
+            "Register custom policies via the jamjet-policy package "
+            "(follow-up F-t3-policy-dsl)."
+        ) from None
+
+
+def resolve_policy_allowlist(policy: str | dict | None) -> set[str] | None:
+    """Return the model allowlist derived from *policy*, or ``None`` for allow-all.
+
+    Parameters
+    ----------
+    policy:
+        ``None``   -> ``None`` (allow-all; the documented v1 default).
+        ``dict``   -> read ``"model_allowlist"`` key; empty/absent -> ``None``.
+        ``str``    -> resolve from :data:`BUILT_IN_POLICIES`; raises on unknown.
+
+    Returns
+    -------
+    ``set[str] | None``
+        The set fed to ``ModelAllowlistMiddleware``; ``None`` means allow-all.
+        Each element can be a provider string (``"anthropic"``) or a full litellm
+        model string (``"anthropic/claude-sonnet-4-6"``).
+
+    Raises
+    ------
+    ``ValueError``
+        When *policy* is a string that is not in :data:`BUILT_IN_POLICIES` and
+        no external registry resolves it.  This is a configuration error — it
+        never silently degrades to allow-all.
+    """
+    if policy is None:
+        return None
+
+    if isinstance(policy, dict):
+        al = policy.get("model_allowlist")
+        if not al:
+            return None  # dict policy with no model_allowlist -> allow-all for models
+        return set(al)
+
+    if isinstance(policy, str):
+        rules = resolve_named_policy(policy)  # raises ValueError for unknown names
+        al = rules.get("model_allowlist")
+        if not al:
+            return None
+        return set(al)
+
+    raise TypeError(
+        f"policy must be str, dict, or None — got {type(policy).__name__!r}"
+    )

--- a/sdk/python/jamjet/runtime/local/executor.py
+++ b/sdk/python/jamjet/runtime/local/executor.py
@@ -85,8 +85,13 @@ class LocalRuntime:
         self,
         spec: AgentSpec | WorkflowSpec,
         execution_id: str,
+        *,
+        governance: GovernanceConfig | None = None,
     ) -> RuntimeResult:
-        return await self.execute(spec, input=None, execution_id=execution_id)
+        # M6 parity: thread governance so a resumed in-process run keeps budget /
+        # allowlist / PII enforcement (without it, a resumed AgentSpec run rebuilt
+        # the seam allow-all / no-budget and silently lost governance).
+        return await self.execute(spec, input=None, execution_id=execution_id, governance=governance)
 
     async def _run_agent(
         self,

--- a/sdk/python/jamjet/runtime/local/executor.py
+++ b/sdk/python/jamjet/runtime/local/executor.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jamjet.runtime.local.checkpoint import CheckpointStore
 from jamjet.runtime.local.injector import inject_runtime_attributes
@@ -25,6 +25,9 @@ from jamjet.runtime.types import (
 )
 from jamjet.spec import AgentSpec, DurableAgentSpec, ToolSpec, WorkflowSpec
 
+if TYPE_CHECKING:
+    from jamjet.agents.governance import GovernanceConfig
+
 
 class LocalRuntime:
     name = "local"
@@ -38,6 +41,7 @@ class LocalRuntime:
         execution_id: str | None = None,
         scope: Scope | None = None,
         on_event: Callable[[RuntimeEvent], None] | None = None,
+        governance: GovernanceConfig | None = None,
     ) -> RuntimeResult:
         eid = execution_id or str(uuid.uuid4())
         t0 = time.perf_counter()
@@ -56,6 +60,7 @@ class LocalRuntime:
                 input,
                 eid,
                 on_event,
+                governance,
             )
         elif isinstance(spec, WorkflowSpec):
             output, steps, tool_calls, llm_calls = await self._run_workflow(
@@ -89,8 +94,13 @@ class LocalRuntime:
         input: Any,
         eid: str,
         on_event: Any,
+        governance: GovernanceConfig | None = None,
     ) -> tuple[Any, list[StepRecord], list[ToolCallRecord], list[LLMCallRecord]]:
-        adapter = get_adapter(spec.llm)
+        # T3-7: thread the agent's GovernanceConfig into the seam-backed adapter
+        # so budget / allowlist / PII enforce on the in-process path (agent.run),
+        # at parity with the durable IR.  A fresh adapter (and therefore fresh
+        # budget accumulator) is built per execution, giving per-run scoping.
+        adapter = get_adapter(spec.llm, governance)
         runner = get_strategy_runner(spec.strategy.name)
         tool_calls_log: list[dict[str, Any]] = []
         openai_tools = [self._tool_to_openai_schema(t) for t in spec.tools]

--- a/sdk/python/jamjet/runtime/local/llm_adapters/__init__.py
+++ b/sdk/python/jamjet/runtime/local/llm_adapters/__init__.py
@@ -1,14 +1,27 @@
 """LLM adapters. Every provider now routes through the governed Model seam."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
 from jamjet.runtime.local.llm_adapters.seam_adapter import SeamAdapter
 from jamjet.spec import LLMConfig
 
+if TYPE_CHECKING:
+    from jamjet.agents.governance import GovernanceConfig
 
-def get_adapter(config: LLMConfig) -> LLMAdapter:
+
+def get_adapter(config: LLMConfig, governance: GovernanceConfig | None = None) -> LLMAdapter:
     """Return the seam-backed adapter for any provider (provider routing is
-    parsed from ``config.model`` inside the seam)."""
-    return SeamAdapter(config)
+    parsed from ``config.model`` inside the seam).
+
+    ``governance`` (T3-7) threads the agent's :class:`GovernanceConfig` into the
+    seam middleware chain so budget / allowlist / PII enforce on the in-process
+    ``agent.run()`` path.  ``None`` keeps the Track-1 default (allow-all, no
+    budget, PII on).
+    """
+    return SeamAdapter(config, governance=governance)
 
 
 __all__ = ["LLMAdapter", "SeamAdapter", "get_adapter"]

--- a/sdk/python/jamjet/runtime/local/llm_adapters/seam_adapter.py
+++ b/sdk/python/jamjet/runtime/local/llm_adapters/seam_adapter.py
@@ -3,25 +3,49 @@
 Strategy runners call ``adapter.generate(messages, tools=...)`` and read
 ``msg.content`` / ``msg.tool_calls``. We return the seam's OpenAI-shaped message
 unchanged so those runners need no edits.
+
+Governance threading (T3-7)
+---------------------------
+``agent.run()`` is the in-process path: ``LocalRuntime`` builds one
+``SeamAdapter`` per execution and the strategy runner drives every model call
+through ``adapter.generate`` -> ``Model.complete`` -> the seam middleware chain.
+Passing the agent's :class:`~jamjet.agents.governance.GovernanceConfig` here
+builds that chain with ``default_model_middleware(governance=...)`` so the
+budget / allowlist / PII knobs ENFORCE on ``agent.run()`` exactly as on the
+durable path — closing the deferred-from-T3-2 in-process budget gap.  Omitting
+``governance`` keeps the Track-1 default (allow-all allowlist, no budget, PII on)
+so callers that construct a bare adapter are unchanged.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jamjet.model.defaults import default_model_middleware
 from jamjet.model.seam import Model
 from jamjet.model.types import ModelRequest, parse_model_ref
 from jamjet.spec import LLMConfig
 
+if TYPE_CHECKING:
+    from jamjet.agents.governance import GovernanceConfig
+
 
 class SeamAdapter:
     config: LLMConfig
 
-    def __init__(self, config: LLMConfig, *, model: Model | None = None) -> None:
+    def __init__(
+        self,
+        config: LLMConfig,
+        *,
+        model: Model | None = None,
+        governance: GovernanceConfig | None = None,
+    ) -> None:
         self.config = config
         self._ref = parse_model_ref(config.model)
-        self._model = model or Model(middleware=default_model_middleware())
+        # Build the governed seam from the agent's GovernanceConfig (T3-7). An
+        # explicit ``model`` (tests) wins; otherwise the chain is built with
+        # ``governance`` so budget/allowlist/PII enforce on the in-process path.
+        self._model = model or Model(middleware=default_model_middleware(governance))
 
     async def generate(
         self,

--- a/sdk/python/jamjet/runtime/stub/__init__.py
+++ b/sdk/python/jamjet/runtime/stub/__init__.py
@@ -30,6 +30,8 @@ class _StubBase:
         self,
         spec: AgentSpec | WorkflowSpec,
         execution_id: str,
+        *,
+        governance: Any | None = None,
     ) -> RuntimeResult:
         raise NotImplementedError(f"{self.name}Runtime.resume lands in Phase 5.")
 

--- a/sdk/python/jamjet/runtime/types.py
+++ b/sdk/python/jamjet/runtime/types.py
@@ -84,4 +84,6 @@ class Runtime(Protocol):
         self,
         spec: AgentSpec | WorkflowSpec,
         execution_id: str,
+        *,
+        governance: Any | None = None,
     ) -> RuntimeResult: ...

--- a/sdk/python/tests/model/test_budget.py
+++ b/sdk/python/tests/model/test_budget.py
@@ -1,0 +1,348 @@
+"""Tests for BudgetMiddleware and BudgetExceededError (T3-2).
+
+Adversarial dual coverage for every enforcement path:
+- Under-budget calls PROCEED (backend IS called).
+- At/over-budget calls are DENIED before the provider (backend NOT called).
+- Token budget and cost budget each have their own dual.
+- No-budget (None) is a complete no-op: all calls pass through.
+- Error message names both the limit and the consumed amount.
+- BudgetExceededError is a ModelDeniedError subclass (fail-closed family).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.agents.governance import Budget
+from jamjet.model.budget import BudgetMiddleware
+from jamjet.model.middleware import BudgetExceededError, ModelDeniedError
+from jamjet.model.seam import Model
+from jamjet.model.types import ModelRequest, ModelResponse, parse_model_ref
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeBackend:
+    """Fake backend. Counts calls and returns a fixed response; never hits a provider."""
+
+    def __init__(self, *, cost_usd: float = 0.05, input_tokens: int = 5, output_tokens: int = 5) -> None:
+        self.call_count = 0
+        self._cost_usd = cost_usd
+        self._input_tokens = input_tokens
+        self._output_tokens = output_tokens
+
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        self.call_count += 1
+        return ModelResponse(
+            message=object(),
+            input_tokens=self._input_tokens,
+            output_tokens=self._output_tokens,
+            cost_usd=self._cost_usd,
+        )
+
+
+def _req() -> ModelRequest:
+    return ModelRequest(ref=parse_model_ref("anthropic/claude-opus-4-8"), messages=[])
+
+
+# ---------------------------------------------------------------------------
+# BudgetExceededError — shape and error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetExceededError:
+    def test_is_model_denied_error(self) -> None:
+        """BudgetExceededError is-a ModelDeniedError (fail-closed family)."""
+        err = BudgetExceededError(limit_usd=0.10, limit_tokens=None, consumed_usd=0.12, consumed_tokens=0)
+        assert isinstance(err, ModelDeniedError)
+
+    def test_code_is_budget_exceeded(self) -> None:
+        err = BudgetExceededError(limit_usd=0.10, limit_tokens=None, consumed_usd=0.12, consumed_tokens=0)
+        assert err.code == "budget_exceeded"
+
+    def test_message_contains_limit_and_consumed_cost(self) -> None:
+        err = BudgetExceededError(limit_usd=0.10, limit_tokens=None, consumed_usd=0.12, consumed_tokens=0)
+        msg = str(err)
+        # Both the consumed amount and the limit must appear in the message.
+        assert "0.12" in msg or "0.120000" in msg
+        assert "0.10" in msg or "0.100000" in msg
+
+    def test_message_contains_limit_and_consumed_tokens(self) -> None:
+        err = BudgetExceededError(limit_usd=None, limit_tokens=100, consumed_usd=0.0, consumed_tokens=150)
+        msg = str(err)
+        assert "150" in msg
+        assert "100" in msg
+
+    def test_fields_accessible(self) -> None:
+        err = BudgetExceededError(limit_usd=1.0, limit_tokens=500, consumed_usd=1.5, consumed_tokens=600)
+        assert err.limit_usd == pytest.approx(1.0)
+        assert err.limit_tokens == 500
+        assert err.consumed_usd == pytest.approx(1.5)
+        assert err.consumed_tokens == 600
+
+    def test_cost_only_budget_message(self) -> None:
+        """Message must name the cost figures when token cap is absent."""
+        err = BudgetExceededError(limit_usd=0.50, limit_tokens=None, consumed_usd=0.50, consumed_tokens=100)
+        msg = str(err)
+        assert "cost" in msg.lower() or "0.50" in msg or "0.500000" in msg
+
+    def test_token_only_budget_message(self) -> None:
+        """Message must name the token figures when cost cap is absent."""
+        err = BudgetExceededError(limit_usd=None, limit_tokens=200, consumed_usd=0.0, consumed_tokens=200)
+        msg = str(err)
+        assert "token" in msg.lower() or "200" in msg
+
+
+# ---------------------------------------------------------------------------
+# BudgetMiddleware unit tests (hooks tested directly, no Model)
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetMiddlewareNoBudget:
+    async def test_before_passes_through(self) -> None:
+        """No budget -> before() returns the request unchanged (no enforcement)."""
+        mw = BudgetMiddleware(None)
+        req = _req()
+        out = await mw.before(req)
+        assert out is req
+
+    async def test_after_does_not_accumulate(self) -> None:
+        """No budget -> after() does not accumulate (no state to corrupt)."""
+        mw = BudgetMiddleware(None)
+        resp = ModelResponse(message=object(), input_tokens=50, output_tokens=50, cost_usd=0.10)
+        await mw.after(_req(), resp)
+        assert mw.consumed_tokens == 0
+        assert mw.consumed_cost_usd == pytest.approx(0.0)
+
+
+class TestBudgetMiddlewareCostBudget:
+    async def test_first_call_under_budget_proceeds(self) -> None:
+        """No spend yet -> before() does not raise (adversarial dual: happy path)."""
+        mw = BudgetMiddleware(Budget(cost_usd=0.10))
+        req = _req()
+        out = await mw.before(req)
+        assert out is req
+
+    async def test_at_budget_denies_next_call(self) -> None:
+        """After spending exactly the limit, the next before() call is DENIED."""
+        mw = BudgetMiddleware(Budget(cost_usd=0.10))
+        # Simulate a completed call that spent exactly the limit.
+        resp = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.10)
+        await mw.after(_req(), resp)
+        assert mw.consumed_cost_usd == pytest.approx(0.10)
+
+        with pytest.raises(BudgetExceededError) as exc_info:
+            await mw.before(_req())
+        assert exc_info.value.code == "budget_exceeded"
+        assert exc_info.value.limit_usd == pytest.approx(0.10)
+        assert exc_info.value.consumed_usd == pytest.approx(0.10)
+
+    async def test_over_budget_denies_next_call(self) -> None:
+        """After spending MORE than the limit, the next before() call is DENIED."""
+        mw = BudgetMiddleware(Budget(cost_usd=0.10))
+        resp = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.15)
+        await mw.after(_req(), resp)
+
+        with pytest.raises(BudgetExceededError):
+            await mw.before(_req())
+
+    async def test_accumulates_cost_across_calls(self) -> None:
+        mw = BudgetMiddleware(Budget(cost_usd=0.50))
+        r1 = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.07)
+        r2 = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.08)
+        await mw.after(_req(), r1)
+        await mw.after(_req(), r2)
+        assert mw.consumed_cost_usd == pytest.approx(0.15)
+
+
+class TestBudgetMiddlewareTokenBudget:
+    async def test_first_call_under_token_budget_proceeds(self) -> None:
+        """No tokens spent -> before() does not raise."""
+        mw = BudgetMiddleware(Budget(tokens=100))
+        req = _req()
+        out = await mw.before(req)
+        assert out is req
+
+    async def test_at_token_budget_denies_next_call(self) -> None:
+        """After spending exactly the token limit, next before() call is DENIED."""
+        mw = BudgetMiddleware(Budget(tokens=100))
+        resp = ModelResponse(message=object(), input_tokens=60, output_tokens=40, cost_usd=0.0)
+        await mw.after(_req(), resp)
+        assert mw.consumed_tokens == 100
+
+        with pytest.raises(BudgetExceededError) as exc_info:
+            await mw.before(_req())
+        err = exc_info.value
+        assert err.limit_tokens == 100
+        assert err.consumed_tokens == 100
+
+    async def test_over_token_budget_denies(self) -> None:
+        mw = BudgetMiddleware(Budget(tokens=100))
+        resp = ModelResponse(message=object(), input_tokens=70, output_tokens=50, cost_usd=0.0)
+        await mw.after(_req(), resp)
+        assert mw.consumed_tokens == 120
+
+        with pytest.raises(BudgetExceededError):
+            await mw.before(_req())
+
+    async def test_tokens_are_input_plus_output(self) -> None:
+        """Accumulated tokens = input_tokens + output_tokens per call."""
+        mw = BudgetMiddleware(Budget(tokens=1000))
+        resp = ModelResponse(message=object(), input_tokens=30, output_tokens=20, cost_usd=0.0)
+        await mw.after(_req(), resp)
+        assert mw.consumed_tokens == 50
+
+
+class TestBudgetMiddlewareBothCaps:
+    async def test_cost_exceeded_triggers_denial_when_tokens_ok(self) -> None:
+        """Either cap exceeded is enough to deny — cost cap hit here."""
+        mw = BudgetMiddleware(Budget(tokens=1000, cost_usd=0.10))
+        # Spend exactly the cost limit; tokens are well under.
+        resp = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.10)
+        await mw.after(_req(), resp)
+
+        with pytest.raises(BudgetExceededError) as exc_info:
+            await mw.before(_req())
+        err = exc_info.value
+        assert err.limit_usd == pytest.approx(0.10)
+        assert err.consumed_usd == pytest.approx(0.10)
+
+    async def test_token_exceeded_triggers_denial_when_cost_ok(self) -> None:
+        """Either cap exceeded is enough to deny — token cap hit here."""
+        mw = BudgetMiddleware(Budget(tokens=10, cost_usd=100.0))
+        # Spend exactly the token limit; cost is well under.
+        resp = ModelResponse(message=object(), input_tokens=5, output_tokens=5, cost_usd=0.01)
+        await mw.after(_req(), resp)
+
+        with pytest.raises(BudgetExceededError):
+            await mw.before(_req())
+
+
+# ---------------------------------------------------------------------------
+# Integration via Model — backend NOT called on denial (adversarial dual)
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetMiddlewareViaModel:
+    async def test_under_cost_budget_backend_is_called(self) -> None:
+        """Happy path: under budget -> call proceeds, backend IS called."""
+        backend = FakeBackend(cost_usd=0.05, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(cost_usd=0.10))])
+        await model.complete(_req())
+        assert backend.call_count == 1
+
+    async def test_at_cost_budget_next_call_denied_backend_not_called(self) -> None:
+        """At budget: next call DENIED; backend is NOT called (adversarial dual)."""
+        # First call exhausts the budget exactly.
+        backend = FakeBackend(cost_usd=0.10, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(cost_usd=0.10))])
+
+        await model.complete(_req())
+        assert backend.call_count == 1  # first call succeeded
+
+        # Second call: accumulated cost == 0.10 >= limit 0.10 -> denied before backend.
+        with pytest.raises(BudgetExceededError):
+            await model.complete(_req())
+        assert backend.call_count == 1, "backend must NOT be called on the denied call"
+
+    async def test_under_token_budget_backend_is_called(self) -> None:
+        """Happy path: under token budget -> call proceeds, backend IS called."""
+        backend = FakeBackend(cost_usd=0.0, input_tokens=4, output_tokens=4)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(tokens=20))])
+        await model.complete(_req())
+        assert backend.call_count == 1
+
+    async def test_at_token_budget_next_call_denied_backend_not_called(self) -> None:
+        """Token budget exhausted: next call DENIED; backend is NOT called."""
+        # Each call uses 10 tokens (5+5); budget is 10.
+        backend = FakeBackend(cost_usd=0.0, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(tokens=10))])
+
+        await model.complete(_req())
+        assert backend.call_count == 1
+
+        with pytest.raises(BudgetExceededError):
+            await model.complete(_req())
+        assert backend.call_count == 1, "backend must NOT be called on the denied call"
+
+    async def test_no_budget_allows_all_calls_backend_called_each_time(self) -> None:
+        """No budget (None): all calls proceed; backend called every time."""
+        backend = FakeBackend(cost_usd=1.0, input_tokens=100, output_tokens=100)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(None)])
+        for _ in range(5):
+            await model.complete(_req())
+        assert backend.call_count == 5
+
+    async def test_error_message_names_limit_and_consumed(self) -> None:
+        """Error message must name both the limit and the consumed amount."""
+        backend = FakeBackend(cost_usd=0.10, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(cost_usd=0.10))])
+        await model.complete(_req())
+
+        with pytest.raises(BudgetExceededError) as exc_info:
+            await model.complete(_req())
+        err = exc_info.value
+        msg = str(err)
+        # Limit and consumed must appear.
+        assert "0.10" in msg or "0.100000" in msg
+        assert err.consumed_usd == pytest.approx(0.10)
+        assert err.limit_usd == pytest.approx(0.10)
+
+    async def test_budget_exceeded_error_is_model_denied_error(self) -> None:
+        """Catching ModelDeniedError catches BudgetExceededError (fail-closed family)."""
+        backend = FakeBackend(cost_usd=0.10, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(cost_usd=0.10))])
+        await model.complete(_req())
+
+        with pytest.raises(ModelDeniedError):
+            await model.complete(_req())
+
+    async def test_multiple_calls_accumulate_then_deny(self) -> None:
+        """Three calls each at $0.03 against a $0.09 limit: third call hits the cap."""
+        backend = FakeBackend(cost_usd=0.03, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=[BudgetMiddleware(Budget(cost_usd=0.09))])
+
+        await model.complete(_req())  # spent: 0.03
+        await model.complete(_req())  # spent: 0.06
+        await model.complete(_req())  # spent: 0.09
+        assert backend.call_count == 3
+
+        # Fourth call: 0.09 >= 0.09 -> denied.
+        with pytest.raises(BudgetExceededError):
+            await model.complete(_req())
+        assert backend.call_count == 3, "fourth call must not reach backend"
+
+
+# ---------------------------------------------------------------------------
+# default_model_middleware integration — budget threads through correctly
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMiddlewareIntegration:
+    async def test_governance_budget_enforced_via_default_middleware(self) -> None:
+        """BudgetMiddleware from default_model_middleware() enforces the governance budget."""
+        from jamjet.agents.governance import normalize_governance
+        from jamjet.model.defaults import default_model_middleware
+
+        gov = normalize_governance(budget=Budget(cost_usd=0.10))
+        backend = FakeBackend(cost_usd=0.10, input_tokens=5, output_tokens=5)
+        model = Model(backend=backend, middleware=default_model_middleware(governance=gov))
+
+        await model.complete(_req())  # spends the budget
+
+        with pytest.raises(BudgetExceededError):
+            await model.complete(_req())
+        assert backend.call_count == 1
+
+    async def test_no_governance_budget_is_no_op(self) -> None:
+        """default_model_middleware() without governance -> no budget enforcement."""
+        from jamjet.model.defaults import default_model_middleware
+
+        backend = FakeBackend(cost_usd=5.0, input_tokens=1000, output_tokens=1000)
+        model = Model(backend=backend, middleware=default_model_middleware())
+
+        for _ in range(3):
+            await model.complete(_req())
+        assert backend.call_count == 3

--- a/sdk/python/tests/model/test_defaults.py
+++ b/sdk/python/tests/model/test_defaults.py
@@ -1,26 +1,40 @@
-"""Tests for the default model-seam middleware factory (updated for T3-2)."""
+"""Tests for the default model-seam middleware factory (updated for T3-3).
 
+Chain order when pii=True (the default):
+  [ModelAllowlistMiddleware, PiiRedactionMiddleware, BudgetMiddleware, MeteringMiddleware]
+
+Chain order when pii=False:
+  [ModelAllowlistMiddleware, BudgetMiddleware, MeteringMiddleware]
+"""
+
+from jamjet.agents.governance import Budget, normalize_governance
 from jamjet.model import default_model_middleware
 from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.metering import MeteringMiddleware
 from jamjet.model.middleware import ModelAllowlistMiddleware
+from jamjet.model.pii import PiiRedactionMiddleware
+
+# ---------------------------------------------------------------------------
+# Default chain (pii=True, no explicit governance)
+# ---------------------------------------------------------------------------
 
 
-def test_default_model_middleware_returns_three_elements() -> None:
-    """T3-2: chain is now [allowlist, budget, metering] — three elements."""
+def test_default_model_middleware_returns_four_elements() -> None:
+    """T3-3: default chain is [allowlist, pii, budget, metering] -- four elements."""
     chain = default_model_middleware()
-    assert len(chain) == 3
+    assert len(chain) == 4
 
 
 def test_default_model_middleware_types() -> None:
     chain = default_model_middleware()
     assert isinstance(chain[0], ModelAllowlistMiddleware)
-    assert isinstance(chain[1], BudgetMiddleware)
-    assert isinstance(chain[2], MeteringMiddleware)
+    assert isinstance(chain[1], PiiRedactionMiddleware)
+    assert isinstance(chain[2], BudgetMiddleware)
+    assert isinstance(chain[3], MeteringMiddleware)
 
 
 def test_default_model_middleware_allowlist_is_allow_all() -> None:
-    """ModelAllowlistMiddleware(None) means allow-all — the Track 1 default."""
+    """ModelAllowlistMiddleware(None) means allow-all -- the Track 1 default."""
     chain = default_model_middleware()
     allowlist_mw = chain[0]
     assert isinstance(allowlist_mw, ModelAllowlistMiddleware)
@@ -30,18 +44,16 @@ def test_default_model_middleware_allowlist_is_allow_all() -> None:
 def test_default_model_middleware_no_governance_budget_is_none() -> None:
     """Without governance, BudgetMiddleware has no budget (no-op pass-through)."""
     chain = default_model_middleware()
-    budget_mw = chain[1]
+    budget_mw = chain[2]
     assert isinstance(budget_mw, BudgetMiddleware)
     assert budget_mw._budget is None
 
 
 def test_default_model_middleware_with_governance_threads_budget() -> None:
     """Passing governance threads budget into BudgetMiddleware."""
-    from jamjet.agents.governance import Budget, normalize_governance
-
     gov = normalize_governance(budget=Budget(cost_usd=0.50))
     chain = default_model_middleware(governance=gov)
-    budget_mw = chain[1]
+    budget_mw = chain[2]
     assert isinstance(budget_mw, BudgetMiddleware)
     assert budget_mw._budget == Budget(cost_usd=0.50)
 
@@ -49,9 +61,10 @@ def test_default_model_middleware_with_governance_threads_budget() -> None:
 def test_default_model_middleware_none_governance_same_as_no_arg() -> None:
     """Explicitly passing governance=None is the same as omitting it."""
     chain = default_model_middleware(governance=None)
-    assert len(chain) == 3
-    assert isinstance(chain[1], BudgetMiddleware)
-    assert chain[1]._budget is None
+    assert len(chain) == 4
+    assert isinstance(chain[1], PiiRedactionMiddleware)
+    assert isinstance(chain[2], BudgetMiddleware)
+    assert chain[2]._budget is None
 
 
 def test_default_model_middleware_returns_fresh_instances() -> None:
@@ -61,3 +74,34 @@ def test_default_model_middleware_returns_fresh_instances() -> None:
     assert a[0] is not b[0]
     assert a[1] is not b[1]
     assert a[2] is not b[2]
+    assert a[3] is not b[3]
+
+
+# ---------------------------------------------------------------------------
+# pii=False: PiiRedactionMiddleware excluded -> 3-element chain
+# ---------------------------------------------------------------------------
+
+
+def test_pii_false_omits_pii_middleware() -> None:
+    """governance.pii=False -> PiiRedactionMiddleware excluded from the chain."""
+    gov = normalize_governance(pii=False)
+    chain = default_model_middleware(governance=gov)
+    assert len(chain) == 3
+    assert isinstance(chain[0], ModelAllowlistMiddleware)
+    assert isinstance(chain[1], BudgetMiddleware)
+    assert isinstance(chain[2], MeteringMiddleware)
+    assert not any(isinstance(mw, PiiRedactionMiddleware) for mw in chain)
+
+
+def test_pii_true_includes_pii_middleware() -> None:
+    """governance.pii=True (default) -> PiiRedactionMiddleware at index 1."""
+    gov = normalize_governance(pii=True)
+    chain = default_model_middleware(governance=gov)
+    assert len(chain) == 4
+    assert isinstance(chain[1], PiiRedactionMiddleware)
+
+
+def test_default_pii_on_without_governance() -> None:
+    """Without governance, PII is ON by default (safe default)."""
+    chain = default_model_middleware()
+    assert any(isinstance(mw, PiiRedactionMiddleware) for mw in chain)

--- a/sdk/python/tests/model/test_defaults.py
+++ b/sdk/python/tests/model/test_defaults.py
@@ -1,19 +1,22 @@
-"""Tests for the default model-seam middleware factory."""
+"""Tests for the default model-seam middleware factory (updated for T3-2)."""
 
 from jamjet.model import default_model_middleware
+from jamjet.model.budget import BudgetMiddleware
 from jamjet.model.metering import MeteringMiddleware
 from jamjet.model.middleware import ModelAllowlistMiddleware
 
 
-def test_default_model_middleware_returns_two_elements() -> None:
+def test_default_model_middleware_returns_three_elements() -> None:
+    """T3-2: chain is now [allowlist, budget, metering] — three elements."""
     chain = default_model_middleware()
-    assert len(chain) == 2
+    assert len(chain) == 3
 
 
 def test_default_model_middleware_types() -> None:
     chain = default_model_middleware()
     assert isinstance(chain[0], ModelAllowlistMiddleware)
-    assert isinstance(chain[1], MeteringMiddleware)
+    assert isinstance(chain[1], BudgetMiddleware)
+    assert isinstance(chain[2], MeteringMiddleware)
 
 
 def test_default_model_middleware_allowlist_is_allow_all() -> None:
@@ -21,8 +24,34 @@ def test_default_model_middleware_allowlist_is_allow_all() -> None:
     chain = default_model_middleware()
     allowlist_mw = chain[0]
     assert isinstance(allowlist_mw, ModelAllowlistMiddleware)
-    # The internal _allowed attribute should be None (allow-all sentinel).
     assert allowlist_mw._allowed is None
+
+
+def test_default_model_middleware_no_governance_budget_is_none() -> None:
+    """Without governance, BudgetMiddleware has no budget (no-op pass-through)."""
+    chain = default_model_middleware()
+    budget_mw = chain[1]
+    assert isinstance(budget_mw, BudgetMiddleware)
+    assert budget_mw._budget is None
+
+
+def test_default_model_middleware_with_governance_threads_budget() -> None:
+    """Passing governance threads budget into BudgetMiddleware."""
+    from jamjet.agents.governance import Budget, normalize_governance
+
+    gov = normalize_governance(budget=Budget(cost_usd=0.50))
+    chain = default_model_middleware(governance=gov)
+    budget_mw = chain[1]
+    assert isinstance(budget_mw, BudgetMiddleware)
+    assert budget_mw._budget == Budget(cost_usd=0.50)
+
+
+def test_default_model_middleware_none_governance_same_as_no_arg() -> None:
+    """Explicitly passing governance=None is the same as omitting it."""
+    chain = default_model_middleware(governance=None)
+    assert len(chain) == 3
+    assert isinstance(chain[1], BudgetMiddleware)
+    assert chain[1]._budget is None
 
 
 def test_default_model_middleware_returns_fresh_instances() -> None:
@@ -31,3 +60,4 @@ def test_default_model_middleware_returns_fresh_instances() -> None:
     b = default_model_middleware()
     assert a[0] is not b[0]
     assert a[1] is not b[1]
+    assert a[2] is not b[2]

--- a/sdk/python/tests/model/test_pii_middleware.py
+++ b/sdk/python/tests/model/test_pii_middleware.py
@@ -12,6 +12,8 @@ assertions can inspect what the provider would actually see.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from jamjet.agents.governance import normalize_governance
@@ -128,6 +130,137 @@ class TestRedactMessages:
         _redact_messages(msgs, mw._detector)
         # Original dict is unchanged.
         assert msgs[0]["content"] == original_content
+
+
+# ---------------------------------------------------------------------------
+# I2 — recursive, fail-CLOSED traversal: every reachable string is redacted, or
+# the call is denied.  No passthrough leak on bare-string lists / non-"text"
+# keys / nested blocks / non-dict messages.
+# ---------------------------------------------------------------------------
+
+
+class _Opaque:
+    """A content part the redactor cannot traverse, holding a hidden string."""
+
+    def __init__(self, secret: str) -> None:
+        self._secret = secret
+
+
+class _MsgObject:
+    """A non-dict message object (like a provider SDK message / test mock)."""
+
+    def __init__(self, content) -> None:
+        self.content = content
+        self.role = "assistant"
+
+
+class TestRecursiveFailClosed:
+    def test_bare_string_list_part_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": ["my ssn is 123-45-6789", "and clean text"]}]
+        out = _redact_messages(msgs, mw._detector)
+        assert "123-45-6789" not in out[0]["content"][0]
+        assert "[REDACTED:US_SSN]" in out[0]["content"][0]
+        assert out[0]["content"][1] == "and clean text"
+
+    def test_text_under_non_text_key_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": [{"type": "input_text", "value": "ssn 123-45-6789"}]}]
+        out = _redact_messages(msgs, mw._detector)
+        assert "123-45-6789" not in out[0]["content"][0]["value"]
+        assert "[REDACTED:US_SSN]" in out[0]["content"][0]["value"]
+
+    def test_deeply_nested_block_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "wrapper", "blocks": [{"inner": {"deep": "email bob@corp.io"}}]}],
+            }
+        ]
+        out = _redact_messages(msgs, mw._detector)
+        flat = json.dumps(out)
+        assert "bob@corp.io" not in flat
+        assert "[REDACTED:EMAIL]" in flat
+
+    def test_non_dict_message_object_content_is_redacted(self) -> None:
+        """The non-dict-message gap: an assistant message OBJECT's content is
+        redacted (was passed through unredacted before)."""
+        mw = PiiRedactionMiddleware()
+        msg = _MsgObject("contact alice@example.com")
+        out = _redact_messages([msg], mw._detector)
+        assert "alice@example.com" not in out[0].content
+        assert "[REDACTED:EMAIL]" in out[0].content
+        # The original object is NOT mutated.
+        assert msg.content == "contact alice@example.com"
+
+    def test_non_dict_message_object_list_content_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msg = _MsgObject([{"type": "text", "text": "ssn 123-45-6789"}])
+        out = _redact_messages([msg], mw._detector)
+        assert "123-45-6789" not in json.dumps(out[0].content)
+
+    def test_unreachable_string_part_is_denied(self) -> None:
+        """Fail-CLOSED: an opaque content part the redactor cannot traverse ->
+        DENY (never forwarded unredacted)."""
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": [_Opaque("ssn 123-45-6789")]}]
+        with pytest.raises(ModelDeniedError) as exc:
+            _redact_messages(msgs, mw._detector)
+        assert exc.value.code == "pii_unredactable_content"
+
+    def test_opaque_message_is_denied(self) -> None:
+        """A non-dict message with no textual surface -> DENY (fail-closed)."""
+        mw = PiiRedactionMiddleware()
+        with pytest.raises(ModelDeniedError) as exc:
+            _redact_messages([object()], mw._detector)
+        assert exc.value.code == "pii_unredactable_content"
+
+    def test_non_textual_parts_pass_through(self) -> None:
+        """Genuinely non-textual leaves (bytes, an image-url with no PII) pass."""
+        mw = PiiRedactionMiddleware()
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+                    {"type": "blob", "data": b"\x00\x01\x02"},
+                    "clean text only",
+                ],
+            }
+        ]
+        out = _redact_messages(msgs, mw._detector)
+        assert out[0]["content"][0]["image_url"]["url"] == "http://example.com/img.png"
+        assert out[0]["content"][1]["data"] == b"\x00\x01\x02"
+        assert out[0]["content"][2] == "clean text only"
+
+
+class TestRecursiveFailClosedViaModel:
+    async def test_backend_receives_redacted_nested_content(self) -> None:
+        """The critical assertion via the seam: the provider never sees raw PII
+        hidden in a bare-string list / non-text key / nested block."""
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=[PiiRedactionMiddleware()])
+        req = _req_multipart(
+            [
+                "leading ssn 111-22-3333",
+                {"type": "input_text", "value": "email carol@corp.io"},
+                {"type": "w", "blocks": [{"deep": "card 4111 1111 1111 1111"}]},
+            ]
+        )
+        await model.complete(req)
+        flat = json.dumps(backend.received[0].messages, default=str)
+        assert "111-22-3333" not in flat
+        assert "carol@corp.io" not in flat
+        assert "4111 1111 1111 1111" not in flat
+
+    async def test_unreachable_string_denies_and_backend_not_called(self) -> None:
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=[PiiRedactionMiddleware()])
+        with pytest.raises(ModelDeniedError) as exc:
+            await model.complete(_req_multipart([_Opaque("ssn 123-45-6789")]))
+        assert exc.value.code == "pii_unredactable_content"
+        assert backend.received == [], "provider must NOT be called when content can't be redacted"
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/model/test_pii_middleware.py
+++ b/sdk/python/tests/model/test_pii_middleware.py
@@ -1,0 +1,270 @@
+"""Tests for PiiRedactionMiddleware (T3-3).
+
+Adversarial dual coverage:
+- A prompt with email + SSN + phone -> backend receives REDACTED form (PII not leaked).
+- pii=False via GovernanceConfig -> backend receives the RAW prompt (passthrough).
+- A clean prompt (no PII) -> backend receives the original unchanged.
+- Redactor failure -> DENY (ModelDeniedError raised, backend NOT called).
+
+Backend-receives tests use a FakeBackend that captures the request it received so
+assertions can inspect what the provider would actually see.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.agents.governance import normalize_governance
+from jamjet.model.middleware import ModelDeniedError
+from jamjet.model.pii import PiiRedactionMiddleware, _redact_messages
+from jamjet.model.seam import Model
+from jamjet.model.types import ModelRequest, ModelResponse, parse_model_ref
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+
+class CapturingBackend:
+    """Fake backend that records every request it receives.
+
+    Never calls a real provider.  Used to assert on what the provider
+    would have seen after the middleware chain ran.
+    """
+
+    def __init__(self) -> None:
+        self.received: list[ModelRequest] = []
+
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        self.received.append(request)
+        return ModelResponse(
+            message=object(),
+            input_tokens=5,
+            output_tokens=5,
+            cost_usd=0.01,
+        )
+
+
+class BrokenDetector:
+    """A detector that always raises (used to test the fail-closed path)."""
+
+    def redact(self, text: str) -> str:
+        raise RuntimeError("detector exploded")
+
+
+def _req(content: str) -> ModelRequest:
+    return ModelRequest(
+        ref=parse_model_ref("anthropic/claude-opus-4-8"),
+        messages=[{"role": "user", "content": content}],
+    )
+
+
+def _req_multipart(parts: list[dict]) -> ModelRequest:
+    return ModelRequest(
+        ref=parse_model_ref("anthropic/claude-opus-4-8"),
+        messages=[{"role": "user", "content": parts}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _redact_messages unit tests (the helper, no Model overhead)
+# ---------------------------------------------------------------------------
+
+
+class TestRedactMessages:
+    def test_email_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": "contact alice@example.com"}]
+        out = _redact_messages(msgs, mw._detector)
+        assert "alice@example.com" not in out[0]["content"]
+        assert "[REDACTED:EMAIL]" in out[0]["content"]
+
+    def test_ssn_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": "ssn 123-45-6789 on file"}]
+        out = _redact_messages(msgs, mw._detector)
+        assert "123-45-6789" not in out[0]["content"]
+        assert "[REDACTED:US_SSN]" in out[0]["content"]
+
+    def test_phone_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [{"role": "user", "content": "call 555-867-5309 now"}]
+        out = _redact_messages(msgs, mw._detector)
+        assert "555-867-5309" not in out[0]["content"]
+
+    def test_clean_prompt_is_unchanged(self) -> None:
+        mw = PiiRedactionMiddleware()
+        original = "What is the capital of France?"
+        msgs = [{"role": "user", "content": original}]
+        out = _redact_messages(msgs, mw._detector)
+        assert out[0]["content"] == original
+
+    def test_multipart_content_text_parts_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "ssn 123-45-6789"},
+                    {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
+                    {"type": "text", "text": "email alice@example.com"},
+                ],
+            }
+        ]
+        out = _redact_messages(msgs, mw._detector)
+        parts = out[0]["content"]
+        assert "123-45-6789" not in parts[0]["text"]
+        assert "[REDACTED:US_SSN]" in parts[0]["text"]
+        assert "alice@example.com" not in parts[2]["text"]
+        assert "[REDACTED:EMAIL]" in parts[2]["text"]
+        # Non-text parts are untouched.
+        assert parts[1]["image_url"]["url"] == "http://example.com/img.png"
+
+    def test_caller_messages_not_mutated(self) -> None:
+        """_redact_messages must not mutate the original list or dicts."""
+        mw = PiiRedactionMiddleware()
+        original_content = "email alice@example.com"
+        msgs = [{"role": "user", "content": original_content}]
+        _redact_messages(msgs, mw._detector)
+        # Original dict is unchanged.
+        assert msgs[0]["content"] == original_content
+
+
+# ---------------------------------------------------------------------------
+# PiiRedactionMiddleware.before unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPiiRedactionMiddlewareBefore:
+    async def test_pii_in_prompt_is_redacted(self) -> None:
+        mw = PiiRedactionMiddleware()
+        req = _req("contact alice@example.com or ssn 123-45-6789")
+        out = await mw.before(req)
+        content = out.messages[0]["content"]
+        assert "alice@example.com" not in content
+        assert "123-45-6789" not in content
+        assert "[REDACTED:EMAIL]" in content
+        assert "[REDACTED:US_SSN]" in content
+
+    async def test_clean_prompt_passes_through_unchanged(self) -> None:
+        mw = PiiRedactionMiddleware()
+        text = "What is the capital of France?"
+        req = _req(text)
+        out = await mw.before(req)
+        assert out.messages[0]["content"] == text
+
+    async def test_redactor_failure_raises_model_denied_error(self) -> None:
+        """Fail-closed: a detector exception -> ModelDeniedError (redact-or-deny)."""
+        mw = PiiRedactionMiddleware(detector=BrokenDetector())
+        req = _req("some content")
+        with pytest.raises(ModelDeniedError) as exc_info:
+            await mw.before(req)
+        assert exc_info.value.code == "pii_redaction_error"
+
+    async def test_redactor_failure_raises_model_denied_subclass(self) -> None:
+        """ModelDeniedError is the fail-closed family root -- verify hierarchy."""
+        mw = PiiRedactionMiddleware(detector=BrokenDetector())
+        with pytest.raises(ModelDeniedError):
+            await mw.before(_req("text"))
+
+
+# ---------------------------------------------------------------------------
+# Integration via Model -- backend receives redacted text (the critical assertion)
+# ---------------------------------------------------------------------------
+
+
+class TestPiiRedactionViaModel:
+    async def test_backend_receives_redacted_prompt(self) -> None:
+        """Core T3-3 assertion: the provider NEVER sees raw PII in the prompt."""
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=[PiiRedactionMiddleware()])
+        await model.complete(_req("contact alice@example.com or ssn 123-45-6789 or call 555-867-5309"))
+        assert backend.received, "backend must have been called"
+        content = backend.received[0].messages[0]["content"]
+        # PII not present.
+        assert "alice@example.com" not in content
+        assert "123-45-6789" not in content
+        # Placeholders present.
+        assert "[REDACTED:EMAIL]" in content
+        assert "[REDACTED:US_SSN]" in content
+
+    async def test_clean_prompt_backend_called_with_original(self) -> None:
+        """A prompt without PII -> backend receives the original text unchanged."""
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=[PiiRedactionMiddleware()])
+        text = "Explain recursion in one sentence."
+        await model.complete(_req(text))
+        assert backend.received[0].messages[0]["content"] == text
+
+    async def test_redactor_failure_backend_not_called(self) -> None:
+        """Fail-closed: redactor error -> provider is NEVER called (adversarial dual)."""
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=[PiiRedactionMiddleware(detector=BrokenDetector())])
+        with pytest.raises(ModelDeniedError) as exc_info:
+            await model.complete(_req("some content"))
+        assert exc_info.value.code == "pii_redaction_error"
+        assert backend.received == [], "backend must NOT be called on redaction failure"
+
+    async def test_pii_off_backend_receives_raw_prompt(self) -> None:
+        """pii=False via GovernanceConfig -> PiiRedactionMiddleware NOT in chain
+        -> backend receives the raw (unredacted) prompt."""
+        from jamjet.model.defaults import default_model_middleware
+
+        backend = CapturingBackend()
+        gov = normalize_governance(pii=False)
+        model = Model(backend=backend, middleware=default_model_middleware(governance=gov))
+        raw_text = "contact alice@example.com or ssn 123-45-6789"
+        await model.complete(_req(raw_text))
+        # Backend receives the RAW text because PII middleware was omitted.
+        content = backend.received[0].messages[0]["content"]
+        assert "alice@example.com" in content
+        assert "123-45-6789" in content
+
+    async def test_pii_default_on_backend_receives_redacted(self) -> None:
+        """Default (no governance) -> PII is ON -> backend never sees raw PII."""
+        from jamjet.model.defaults import default_model_middleware
+
+        backend = CapturingBackend()
+        model = Model(backend=backend, middleware=default_model_middleware())
+        await model.complete(_req("contact alice@example.com"))
+        content = backend.received[0].messages[0]["content"]
+        assert "alice@example.com" not in content
+        assert "[REDACTED:EMAIL]" in content
+
+
+# ---------------------------------------------------------------------------
+# default_model_middleware integration
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMiddlewarePiiIntegration:
+    async def test_governance_pii_true_includes_pii_middleware(self) -> None:
+        """governance.pii=True -> PiiRedactionMiddleware in the chain."""
+        from jamjet.model.defaults import default_model_middleware
+        from jamjet.model.pii import PiiRedactionMiddleware
+
+        gov = normalize_governance(pii=True)
+        chain = default_model_middleware(governance=gov)
+        assert any(isinstance(mw, PiiRedactionMiddleware) for mw in chain)
+
+    async def test_governance_pii_false_excludes_pii_middleware(self) -> None:
+        """governance.pii=False -> PiiRedactionMiddleware NOT in the chain."""
+        from jamjet.model.defaults import default_model_middleware
+        from jamjet.model.pii import PiiRedactionMiddleware
+
+        gov = normalize_governance(pii=False)
+        chain = default_model_middleware(governance=gov)
+        assert not any(isinstance(mw, PiiRedactionMiddleware) for mw in chain)
+
+    async def test_pii_redaction_before_budget_check(self) -> None:
+        """PII runs at index 1 (before budget at index 2) -- order documented."""
+        from jamjet.agents.governance import Budget
+        from jamjet.model.budget import BudgetMiddleware
+        from jamjet.model.defaults import default_model_middleware
+        from jamjet.model.pii import PiiRedactionMiddleware
+
+        gov = normalize_governance(budget=Budget(cost_usd=1.0))
+        chain = default_model_middleware(governance=gov)
+        pii_idx = next(i for i, mw in enumerate(chain) if isinstance(mw, PiiRedactionMiddleware))
+        budget_idx = next(i for i, mw in enumerate(chain) if isinstance(mw, BudgetMiddleware))
+        assert pii_idx < budget_idx, "PII must run before budget check"

--- a/sdk/python/tests/model/test_policy_allowlist.py
+++ b/sdk/python/tests/model/test_policy_allowlist.py
@@ -50,9 +50,7 @@ class TestDictPolicyAllowlist:
 
     def test_allowed_model_passes(self):
         """A model in the dict allowlist is not denied."""
-        allowlist = resolve_policy_allowlist(
-            {"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
-        )
+        allowlist = resolve_policy_allowlist({"model_allowlist": ["anthropic/claude-sonnet-4-6"]})
         assert allowlist == {"anthropic/claude-sonnet-4-6"}
 
     def test_allowed_by_provider_passes(self):
@@ -72,9 +70,7 @@ class TestDictPolicyAllowlist:
     @pytest.mark.asyncio
     async def test_disallowed_model_raises_before_provider(self):
         """A model call whose provider/model is not in the allowlist raises ModelDeniedError."""
-        gov = normalize_governance(
-            policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
-        )
+        gov = normalize_governance(policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]})
         chain = default_model_middleware(governance=gov)
         allowlist_mw = chain[0]
         assert isinstance(allowlist_mw, ModelAllowlistMiddleware)
@@ -86,9 +82,7 @@ class TestDictPolicyAllowlist:
     @pytest.mark.asyncio
     async def test_allowed_model_does_not_raise(self):
         """A model call whose model string IS in the allowlist proceeds."""
-        gov = normalize_governance(
-            policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
-        )
+        gov = normalize_governance(policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]})
         chain = default_model_middleware(governance=gov)
         allowlist_mw = chain[0]
         assert isinstance(allowlist_mw, ModelAllowlistMiddleware)

--- a/sdk/python/tests/model/test_policy_allowlist.py
+++ b/sdk/python/tests/model/test_policy_allowlist.py
@@ -1,0 +1,443 @@
+"""T3-6: policy-derived model allowlist + approval_required in-process parity.
+
+Tests cover:
+1. Dict policy with ``model_allowlist``   -> allowed model passes; disallowed denied.
+2. ``policy=None``                         -> all models allowed (rest of governance on).
+3. String ``"strict"``                     -> resolved allowlist (Anthropic only);
+                                             disallowed model (e.g. openai) is DENIED.
+4. String ``"open"``                       -> explicit allow-all alias.
+5. Unknown string policy                   -> ``ValueError`` raised (never silently allows).
+6. ``approval_required`` on in-process     -> ``UserWarning`` emitted; never silently no-ops.
+7. Adversarial: allowlist denial path      -> ``ModelDeniedError`` raised *before* provider.
+8. default_model_middleware wiring         -> policy resolves at chain-build time.
+
+Run:
+    uv run python -m pytest tests/model/test_policy_allowlist.py -v
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from jamjet.agents.governance import normalize_governance
+from jamjet.model.defaults import default_model_middleware
+from jamjet.model.middleware import ModelAllowlistMiddleware, ModelDeniedError
+from jamjet.model.policy_resolver import (
+    BUILT_IN_POLICIES,
+    resolve_named_policy,
+    resolve_policy_allowlist,
+)
+from jamjet.model.types import ModelRequest, parse_model_ref
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _req(model: str) -> ModelRequest:
+    return ModelRequest(ref=parse_model_ref(model), messages=[{"role": "user", "content": "hi"}])
+
+
+# ---------------------------------------------------------------------------
+# 1. Dict policy with model_allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestDictPolicyAllowlist:
+    """policy=dict with model_allowlist-> seam denies unlisted models."""
+
+    def test_allowed_model_passes(self):
+        """A model in the dict allowlist is not denied."""
+        allowlist = resolve_policy_allowlist(
+            {"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
+        )
+        assert allowlist == {"anthropic/claude-sonnet-4-6"}
+
+    def test_allowed_by_provider_passes(self):
+        allowlist = resolve_policy_allowlist({"model_allowlist": ["anthropic"]})
+        assert "anthropic" in allowlist
+
+    def test_dict_no_model_allowlist_is_allow_all(self):
+        """Dict without model_allowlist key -> allow-all (None)."""
+        allowlist = resolve_policy_allowlist({"blocked_tools": ["rm_*"]})
+        assert allowlist is None
+
+    def test_dict_empty_model_allowlist_is_allow_all(self):
+        """Empty model_allowlist -> allow-all (None)."""
+        allowlist = resolve_policy_allowlist({"model_allowlist": []})
+        assert allowlist is None
+
+    @pytest.mark.asyncio
+    async def test_disallowed_model_raises_before_provider(self):
+        """A model call whose provider/model is not in the allowlist raises ModelDeniedError."""
+        gov = normalize_governance(
+            policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
+        )
+        chain = default_model_middleware(governance=gov)
+        allowlist_mw = chain[0]
+        assert isinstance(allowlist_mw, ModelAllowlistMiddleware)
+        # openai/gpt-4o is NOT in the allowlist
+        with pytest.raises(ModelDeniedError) as exc:
+            await allowlist_mw.before(_req("openai/gpt-4o"))
+        assert exc.value.code == "model_not_allowed"
+
+    @pytest.mark.asyncio
+    async def test_allowed_model_does_not_raise(self):
+        """A model call whose model string IS in the allowlist proceeds."""
+        gov = normalize_governance(
+            policy={"model_allowlist": ["anthropic/claude-sonnet-4-6"]}
+        )
+        chain = default_model_middleware(governance=gov)
+        allowlist_mw = chain[0]
+        assert isinstance(allowlist_mw, ModelAllowlistMiddleware)
+        req = _req("anthropic/claude-sonnet-4-6")
+        result = await allowlist_mw.before(req)
+        assert result is req  # passed through unchanged
+
+
+# ---------------------------------------------------------------------------
+# 2. policy=None -> allow-all (rest of governance still on)
+# ---------------------------------------------------------------------------
+
+
+class TestNoPolicyAllowAll:
+    """policy=None -> allow-all; audit/PII/budget still active."""
+
+    def test_none_policy_returns_none_allowlist(self):
+        allowlist = resolve_policy_allowlist(None)
+        assert allowlist is None
+
+    def test_no_policy_middleware_allowlist_is_none(self):
+        chain = default_model_middleware(governance=None)
+        mw = chain[0]
+        assert isinstance(mw, ModelAllowlistMiddleware)
+        assert mw._allowed is None  # allow-all
+
+    def test_no_policy_governance_allowlist_is_none(self):
+        """Explicit governance with no policy also keeps allow-all."""
+        gov = normalize_governance(policy=None)
+        chain = default_model_middleware(governance=gov)
+        mw = chain[0]
+        assert mw._allowed is None
+
+
+# ---------------------------------------------------------------------------
+# 3. String "strict" -> Anthropic-only
+# ---------------------------------------------------------------------------
+
+
+class TestStrictNamedPolicy:
+    """policy="strict" resolves to the Anthropic-only allowlist."""
+
+    def test_strict_resolves_to_dict(self):
+        rules = resolve_named_policy("strict")
+        assert "model_allowlist" in rules
+        assert "anthropic" in rules["model_allowlist"]
+
+    def test_strict_allowlist_contains_anthropic(self):
+        allowlist = resolve_policy_allowlist("strict")
+        assert allowlist is not None
+        assert "anthropic" in allowlist
+
+    def test_strict_allows_anthropic_provider(self):
+        """Any anthropic/ model passes the strict allowlist."""
+        allowlist = resolve_policy_allowlist("strict")
+        assert allowlist is not None
+        # provider check: "anthropic" in allowed -> anthropic/any-model passes
+        assert "anthropic" in allowlist
+
+    @pytest.mark.asyncio
+    async def test_strict_allows_anthropic_model_call(self):
+        gov = normalize_governance(policy="strict")
+        chain = default_model_middleware(governance=gov)
+        mw = chain[0]
+        req = _req("anthropic/claude-sonnet-4-6")
+        result = await mw.before(req)
+        assert result is req
+
+    @pytest.mark.asyncio
+    async def test_strict_denies_openai_model(self):
+        """strict policy: openai model calls are DENIED (adversarial dual)."""
+        gov = normalize_governance(policy="strict")
+        chain = default_model_middleware(governance=gov)
+        mw = chain[0]
+        with pytest.raises(ModelDeniedError) as exc:
+            await mw.before(_req("openai/gpt-4o"))
+        assert exc.value.code == "model_not_allowed"
+
+    @pytest.mark.asyncio
+    async def test_strict_denies_non_anthropic_provider(self):
+        """Any non-anthropic provider is denied under strict policy."""
+        gov = normalize_governance(policy="strict")
+        chain = default_model_middleware(governance=gov)
+        mw = chain[0]
+        with pytest.raises(ModelDeniedError):
+            await mw.before(_req("openai/gpt-3.5-turbo"))
+
+
+# ---------------------------------------------------------------------------
+# 4. String "open" -> allow-all
+# ---------------------------------------------------------------------------
+
+
+class TestOpenNamedPolicy:
+    def test_open_allowlist_is_none(self):
+        """open policy is an explicit allow-all alias."""
+        allowlist = resolve_policy_allowlist("open")
+        assert allowlist is None
+
+    @pytest.mark.asyncio
+    async def test_open_allows_any_model(self):
+        gov = normalize_governance(policy="open")
+        chain = default_model_middleware(governance=gov)
+        mw = chain[0]
+        req = _req("openai/gpt-4o")
+        result = await mw.before(req)
+        assert result is req
+
+
+# ---------------------------------------------------------------------------
+# 5. Unknown string policy -> ValueError (fail LOUD, never silent-allow)
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownNamedPolicyFails:
+    """An unknown policy name is a hard error, not a silent allow-all."""
+
+    def test_unknown_policy_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown named policy"):
+            resolve_named_policy("nonexistent-policy-xyz")
+
+    def test_unknown_policy_raises_in_resolver(self):
+        with pytest.raises(ValueError, match="Unknown named policy"):
+            resolve_policy_allowlist("typo-strict")
+
+    def test_unknown_policy_message_names_known_policies(self):
+        """Error message lists the built-in policies so the user can fix the typo."""
+        with pytest.raises(ValueError) as exc:
+            resolve_named_policy("typo")
+        msg = str(exc.value)
+        for name in BUILT_IN_POLICIES:
+            assert name in msg
+
+    def test_unknown_policy_in_middleware_chain_raises(self):
+        """Building the middleware chain with an unknown policy raises — never allow-all."""
+        gov = normalize_governance(policy="allow-everything-please")
+        with pytest.raises(ValueError, match="Unknown named policy"):
+            default_model_middleware(governance=gov)
+
+
+# ---------------------------------------------------------------------------
+# 6. approval_required on the in-process path -> UserWarning (never silent no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalRequiredInProcessWarning:
+    """approval_required must never silently no-op on agent.run()."""
+
+    @pytest.fixture
+    def dummy_tool(self):
+        from jamjet.tools.decorators import tool
+
+        @tool
+        async def noop(x: str) -> str:
+            """Does nothing."""
+            return x
+
+        return noop
+
+    def test_approval_required_true_warns_on_run(self, dummy_tool):
+        """approval_required=True on agent.run() emits a UserWarning."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from jamjet.agents.agent import Agent
+        from jamjet.runtime.local import LocalRuntime
+
+        agent = Agent(
+            "gated",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[dummy_tool],
+            approval_required=True,
+        )
+
+        # Mock LocalRuntime.execute so we don't need a real model.
+        fake_result = AsyncMock(
+            output="ok",
+            tool_calls=[],
+            duration_ms=1,
+        )
+
+        async def _run():
+            with patch.object(LocalRuntime, "execute", return_value=fake_result):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    await agent.run("test prompt")
+            return w
+
+        caught = asyncio.run(_run())
+        user_warnings = [x for x in caught if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) >= 1
+        msg = str(user_warnings[0].message)
+        assert "approval_required" in msg
+        assert "in-process" in msg.lower() or "run_durable" in msg
+
+    def test_approval_required_list_warns_on_run(self, dummy_tool):
+        """approval_required=[...] on agent.run() emits a UserWarning."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from jamjet.agents.agent import Agent
+        from jamjet.runtime.local import LocalRuntime
+
+        agent = Agent(
+            "gated",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[dummy_tool],
+            approval_required=["delete_*"],
+        )
+
+        fake_result = AsyncMock(
+            output="ok",
+            tool_calls=[],
+            duration_ms=1,
+        )
+
+        async def _run():
+            with patch.object(LocalRuntime, "execute", return_value=fake_result):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    await agent.run("test")
+            return w
+
+        caught = asyncio.run(_run())
+        user_warnings = [x for x in caught if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) >= 1
+
+    def test_approval_required_false_does_not_warn(self, dummy_tool):
+        """approval_required=False (default) -> NO warning on agent.run()."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from jamjet.agents.agent import Agent
+        from jamjet.runtime.local import LocalRuntime
+
+        agent = Agent(
+            "plain",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[dummy_tool],
+        )
+
+        fake_result = AsyncMock(
+            output="ok",
+            tool_calls=[],
+            duration_ms=1,
+        )
+
+        async def _run():
+            with patch.object(LocalRuntime, "execute", return_value=fake_result):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    await agent.run("test")
+            return w
+
+        caught = asyncio.run(_run())
+        user_warnings = [x for x in caught if issubclass(x.category, UserWarning)]
+        # No approval_required warnings
+        approval_warns = [x for x in user_warnings if "approval" in str(x.message).lower()]
+        assert len(approval_warns) == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. IR compiler: string policy resolves to real model_allowlist in the IR
+# ---------------------------------------------------------------------------
+
+
+class TestStringPolicyInIr:
+    """policy="strict" produces a real model_allowlist in the compiled IR (not empty)."""
+
+    @pytest.fixture
+    def weather_tool(self):
+        from jamjet.tools.decorators import tool
+
+        @tool
+        async def get_weather(city: str) -> str:
+            """Return weather."""
+            return f"sunny in {city}"
+
+        return get_weather
+
+    def test_strict_policy_emits_model_allowlist_in_ir(self, weather_tool):
+        from jamjet.agents.agent import Agent
+        from jamjet.compiler.agent_ir import compile_agent_to_ir
+
+        agent = Agent(
+            "governed",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[weather_tool],
+            policy="strict",
+        )
+        ir = compile_agent_to_ir(agent, "hello")
+        policy = ir.get("policy")
+        assert policy is not None
+        # "strict" -> model_allowlist: ["anthropic"] — not an empty list
+        assert policy["model_allowlist"] == ["anthropic"]
+
+    def test_open_policy_does_not_raise_in_ir(self, weather_tool):
+        """policy="open" compiles without error (it resolves to empty rules -> no IR policy block)."""
+        from jamjet.agents.agent import Agent
+        from jamjet.compiler.agent_ir import compile_agent_to_ir
+
+        agent = Agent(
+            "governed",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[weather_tool],
+            policy="open",
+        )
+        # "open" resolves to empty blocked/approval/allowlist -> no policy block emitted.
+        # The important invariant: it does NOT raise, and doesn't silently allow-all
+        # without expressing intent.
+        compile_agent_to_ir(agent, "hello")  # must not raise
+
+    def test_unknown_string_policy_raises_in_ir_compiler(self, weather_tool):
+        """Compiling an Agent with an unknown string policy raises ValueError."""
+        from jamjet.agents.agent import Agent
+        from jamjet.compiler.agent_ir import compile_agent_to_ir
+
+        agent = Agent(
+            "governed",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[weather_tool],
+            policy="nonexistent-policy",
+        )
+        with pytest.raises(ValueError, match="Unknown named policy"):
+            compile_agent_to_ir(agent, "hello")
+
+
+# ---------------------------------------------------------------------------
+# 8. defaults.py: existing tests still pass (non-regression)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsNonRegression:
+    """Ensure T3-6 wiring doesn't regress the T3-1..4 defaults test invariants."""
+
+    def test_no_governance_allowlist_is_none(self):
+        """No governance -> allow-all (None allowlist) — the Track 1 default."""
+        chain = default_model_middleware()
+        mw = chain[0]
+        assert isinstance(mw, ModelAllowlistMiddleware)
+        assert mw._allowed is None
+
+    def test_none_policy_keeps_allow_all(self):
+        gov = normalize_governance(policy=None)
+        chain = default_model_middleware(governance=gov)
+        assert chain[0]._allowed is None
+
+    def test_dict_policy_without_allowlist_keeps_allow_all(self):
+        """Dict policy with only blocked_tools -> model allowlist stays None."""
+        gov = normalize_governance(policy={"blocked_tools": ["rm_*"]})
+        chain = default_model_middleware(governance=gov)
+        assert chain[0]._allowed is None

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -437,6 +437,7 @@ def test_get_model_has_governed_middleware() -> None:
     This test would FAIL against the old bare ``Model()`` construction (no middleware)
     and PASSES once ``default_model_middleware()`` is wired in.
     """
+    from jamjet.model.budget import BudgetMiddleware
     from jamjet.model.metering import MeteringMiddleware
     from jamjet.model.middleware import ModelAllowlistMiddleware
 
@@ -451,6 +452,7 @@ def test_get_model_has_governed_middleware() -> None:
     assert ModelAllowlistMiddleware in mw_types, (
         "ModelAllowlistMiddleware must be in the sidecar Model's middleware chain"
     )
+    assert BudgetMiddleware in mw_types, "BudgetMiddleware must be in the sidecar Model's middleware chain (T3-2)"
     assert MeteringMiddleware in mw_types, "MeteringMiddleware must be in the sidecar Model's middleware chain"
 
     # Restore singleton state so subsequent tests get a fresh instance.

--- a/sdk/python/tests/test_agent_durable_loop_parity.py
+++ b/sdk/python/tests/test_agent_durable_loop_parity.py
@@ -383,7 +383,9 @@ async def test_inprocess_run_matches_durable_loop_answer(monkeypatch: Any) -> No
     # adapter seam (so neither litellm nor the network is touched).
     monkeypatch.setattr(
         "jamjet.runtime.local.executor.get_adapter",
-        lambda _cfg: ScriptedAdapter(ScriptedModel()),
+        # T3-7: get_adapter now takes (config, governance); the scripted adapter
+        # ignores governance because it injects its own ScriptedModel.
+        lambda _cfg, _gov=None: ScriptedAdapter(ScriptedModel()),
     )
     inproc = await agent.run(_PROMPT)
 

--- a/sdk/python/tests/test_agent_ir.py
+++ b/sdk/python/tests/test_agent_ir.py
@@ -325,9 +325,7 @@ class TestGovernanceIrBudget:
         assert ir.get("token_budget") == {"total_tokens": 1000}
 
     def test_budget_both_fields_emits_both_ir_keys(self):
-        ir = compile_agent_to_ir(
-            _governed_agent(budget=Budget(tokens=5000, cost_usd=1.00)), "hi"
-        )
+        ir = compile_agent_to_ir(_governed_agent(budget=Budget(tokens=5000, cost_usd=1.00)), "hi")
         assert ir.get("cost_budget_usd") == 1.00
         assert ir.get("token_budget") == {"total_tokens": 5000}
 
@@ -378,9 +376,7 @@ class TestGovernanceIrPolicy:
     def test_dict_policy_and_approval_required_are_merged(self):
         """approval_required globs are union-appended into a dict policy's require_approval_for."""
         p = {"require_approval_for": ["pay_*"]}
-        ir = compile_agent_to_ir(
-            _governed_agent(policy=p, approval_required=["delete_*"]), "hi"
-        )
+        ir = compile_agent_to_ir(_governed_agent(policy=p, approval_required=["delete_*"]), "hi")
         policy = ir.get("policy")
         assert policy is not None
         assert "pay_*" in policy["require_approval_for"]
@@ -435,7 +431,5 @@ class TestGovernanceIrCacheKey:
 
     def test_adding_approval_changes_version(self):
         base_version = compile_agent_to_ir(_agent(), "hi")["version"]
-        approved_version = compile_agent_to_ir(
-            _governed_agent(approval_required=["delete_*"]), "hi"
-        )["version"]
+        approved_version = compile_agent_to_ir(_governed_agent(approval_required=["delete_*"]), "hi")["version"]
         assert base_version != approved_version

--- a/sdk/python/tests/test_agent_ir.py
+++ b/sdk/python/tests/test_agent_ir.py
@@ -1,8 +1,15 @@
-"""Structural tests for the agent-loop IR builder (Track 2j-3).
+"""Structural tests for the agent-loop IR builder (Track 2j-3 + T3-5).
 
 No engine: assert the compiled ``WorkflowIr`` dict has the model/condition/
 tool-dispatch nodes, the correct edges (model -> gate -> (tools -> next | end)),
 and the canonical top-level shape the Rust engine deserializes.
+
+T3-5 section (at the bottom) verifies that governance knobs from GovernanceConfig
+compile into the correct IR fields:
+  budget.cost_usd  -> cost_budget_usd
+  budget.tokens    -> token_budget.total_tokens
+  policy/approval_required -> policy.require_approval_for
+  pii=True (default) -> data_policy with standard PII detectors
 """
 
 from __future__ import annotations
@@ -10,6 +17,7 @@ from __future__ import annotations
 import pytest
 
 from jamjet.agents.agent import Agent
+from jamjet.agents.governance import Budget
 from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir
 from jamjet.tools.decorators import tool
 
@@ -276,3 +284,158 @@ def test_description_is_stable_and_never_the_prompt():
     ir_bare = compile_agent_to_ir(bare, prompt, max_turns=2)
     assert ir_bare["description"] == "Durable agent: bare"
     assert prompt not in ir_bare["description"]
+
+
+# ── Governance IR (T3-5) ──────────────────────────────────────────────────────
+#
+# Verify that GovernanceConfig knobs compile into the correct Rust WorkflowIr
+# fields.  Field names must match workflow.rs exactly (serde snake_case):
+#   cost_budget_usd           -> Option<f64>
+#   token_budget.total_tokens -> Option<u32>  (inside TokenBudgetIr)
+#   policy.require_approval_for -> Vec<String> (inside PolicySetIr)
+#   data_policy.pii_detectors   -> Vec<String> (inside DataPolicyIr)
+
+
+def _governed_agent(**kwargs) -> Agent:
+    """Build a minimal Agent with governance knobs for IR tests."""
+    return Agent(
+        "governed",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather],
+        **kwargs,
+    )
+
+
+class TestGovernanceIrBudget:
+    """budget= knob compiles to cost_budget_usd / token_budget IR fields."""
+
+    def test_float_budget_emits_cost_budget_usd(self):
+        ir = compile_agent_to_ir(_governed_agent(budget=0.50), "hi")
+        assert ir.get("cost_budget_usd") == 0.50
+        assert "token_budget" not in ir
+
+    def test_int_budget_emits_cost_budget_usd(self):
+        ir = compile_agent_to_ir(_governed_agent(budget=2), "hi")
+        assert ir.get("cost_budget_usd") == 2.0
+        assert "token_budget" not in ir
+
+    def test_budget_tokens_emits_token_budget(self):
+        ir = compile_agent_to_ir(_governed_agent(budget=Budget(tokens=1000)), "hi")
+        assert "cost_budget_usd" not in ir
+        assert ir.get("token_budget") == {"total_tokens": 1000}
+
+    def test_budget_both_fields_emits_both_ir_keys(self):
+        ir = compile_agent_to_ir(
+            _governed_agent(budget=Budget(tokens=5000, cost_usd=1.00)), "hi"
+        )
+        assert ir.get("cost_budget_usd") == 1.00
+        assert ir.get("token_budget") == {"total_tokens": 5000}
+
+    def test_no_budget_emits_no_budget_fields(self):
+        """A plain Agent() must not produce budget IR — a zero-value would deny all runs."""
+        ir = compile_agent_to_ir(_agent(), "hi")
+        assert "cost_budget_usd" not in ir
+        assert "token_budget" not in ir
+
+
+class TestGovernanceIrPolicy:
+    """policy= and approval_required= knobs compile to the PolicySetIr block."""
+
+    def test_approval_required_list_emits_require_approval_for(self):
+        ir = compile_agent_to_ir(
+            _governed_agent(policy="strict", approval_required=["delete_*"], budget=0.50),
+            "hi",
+        )
+        # budget
+        assert ir.get("cost_budget_usd") == 0.50
+        # policy block with the glob
+        policy = ir.get("policy")
+        assert policy is not None, "policy block must be present"
+        assert policy["require_approval_for"] == ["delete_*"]
+
+    def test_approval_required_true_maps_to_wildcard(self):
+        ir = compile_agent_to_ir(_governed_agent(approval_required=True), "hi")
+        policy = ir.get("policy")
+        assert policy is not None
+        assert policy["require_approval_for"] == ["*"]
+
+    def test_approval_required_multi_glob(self):
+        globs = ["send_*", "transfer_*"]
+        ir = compile_agent_to_ir(_governed_agent(approval_required=globs), "hi")
+        policy = ir.get("policy")
+        assert policy is not None
+        assert policy["require_approval_for"] == globs
+
+    def test_dict_policy_passes_through_blocked_tools_and_allowlist(self):
+        p = {"blocked_tools": ["rm_*"], "model_allowlist": ["claude-*"]}
+        ir = compile_agent_to_ir(_governed_agent(policy=p), "hi")
+        policy = ir.get("policy")
+        assert policy is not None
+        assert policy["blocked_tools"] == ["rm_*"]
+        assert policy["model_allowlist"] == ["claude-*"]
+        assert policy["require_approval_for"] == []
+
+    def test_dict_policy_and_approval_required_are_merged(self):
+        """approval_required globs are union-appended into a dict policy's require_approval_for."""
+        p = {"require_approval_for": ["pay_*"]}
+        ir = compile_agent_to_ir(
+            _governed_agent(policy=p, approval_required=["delete_*"]), "hi"
+        )
+        policy = ir.get("policy")
+        assert policy is not None
+        assert "pay_*" in policy["require_approval_for"]
+        assert "delete_*" in policy["require_approval_for"]
+
+    def test_no_policy_no_approval_omits_policy_block(self):
+        """A plain Agent() must not emit a policy block."""
+        ir = compile_agent_to_ir(_agent(), "hi")
+        assert "policy" not in ir
+
+    def test_approval_required_false_and_no_policy_omits_policy_block(self):
+        ir = compile_agent_to_ir(_governed_agent(approval_required=False), "hi")
+        assert "policy" not in ir
+
+    def test_empty_approval_list_omits_policy_block(self):
+        ir = compile_agent_to_ir(_governed_agent(approval_required=[]), "hi")
+        assert "policy" not in ir
+
+
+class TestGovernanceIrDataPolicy:
+    """pii= knob compiles to the DataPolicyIr block."""
+
+    def test_default_pii_true_emits_data_policy(self):
+        """pii=True (default) -> data_policy with the five standard detectors."""
+        ir = compile_agent_to_ir(_agent(), "hi")
+        dp = ir.get("data_policy")
+        assert dp is not None, "data_policy must be present when pii=True"
+        detectors = dp["pii_detectors"]
+        for expected in ("email", "ssn", "credit_card", "phone", "ip_address"):
+            assert expected in detectors, f"missing detector: {expected}"
+        assert dp["redaction_mode"] == "mask"
+        assert dp["retain_prompts"] is False
+        assert dp["retain_outputs"] is True
+
+    def test_explicit_pii_true_emits_data_policy(self):
+        ir = compile_agent_to_ir(_governed_agent(pii=True), "hi")
+        assert ir.get("data_policy") is not None
+
+    def test_pii_false_omits_data_policy(self):
+        """pii=False -> no data_policy emitted (no Rust-side PII redaction)."""
+        ir = compile_agent_to_ir(_governed_agent(pii=False), "hi")
+        assert "data_policy" not in ir
+
+
+class TestGovernanceIrCacheKey:
+    """Governance changes must produce a different content-version (cache key)."""
+
+    def test_adding_budget_changes_version(self):
+        base_version = compile_agent_to_ir(_agent(), "hi")["version"]
+        budgeted_version = compile_agent_to_ir(_governed_agent(budget=0.50), "hi")["version"]
+        assert base_version != budgeted_version
+
+    def test_adding_approval_changes_version(self):
+        base_version = compile_agent_to_ir(_agent(), "hi")["version"]
+        approved_version = compile_agent_to_ir(
+            _governed_agent(approval_required=["delete_*"]), "hi"
+        )["version"]
+        assert base_version != approved_version

--- a/sdk/python/tests/test_agent_receipts.py
+++ b/sdk/python/tests/test_agent_receipts.py
@@ -23,7 +23,7 @@ class FakeLocalRuntime:
     name = "local"
     supported_ir_versions = ("1.0",)
 
-    async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None):
+    async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None):
         return RuntimeResult(
             output=_OUTPUT,
             execution_id="ex1",

--- a/sdk/python/tests/test_agent_receipts.py
+++ b/sdk/python/tests/test_agent_receipts.py
@@ -1,0 +1,130 @@
+"""AgentBoundary receipts on by default for governed agent turns (T3-4).
+
+A plain governed :class:`Agent` produces a valid, conformant Action Receipt
+for every turn without the developer opting in. ``receipts=False`` turns it
+off. The receipt is bound to the action (provenance) via ``arguments_hash``.
+"""
+
+import pytest
+from agentboundary import check_conformance, validate_receipt
+from agentboundary.hashing import compute_arguments_hash
+
+from jamjet import Agent
+from jamjet.agents.receipts import agent_action_arguments
+from jamjet.runtime.types import RuntimeResult
+
+_PROMPT = "summarize the latest trends in agent runtimes"
+_OUTPUT = "the answer is 42"
+
+
+class FakeLocalRuntime:
+    """Returns a fixed result so run() never touches a real model."""
+
+    name = "local"
+    supported_ir_versions = ("1.0",)
+
+    async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None):
+        return RuntimeResult(
+            output=_OUTPUT,
+            execution_id="ex1",
+            duration_ms=1.0,
+            steps=[],
+            tool_calls=[],
+            llm_calls=[],
+        )
+
+    async def resume(self, spec, execution_id):
+        raise NotImplementedError
+
+
+def _fake_runtime(monkeypatch):
+    monkeypatch.setattr("jamjet.agents.agent.LocalRuntime", FakeLocalRuntime)
+
+
+@pytest.mark.asyncio
+async def test_governed_turn_emits_a_valid_conformant_receipt(monkeypatch):
+    _fake_runtime(monkeypatch)
+    agent = Agent("researcher", model="gpt-4o", tools=[], strategy="react")
+
+    result = await agent.run(_PROMPT)
+
+    receipt = result.receipt
+    assert receipt is not None, "receipts are ON by default"
+    # Schema valid.
+    assert validate_receipt(receipt) == []
+    # Level 3 (Portable Proof) conformance: no fail-severity checks. Passing the
+    # original arguments exercises the arguments_hash recompute too.
+    args = agent_action_arguments(agent_name="researcher", model="gpt-4o", prompt=_PROMPT)
+    fails = [c for c in check_conformance(receipt, level=3, arguments=args) if c.severity == "fail"]
+    assert fails == [], f"conformance failures: {fails}"
+    # The decision is recorded (Level 2 policy-bound).
+    assert receipt["policy"]["decision"] == "allow"
+    assert receipt["execution"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_default_agent_has_receipts_on(monkeypatch):
+    _fake_runtime(monkeypatch)
+    # No governance kwargs at all -> still governed, still mints.
+    agent = Agent("plain", model="gpt-4o", tools=[])
+    assert agent.governance.receipts is True
+
+    result = await agent.run("hi")
+
+    assert result.receipt is not None
+    assert validate_receipt(result.receipt) == []
+
+
+@pytest.mark.asyncio
+async def test_receipts_false_produces_no_receipt(monkeypatch):
+    _fake_runtime(monkeypatch)
+    agent = Agent("researcher", model="gpt-4o", tools=[], receipts=False)
+
+    result = await agent.run(_PROMPT)
+
+    assert result.receipt is None
+
+
+@pytest.mark.asyncio
+async def test_receipt_links_to_the_action_provenance(monkeypatch):
+    _fake_runtime(monkeypatch)
+    agent = Agent("researcher", model="gpt-4o", tools=[])
+
+    result = await agent.run(_PROMPT)
+    receipt = result.receipt
+
+    # arguments_hash binds the receipt to THIS prompt/agent/model.
+    expected = compute_arguments_hash(agent_action_arguments(agent_name="researcher", model="gpt-4o", prompt=_PROMPT))
+    assert receipt["arguments_hash"] == expected
+    # A different prompt would hash differently -> the receipt is not generic.
+    other = compute_arguments_hash(
+        agent_action_arguments(agent_name="researcher", model="gpt-4o", prompt="something else")
+    )
+    assert receipt["arguments_hash"] != other
+    # The capability identifies the agent that acted.
+    assert receipt["tool"]["capability"] == "agent.researcher"
+    assert receipt["actor"]["type"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_receipt_emitter_ships_the_receipt(monkeypatch):
+    _fake_runtime(monkeypatch)
+    shipped: list[dict] = []
+    agent = Agent("researcher", model="gpt-4o", tools=[], receipt_emitter=shipped.append)
+
+    result = await agent.run(_PROMPT)
+
+    assert len(shipped) == 1
+    assert shipped[0] == result.receipt
+    assert validate_receipt(shipped[0]) == []
+
+
+@pytest.mark.asyncio
+async def test_emitter_not_called_when_receipts_off(monkeypatch):
+    _fake_runtime(monkeypatch)
+    shipped: list[dict] = []
+    agent = Agent("researcher", model="gpt-4o", tools=[], receipts=False, receipt_emitter=shipped.append)
+
+    await agent.run(_PROMPT)
+
+    assert shipped == []

--- a/sdk/python/tests/test_governance.py
+++ b/sdk/python/tests/test_governance.py
@@ -1,0 +1,352 @@
+"""Tests for GovernanceConfig, Budget, normalize_governance, and Agent governance knobs.
+
+Run with:
+    uv run python -m pytest tests -k governance -v
+
+Covers T3-1: typed config + threading.  No enforcement happens here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
+
+# ---------------------------------------------------------------------------
+# Budget coercions
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeGovernanceBudget:
+    """normalize_governance(budget=…) coercion matrix."""
+
+    def test_float_becomes_cost_usd(self):
+        cfg = normalize_governance(budget=0.50)
+        assert cfg.budget == Budget(cost_usd=0.50)
+
+    def test_int_becomes_cost_usd(self):
+        cfg = normalize_governance(budget=2)
+        assert cfg.budget == Budget(cost_usd=2.0)
+
+    def test_budget_object_preserved(self):
+        b = Budget(tokens=1000)
+        cfg = normalize_governance(budget=b)
+        assert cfg.budget is b
+
+    def test_budget_object_with_both_fields(self):
+        b = Budget(tokens=5000, cost_usd=3.0)
+        cfg = normalize_governance(budget=b)
+        assert cfg.budget == Budget(tokens=5000, cost_usd=3.0)
+
+    def test_dict_with_cost_usd_and_tokens(self):
+        cfg = normalize_governance(budget={"cost_usd": 1.0, "tokens": 500})
+        assert cfg.budget == Budget(cost_usd=1.0, tokens=500)
+
+    def test_dict_cost_usd_only(self):
+        cfg = normalize_governance(budget={"cost_usd": 0.25})
+        assert cfg.budget == Budget(cost_usd=0.25)
+
+    def test_dict_tokens_only(self):
+        cfg = normalize_governance(budget={"tokens": 10_000})
+        assert cfg.budget == Budget(tokens=10_000)
+
+    def test_none_stays_none(self):
+        cfg = normalize_governance(budget=None)
+        assert cfg.budget is None
+
+    def test_unknown_dict_key_raises(self):
+        with pytest.raises(ValueError, match="Unknown budget keys"):
+            normalize_governance(budget={"max_usd": 1.0})
+
+    def test_bad_type_raises(self):
+        with pytest.raises(TypeError, match="budget must be"):
+            normalize_governance(budget="$2.00")  # type: ignore[arg-type]
+
+    def test_budget_zero_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            normalize_governance(budget=0.0)
+
+    def test_budget_negative_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            normalize_governance(budget=-5.0)
+
+
+# ---------------------------------------------------------------------------
+# approval_required coercions
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeGovernanceApproval:
+    """normalize_governance(approval_required=…) coercion matrix."""
+
+    def test_true_stored(self):
+        cfg = normalize_governance(approval_required=True)
+        assert cfg.approval_required is True
+
+    def test_false_stored(self):
+        cfg = normalize_governance(approval_required=False)
+        assert cfg.approval_required is False
+
+    def test_list_stored(self):
+        globs = ["delete_*", "send_*"]
+        cfg = normalize_governance(approval_required=globs)
+        assert cfg.approval_required == globs
+
+    def test_empty_list_stored(self):
+        cfg = normalize_governance(approval_required=[])
+        assert cfg.approval_required == []
+
+    def test_bad_list_entry_raises(self):
+        with pytest.raises(TypeError, match="list entries must be strings"):
+            normalize_governance(approval_required=[True])  # type: ignore[list-item]
+
+    def test_bad_type_raises(self):
+        with pytest.raises(TypeError, match="approval_required must be bool or list"):
+            normalize_governance(approval_required="all")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# GovernanceConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceConfigDefaults:
+    """A bare GovernanceConfig() must have all safety defaults ON."""
+
+    def test_default_pii_on(self):
+        assert GovernanceConfig().pii is True
+
+    def test_default_audit_on(self):
+        assert GovernanceConfig().audit is True
+
+    def test_default_receipts_on(self):
+        assert GovernanceConfig().receipts is True
+
+    def test_default_approval_required_false(self):
+        assert GovernanceConfig().approval_required is False
+
+    def test_default_policy_none(self):
+        assert GovernanceConfig().policy is None
+
+    def test_default_budget_none(self):
+        assert GovernanceConfig().budget is None
+
+    def test_frozen(self):
+        cfg = GovernanceConfig()
+        with pytest.raises((TypeError, AttributeError)):
+            cfg.pii = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# normalize_governance defaults
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeGovernanceDefaults:
+    """normalize_governance() with no args == GovernanceConfig() defaults."""
+
+    def test_defaults_match_config_defaults(self):
+        cfg = normalize_governance()
+        assert cfg.pii is True
+        assert cfg.audit is True
+        assert cfg.receipts is True
+        assert cfg.approval_required is False
+        assert cfg.policy is None
+        assert cfg.budget is None
+
+
+# ---------------------------------------------------------------------------
+# policy field
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeGovernancePolicy:
+    def test_str_policy(self):
+        cfg = normalize_governance(policy="strict")
+        assert cfg.policy == "strict"
+
+    def test_dict_policy(self):
+        p = {"blocked_tools": ["rm_*"], "model_allowlist": ["claude-*"]}
+        cfg = normalize_governance(policy=p)
+        assert cfg.policy == p
+
+    def test_none_policy(self):
+        cfg = normalize_governance(policy=None)
+        assert cfg.policy is None
+
+
+# ---------------------------------------------------------------------------
+# Agent integration — governance knobs thread through correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dummy_tool(tmp_path):
+    """A minimal @tool function for constructing test Agents."""
+    from jamjet.tools.decorators import tool
+
+    @tool
+    async def noop(x: str) -> str:
+        """Does nothing."""
+        return x
+
+    return noop
+
+
+class TestAgentGovernanceKnobs:
+    """Agent(policy=, budget=, approval_required=).governance is correct."""
+
+    def test_explicit_knobs(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "test-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            policy="strict",
+            budget=0.25,
+            approval_required=["delete_*"],
+        )
+        gov = agent.governance
+        assert gov.policy == "strict"
+        assert gov.budget == Budget(cost_usd=0.25)
+        assert gov.approval_required == ["delete_*"]
+        # defaults ON
+        assert gov.pii is True
+        assert gov.audit is True
+        assert gov.receipts is True
+
+    def test_default_agent_carries_all_default_governance(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "plain-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+        )
+        gov = agent.governance
+        assert gov.pii is True
+        assert gov.audit is True
+        assert gov.receipts is True
+        assert gov.approval_required is False
+        assert gov.policy is None
+        assert gov.budget is None
+
+    def test_approval_required_true(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "gated-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            approval_required=True,
+        )
+        assert agent.governance.approval_required is True
+
+    def test_approval_required_list(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        globs = ["send_*", "transfer_*"]
+        agent = Agent(
+            "gated-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            approval_required=globs,
+        )
+        assert agent.governance.approval_required == globs
+
+    def test_pii_off(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "no-pii-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            pii=False,
+        )
+        assert agent.governance.pii is False
+
+    def test_budget_object_accepted(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        b = Budget(tokens=5000, cost_usd=1.0)
+        agent = Agent(
+            "budgeted-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            budget=b,
+        )
+        assert agent.governance.budget == b
+
+    def test_governance_is_governance_config(self, dummy_tool):
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "typed-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+        )
+        assert isinstance(agent.governance, GovernanceConfig)
+
+    def test_max_cost_usd_folds_into_budget_when_budget_not_set(self, dummy_tool):
+        """Non-default max_cost_usd is mirrored into governance.budget.cost_usd."""
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "legacy-budget-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            max_cost_usd=0.75,
+        )
+        assert agent.governance.budget == Budget(cost_usd=0.75)
+
+    def test_default_max_cost_usd_does_not_create_budget(self, dummy_tool):
+        """The sentinel default (1.0) must NOT create a governance budget."""
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "default-budget-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            # max_cost_usd defaults to 1.0 — should not be mirrored
+        )
+        assert agent.governance.budget is None
+
+    def test_explicit_budget_wins_over_max_cost_usd(self, dummy_tool):
+        """When budget= is explicit it takes precedence; max_cost_usd is ignored."""
+        from jamjet.agents.agent import Agent
+
+        agent = Agent(
+            "dual-budget-agent",
+            model="claude-sonnet-4-6",
+            tools=[dummy_tool],
+            max_cost_usd=2.0,
+            budget=0.50,
+        )
+        # Explicit budget wins
+        assert agent.governance.budget == Budget(cost_usd=0.50)
+
+
+# ---------------------------------------------------------------------------
+# Budget dataclass constraints
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetConstraints:
+    def test_both_fields_none_is_valid(self):
+        b = Budget()
+        assert b.tokens is None
+        assert b.cost_usd is None
+
+    def test_negative_tokens_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            Budget(tokens=-1)
+
+    def test_zero_cost_usd_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            Budget(cost_usd=0.0)
+
+    def test_frozen_budget(self):
+        b = Budget(cost_usd=1.0)
+        with pytest.raises((TypeError, AttributeError)):
+            b.cost_usd = 2.0  # type: ignore[misc]

--- a/sdk/python/tests/test_governance_parity.py
+++ b/sdk/python/tests/test_governance_parity.py
@@ -1,0 +1,527 @@
+"""T3-7: enforcement PARITY across the in-process and durable paths + the
+consolidated fail-closed adversarial duals.
+
+The load-bearing invariant (plan, Global Constraints): a governance knob MUST
+take effect on BOTH ``agent.run()`` (in-process) AND the durable IR, or it must
+fail LOUD where it cannot.  NEVER a silent no-op.
+
+What T3-7 wires
+---------------
+Before T3-7 the in-process seam was built ``default_model_middleware()`` WITHOUT
+the agent's ``GovernanceConfig``, so ``budget=`` / ``policy=`` silently no-opped
+on ``agent.run()`` (PII was already on by the factory default).  T3-7 threads
+``agent.governance`` through ``agent.run()`` -> ``LocalRuntime.execute`` ->
+``_run_agent`` -> ``get_adapter(spec.llm, governance)`` -> ``SeamAdapter`` ->
+``Model(middleware=default_model_middleware(governance))`` so budget, the
+policy-derived allowlist, and PII all ENFORCE on the in-process path at parity
+with the durable path.
+
+Parity matrix asserted here
+---------------------------
+================  ==========================  ===============================
+knob              in-process (agent.run)      durable (compile_agent_to_ir)
+================  ==========================  ===============================
+budget=           BudgetExceededError (deny)  cost_budget_usd / token_budget
+policy= allowlist ModelDeniedError    (deny)  policy.model_allowlist
+pii=              redacted before backend     data_policy
+approval_required UserWarning (fail-LOUD)     policy.require_approval_for
+================  ==========================  ===============================
+
+Run:
+    uv run python -m pytest tests/test_governance_parity.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sys
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jamjet import Agent, tool
+from jamjet.agents.governance import Budget, normalize_governance
+from jamjet.compiler.agent_ir import compile_agent_to_ir
+from jamjet.model.budget import BudgetMiddleware
+from jamjet.model.defaults import default_model_middleware
+from jamjet.model.metering import MeteringMiddleware
+from jamjet.model.middleware import (
+    BudgetExceededError,
+    ModelAllowlistMiddleware,
+    ModelDeniedError,
+)
+from jamjet.model.pii import PiiRedactionMiddleware
+from jamjet.model.policy_resolver import resolve_policy_allowlist
+from jamjet.model.types import ModelRequest, parse_model_ref
+from jamjet.runtime.local.llm_adapters import SeamAdapter, get_adapter
+
+# Repo root (.../jamjet) from .../sdk/python/tests/<this file>.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@tool
+async def search(query: str) -> str:
+    """A trivial tool that drives the in-process strategy loop (forces a model
+    call that returns tool_calls, then a second model call)."""
+    return f"Results for: {query}"
+
+
+# ---------------------------------------------------------------------------
+# Test harness — drive agent.run() through the REAL seam while controlling cost
+# and capturing exactly what the backend received (post-middleware).
+# ---------------------------------------------------------------------------
+
+
+class _Backend:
+    """Records every (redacted) request the backend receives + the call count.
+
+    The conftest autouse fixture installs a litellm mock; we wrap its
+    ``acompletion`` so we both count provider calls (to prove deny-before-provider)
+    and snapshot the messages the provider actually saw (to prove PII redaction
+    happened upstream at the seam).  ``cost`` sets a fixed per-call cost so the
+    run-scoped budget accumulator trips deterministically.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seen: list[Any] = []
+
+
+def _install_backend(monkeypatch: pytest.MonkeyPatch, *, cost: float = 0.0) -> _Backend:
+    lm = sys.modules["litellm"]
+    rec = _Backend()
+    original = lm.acompletion
+
+    async def _acompletion(model: str, messages: list, tools: list | None = None, **kw: object) -> object:
+        rec.calls += 1
+        # Snapshot what the provider actually received (after seam middleware).
+        rec.seen.append(json.loads(json.dumps(messages, default=str)))
+        return await original(model=model, messages=messages, tools=tools, **kw)
+
+    monkeypatch.setattr(lm, "acompletion", _acompletion)
+    monkeypatch.setattr(lm, "completion_cost", lambda completion_response=None, **kw: cost)
+    return rec
+
+
+def _llm_config(model: str):
+    """Build a real LLMConfig the way Agent.compile() does."""
+    return Agent("cfg", model=model, tools=[search]).compile().llm
+
+
+def _seam_middleware(adapter: SeamAdapter) -> list:
+    return adapter._model._middleware  # noqa: SLF001 - test introspection
+
+
+# ===========================================================================
+# 1. ON BY DEFAULT — a plain Agent() is governed (PII + metering + audit +
+#    receipts ON), with allow-all allowlist and no budget cap (the documented
+#    defaults).  Assert the default seam chain.
+# ===========================================================================
+
+
+class TestOnByDefault:
+    def test_plain_agent_governance_defaults_are_on(self) -> None:
+        agent = Agent("plain", model="anthropic/claude-sonnet-4-6", tools=[search])
+        g = agent.governance
+        # Safe defaults ON without the developer opting in.
+        assert g.pii is True
+        assert g.audit is True
+        assert g.receipts is True
+        # No cap / no policy by default (allow-all model layer; documented v1).
+        assert g.budget is None
+        assert g.policy is None
+        assert g.approval_required is False
+
+    def test_plain_agent_default_chain_is_allowlist_pii_budget_metering(self) -> None:
+        """The documented default seam chain for a plain Agent()."""
+        agent = Agent("plain", model="anthropic/claude-sonnet-4-6", tools=[search])
+        chain = default_model_middleware(agent.governance)
+        assert [type(mw).__name__ for mw in chain] == [
+            "ModelAllowlistMiddleware",
+            "PiiRedactionMiddleware",
+            "BudgetMiddleware",
+            "MeteringMiddleware",
+        ]
+        # allow-all (no policy) + uncapped (no budget) — PII + metering active.
+        assert isinstance(chain[0], ModelAllowlistMiddleware)
+        assert chain[0]._allowed is None  # noqa: SLF001
+        assert isinstance(chain[1], PiiRedactionMiddleware)
+        assert isinstance(chain[2], BudgetMiddleware)
+        assert chain[2]._budget is None  # noqa: SLF001
+        assert isinstance(chain[3], MeteringMiddleware)
+
+    def test_plain_agent_inprocess_seam_has_pii_and_metering_on(self) -> None:
+        """The in-process adapter a plain Agent() runs through carries PII +
+        metering (the on-by-default proof, end of the threading)."""
+        agent = Agent("plain", model="anthropic/claude-sonnet-4-6", tools=[search])
+        adapter = get_adapter(agent.compile().llm, agent.governance)
+        mws = _seam_middleware(adapter)
+        assert any(isinstance(m, PiiRedactionMiddleware) for m in mws)
+        assert any(isinstance(m, MeteringMiddleware) for m in mws)
+
+
+# ===========================================================================
+# 2. THE KEY GAP CLOSED — governance is threaded into the in-process seam.
+# ===========================================================================
+
+
+class TestInProcessSeamThreading:
+    def test_get_adapter_threads_budget_into_seam(self) -> None:
+        gov = normalize_governance(budget=Budget(cost_usd=0.25))
+        adapter = get_adapter(_llm_config("anthropic/claude-sonnet-4-6"), gov)
+        budget_mw = next(m for m in _seam_middleware(adapter) if isinstance(m, BudgetMiddleware))
+        assert budget_mw._budget == Budget(cost_usd=0.25)  # noqa: SLF001
+
+    def test_get_adapter_threads_policy_allowlist_into_seam(self) -> None:
+        gov = normalize_governance(policy="strict")
+        adapter = get_adapter(_llm_config("anthropic/claude-sonnet-4-6"), gov)
+        allow_mw = _seam_middleware(adapter)[0]
+        assert isinstance(allow_mw, ModelAllowlistMiddleware)
+        assert allow_mw._allowed == {"anthropic"}  # noqa: SLF001
+
+    def test_get_adapter_omits_pii_when_pii_false(self) -> None:
+        gov = normalize_governance(pii=False)
+        adapter = get_adapter(_llm_config("anthropic/claude-sonnet-4-6"), gov)
+        assert not any(isinstance(m, PiiRedactionMiddleware) for m in _seam_middleware(adapter))
+
+    def test_get_adapter_without_governance_is_allow_all_no_budget(self) -> None:
+        """Back-compat: no governance -> Track-1 default (allow-all, no budget)."""
+        adapter = get_adapter(_llm_config("anthropic/claude-sonnet-4-6"))
+        mws = _seam_middleware(adapter)
+        assert mws[0]._allowed is None  # noqa: SLF001
+        budget_mw = next(m for m in mws if isinstance(m, BudgetMiddleware))
+        assert budget_mw._budget is None  # noqa: SLF001
+
+
+# ===========================================================================
+# 3. BUDGET PARITY — enforces on agent.run() AND carried in the durable IR.
+# ===========================================================================
+
+
+class TestBudgetParity:
+    def test_inprocess_run_denies_over_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """agent.run() DENIES the over-budget model call (BudgetExceededError).
+
+        react: call 1 proceeds (consumed $0.50), call 2's pre-provider check sees
+        $0.50 >= $0.40 and denies BEFORE the provider — backend hit exactly once.
+        """
+        backend = _install_backend(monkeypatch, cost=0.5)
+        agent = Agent("b", model="gpt-5.2", tools=[search], strategy="react", budget=0.4)
+        with pytest.raises(BudgetExceededError):
+            asyncio.run(agent.run("q"))
+        assert backend.calls == 1  # the over-budget 2nd call never reached the provider
+
+    def test_durable_ir_carries_cost_and_token_budget(self) -> None:
+        agent = Agent(
+            "b",
+            model="gpt-5.2",
+            tools=[search],
+            budget=Budget(cost_usd=2.0, tokens=5000),
+        )
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["cost_budget_usd"] == 2.0
+        assert ir["token_budget"] == {"total_tokens": 5000}
+
+
+# ===========================================================================
+# 4. POLICY / ALLOWLIST PARITY — denies on agent.run() AND carried in the IR.
+# ===========================================================================
+
+
+class TestPolicyParity:
+    def test_inprocess_run_denies_disallowed_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """agent.run() with policy='strict' (Anthropic-only) DENIES an openai model
+        before any provider call."""
+        backend = _install_backend(monkeypatch)
+        agent = Agent("p", model="gpt-5.2", tools=[search], strategy="react", policy="strict")
+        with pytest.raises(ModelDeniedError) as exc:
+            asyncio.run(agent.run("q"))
+        assert exc.value.code == "model_not_allowed"
+        assert backend.calls == 0  # denied at the seam, never reached the provider
+
+    def test_inprocess_run_allows_listed_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dual happy path: an allowed model is NOT denied."""
+        backend = _install_backend(monkeypatch)
+        agent = Agent(
+            "p",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            policy="strict",
+        )
+        result = asyncio.run(agent.run("q"))
+        assert result.output  # ran to completion
+        assert backend.calls >= 1
+
+    def test_durable_ir_carries_policy_allowlist(self) -> None:
+        agent = Agent(
+            "p",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            policy="strict",
+        )
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["policy"]["model_allowlist"] == ["anthropic"]
+
+
+# ===========================================================================
+# 5. PII PARITY — redacts before the backend on agent.run() AND sets data_policy
+#    in the durable IR.
+# ===========================================================================
+
+
+class TestPiiParity:
+    def test_inprocess_run_redacts_pii_before_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend = _install_backend(monkeypatch)
+        agent = Agent("pii", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        asyncio.run(agent.run("email alice@example.com and SSN 123-45-6789"))
+        flat = json.dumps(backend.seen)
+        assert backend.calls >= 1
+        # The provider NEVER saw the raw PII.
+        assert "alice@example.com" not in flat
+        assert "123-45-6789" not in flat
+        # It saw the typed redaction tokens instead.
+        assert "[REDACTED:EMAIL]" in flat
+        assert "[REDACTED:US_SSN]" in flat
+
+    def test_inprocess_run_pii_false_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """pii=False is an explicit opt-out: the provider receives unredacted text."""
+        backend = _install_backend(monkeypatch)
+        agent = Agent(
+            "nopii",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            pii=False,
+        )
+        asyncio.run(agent.run("email alice@example.com"))
+        flat = json.dumps(backend.seen)
+        assert "alice@example.com" in flat  # not redacted when pii=False
+
+    def test_durable_ir_sets_data_policy_when_pii_on(self) -> None:
+        agent = Agent("pii", model="anthropic/claude-sonnet-4-6", tools=[search])  # pii on by default
+        ir = compile_agent_to_ir(agent, "q")
+        assert "data_policy" in ir
+        assert "email" in ir["data_policy"]["pii_detectors"]
+        assert "ssn" in ir["data_policy"]["pii_detectors"]
+
+    def test_durable_ir_omits_data_policy_when_pii_off(self) -> None:
+        agent = Agent("nopii", model="anthropic/claude-sonnet-4-6", tools=[search], pii=False)
+        ir = compile_agent_to_ir(agent, "q")
+        assert "data_policy" not in ir
+
+
+# ===========================================================================
+# 6. APPROVAL_REQUIRED PARITY — in-process fails LOUD (UserWarning), durable IR
+#    carries require_approval_for.  It NEVER silently no-ops.
+# ===========================================================================
+
+
+class TestApprovalParity:
+    def test_inprocess_run_warns_never_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """approval_required on agent.run() emits a UserWarning (fail-LOUD).
+
+        The in-process strategy runner cannot enforce tool-level approval gates
+        (F-t3-inprocess-approval); rather than silently no-op, it warns and points
+        the developer at run_durable().
+        """
+        _install_backend(monkeypatch)
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            approval_required=["delete_*"],
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            asyncio.run(agent.run("q"))
+        approval = [w for w in caught if issubclass(w.category, UserWarning) and "approval_required" in str(w.message)]
+        assert len(approval) >= 1
+        assert "run_durable" in str(approval[0].message)
+
+    def test_no_approval_no_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dual: a plain agent does NOT emit a spurious approval warning."""
+        _install_backend(monkeypatch)
+        agent = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            asyncio.run(agent.run("q"))
+        approval = [w for w in caught if "approval" in str(w.message).lower()]
+        assert approval == []
+
+    def test_durable_ir_carries_require_approval_for_list(self) -> None:
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            approval_required=["delete_*", "send_*"],
+        )
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["policy"]["require_approval_for"] == ["delete_*", "send_*"]
+
+    def test_durable_ir_approval_true_is_wildcard(self) -> None:
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            approval_required=True,
+        )
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["policy"]["require_approval_for"] == ["*"]
+
+
+# ===========================================================================
+# 7. CONSOLIDATED ADVERSARIAL DUALS — the fail-closed proof (second-review).
+# ===========================================================================
+
+
+class TestAdversarialDuals:
+    # -- budget-exceed -> DENIED (not warned), backend not hit ----------------
+    def test_dual_budget_exceed_is_denied_not_warned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend = _install_backend(monkeypatch, cost=1.0)
+        agent = Agent("d", model="gpt-5.2", tools=[search], strategy="react", budget=0.5)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(BudgetExceededError):
+                asyncio.run(agent.run("q"))
+        # It is a hard DENY, not a soft warning-and-continue.
+        assert backend.calls == 1
+        budget_warns = [w for w in caught if "budget" in str(w.message).lower()]
+        assert budget_warns == []
+
+    # -- allowlist miss -> DENIED, backend not hit ----------------------------
+    def test_dual_allowlist_miss_is_denied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend = _install_backend(monkeypatch)
+        agent = Agent("d", model="openai/gpt-4o", tools=[search], strategy="react", policy="strict")
+        with pytest.raises(ModelDeniedError):
+            asyncio.run(agent.run("q"))
+        assert backend.calls == 0
+
+    # -- PII (email / SSN / card) -> NOT leaked to the provider ----------------
+    def test_dual_pii_not_leaked_to_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend = _install_backend(monkeypatch)
+        agent = Agent("d", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        asyncio.run(agent.run("card 4111 1111 1111 1111 mail to bob@corp.io ssn 987-65-4321"))
+        flat = json.dumps(backend.seen)
+        assert backend.calls >= 1
+        assert "bob@corp.io" not in flat
+        assert "987-65-4321" not in flat
+        assert "4111 1111 1111 1111" not in flat
+
+    # -- a budget of 0 -> fail-LOUD at construction (fail-closed, never allow) --
+    def test_dual_zero_budget_fails_loud(self) -> None:
+        """A zero budget can never silently allow: it is rejected at config time."""
+        with pytest.raises(ValueError, match="must be positive"):
+            Budget(cost_usd=0)
+        with pytest.raises(ValueError, match="must be positive"):
+            Agent("z", model="anthropic/claude-sonnet-4-6", tools=[search], budget=0)
+
+    # -- an empty allowlist SET -> deny-all (the primitive is fail-closed) -----
+    def test_dual_empty_allowlist_set_denies_all(self) -> None:
+        """``ModelAllowlistMiddleware(set())`` (a genuinely empty allowlist) DENIES
+        every model — the enforcement primitive does not fail open."""
+        mw = ModelAllowlistMiddleware(set())
+        req = ModelRequest(ref=parse_model_ref("anthropic/claude-sonnet-4-6"), messages=[])
+        with pytest.raises(ModelDeniedError):
+            asyncio.run(mw.before(req))
+
+    def test_documented_open_default_is_not_a_silent_bypass(self) -> None:
+        """The resolver maps None / "open" / an empty model_allowlist list -> allow-all
+        (the documented v1 "open" default).  Asserted here so it is a DOCUMENTED
+        choice, never a silent surprise: an empty LIST means open; an empty SET
+        (above) means deny.  A restrictive non-empty allowlist denies the outsider.
+        """
+        assert resolve_policy_allowlist(None) is None
+        assert resolve_policy_allowlist("open") is None
+        assert resolve_policy_allowlist({"model_allowlist": []}) is None
+        # A real, non-empty allowlist is fail-closed for an outsider.
+        assert resolve_policy_allowlist({"model_allowlist": ["anthropic"]}) == {"anthropic"}
+
+    # -- audit tamper -> verification fails (Python bundle + Rust chain) -------
+    def test_dual_audit_tamper_detected_python(self) -> None:
+        """A tampered signed audit bundle fails ed25519 verification (the cloud
+        export path).  Executable re-assert of "audit tamper -> verify fails"."""
+        pytest.importorskip("cryptography")
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        from jamjet.cloud.audit_verify import verify_package
+
+        bundle = b'{"schema_version":"1.0","payload":"governed-action"}\n'
+        sk = Ed25519PrivateKey.generate()
+        sig = sk.sign(hashlib.sha256(bundle).digest())
+        pk_bytes = sk.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        assert verify_package(bundle, sig, pk_bytes).ok is True
+        tampered = bundle.replace(b"governed-action", b"forged-action")
+        assert verify_package(tampered, sig, pk_bytes).ok is False
+
+    def test_dual_audit_tamper_dual_present_in_rust(self) -> None:
+        """Guard the T3-4 Rust signed-chain tamper dual so the cross-language
+        reference can't silently rot: tampering a sealed entry breaks
+        ``verify_chain`` (HashMismatch)."""
+        rust = _REPO_ROOT / "runtime" / "api" / "tests" / "audit_emit.rs"
+        if not rust.exists():
+            pytest.skip(f"runtime workspace not present at {rust}")
+        text = rust.read_text()
+        assert "verify_chain(&tampered" in text
+        assert "HashMismatch" in text
+
+
+# ===========================================================================
+# 8. NO KNOB SILENTLY NO-OPS — a single matrix that, for every knob, asserts it
+#    either enforces on agent.run() or fails LOUD.  This is the M1-moat claim.
+# ===========================================================================
+
+
+class TestNoKnobSilentlyNoOps:
+    def test_budget_does_not_silently_noop_inprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        backend = _install_backend(monkeypatch, cost=0.9)
+        agent = Agent("n", model="gpt-5.2", tools=[search], strategy="react", budget=0.5)
+        with pytest.raises(BudgetExceededError):
+            asyncio.run(agent.run("q"))
+        assert backend.calls == 1
+
+    def test_policy_does_not_silently_noop_inprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_backend(monkeypatch)
+        agent = Agent("n", model="gpt-5.2", tools=[search], strategy="react", policy="strict")
+        with pytest.raises(ModelDeniedError):
+            asyncio.run(agent.run("q"))
+
+    def test_approval_does_not_silently_noop_inprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_backend(monkeypatch)
+        agent = Agent(
+            "n",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            approval_required=True,
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            asyncio.run(agent.run("q"))
+        assert any("approval_required" in str(w.message) for w in caught)
+
+    def test_every_knob_compiles_into_the_durable_ir(self) -> None:
+        """One fully-governed agent -> every knob lands in the durable IR."""
+        agent = Agent(
+            "full",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            budget=Budget(cost_usd=1.5, tokens=2000),
+            policy="strict",
+            approval_required=["delete_*"],
+        )  # pii on by default
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["cost_budget_usd"] == 1.5
+        assert ir["token_budget"] == {"total_tokens": 2000}
+        assert ir["policy"]["model_allowlist"] == ["anthropic"]
+        assert ir["policy"]["require_approval_for"] == ["delete_*"]
+        assert "data_policy" in ir

--- a/sdk/python/tests/test_governance_parity.py
+++ b/sdk/python/tests/test_governance_parity.py
@@ -44,6 +44,7 @@ from typing import Any
 import pytest
 
 from jamjet import Agent, tool
+from jamjet.agents.audit import AuditSigner, ChainError, resolve_signer, verify_chain
 from jamjet.agents.governance import Budget, normalize_governance
 from jamjet.compiler.agent_ir import compile_agent_to_ir
 from jamjet.model.budget import BudgetMiddleware
@@ -57,6 +58,7 @@ from jamjet.model.middleware import (
 from jamjet.model.pii import PiiRedactionMiddleware
 from jamjet.model.policy_resolver import resolve_policy_allowlist
 from jamjet.model.types import ModelRequest, parse_model_ref
+from jamjet.runtime.local import LocalRuntime
 from jamjet.runtime.local.llm_adapters import SeamAdapter, get_adapter
 
 # Repo root (.../jamjet) from .../sdk/python/tests/<this file>.
@@ -525,3 +527,143 @@ class TestNoKnobSilentlyNoOps:
         assert ir["policy"]["model_allowlist"] == ["anthropic"]
         assert ir["policy"]["require_approval_for"] == ["delete_*"]
         assert "data_policy" in ir
+
+
+# ===========================================================================
+# 9. C1 — PER-ACTION SIGNED AUDIT IS ON BY DEFAULT (the false-guarantee fix).
+#    A governed agent.run() emits a signed, hash-chained audit record for every
+#    action (tool calls + the turn); audit=False emits none; tamper breaks it.
+# ===========================================================================
+
+
+class TestPerActionAuditOnByDefault:
+    def test_governed_run_emits_verifiable_signed_audit_chain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A plain governed agent.run() produces signed audit entries that
+        verify_chain accepts — audit is TRUE, not just claimed."""
+        monkeypatch.setenv("JAMJET_AUDIT_SIGNING_KEY", "review-fix-test-key")
+        _install_backend(monkeypatch)
+        agent = Agent("aud", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        result = asyncio.run(agent.run("look up the weather"))
+        assert result.audit is not None, "audit on by default -> a chain is attached"
+        # Per-ACTION: at least the model turn, plus one per tool call.
+        assert len(result.audit) >= 1
+        assert result.audit[-1].action_type == "agent_turn"
+        assert any(e.action_type == "tool_call" for e in result.audit), "tool calls are audited"
+        # Every entry is sealed + signed.
+        assert all(e.entry_hash and e.signature for e in result.audit)
+        # The chain verifies under the same signing key.
+        verify_chain(result.audit, resolve_signer())
+
+    def test_audit_false_emits_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JAMJET_AUDIT_SIGNING_KEY", "review-fix-test-key")
+        _install_backend(monkeypatch)
+        agent = Agent("noaud", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react", audit=False)
+        result = asyncio.run(agent.run("q"))
+        assert result.audit is None, "audit=False -> no emission"
+
+    def test_audit_tamper_breaks_verification(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JAMJET_AUDIT_SIGNING_KEY", "review-fix-test-key")
+        _install_backend(monkeypatch)
+        agent = Agent("aud", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        result = asyncio.run(agent.run("q"))
+        signer = resolve_signer()
+        verify_chain(result.audit, signer)  # clean chain verifies
+        # Mutate a sealed entry's content -> recomputed hash no longer matches.
+        result.audit[0].result_hash = "forged"
+        with pytest.raises(ChainError):
+            verify_chain(result.audit, signer)
+
+    def test_audit_unsigned_without_key_is_honest_not_forged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No key + no opt-in -> entries are chained but UNSIGNED; verify_chain
+        reports them as unsigned rather than trusting a forgeable dev key."""
+        monkeypatch.delenv("JAMJET_AUDIT_SIGNING_KEY", raising=False)
+        monkeypatch.delenv("JAMJET_AUDIT_ALLOW_INSECURE_KEY", raising=False)
+        _install_backend(monkeypatch)
+        agent = Agent("aud", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        result = asyncio.run(agent.run("q"))
+        assert result.audit is not None
+        assert all(e.signature is None for e in result.audit), "no key -> unsigned, never forged"
+        with pytest.raises(ChainError) as exc:
+            verify_chain(result.audit, resolve_signer())
+        assert exc.value.reason == "unsigned"
+
+    def test_wrong_key_fails_signature_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JAMJET_AUDIT_SIGNING_KEY", "the-real-key")
+        _install_backend(monkeypatch)
+        agent = Agent("aud", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
+        result = asyncio.run(agent.run("q"))
+        with pytest.raises(ChainError) as exc:
+            verify_chain(result.audit, AuditSigner(b"attacker-key"))
+        assert exc.value.reason == "bad_signature"
+
+
+# ===========================================================================
+# 10. M6 — RESUME + STREAM GOVERNANCE PARITY (never a silent no-op).
+# ===========================================================================
+
+
+class TestResumeGovernanceParity:
+    def test_resume_threads_governance_and_denies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A resumed in-process run KEEPS governance: policy='strict' on a gpt
+        model denies at the seam (was a silent no-op before — resume dropped it)."""
+        backend = _install_backend(monkeypatch)
+        spec = Agent("r", model="gpt-5.2", tools=[search], strategy="react").compile()
+        gov = normalize_governance(policy="strict")
+        with pytest.raises(ModelDeniedError):
+            asyncio.run(LocalRuntime().resume(spec, "exec-resume-1", governance=gov))
+        assert backend.calls == 0, "denied at the seam on resume, never reached the provider"
+
+    def test_resume_without_governance_does_not_deny(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dual: resume with no governance is allow-all (back-compat)."""
+        backend = _install_backend(monkeypatch)
+        spec = Agent("r", model="gpt-5.2", tools=[search], strategy="react").compile()
+        asyncio.run(LocalRuntime().resume(spec, "exec-resume-2"))
+        assert backend.calls >= 1
+
+
+class TestStreamGovernanceParity:
+    def test_stream_with_budget_fails_loud(self) -> None:
+        """A budget-capped agent.stream() FAILS LOUD (streams can't accumulate
+        budget) rather than silently running ungoverned."""
+        agent = Agent("s", model="anthropic/claude-sonnet-4-6", tools=[search], budget=0.5)
+
+        async def _drain() -> None:
+            async for _ in agent.stream("hi"):
+                pass
+
+        with pytest.raises(RuntimeError, match="budget"):
+            asyncio.run(_drain())
+
+    def test_stream_without_budget_enforces_pii_in_before_chain(self) -> None:
+        """The dual: a plain agent streams, and PII/allowlist still enforce via
+        the before-chain (no silent ungoverned stream).  The seam is built with
+        the agent's governance middleware + a stub backend so we can inspect the
+        request the backend actually received."""
+        from jamjet.model.seam import Model
+        from jamjet.model.types import StreamChunk
+
+        class _StreamBackend:
+            def __init__(self) -> None:
+                self.seen = None
+
+            async def complete(self, request):  # pragma: no cover
+                raise AssertionError("stream must not call complete")
+
+            async def stream(self, request):
+                self.seen = request
+                yield StreamChunk(delta="ok")
+
+        backend = _StreamBackend()
+        agent = Agent("s", model="anthropic/claude-sonnet-4-6", tools=[search], instructions="be brief")
+        # The governed seam: agent.governance middleware (incl. PII) + stub backend.
+        seam = Model(middleware=default_model_middleware(agent.governance), backend=backend)
+
+        async def _drain() -> list[str]:
+            return [c.delta async for c in agent.stream("email me at a@b.com", model=seam)]
+
+        out = asyncio.run(_drain())
+        assert out == ["ok"]
+        # PiiRedactionMiddleware ran in the before-chain: the backend saw redacted text.
+        flat = json.dumps(backend.seen.messages, default=str)
+        assert "a@b.com" not in flat
+        assert "[REDACTED:EMAIL]" in flat

--- a/sdk/python/tests/test_run_through_local_runtime.py
+++ b/sdk/python/tests/test_run_through_local_runtime.py
@@ -12,9 +12,10 @@ async def test_agent_run_dispatches_to_local_runtime(monkeypatch):
         name = "local"
         supported_ir_versions = ("1.0",)
 
-        async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None):
+        async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None):
             seen["spec"] = spec
             seen["input"] = input
+            seen["governance"] = governance
             return RuntimeResult(
                 output="fake-output",
                 execution_id="ex1",
@@ -34,3 +35,6 @@ async def test_agent_run_dispatches_to_local_runtime(monkeypatch):
     assert result.output == "fake-output"
     assert seen["input"] == "hello"
     assert seen["spec"].name == "x"
+    # T3-7: run() threads the agent's GovernanceConfig into the in-process
+    # runtime so the seam enforces budget/allowlist/PII (parity with durable).
+    assert seen["governance"] is a.governance


### PR DESCRIPTION
## What

Track 3 of the 9-track ADK plan — the M1 governance moat. Every agent is governed without the developer writing governance code: `Agent(policy=..., approval_required=..., budget=...)` are one-argument knobs, sane defaults are on, and the knobs enforce on both the in-process and the durable path.

## How

- **Knobs** (`agents/governance.py`): `policy`, `approval_required`, `budget`, plus `pii`/`audit`/`receipts` (default on), normalized into a single `GovernanceConfig` the seam middleware and the IR compiler both read.
- **Seam middleware** (model calls, both paths): a fail-closed budget enforcer (denies before the call once the run's accumulated spend hits the budget), PII redaction (recurses every string in the prompt and denies opaque content rather than leak it), and a policy-derived model allowlist (an unknown named policy fails loud, never silent-allow).
- **Durable IR** (`compiler/agent_ir.py`): the knobs compile into the IR fields the Rust engine already enforces fail-closed (`cost_budget_usd`, `token_budget`, `policy`, approval). A Rust deserialize test pins the shape.
- **Prove** (`agents/audit.py` + `runtime/audit`): signed, hash-chained, tamper-evident audit entries emitted per governed action (gated on the `audit` knob), and AgentBoundary receipts on by default.

## Honesty (what is on vs deferred)

A whole-branch adversarial review caught and forced fixes for a real overstatement and several fail-open gaps. The claims now match the code:

- **Enforced:** policy allowlist; fail-closed PII redaction; budget on both paths; SDK per-action signed/chained audit; receipts.
- **Disclosed as deferred** (not claimed as done): per-node engine-internal audit on the fenced commit path (F-t3-audit-emit); `RequestContext.data_policy` so native Rust adapters redact without the sidecar (durable PII is the sidecar path today, which 2e makes prod-mandatory) (F-t3-durable-data-policy); full in-process tool-level approval (it fails loud, pointing to `run_durable()`, rather than silently no-op).
- The audit signer requires a real `JAMJET_AUDIT_SIGNING_KEY`; the insecure dev key is opt-in only (`JAMJET_AUDIT_ALLOW_INSECURE_KEY`), and a no-key audit reports as unsigned rather than masquerading as signed.

## Tests

1122 Python passed and the Rust workspace green, including the fail-closed adversarial duals (budget-exceed denied, allowlist miss denied, PII not leaked, audit tamper detected, no knob silently no-ops, resume/stream parity).

## Follow-ups

F-t3-audit-emit, F-t3-durable-data-policy, F-t3-inprocess-approval, F-t3-policy-dsl, F-t3-key-mgmt, F-t3-pii-output, F-t3-pii-keys.
