### PR TITLE
feat(track-4): sessions, memory, artifacts (Session + memory= knob + artifact API)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,10 @@ Numbered examples in this directory:
 Each example is self-contained. The fifth example includes its own virtual
 environment setup script and runs without a model API key.
 
+## Sessions, memory, artifacts
+
+- `session-memory/` - An agent with a persistent `Session` running across two turns. The second turn receives the full prior thread (session continuity), a retrieved memory block (Engram recall), and fetches an artifact stored before a simulated restart. Demo mode requires no API key. See `session-memory/README.md`.
+
 ## Durable agents (Python)
 
 - `react-agent-durable/` - a ReAct-style `Agent` (model + two `@tool` functions +

--- a/examples/session-memory/README.md
+++ b/examples/session-memory/README.md
@@ -1,0 +1,62 @@
+# session-memory — multi-turn agent with memory and an artifact
+
+Demonstrates the three Track-4 guarantees in a single two-turn session:
+
+1. **Thread continuity** — a second run of the same agent continues the conversation thread from the first run, so the model sees prior turns even after a simulated process restart.
+2. **Memory recall** — with `Agent(memory=True)` (or an injected memory backend), the governed retrieve-at-start / record-at-end loop retrieves context from the prior session turn and injects it into run 2.
+3. **Artifact round-trip** — `session.artifacts.put(bytes)` stores content by hash before the restart; `session.artifacts.get(hash)` retrieves it after.
+
+## Prerequisites
+
+Python 3.11+, `jamjet` installed.
+
+    pip install jamjet
+
+For the live mode (real model + real Engram):
+
+    pip install 'jamjet[memory]'
+
+## Run
+
+**Demo mode** (no API key, scripted model, in-process fake memory):
+
+    python main.py
+
+**Live mode** (real Anthropic model + real Engram server):
+
+    ANTHROPIC_API_KEY=sk-...
+    ENGRAM_URL=http://localhost:8765  # or wherever your Engram server runs
+    python main.py --live
+
+For the durable execution path (engine + worker + sidecar), see `react-agent-durable/README.md`. The in-process `agent.run(session=...)` form used here is simpler and demonstrates the same API.
+
+## What happens
+
+Turn 1: the agent is told "My project is called Hermes." The turn is persisted to the `Session` and recorded to memory. A short artifact is stored by hash.
+
+Turn 2 (after a simulated restart with a fresh `Agent` + `SessionStore`): the agent is asked "What is my project called?" The model receives both the prior thread (turn 1) and the retrieved memory block. The artifact stored before the restart is fetched by its hash.
+
+## Key API
+
+```python
+from jamjet import Agent, Session, SessionStore, tool
+
+store = SessionStore()               # defaults to ~/.jamjet/sessions.db
+session = store.create("my-session")
+
+agent = Agent(
+    "assistant",
+    model="claude-sonnet-4-6",
+    tools=[...],
+    memory=True,                     # opt-in Engram; pip install 'jamjet[memory]'
+    session_store=store,
+)
+
+r1 = await agent.run("Turn 1 prompt", session=session)
+ref = await session.artifacts.put(b"some bytes", "text/plain")
+
+# Reload after restart:
+session2 = SessionStore().load("my-session")
+r2 = await agent.run("Turn 2 prompt", session=session2)  # sees turn 1 + memory
+data = await session2.artifacts.get(ref.hash)
+```

--- a/examples/session-memory/README.md
+++ b/examples/session-memory/README.md
@@ -39,10 +39,12 @@ Turn 2 (after a simulated restart with a fresh `Agent` + `SessionStore`): the ag
 ## Key API
 
 ```python
-from jamjet import Agent, Session, SessionStore, tool
+from jamjet import Agent, JamjetClient, Session, SessionStore, tool
 
 store = SessionStore()               # defaults to ~/.jamjet/sessions.db
 session = store.create("my-session")
+# Artifacts go through a runtime client; attach one before session.artifacts.
+session.attach_client(JamjetClient("http://127.0.0.1:7700"))
 
 agent = Agent(
     "assistant",
@@ -57,6 +59,7 @@ ref = await session.artifacts.put(b"some bytes", "text/plain")
 
 # Reload after restart:
 session2 = SessionStore().load("my-session")
+session2.attach_client(JamjetClient("http://127.0.0.1:7700"))  # binding is not persisted; reattach
 r2 = await agent.run("Turn 2 prompt", session=session2)  # sees turn 1 + memory
 data = await session2.artifacts.get(ref.hash)
 ```

--- a/examples/session-memory/main.py
+++ b/examples/session-memory/main.py
@@ -1,0 +1,247 @@
+"""Multi-turn session example: thread continuity + memory + artifact.
+
+An agent with a persistent Session runs two turns. The second turn sees
+the prior thread AND a retrieved memory block (session continuity + memory
+recall), then writes a summary artifact that is fetched by hash.
+
+Demo mode (no API key, no Engram, scripted model):
+
+    python main.py
+
+Live mode (needs ANTHROPIC_API_KEY and a running Engram server):
+
+    pip install 'jamjet[memory]'
+    ANTHROPIC_API_KEY=sk-... ENGRAM_URL=http://localhost:8765 python main.py --live
+
+In demo mode the model is scripted and memory uses a local in-process fake so
+the flow runs end-to-end without any external services.  In live mode
+``Agent(memory=True)`` opens the default embedded Engram bridge; retrieve-at-start
+and record-at-end run against a real Engram server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import sys
+import types
+from contextlib import contextmanager
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from jamjet import Agent, ArtifactRef, Session, SessionStore, tool
+
+
+# ---------------------------------------------------------------------------
+# Shared tool
+# ---------------------------------------------------------------------------
+
+
+@tool
+async def summarize(text: str) -> str:
+    """Summarize the given text."""
+    return f"Summary: {text[:80]}"
+
+
+# ---------------------------------------------------------------------------
+# Demo-mode helpers: scripted model + fake memory + fake artifact transport
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedModel:
+    """Scripted stand-in for litellm; no API key required."""
+
+    async def acompletion(
+        self,
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        last_user = next(
+            (m.get("content", "") for m in reversed(messages) if m.get("role") == "user"),
+            "",
+        )
+        if "project" in last_user.lower() and "hermes" in last_user.lower():
+            reply = "Got it — the project is called Hermes."
+        elif "project" in last_user.lower() or "name" in last_user.lower():
+            reply = "The project is Hermes."
+        else:
+            reply = f"Noted: {last_user}"
+
+        msg = MagicMock()
+        msg.content = reply
+        msg.role = "assistant"
+        msg.tool_calls = []
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=msg)]
+        return resp
+
+
+class _FakeMemory:
+    """In-process duck-typed AgentMemory for demo mode."""
+
+    def __init__(self) -> None:
+        self._store: list[str] = []
+        self._scoped_user_id: str | None = None
+
+    @contextmanager
+    def as_scope(
+        self,
+        *,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> Generator[_FakeMemory, None, None]:
+        old = self._scoped_user_id
+        self._scoped_user_id = user_id
+        try:
+            yield self
+        finally:
+            self._scoped_user_id = old
+
+    async def record(self, text: str, **kwargs: Any) -> None:
+        self._store.append(text)
+
+    async def context(self, query: str, **kwargs: Any) -> str:
+        if not self._store:
+            return ""
+        # Return a summary of what was recorded in the session.
+        recorded = "; ".join(self._store[-3:])
+        return f"[Recalled from session memory: {recorded}]"
+
+
+class _FakeArtifactClient:
+    """In-memory content-addressed store for demo mode."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, bytes] = {}
+
+    async def put_artifact(self, data: bytes, media_type: str | None = None) -> ArtifactRef:
+        digest = hashlib.sha256(data).hexdigest()
+        self._blobs[digest] = data
+        return ArtifactRef(hash=digest, size=len(data), media_type=media_type)
+
+    async def get_artifact(self, hash: str) -> bytes:
+        return self._blobs[hash]
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+
+async def run(*, live: bool, db_path: str) -> None:
+    """Two-turn session demonstrating thread continuity, memory recall, artifacts."""
+    print("JamJet session-memory example")
+    print(f"  mode={'live' if live else 'demo'}")
+    print()
+
+    # Wire up memory backend.
+    if live:
+        # Real Engram bridge — requires 'jamjet[memory]' and a running Engram.
+        memory: Any = True
+    else:
+        memory = _FakeMemory()
+
+    # Wire up artifact transport.
+    artifact_client = _FakeArtifactClient()  # in demo and live demo; swap for JamjetClient() in prod
+
+    # ---- Run 1: introduce the project ------------------------------------ #
+    store = SessionStore(db_path)
+    session = store.create("demo-session")
+    session.attach_client(artifact_client)
+
+    agent = Agent(
+        "assistant",
+        model="claude-sonnet-4-6" if live else "gpt-4o-mini",
+        tools=[summarize],
+        strategy="react",
+        instructions="You are a helpful assistant. Remember what the user tells you.",
+        memory=memory,
+        session_store=store,
+    )
+
+    print("Turn 1: introducing the project")
+    r1 = await agent.run(
+        "My project is called Hermes. Please remember that.",
+        session=session,
+    )
+    print(f"  Agent: {r1.output}")
+    print()
+
+    # Store a session artifact (a simple text note).
+    ref = await session.artifacts.put(
+        b"Project Hermes - introduced in turn 1.",
+        "text/plain",
+    )
+    print(f"Artifact stored: hash={ref.hash[:16]}...  size={ref.size} bytes")
+    print()
+
+    # ---- Simulated restart ----------------------------------------------- #
+    # Discard the first agent and store; reload from the same DB.
+    del agent, store
+    store2 = SessionStore(db_path)
+    session2 = store2.load("demo-session")
+    assert session2 is not None
+    session2.attach_client(artifact_client)
+
+    agent2 = Agent(
+        "assistant",
+        model="claude-sonnet-4-6" if live else "gpt-4o-mini",
+        tools=[summarize],
+        strategy="react",
+        instructions="You are a helpful assistant. Remember what the user tells you.",
+        memory=memory,
+        session_store=store2,
+    )
+
+    # ---- Run 2: test recall ---------------------------------------------- #
+    print("Turn 2 (after simulated restart): testing recall")
+    r2 = await agent2.run(
+        "What is my project called?",
+        session=session2,
+    )
+    print(f"  Agent: {r2.output}")
+    print()
+
+    # Fetch the artifact by hash.
+    data = await session2.artifacts.get(ref.hash)
+    print(f"Artifact fetched: {data.decode()}")
+    print()
+
+    print("All three guarantees demonstrated:")
+    print("  1. Thread continuity — turn 2 sees turn 1 in the message thread.")
+    print("  2. Memory recall     — retrieved memory block injected into turn 2.")
+    print("  3. Artifact          — bytes stored before restart fetched by hash after.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="JamJet session-memory example")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Use a real model (ANTHROPIC_API_KEY) and real Engram (ENGRAM_URL).",
+    )
+    parser.add_argument(
+        "--db",
+        default=str(Path.home() / ".jamjet" / "example-sessions.db"),
+        help="Path to the session database (default: ~/.jamjet/example-sessions.db).",
+    )
+    args = parser.parse_args()
+
+    if not args.live:
+        # Patch litellm with the scripted model so no API key is needed.
+        scripted = _ScriptedModel()
+        mock_litellm = types.ModuleType("litellm")
+        mock_litellm.acompletion = scripted.acompletion  # type: ignore[attr-defined]
+        mock_litellm.completion_cost = lambda *a, **kw: 0.0  # type: ignore[attr-defined]
+        sys.modules["litellm"] = mock_litellm
+
+    asyncio.run(run(live=args.live, db_path=args.db))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/session-memory/main.py
+++ b/examples/session-memory/main.py
@@ -26,14 +26,13 @@ import asyncio
 import hashlib
 import sys
 import types
-from contextlib import contextmanager
 from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from jamjet import Agent, ArtifactRef, Session, SessionStore, tool
-
+from jamjet import Agent, ArtifactRef, SessionStore, tool
 
 # ---------------------------------------------------------------------------
 # Shared tool
@@ -81,26 +80,15 @@ class _ScriptedModel:
         return resp
 
 
-class _FakeMemory:
-    """In-process duck-typed AgentMemory for demo mode."""
+class _ScopedFakeMemory:
+    """A scope-bound view yielded by ``_FakeMemory.as_scope``.
 
-    def __init__(self) -> None:
-        self._store: list[str] = []
-        self._scoped_user_id: str | None = None
+    Reads/writes ONLY the list for its scope, so memory never bleeds across
+    sessions, mirroring the real ``AgentMemory.as_scope`` per-run clone.
+    """
 
-    @contextmanager
-    def as_scope(
-        self,
-        *,
-        user_id: str | None = None,
-        org_id: str | None = None,
-    ) -> Generator[_FakeMemory, None, None]:
-        old = self._scoped_user_id
-        self._scoped_user_id = user_id
-        try:
-            yield self
-        finally:
-            self._scoped_user_id = old
+    def __init__(self, store: list[str]) -> None:
+        self._store = store
 
     async def record(self, text: str, **kwargs: Any) -> None:
         self._store.append(text)
@@ -108,9 +96,31 @@ class _FakeMemory:
     async def context(self, query: str, **kwargs: Any) -> str:
         if not self._store:
             return ""
-        # Return a summary of what was recorded in the session.
+        # Return a summary of what was recorded in THIS scope.
         recorded = "; ".join(self._store[-3:])
         return f"[Recalled from session memory: {recorded}]"
+
+
+class _FakeMemory:
+    """In-process duck-typed AgentMemory for demo mode.
+
+    Storage is keyed by scope ``user_id`` (the agent scopes every retrieve/record
+    by the stable ``session.id``), and ``as_scope`` yields a scoped instance bound
+    to that key, so two different sessions never see each other's memory, exactly
+    like the real ``AgentMemory``.
+    """
+
+    def __init__(self) -> None:
+        self._by_scope: dict[str | None, list[str]] = {}
+
+    @contextmanager
+    def as_scope(
+        self,
+        *,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> Generator[_ScopedFakeMemory, None, None]:
+        yield _ScopedFakeMemory(self._by_scope.setdefault(user_id, []))
 
 
 class _FakeArtifactClient:

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -4,13 +4,20 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use axum::{
     body::Bytes,
-    extract::{Extension, Path, Query, State},
+    extract::{DefaultBodyLimit, Extension, Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     middleware,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
 };
+
+/// Maximum request body for `POST /artifacts`. Set EXPLICITLY (rather than
+/// inheriting axum's implicit 2 MiB default) so the cap on the content-addressed
+/// store is an intentional contract: artifacts are developer-supplied blobs
+/// (tool outputs, small files), so a few MiB is the sane ceiling. Bodies over
+/// this are rejected with `413 Payload Too Large` before the handler runs.
+const ARTIFACT_MAX_BODY_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
 use chrono::Utc;
 use jamjet_agents::{AgentCard, AgentFilter, AgentStatus};
 use jamjet_audit::backend::AuditQuery;
@@ -49,8 +56,12 @@ pub fn build_router_with_opts(state: AppState, dev_mode: bool) -> Router {
             get(list_approvals_for_execution),
         )
         .route("/executions/:id/external-event", post(send_external_event))
-        // Artifacts (content-addressed store) — tenant-scoped developer API
-        .route("/artifacts", post(put_artifact))
+        // Artifacts (content-addressed store) — tenant-scoped developer API.
+        // The POST carries an explicit body limit (see ARTIFACT_MAX_BODY_BYTES).
+        .route(
+            "/artifacts",
+            post(put_artifact).layer(DefaultBodyLimit::max(ARTIFACT_MAX_BODY_BYTES)),
+        )
         .route("/artifacts/:hash", get(get_artifact))
         // Agents
         .route("/agents", post(register_agent).get(list_agents))
@@ -612,6 +623,9 @@ struct PutArtifactQuery {
 /// `'default'`-pinned base path.
 ///
 /// Returns `200 { "hash": <sha256 hex>, "size": <bytes>, "media_type": <type|null> }`.
+///
+/// The route carries an explicit `DefaultBodyLimit` of `ARTIFACT_MAX_BODY_BYTES`;
+/// bodies larger than that are rejected with `413` before this handler runs.
 async fn put_artifact(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
@@ -1482,6 +1496,46 @@ mod tests {
         assert!(
             matches!(got_b, Err(ApiError::NotFound(_))),
             "tenant B must not read tenant A's artifact (tenant isolation)"
+        );
+    }
+
+    /// `POST /artifacts` enforces the explicit body limit: a body over
+    /// `ARTIFACT_MAX_BODY_BYTES` is rejected with `413`, while a small body is
+    /// accepted — exercised through the real router so the `DefaultBodyLimit`
+    /// layer (not just the handler) is on the path.
+    #[tokio::test]
+    async fn put_artifact_enforces_explicit_body_limit() {
+        use tower::ServiceExt; // for `oneshot`
+
+        let app = build_router_with_opts(tenant_routing_state(), /* dev_mode */ true);
+
+        // Just over the cap -> 413 Payload Too Large.
+        let oversized = vec![0u8; ARTIFACT_MAX_BODY_BYTES + 1];
+        let too_big_req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/artifacts")
+            .header("content-type", "application/octet-stream")
+            .body(axum::body::Body::from(oversized))
+            .unwrap();
+        let resp = app.clone().oneshot(too_big_req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "oversized artifact body must be rejected with 413"
+        );
+
+        // A small body still succeeds (the limit didn't break the happy path).
+        let small_req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/artifacts")
+            .header("content-type", "text/plain")
+            .body(axum::body::Body::from("ok"))
+            .unwrap();
+        let resp = app.oneshot(small_req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a small artifact body must still be accepted"
         );
     }
 }

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -3,9 +3,11 @@ use crate::cron::{create_cron, delete_cron, list_cron};
 use crate::error::ApiError;
 use crate::state::AppState;
 use axum::{
+    body::Bytes,
     extract::{Extension, Path, Query, State},
-    http::StatusCode,
+    http::{header, HeaderMap, StatusCode},
     middleware,
+    response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
 };
@@ -47,6 +49,9 @@ pub fn build_router_with_opts(state: AppState, dev_mode: bool) -> Router {
             get(list_approvals_for_execution),
         )
         .route("/executions/:id/external-event", post(send_external_event))
+        // Artifacts (content-addressed store) — tenant-scoped developer API
+        .route("/artifacts", post(put_artifact))
+        .route("/artifacts/:hash", get(get_artifact))
         // Agents
         .route("/agents", post(register_agent).get(list_agents))
         .route("/agents/discover", post(discover_agent))
@@ -586,6 +591,70 @@ async fn send_external_event(
     backend.append_event(event).await?;
 
     Ok(Json(json!({ "execution_id": id, "accepted": true })))
+}
+
+// ── Artifacts (content-addressed store) ──────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PutArtifactQuery {
+    /// Optional media type override. When present it wins over the
+    /// `Content-Type` request header.
+    media_type: Option<String>,
+}
+
+/// `POST /artifacts` — store raw bytes in the tenant-scoped content-addressed
+/// store and return the resulting `ArtifactRef` as JSON.
+///
+/// The request body is the raw artifact bytes. The media type is taken from the
+/// `?media_type=` query parameter if present, otherwise from the `Content-Type`
+/// request header. Writes go through the TENANT-SCOPED backend
+/// (`backend_for(&tenant_id)`) so artifacts are isolated per tenant — never the
+/// `'default'`-pinned base path.
+///
+/// Returns `200 { "hash": <sha256 hex>, "size": <bytes>, "media_type": <type|null> }`.
+async fn put_artifact(
+    State(state): State<AppState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Query(query): Query<PutArtifactQuery>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<Value>, ApiError> {
+    let media_type = query.media_type.or_else(|| {
+        headers
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    });
+    let backend = state.backend_for(&tenant_id);
+    let artifact_ref = backend.put_artifact(&body, media_type.as_deref()).await?;
+    Ok(Json(json!({
+        "hash": artifact_ref.hash,
+        "size": artifact_ref.size,
+        "media_type": artifact_ref.media_type,
+    })))
+}
+
+/// `GET /artifacts/:hash` — fetch artifact bytes from the tenant-scoped store.
+///
+/// Returns `200` with the raw bytes or `404` when no artifact with that hash
+/// exists for the caller's tenant. Reads go through `backend_for(&tenant_id)`
+/// so a tenant can only read its own artifacts.
+///
+/// The response `Content-Type` is `application/octet-stream`: `get_artifact`
+/// yields only the bytes, not the stored media type (that is returned on the
+/// `POST /artifacts` response). Surfacing the media type on GET is a follow-up
+/// (F-2i-media-type) that would need the backend to return it alongside bytes.
+async fn get_artifact(
+    State(state): State<AppState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Path(hash): Path<String>,
+) -> Result<Response, ApiError> {
+    let backend = state.backend_for(&tenant_id);
+    match backend.get_artifact(&hash).await? {
+        // `Vec<u8>` renders as `application/octet-stream` by default.
+        Some(bytes) => Ok(bytes.into_response()),
+        None => Err(ApiError::NotFound(format!("artifact {hash}"))),
+    }
 }
 
 // ── Agents ───────────────────────────────────────────────────────────────────
@@ -1322,4 +1391,97 @@ fn parse_execution_id(s: &str) -> Result<ExecutionId, ApiError> {
     let uuid = uuid::Uuid::parse_str(hex)
         .map_err(|_| ApiError::BadRequest(format!("invalid execution id: {s}")))?;
     Ok(ExecutionId(uuid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+    use jamjet_agents::InMemoryAgentRegistry;
+    use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+    use jamjet_state::InMemoryBackend;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// Build an `AppState` whose `backend_for` returns a DISTINCT in-memory
+    /// backend per tenant id (created on first use). This lets a test prove the
+    /// artifact routes are genuinely tenant-scoped: the real
+    /// `TenantScopedSqliteBackend` binds the tenant inside its SQL, and here a
+    /// per-tenant backend stands in so bytes written under one tenant are
+    /// invisible to another. The dev/prod HTTP middleware pins a single tenant,
+    /// so the handlers are exercised directly with chosen `TenantId`s.
+    fn tenant_routing_state() -> AppState {
+        let backends: Arc<Mutex<HashMap<String, Arc<InMemoryBackend>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let backends_for = backends.clone();
+        let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+        let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+        let base = Arc::new(InMemoryBackend::new());
+        AppState {
+            backend: base as Arc<dyn jamjet_state::StateBackend>,
+            backend_for_fn: Arc::new(move |tenant_id: &TenantId| {
+                let mut map = backends_for.lock().unwrap();
+                let backend = map
+                    .entry(tenant_id.0.clone())
+                    .or_insert_with(|| Arc::new(InMemoryBackend::new()));
+                backend.clone() as Arc<dyn jamjet_state::StateBackend>
+            }),
+            agents: Arc::new(InMemoryAgentRegistry::new()),
+            audit,
+            enricher,
+            protocols: crate::state::default_protocol_registry(),
+            cron_store: None,
+        }
+    }
+
+    /// An artifact stored under tenant A must NOT be readable as tenant B, and
+    /// the routes must thread the request's tenant into `backend_for` (not the
+    /// `'default'` base path). Also covers the put -> get happy path and the
+    /// `media_type` round-trip on the `POST` response.
+    #[tokio::test]
+    async fn artifacts_are_tenant_isolated() {
+        let state = tenant_routing_state();
+        let tenant_a = TenantId::from("tenant-a");
+        let tenant_b = TenantId::from("tenant-b");
+
+        // Store bytes under tenant A.
+        let put = put_artifact(
+            State(state.clone()),
+            Extension(tenant_a.clone()),
+            Query(PutArtifactQuery {
+                media_type: Some("text/plain".into()),
+            }),
+            HeaderMap::new(),
+            Bytes::from_static(b"secret-a"),
+        )
+        .await
+        .expect("put under tenant A");
+        let hash = put.0["hash"].as_str().expect("hash present").to_string();
+        assert_eq!(hash.len(), 64, "hash is sha256 hex");
+        assert_eq!(put.0["size"].as_u64(), Some(8));
+        assert_eq!(put.0["media_type"], "text/plain");
+
+        // Tenant A reads its own bytes back (happy path).
+        let got_a = get_artifact(
+            State(state.clone()),
+            Extension(tenant_a.clone()),
+            Path(hash.clone()),
+        )
+        .await
+        .expect("tenant A reads its artifact");
+        let body_a = got_a.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body_a[..], b"secret-a");
+
+        // Tenant B must not see tenant A's artifact -> 404 (NotFound).
+        let got_b = get_artifact(
+            State(state.clone()),
+            Extension(tenant_b.clone()),
+            Path(hash.clone()),
+        )
+        .await;
+        assert!(
+            matches!(got_b, Err(ApiError::NotFound(_))),
+            "tenant B must not read tenant A's artifact (tenant isolation)"
+        );
+    }
 }

--- a/runtime/api/tests/artifact_api.rs
+++ b/runtime/api/tests/artifact_api.rs
@@ -1,0 +1,133 @@
+//! Task T4-4: the developer-facing artifact HTTP API over the 2i CAS.
+//!
+//! Exercises the real router (dev mode injects the `default` tenant) end to end:
+//!   1. POST /artifacts (raw bytes + Content-Type) -> 200 with {hash, size, media_type}.
+//!   2. GET /artifacts/:hash -> 200 with the EXACT bytes that were stored.
+//!   3. GET /artifacts/<unknown hash> -> 404.
+//!
+//! Tenant isolation (a put under tenant A is not GETtable as tenant B) is covered
+//! by the in-crate unit test `routes::tests::artifacts_are_tenant_isolated`, which
+//! drives the handlers with distinct `TenantId`s (the dev/prod middleware pins a
+//! single tenant, so it cannot vary the tenant through the HTTP layer).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_state::InMemoryBackend;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn make_state(backend: Arc<InMemoryBackend>) -> AppState {
+    let backend_clone = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone() as Arc<dyn jamjet_state::StateBackend>,
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| {
+            backend_clone.clone() as Arc<dyn jamjet_state::StateBackend>
+        }),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+async fn body_bytes(body: Body) -> Vec<u8> {
+    body.collect().await.unwrap().to_bytes().to_vec()
+}
+
+/// POST raw bytes -> 200 + ArtifactRef JSON; GET by that hash -> the exact bytes.
+#[tokio::test]
+async fn put_then_get_roundtrips_bytes() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let app = build_router_with_opts(make_state(backend), true);
+
+    let payload = b"hello artifact world".to_vec();
+
+    // POST /artifacts with a Content-Type header (the media type source).
+    let put_resp = app
+        .clone()
+        .oneshot(
+            Request::post("/artifacts")
+                .header("content-type", "text/plain")
+                .body(Body::from(payload.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(put_resp.status(), StatusCode::OK);
+    let put_json: Value = serde_json::from_slice(&body_bytes(put_resp.into_body()).await).unwrap();
+
+    let hash = put_json["hash"].as_str().expect("hash present").to_string();
+    assert_eq!(hash.len(), 64, "hash is sha256 hex");
+    assert!(
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash is hex: {hash}"
+    );
+    assert_eq!(put_json["size"].as_u64(), Some(payload.len() as u64));
+    assert_eq!(
+        put_json["media_type"], "text/plain",
+        "media type comes from the Content-Type header"
+    );
+
+    // GET /artifacts/:hash -> the exact bytes back.
+    let get_resp = app
+        .oneshot(
+            Request::get(format!("/artifacts/{hash}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_resp.status(), StatusCode::OK);
+    let got = body_bytes(get_resp.into_body()).await;
+    assert_eq!(got, payload, "GET returns the exact stored bytes");
+}
+
+/// The `?media_type=` query parameter overrides the Content-Type header.
+#[tokio::test]
+async fn put_media_type_query_overrides_header() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let app = build_router_with_opts(make_state(backend), true);
+
+    let put_resp = app
+        .oneshot(
+            Request::post("/artifacts?media_type=application/json")
+                .header("content-type", "text/plain")
+                .body(Body::from(b"{}".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(put_resp.status(), StatusCode::OK);
+    let put_json: Value = serde_json::from_slice(&body_bytes(put_resp.into_body()).await).unwrap();
+    assert_eq!(put_json["media_type"], "application/json");
+}
+
+/// GET for a well-formed-but-absent hash -> 404 (never a 5xx, never a panic).
+#[tokio::test]
+async fn get_unknown_hash_returns_404() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let app = build_router_with_opts(make_state(backend), true);
+
+    let unknown = "0".repeat(64);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/artifacts/{unknown}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -336,13 +336,20 @@ impl StateBackend for InMemoryBackend {
         let hash = crate::hashing::sha256_hex(bytes);
         let size = bytes.len() as u64;
         // Dedupe: only insert if not already present (INSERT OR IGNORE semantics).
-        self.artifacts
-            .entry(("default".to_string(), hash.clone()))
-            .or_insert_with(|| (bytes.to_vec(), media_type.map(|s| s.to_string())));
+        // Read the canonical (FIRST-stored) media_type back out so a second put of
+        // the same bytes with a different media_type returns what is actually
+        // stored, not this request's value (mirrors the SQLite backends).
+        let stored_media_type = {
+            let entry = self
+                .artifacts
+                .entry(("default".to_string(), hash.clone()))
+                .or_insert_with(|| (bytes.to_vec(), media_type.map(|s| s.to_string())));
+            entry.1.clone()
+        };
         Ok(crate::artifact::ArtifactRef {
             hash,
             size,
-            media_type: media_type.map(|s| s.to_string()),
+            media_type: stored_media_type,
         })
     }
 

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -883,10 +883,23 @@ impl StateBackend for SqliteBackend {
         .await
         .map_err(map_db_err)?;
 
+        // INSERT OR IGNORE keeps the FIRST row for a given (tenant, hash), so a
+        // second put of the same bytes with a different media_type does not change
+        // what is stored. Read the canonical media_type back rather than echoing
+        // this request's value, so the returned ref reflects what is actually
+        // persisted (and matches a later GET).
+        let media_type: Option<String> = sqlx::query_scalar(
+            "SELECT media_type FROM artifacts WHERE tenant_id = 'default' AND hash = ?",
+        )
+        .bind(&hash)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
         Ok(crate::artifact::ArtifactRef {
             hash,
             size,
-            media_type: media_type.map(|s| s.to_string()),
+            media_type,
         })
     }
 

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -811,10 +811,23 @@ impl StateBackend for TenantScopedSqliteBackend {
         .await
         .map_err(map_db_err)?;
 
+        // INSERT OR IGNORE keeps the FIRST row for a given (tenant, hash), so a
+        // second put of the same bytes with a different media_type does not change
+        // what is stored. Read the canonical media_type back rather than echoing
+        // this request's value, so the returned ref reflects what is actually
+        // persisted (and matches a later GET).
+        let media_type: Option<String> =
+            sqlx::query_scalar("SELECT media_type FROM artifacts WHERE tenant_id = ? AND hash = ?")
+                .bind(&self.tenant_id.0)
+                .bind(&hash)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(map_db_err)?;
+
         Ok(crate::artifact::ArtifactRef {
             hash,
             size,
-            media_type: media_type.map(|s| s.to_string()),
+            media_type,
         })
     }
 

--- a/runtime/state/tests/artifacts.rs
+++ b/runtime/state/tests/artifacts.rs
@@ -715,3 +715,94 @@ async fn tenant_scoped_dangling_ref_returns_error_no_panic() {
         "dangling ref via TenantScopedSqliteBackend must return Err, never panic"
     );
 }
+
+// == Group F: Canonical media_type on a deduped put ===========================
+//
+// put_artifact is INSERT OR IGNORE on (tenant_id, hash): a second put of the
+// SAME bytes with a DIFFERENT media_type keeps the original row, so the
+// returned ArtifactRef must carry the FIRST (stored) media_type — never the
+// new request's value that was never persisted. Covers all three backends.
+
+#[tokio::test]
+async fn sqlite_deduped_put_returns_stored_media_type() {
+    let db = open_db().await;
+    let bytes = b"canonical media type payload";
+
+    let ref1 = db.put_artifact(bytes, Some("text/plain")).await.unwrap();
+    assert_eq!(ref1.media_type, Some("text/plain".to_string()));
+
+    // Second put of identical bytes with a DIFFERENT media type.
+    let ref2 = db
+        .put_artifact(bytes, Some("application/json"))
+        .await
+        .unwrap();
+    assert_eq!(ref1.hash, ref2.hash, "same bytes must dedupe to one hash");
+    assert_eq!(
+        ref2.media_type,
+        Some("text/plain".to_string()),
+        "deduped put must return the stored media type, not the new request's"
+    );
+}
+
+/// First store with NO media_type, then re-put the same bytes WITH one: the
+/// stored value (NULL) wins, so the returned ref must be None — exercises the
+/// nullable read-back path.
+#[tokio::test]
+async fn sqlite_deduped_put_returns_stored_null_media_type() {
+    let db = open_db().await;
+    let bytes = b"null media type payload";
+
+    let ref1 = db.put_artifact(bytes, None).await.unwrap();
+    assert_eq!(ref1.media_type, None);
+
+    let ref2 = db.put_artifact(bytes, Some("text/plain")).await.unwrap();
+    assert_eq!(
+        ref2.media_type, None,
+        "stored NULL media type must win over a later request's value"
+    );
+}
+
+#[tokio::test]
+async fn memory_deduped_put_returns_stored_media_type() {
+    let backend = InMemoryBackend::new();
+    let bytes = b"in-memory canonical media type";
+
+    let ref1 = backend
+        .put_artifact(bytes, Some("text/plain"))
+        .await
+        .unwrap();
+    let ref2 = backend
+        .put_artifact(bytes, Some("application/json"))
+        .await
+        .unwrap();
+
+    assert_eq!(ref1.hash, ref2.hash);
+    assert_eq!(
+        ref2.media_type,
+        Some("text/plain".to_string()),
+        "in-memory deduped put must return the stored media type"
+    );
+}
+
+#[tokio::test]
+async fn tenant_scoped_deduped_put_returns_stored_media_type() {
+    let db = open_db().await;
+    let backend = db.for_tenant(TenantId::from("tenant-mt"));
+    let bytes = b"tenant canonical media type";
+
+    let ref1 = backend
+        .put_artifact(bytes, Some("text/plain"))
+        .await
+        .unwrap();
+    let ref2 = backend
+        .put_artifact(bytes, Some("application/json"))
+        .await
+        .unwrap();
+
+    assert_eq!(ref1.hash, ref2.hash);
+    assert_eq!(
+        ref2.media_type,
+        Some("text/plain".to_string()),
+        "tenant-scoped deduped put must return the stored media type"
+    );
+}

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -32,9 +32,10 @@ Quick start:
 # MUST come after `from jamjet.workflow.workflow import Workflow` so the
 # `workflow` name in this namespace binds to the decorator, not the subpackage.
 from jamjet.agents.agent import Agent, AgentResult
+from jamjet.agents.artifacts import ArtifactStore
 from jamjet.agents.session import Session, SessionStore
 from jamjet.agents.task import task
-from jamjet.client import JamjetClient
+from jamjet.client import ArtifactRef, JamjetClient
 from jamjet.durable import (
     durable,
     durable_run,
@@ -70,6 +71,8 @@ __all__ = [
     "AgentResult",
     "AgentMemory",
     "AgentSpec",
+    "ArtifactRef",
+    "ArtifactStore",
     "Session",
     "SessionStore",
     "DurabilityConfig",

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -32,6 +32,7 @@ Quick start:
 # MUST come after `from jamjet.workflow.workflow import Workflow` so the
 # `workflow` name in this namespace binds to the decorator, not the subpackage.
 from jamjet.agents.agent import Agent, AgentResult
+from jamjet.agents.session import Session, SessionStore
 from jamjet.agents.task import task
 from jamjet.client import JamjetClient
 from jamjet.durable import (
@@ -69,6 +70,8 @@ __all__ = [
     "AgentResult",
     "AgentMemory",
     "AgentSpec",
+    "Session",
+    "SessionStore",
     "DurabilityConfig",
     "DurableAgent",
     "DurableAgentSpec",

--- a/sdk/python/jamjet/agents/__init__.py
+++ b/sdk/python/jamjet/agents/__init__.py
@@ -5,9 +5,14 @@ from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governa
 from jamjet.agents.session import Session, SessionStore
 from jamjet.agents.task import task
 
+# Re-exported from jamjet.client so `from jamjet.agents import ArtifactRef` works
+# alongside ArtifactStore / Session (the artifact API surface lives here too).
+from jamjet.client import ArtifactRef
+
 __all__ = [
     "Agent",
     "AgentResult",
+    "ArtifactRef",
     "ArtifactStore",
     "Budget",
     "GovernanceConfig",

--- a/sdk/python/jamjet/agents/__init__.py
+++ b/sdk/python/jamjet/agents/__init__.py
@@ -1,5 +1,6 @@
 # Agent management Python API
 from jamjet.agents.agent import Agent, AgentResult
+from jamjet.agents.artifacts import ArtifactStore
 from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
 from jamjet.agents.session import Session, SessionStore
 from jamjet.agents.task import task
@@ -7,6 +8,7 @@ from jamjet.agents.task import task
 __all__ = [
     "Agent",
     "AgentResult",
+    "ArtifactStore",
     "Budget",
     "GovernanceConfig",
     "Session",

--- a/sdk/python/jamjet/agents/__init__.py
+++ b/sdk/python/jamjet/agents/__init__.py
@@ -1,6 +1,16 @@
 # Agent management Python API
 from jamjet.agents.agent import Agent, AgentResult
 from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
+from jamjet.agents.session import Session, SessionStore
 from jamjet.agents.task import task
 
-__all__ = ["Agent", "AgentResult", "Budget", "GovernanceConfig", "normalize_governance", "task"]
+__all__ = [
+    "Agent",
+    "AgentResult",
+    "Budget",
+    "GovernanceConfig",
+    "Session",
+    "SessionStore",
+    "normalize_governance",
+    "task",
+]

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -33,6 +33,7 @@ import json
 import time
 import warnings
 from collections.abc import AsyncIterator, Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
@@ -42,6 +43,7 @@ from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
 
 if TYPE_CHECKING:
+    from jamjet.memory.engram_bridge import AgentMemory
     from jamjet.spec import AgentSpec
 
 # Terminal execution statuses (WorkflowStatus, snake_case) the durable poll stops on.
@@ -92,6 +94,15 @@ class Agent:
         # themselves can still omit this; the agent only touches the store when
         # session= is set on a run call.
         session_store: SessionStore | None = None,
+        # T4-3: opt-in Engram memory with an AUTOMATIC, GOVERNED retrieve-at-
+        # start / record-at-end loop keyed by the session id.  OFF by default.
+        #   None / False        -> no memory (default; no behaviour change).
+        #   True                -> the default embedded Engram bridge (opened
+        #                          lazily on first run; FAILS LOUD here if the
+        #                          optional jamjet-engram extra is not installed).
+        #   an AgentMemory-like -> used as-is (duck-typed, so a fake can be
+        #                          injected in tests without a real Engram).
+        memory: bool | AgentMemory | None = None,
     ) -> None:
         self.name = name
         self.model = model
@@ -100,6 +111,30 @@ class Agent:
         self._on_limit_exceeded = on_limit_exceeded
         self._receipt_emitter = receipt_emitter
         self._session_store: SessionStore | None = session_store
+
+        # T4-3: resolve the memory= knob.  See the constructor docstring above.
+        # The default embedded Engram (memory=True) is opened LAZILY on the first
+        # run because Engram.open is async and __init__ is sync; we only verify
+        # the optional extra is importable HERE so the failure is loud and early.
+        self._memory_enabled: bool = False
+        self._memory_resolved: AgentMemory | None = None
+        self._engram: Any | None = None  # the lazily-opened embedded Engram (memory=True)
+        if memory is None or memory is False:
+            self._memory_enabled = False
+        elif memory is True:
+            try:
+                import engram  # noqa: F401, PLC0415
+            except ImportError as e:
+                raise ImportError(
+                    "Agent(memory=True) requires the optional 'memory' extra "
+                    "(jamjet-engram). Install with: pip install 'jamjet[memory]'."
+                ) from e
+            self._memory_enabled = True
+        else:
+            # A memory backend object: a real AgentMemory or a duck-typed fake.
+            self._memory_resolved = memory
+            self._memory_enabled = True
+
         self.limits = StrategyLimits(
             max_iterations=max_iterations,
             max_cost_usd=max_cost_usd,
@@ -261,6 +296,164 @@ class Agent:
             )
         return loaded
 
+    # ── Memory: governed auto retrieve/record loop (T4-3) ──────────────────
+
+    async def _ensure_memory(self) -> AgentMemory | None:
+        """Return the agent's memory backend, opening the default Engram lazily.
+
+        - memory off          -> ``None``.
+        - an injected backend -> returned as-is (the caller owns its lifecycle).
+        - ``memory=True``     -> open the embedded Engram ONCE and cache an
+          :class:`~jamjet.memory.engram_bridge.AgentMemory` over it.  The same
+          instance is reused across runs so memory persists; close it with
+          :meth:`aclose`.  FAILS LOUD if the optional extra is missing (already
+          verified at ``__init__``, re-guarded here for safety).
+        """
+        if not self._memory_enabled:
+            return None
+        if self._memory_resolved is not None:
+            return self._memory_resolved
+        try:
+            from engram import Engram  # noqa: PLC0415
+            from engram import Scope as EngramScope  # noqa: PLC0415
+        except ImportError as e:  # pragma: no cover - guarded at __init__
+            raise ImportError(
+                "Agent(memory=True) requires the optional 'memory' extra "
+                "(jamjet-engram). Install with: pip install 'jamjet[memory]'."
+            ) from e
+        from jamjet.memory.engram_bridge import AgentMemory  # noqa: PLC0415
+        from jamjet.spec import MemoryConfig  # noqa: PLC0415
+
+        db_path = Path.home() / ".jamjet" / "engram.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        engram = await Engram.open(path=str(db_path))
+        self._engram = engram
+        # The per-run memory KEY is the stable session id, applied at call time
+        # via as_scope() (Engram retrieval filters by scope); org defaults here.
+        self._memory_resolved = AgentMemory(
+            engram,
+            scope=EngramScope(user_id="default", org_id="default"),
+            config=MemoryConfig(),
+        )
+        return self._memory_resolved
+
+    async def _prepare_run(
+        self,
+        session: Session | str | None,
+        prompt: str,
+    ) -> tuple[Session | None, AgentMemory | None, list[dict[str, Any]] | None]:
+        """Resolve session + memory and build the seed messages for a run.
+
+        Returns ``(resolved_session, memory, initial_messages)`` shared by both
+        :meth:`run` (in-process) and :meth:`run_durable` (durable):
+
+        - *memory* is the resolved backend, or ``None`` when memory is off.
+        - When memory is ON it REQUIRES a ``session`` to key on — fail LOUD if
+          none was given.  Memory is keyed by the stable ``session.id`` so it
+          persists and is retrievable across runs; an ephemeral per-run key
+          would never retrieve, silently defeating cross-run memory.
+        - *initial_messages* carries the session thread (T4-2) and, when memory
+          is on, the AUTO-RETRIEVED "Relevant memory" block prepended after the
+          system instruction.  ``None`` means the default scratch seed (no
+          session, no memory) — existing behaviour unchanged.
+        """
+        resolved_session = self._resolve_session(session)
+        memory = await self._ensure_memory()
+
+        if memory is not None and resolved_session is None:
+            raise RuntimeError(
+                f"Agent {self.name!r}: memory= is enabled but no session= was "
+                "provided to the run. Memory is keyed by the stable session.id so "
+                "it can persist and be retrieved across runs; an ephemeral per-run "
+                "key would never retrieve. Pass session=<Session or id> to "
+                "run()/run_durable(), or drop memory= for a stateless run."
+            )
+
+        system = self.instructions or "You are a helpful assistant."
+        initial_messages: list[dict[str, Any]] | None = None
+        if resolved_session is not None:
+            initial_messages = seed_messages_for_run(resolved_session, system, prompt)
+
+        if memory is not None and resolved_session is not None:
+            ctx = await self._memory_retrieve(memory, resolved_session.id, prompt)
+            if ctx:
+                initial_messages = self._inject_memory_block(initial_messages, ctx)
+
+        return resolved_session, memory, initial_messages
+
+    async def _memory_retrieve(self, memory: AgentMemory, session_id: str, query: str) -> str:
+        """Retrieve a context block for *query*, keyed (scoped) by *session_id*.
+
+        The read is scoped to the stable session id via ``as_scope`` (Engram
+        retrieval filters by scope — see ``memory/engram_bridge.py``), so a run
+        only sees memory written under the same session.  Returns the
+        token-budgeted context block (possibly an empty string).
+        """
+        with memory.as_scope(user_id=session_id) as scoped:
+            ctx = await scoped.context(query=query)
+        return ctx or ""
+
+    async def _record_turn(
+        self,
+        memory: AgentMemory,
+        session_id: str,
+        prompt: str,
+        output: Any,
+    ) -> None:
+        """Record this turn to memory, keyed by *session_id*, PII-REDACTED.
+
+        Governance: the user prompt and the assistant output are PII-redacted
+        (the Track-3 redactor, :meth:`_redact_for_memory`) BEFORE the write, so
+        raw PII never lands in the durable temporal KG.  Both records are scoped
+        to the stable session id.
+        """
+        user_text = self._redact_for_memory(prompt)
+        with memory.as_scope(user_id=session_id) as scoped:
+            await scoped.record(user_text, role="user")
+            if output is not None and str(output):
+                assistant_text = self._redact_for_memory(str(output))
+                await scoped.record(assistant_text, role="assistant")
+
+    def _redact_for_memory(self, text: str) -> str:
+        """Redact PII from *text* before a memory write (governed write).
+
+        Uses the same conservative, high-signal PII types as the model seam
+        (``jamjet.model.pii``) so memory redaction matches outbound-prompt
+        redaction.  Respects ``governance.pii``: when PII governance is disabled
+        the caller has opted out and the text is written verbatim, consistent
+        with the model seam (which only redacts when ``pii`` is on).
+        """
+        if not self.governance.pii:
+            return text
+        from jamjet.cloud.middleware.pii import RegexDetector  # noqa: PLC0415
+        from jamjet.model.pii import _DEFAULT_PII_TYPES  # noqa: PLC0415
+
+        return RegexDetector(types=list(_DEFAULT_PII_TYPES)).redact(text)
+
+    @staticmethod
+    def _inject_memory_block(messages: list[dict[str, Any]] | None, ctx: str) -> list[dict[str, Any]]:
+        """Insert a 'Relevant memory' system block into the seed *messages*.
+
+        The block is placed right after the agent's system instruction so the
+        model sees prior-session knowledge before the conversation thread.
+        """
+        block = {"role": "system", "content": f"Relevant memory from prior sessions:\n{ctx}"}
+        msgs = list(messages or [])
+        if msgs and msgs[0].get("role") == "system":
+            return [msgs[0], block, *msgs[1:]]
+        return [block, *msgs]
+
+    async def aclose(self) -> None:
+        """Close the embedded Engram opened by ``memory=True`` (if any).
+
+        Injected memory backends are owned by the caller and are NOT closed
+        here.  Safe to call when memory is off (no-op).
+        """
+        engram = self._engram
+        if engram is not None:
+            self._engram = None
+            await engram.close()
+
     # ── Public run interface ───────────────────────────────────────────────
 
     async def run(self, prompt: str, *, session: Session | str | None = None) -> AgentResult:
@@ -278,6 +471,17 @@ class Agent:
         conversation thread instead of re-seeding from scratch.  The model
         receives the full prior thread followed by the new user prompt.  After
         the run the session is updated with the new turn and persisted.
+
+        T4-3 — Memory (``memory=``)
+        ---------------------------
+        When the agent was built with ``memory=`` (a bool or an
+        :class:`~jamjet.memory.engram_bridge.AgentMemory`), the run runs an
+        AUTOMATIC, GOVERNED loop keyed by the stable ``session.id``: it RETRIEVES
+        a "Relevant memory" context block and injects it before the thread
+        (retrieve-at-start), then RECORDS the turn after the run
+        (record-at-end), PII-REDACTED so no raw PII is written to the temporal
+        KG.  Memory requires a ``session`` to key on (fail-loud if absent) and is
+        OFF by default.
 
         Args:
             prompt: The user turn to run.
@@ -305,12 +509,10 @@ class Agent:
                 stacklevel=2,
             )
 
-        # T4-2: resolve session and build the seed messages for this run.
-        resolved_session = self._resolve_session(session)
-        system = self.instructions or "You are a helpful assistant."
-        initial_messages: list[dict[str, Any]] | None = None
-        if resolved_session is not None:
-            initial_messages = seed_messages_for_run(resolved_session, system, prompt)
+        # T4-2/T4-3: resolve session + memory and build the seed messages.  The
+        # seed carries the session thread (T4-2) plus, when memory is on, the
+        # auto-retrieved "Relevant memory" block (T4-3 retrieve-at-start).
+        resolved_session, memory, initial_messages = await self._prepare_run(session, prompt)
 
         spec = self.compile()
         rt = LocalRuntime()
@@ -346,6 +548,11 @@ class Agent:
                 full_messages=None,  # in-process path; reconstruct from prompt+output
                 store=store,
             )
+
+        # T4-3: record-at-end — write this turn to memory keyed by session.id,
+        # PII-redacted (governed write).  No-op when memory is off.
+        if memory is not None and resolved_session is not None:
+            await self._record_turn(memory, resolved_session.id, prompt, agent_result.output)
 
         return agent_result
 
@@ -413,11 +620,10 @@ class Agent:
         from jamjet.client import JamjetClient  # noqa: PLC0415 - patch point / avoid import cycle
         from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir  # noqa: PLC0415
 
-        # T4-2: resolve session and build the seed using the shared helper.
-        resolved_session = self._resolve_session(session)
-        if resolved_session is not None:
-            system = self.instructions or "You are a helpful assistant."
-            seeded_messages = seed_messages_for_run(resolved_session, system, prompt)
+        # T4-2/T4-3: resolve session + memory and build the seed (session thread
+        # plus the auto-retrieved "Relevant memory" block when memory is on).
+        resolved_session, memory, seeded_messages = await self._prepare_run(session, prompt)
+        if seeded_messages is not None:
             initial_input = build_initial_state(self, prompt, initial_messages=seeded_messages)
         else:
             initial_input = build_initial_state(self, prompt)
@@ -465,6 +671,11 @@ class Agent:
                 full_messages=full_messages,
                 store=store,
             )
+
+        # T4-3: record-at-end — write this turn to memory keyed by session.id,
+        # PII-redacted (governed write).  No-op when memory is off.
+        if memory is not None and resolved_session is not None:
+            await self._record_turn(memory, resolved_session.id, prompt, result.output)
 
         return result
 

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -119,6 +119,10 @@ class Agent:
         self._memory_enabled: bool = False
         self._memory_resolved: AgentMemory | None = None
         self._engram: Any | None = None  # the lazily-opened embedded Engram (memory=True)
+        # Serializes the FIRST embedded-Engram init so two concurrent first runs
+        # open it exactly once (see _ensure_memory).  Created lazily inside the
+        # running loop to stay loop-agnostic across separate asyncio.run() calls.
+        self._memory_lock: asyncio.Lock | None = None
         if memory is None or memory is False:
             self._memory_enabled = False
         elif memory is True:
@@ -278,7 +282,9 @@ class Agent:
         """Return a Session object.
 
         - ``None`` -> ``None`` (no session, default path unchanged).
-        - :class:`Session` -> returned as-is (caller owns persistence).
+        - :class:`Session` -> returned as-is (caller owns persistence).  A Session
+          loaded from a store carries a back-reference to that store (set by
+          ``SessionStore.load``/``create``), so the run persists it back there.
         - ``str`` -> loaded from the agent's session store; raises
           ``ValueError`` if not found.
         """
@@ -295,6 +301,20 @@ class Agent:
                 "Create it first with SessionStore.create()."
             )
         return loaded
+
+    def _store_for_session(self, session: Session) -> SessionStore:
+        """The :class:`SessionStore` a run should persist *session* back to.
+
+        A session loaded/created via a ``SessionStore`` carries a back-reference
+        to that store (``session._store``); using it means a session loaded from
+        store X is saved back to X, not silently to the agent's default store.  A
+        bare ``Session(...)`` constructed by the caller has no originating store,
+        so it falls back to the agent's store (documented behaviour).
+        """
+        store = getattr(session, "_store", None)
+        if store is not None:
+            return store
+        return self._get_default_store()
 
     # ── Memory: governed auto retrieve/record loop (T4-3) ──────────────────
 
@@ -313,29 +333,41 @@ class Agent:
             return None
         if self._memory_resolved is not None:
             return self._memory_resolved
-        try:
-            from engram import Engram  # noqa: PLC0415
-            from engram import Scope as EngramScope  # noqa: PLC0415
-        except ImportError as e:  # pragma: no cover - guarded at __init__
-            raise ImportError(
-                "Agent(memory=True) requires the optional 'memory' extra "
-                "(jamjet-engram). Install with: pip install 'jamjet[memory]'."
-            ) from e
-        from jamjet.memory.engram_bridge import AgentMemory  # noqa: PLC0415
-        from jamjet.spec import MemoryConfig  # noqa: PLC0415
+        # Serialize the first init: two concurrent first runs both see
+        # _memory_resolved is None, so without a lock each would await
+        # Engram.open(), leaking a handle and breaking open-once.  Create the lock
+        # lazily here (a pure sync check, race-free in the single-threaded loop);
+        # after the first init succeeds _memory_resolved short-circuits above so
+        # the lock is never taken again.
+        if self._memory_lock is None:
+            self._memory_lock = asyncio.Lock()
+        async with self._memory_lock:
+            # Double-checked: a racing first run may have opened it while we waited.
+            if self._memory_resolved is not None:
+                return self._memory_resolved
+            try:
+                from engram import Engram  # noqa: PLC0415
+                from engram import Scope as EngramScope  # noqa: PLC0415
+            except ImportError as e:  # pragma: no cover - guarded at __init__
+                raise ImportError(
+                    "Agent(memory=True) requires the optional 'memory' extra "
+                    "(jamjet-engram). Install with: pip install 'jamjet[memory]'."
+                ) from e
+            from jamjet.memory.engram_bridge import AgentMemory  # noqa: PLC0415
+            from jamjet.spec import MemoryConfig  # noqa: PLC0415
 
-        db_path = Path.home() / ".jamjet" / "engram.db"
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-        engram = await Engram.open(path=str(db_path))
-        self._engram = engram
-        # The per-run memory KEY is the stable session id, applied at call time
-        # via as_scope() (Engram retrieval filters by scope); org defaults here.
-        self._memory_resolved = AgentMemory(
-            engram,
-            scope=EngramScope(user_id="default", org_id="default"),
-            config=MemoryConfig(),
-        )
-        return self._memory_resolved
+            db_path = Path.home() / ".jamjet" / "engram.db"
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            engram = await Engram.open(path=str(db_path))
+            self._engram = engram
+            # The per-run memory KEY is the stable session id, applied at call time
+            # via as_scope() (Engram retrieval filters by scope); org defaults here.
+            self._memory_resolved = AgentMemory(
+                engram,
+                scope=EngramScope(user_id="default", org_id="default"),
+                config=MemoryConfig(),
+            )
+            return self._memory_resolved
 
     async def _prepare_run(
         self,
@@ -441,10 +473,15 @@ class Agent:
     def _inject_memory_block(messages: list[dict[str, Any]] | None, ctx: str) -> list[dict[str, Any]]:
         """Insert a 'Relevant memory' system block into the seed *messages*.
 
-        The block is placed right after the agent's system instruction so the
-        model sees prior-session knowledge before the conversation thread.
+        The block is placed right after the agent's system instruction (when one
+        is present) so the model sees prior-session knowledge before the
+        conversation thread.  It is tagged with :data:`MEMORY_BLOCK_PREFIX` so the
+        non-react strategies' ``seed_history`` can tell it apart from the
+        instruction slot and never clobber it (see ``strategies/base.py``).
         """
-        block = {"role": "system", "content": f"Relevant memory from prior sessions:\n{ctx}"}
+        from jamjet.runtime.local.strategies.base import MEMORY_BLOCK_PREFIX  # noqa: PLC0415
+
+        block = {"role": "system", "content": f"{MEMORY_BLOCK_PREFIX}\n{ctx}"}
         msgs = list(messages or [])
         if msgs and msgs[0].get("role") == "system":
             return [msgs[0], block, *msgs[1:]]
@@ -546,7 +583,7 @@ class Agent:
 
         # T4-2: persist the session turn (in-process path: no full_messages).
         if resolved_session is not None:
-            store = self._get_default_store()
+            store = self._store_for_session(resolved_session)
             persist_session_turn(
                 resolved_session,
                 prompt,
@@ -669,7 +706,7 @@ class Agent:
         if resolved_session is not None:
             state = execution.get("current_state") or {}
             full_messages: list[dict[str, Any]] | None = state.get("messages")
-            store = self._get_default_store()
+            store = self._store_for_session(resolved_session)
             persist_session_turn(
                 resolved_session,
                 prompt,

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -36,6 +36,7 @@ from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
 from jamjet.agents.governance import Budget, GovernanceConfig, normalize_governance
+from jamjet.agents.session import Session, SessionStore, persist_session_turn, seed_messages_for_run
 from jamjet.compiler.strategies import StrategyLimits
 from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
@@ -84,6 +85,13 @@ class Agent:
         # is always attached to the run result regardless.  Defaults to None so
         # receipts ship nowhere noisy by default while still being produced.
         receipt_emitter: Callable[[dict[str, Any]], None] | None = None,
+        # T4-2: optional SessionStore for resolving str session ids and for
+        # auto-saving sessions after run()/run_durable().  When None, a default
+        # SessionStore() (~/.jamjet/sessions.db) is created lazily on first use.
+        # Callers that pass Session objects directly and manage persistence
+        # themselves can still omit this; the agent only touches the store when
+        # session= is set on a run call.
+        session_store: SessionStore | None = None,
     ) -> None:
         self.name = name
         self.model = model
@@ -91,6 +99,7 @@ class Agent:
         self.strategy = strategy
         self._on_limit_exceeded = on_limit_exceeded
         self._receipt_emitter = receipt_emitter
+        self._session_store: SessionStore | None = session_store
         self.limits = StrategyLimits(
             max_iterations=max_iterations,
             max_cost_usd=max_cost_usd,
@@ -222,15 +231,61 @@ class Agent:
             tool_calls=result.tool_calls,
         )
 
+    # ── Session helpers (T4-2) ────────────────────────────────────────────
+
+    def _get_default_store(self) -> SessionStore:
+        """Return the agent's SessionStore, creating a default one lazily."""
+        if self._session_store is None:
+            self._session_store = SessionStore()
+        return self._session_store
+
+    def _resolve_session(self, session: Session | str | None) -> Session | None:
+        """Return a Session object.
+
+        - ``None`` -> ``None`` (no session, default path unchanged).
+        - :class:`Session` -> returned as-is (caller owns persistence).
+        - ``str`` -> loaded from the agent's session store; raises
+          ``ValueError`` if not found.
+        """
+        if session is None:
+            return None
+        if isinstance(session, Session):
+            return session
+        # str session id: resolve from store
+        store = self._get_default_store()
+        loaded = store.load(session)
+        if loaded is None:
+            raise ValueError(
+                f"Session {session!r} not found in the agent's SessionStore. "
+                "Create it first with SessionStore.create()."
+            )
+        return loaded
+
     # ── Public run interface ───────────────────────────────────────────────
 
-    async def run(self, prompt: str) -> AgentResult:
+    async def run(self, prompt: str, *, session: Session | str | None = None) -> AgentResult:
         """
         Run the agent on a single prompt via LocalRuntime.
 
         Compiles to AgentSpec, hands off to LocalRuntime which dispatches to
         the appropriate strategy runner. Emits a signed-audit-aligned
         AgentBoundary receipt for the turn (on by default).
+
+        T4-2 — Session continuation
+        ---------------------------
+        When *session* is provided (a :class:`~jamjet.agents.session.Session`
+        object or a session id string), the run CONTINUES the session's
+        conversation thread instead of re-seeding from scratch.  The model
+        receives the full prior thread followed by the new user prompt.  After
+        the run the session is updated with the new turn and persisted.
+
+        Args:
+            prompt: The user turn to run.
+            session: Optional session to continue.  Pass a
+                     :class:`~jamjet.agents.session.Session` object (caller
+                     manages the store) or a ``str`` session id (resolved via
+                     the agent's ``session_store``).  ``None`` (default) runs
+                     from scratch — existing behaviour unchanged.
         """
         # T3-6: approval_required parity — the in-process path cannot enforce
         # tool-level approval gates (the @gate mechanism is opt-in per function;
@@ -249,6 +304,14 @@ class Agent:
                 UserWarning,
                 stacklevel=2,
             )
+
+        # T4-2: resolve session and build the seed messages for this run.
+        resolved_session = self._resolve_session(session)
+        system = self.instructions or "You are a helpful assistant."
+        initial_messages: list[dict[str, Any]] | None = None
+        if resolved_session is not None:
+            initial_messages = seed_messages_for_run(resolved_session, system, prompt)
+
         spec = self.compile()
         rt = LocalRuntime()
         # T3-7: thread governance into the in-process seam so budget / allowlist
@@ -256,7 +319,12 @@ class Agent:
         # (the durable IR).  Without this the seam was built allow-all / no-budget
         # and the budget + policy knobs silently no-opped on the in-process path
         # (the gap deferred from T3-2).
-        result = await rt.execute(spec, prompt, governance=self.governance)
+        result = await rt.execute(
+            spec,
+            prompt,
+            governance=self.governance,
+            initial_messages=initial_messages,
+        )
         receipt = self._maybe_mint_receipt(prompt, result.output)
         agent_result = AgentResult(
             output=result.output,
@@ -266,6 +334,19 @@ class Agent:
             receipt=receipt,
         )
         agent_result.audit = self._maybe_emit_audit(prompt, agent_result, execution_id=result.execution_id)
+
+        # T4-2: persist the session turn (in-process path: no full_messages).
+        if resolved_session is not None:
+            store = self._get_default_store()
+            persist_session_turn(
+                resolved_session,
+                prompt,
+                agent_result.output,
+                result.execution_id,
+                full_messages=None,  # in-process path; reconstruct from prompt+output
+                store=store,
+            )
+
         return agent_result
 
     def run_sync(self, prompt: str) -> AgentResult:
@@ -278,6 +359,7 @@ class Agent:
         *,
         max_turns: int = 8,
         runtime_url: str = "http://127.0.0.1:7700",
+        session: Session | str | None = None,
     ) -> AgentResult:
         """Run the agent durably on the JamJet engine, mirroring :meth:`run`.
 
@@ -293,6 +375,14 @@ class Agent:
         and tool dispatch through the durable event-sourced engine, so the run
         gets the event log, replay, idempotency, park-on-429, and artifacts for
         free.
+
+        T4-2 — Session continuation
+        ---------------------------
+        Same carried-state contract as :meth:`run`.  When *session* is provided
+        the run is seeded from the session's persisted ``messages`` thread plus
+        the new user prompt.  After the run the full ``messages`` ledger from
+        ``current_state`` (which includes all tool turns) is persisted back to
+        the session.
 
         v1 limitations
         --------------
@@ -323,8 +413,16 @@ class Agent:
         from jamjet.client import JamjetClient  # noqa: PLC0415 - patch point / avoid import cycle
         from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir  # noqa: PLC0415
 
+        # T4-2: resolve session and build the seed using the shared helper.
+        resolved_session = self._resolve_session(session)
+        if resolved_session is not None:
+            system = self.instructions or "You are a helpful assistant."
+            seeded_messages = seed_messages_for_run(resolved_session, system, prompt)
+            initial_input = build_initial_state(self, prompt, initial_messages=seeded_messages)
+        else:
+            initial_input = build_initial_state(self, prompt)
+
         ir = compile_agent_to_ir(self, prompt, max_turns)
-        initial_input = build_initial_state(self, prompt)
         workflow_id: str = ir["workflow_id"]
         workflow_version: str | None = ir.get("version")
 
@@ -352,6 +450,22 @@ class Agent:
         # durable run's extracted result (both on by default), mirroring run().
         result.receipt = self._maybe_mint_receipt(prompt, result.output)
         result.audit = self._maybe_emit_audit(prompt, result, execution_id=exec_id)
+
+        # T4-2: persist the session with the full messages from the engine
+        # (durable path has the complete tool-interleaved thread in current_state).
+        if resolved_session is not None:
+            state = execution.get("current_state") or {}
+            full_messages: list[dict[str, Any]] | None = state.get("messages")
+            store = self._get_default_store()
+            persist_session_turn(
+                resolved_session,
+                prompt,
+                result.output,
+                exec_id,
+                full_messages=full_messages,
+                store=store,
+            )
+
         return result
 
     async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -358,9 +358,14 @@ class Agent:
           session, no memory) — existing behaviour unchanged.
         """
         resolved_session = self._resolve_session(session)
-        memory = await self._ensure_memory()
 
-        if memory is not None and resolved_session is None:
+        # Memory requires a session to key on.  Do this fail-loud check BEFORE
+        # opening any Engram handle: ``memory=True`` opens a DB handle inside
+        # ``_ensure_memory`` (cached for the agent's lifetime), so raising first
+        # means the no-session error path never leaks an open handle.  We key off
+        # ``self._memory_enabled`` (set at __init__) rather than the resolved
+        # backend so we never construct it on the error path.
+        if self._memory_enabled and resolved_session is None:
             raise RuntimeError(
                 f"Agent {self.name!r}: memory= is enabled but no session= was "
                 "provided to the run. Memory is keyed by the stable session.id so "
@@ -368,6 +373,8 @@ class Agent:
                 "key would never retrieve. Pass session=<Session or id> to "
                 "run()/run_durable(), or drop memory= for a stateless run."
             )
+
+        memory = await self._ensure_memory()
 
         system = self.instructions or "You are a helpful assistant."
         initial_messages: list[dict[str, Any]] | None = None

--- a/sdk/python/jamjet/agents/artifacts.py
+++ b/sdk/python/jamjet/agents/artifacts.py
@@ -1,0 +1,48 @@
+"""Thin artifact store over the JamJet runtime CAS (Track 4 / T4-4).
+
+``ArtifactStore`` wraps a :class:`~jamjet.client.JamjetClient` (or any object
+exposing the same async ``put_artifact``/``get_artifact`` methods) and gives a
+session a small store/fetch namespace surfaced as ``Session.artifacts``:
+
+    >>> ref = await session.artifacts.put(b"report bytes", "text/plain")
+    >>> data = await session.artifacts.get(ref.hash)
+
+Keep it thin: the store adds no state of its own — artifacts are
+content-addressed by the runtime and isolated per tenant by the server's
+tenant-scoped backend.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from jamjet.client import ArtifactRef
+
+
+class _ArtifactClient(Protocol):
+    """The subset of :class:`~jamjet.client.JamjetClient` an ArtifactStore needs."""
+
+    async def put_artifact(self, data: bytes, media_type: str | None = ...) -> ArtifactRef: ...
+
+    async def get_artifact(self, hash: str) -> bytes: ...
+
+
+class ArtifactStore:
+    """Store and fetch content-addressed artifacts over a JamjetClient.
+
+    Args:
+        client: A :class:`~jamjet.client.JamjetClient` (or compatible object)
+                used for the underlying HTTP calls.
+    """
+
+    def __init__(self, client: _ArtifactClient) -> None:
+        self._client = client
+
+    async def put(self, data: bytes, media_type: str | None = None) -> ArtifactRef:
+        """Store *data* and return its :class:`~jamjet.client.ArtifactRef`."""
+        return await self._client.put_artifact(data, media_type)
+
+    async def get(self, hash: str) -> bytes:
+        """Fetch the bytes for a previously-stored artifact *hash*."""
+        return await self._client.get_artifact(hash)

--- a/sdk/python/jamjet/agents/artifacts.py
+++ b/sdk/python/jamjet/agents/artifacts.py
@@ -2,8 +2,10 @@
 
 ``ArtifactStore`` wraps a :class:`~jamjet.client.JamjetClient` (or any object
 exposing the same async ``put_artifact``/``get_artifact`` methods) and gives a
-session a small store/fetch namespace surfaced as ``Session.artifacts``:
+session a small store/fetch namespace surfaced as ``Session.artifacts``
+(attach a client first — ``Session.artifacts`` fails loud without one):
 
+    >>> session.attach_client(JamjetClient("http://127.0.0.1:7700"))
     >>> ref = await session.artifacts.put(b"report bytes", "text/plain")
     >>> data = await session.artifacts.get(ref.hash)
 

--- a/sdk/python/jamjet/agents/session.py
+++ b/sdk/python/jamjet/agents/session.py
@@ -8,6 +8,13 @@ Storage: a single SQLite file at ``~/.jamjet/sessions.db`` (one row per
 session), reusing the same ``~/.jamjet/`` directory convention as the
 CheckpointStore.  All public methods are synchronous; no async overhead
 for simple session state.
+
+T4-2 helpers
+------------
+``seed_messages_for_run`` and ``persist_session_turn`` are the SHARED
+carried-state contract used by BOTH ``Agent.run()`` (in-process) and
+``Agent.run_durable()`` (durable engine path) to ensure a session thread is
+seeded and persisted identically regardless of which run path is used.
 """
 
 from __future__ import annotations
@@ -18,6 +25,10 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from jamjet.agents.agent import Agent, AgentResult
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS sessions (
@@ -41,8 +52,9 @@ class Session:
             This is NOT the engine's internal ``execution_id``; the two
             are explicitly separate (see ``latest_execution_id``).
         messages: The running conversation thread — a list of
-            ``{"role": str, "content": str}`` dicts, the same shape that
-            ``build_initial_state`` emits.
+            ``{"role": str, "content": str}`` dicts.  System messages are
+            **not** stored here; they are always re-injected from the
+            agent's current ``instructions`` at seed time.
         latest_execution_id: The engine's internal lineage id for the most
             recent run started under this session.  Distinct from ``id``.
         metadata: Arbitrary caller-supplied key/value data.
@@ -56,6 +68,35 @@ class Session:
     def append_message(self, role: str, content: str) -> None:
         """Append a ``{"role", "content"}`` dict to the message thread."""
         self.messages.append({"role": role, "content": content})
+
+    async def run(
+        self,
+        agent: Agent,
+        prompt: str,
+        *,
+        durable: bool = False,
+        **kwargs: Any,
+    ) -> AgentResult:
+        """Ergonomic form: run *agent* on *prompt* continuing this session thread.
+
+        Equivalent to ``agent.run(prompt, session=self)`` (or
+        ``agent.run_durable`` when ``durable=True``).
+
+        Args:
+            agent: The :class:`~jamjet.agents.agent.Agent` to invoke.
+            prompt: The new user turn to add to this session.
+            durable: When ``True`` use :meth:`~jamjet.agents.agent.Agent.run_durable`
+                     instead of :meth:`~jamjet.agents.agent.Agent.run`.
+            **kwargs: Forwarded to the chosen run method (e.g. ``max_turns``,
+                      ``runtime_url`` for ``run_durable``).
+
+        Returns:
+            :class:`~jamjet.agents.agent.AgentResult` — same shape as the
+            direct ``agent.run()`` / ``agent.run_durable()`` result.
+        """
+        if durable:
+            return await agent.run_durable(prompt, session=self, **kwargs)
+        return await agent.run(prompt, session=self, **kwargs)
 
 
 class SessionStore:
@@ -156,3 +197,107 @@ class SessionStore:
         with sqlite3.connect(self._db_path) as conn:
             cur = conn.execute("SELECT session_id FROM sessions ORDER BY updated_at")
             return [row[0] for row in cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# T4-2 shared carried-state helpers
+# ---------------------------------------------------------------------------
+# These two functions are the SINGLE source of truth for how a session thread
+# is seeded into a run and how the completed turn is persisted back.  Both
+# ``Agent.run()`` (in-process) and ``Agent.run_durable()`` (durable engine)
+# call the same helpers so the thread is consistent across the two paths.
+
+
+def seed_messages_for_run(
+    session: Session | None,
+    system_instructions: str,
+    prompt: str,
+) -> list[dict[str, Any]]:
+    """Build the initial messages list for a run.
+
+    When *session* is ``None`` (or empty), returns the default scratch seed::
+
+        [{"role": "system", "content": system_instructions},
+         {"role": "user",   "content": prompt}]
+
+    When *session* is provided, returns the carried thread (prior turns) with
+    the current agent's system instruction and the new user prompt appended::
+
+        [{"role": "system",    "content": system_instructions},   # always fresh
+         {"role": "user",      "content": "<turn 1>"},            # from session
+         {"role": "assistant", "content": "<reply 1>"},           # from session
+         ...                                                       # more turns
+         {"role": "user",      "content": prompt}]                # new turn
+
+    System messages stored in *session.messages* are stripped here; the
+    current agent's instructions always win as the single system message.
+    This keeps session threads portable across agent versions.
+
+    Args:
+        session: The :class:`Session` carrying prior turns, or ``None`` for a
+                 fresh run (default behaviour, no change to callers that omit
+                 ``session=``).
+        system_instructions: The agent's current ``instructions`` string.
+        prompt: The new user turn to add.
+
+    Returns:
+        The ``messages`` list ready to pass to a model / strategy runner.
+    """
+    msgs: list[dict[str, Any]] = []
+    if system_instructions:
+        msgs.append({"role": "system", "content": system_instructions})
+
+    if session is not None and session.messages:
+        # Re-inject prior turns, skipping any stale system messages.
+        for m in session.messages:
+            if m.get("role") != "system":
+                msgs.append(dict(m))
+
+    msgs.append({"role": "user", "content": prompt})
+    return msgs
+
+
+def persist_session_turn(
+    session: Session,
+    prompt: str,
+    output: str,
+    execution_id: str | None,
+    full_messages: list[dict[str, Any]] | None,
+    store: SessionStore,
+) -> None:
+    """Append the completed turn to *session* and persist via *store*.
+
+    Called after BOTH ``Agent.run()`` and ``Agent.run_durable()`` so the
+    session thread is updated regardless of which path ran.
+
+    When *full_messages* is provided (the durable engine's
+    ``current_state["messages"]``), the session thread is replaced with those
+    messages minus any system messages (the full, tool-interleaved thread).
+
+    When *full_messages* is ``None`` (in-process path; strategy runners own
+    their message list internally), the turn is reconstructed from *prompt* +
+    *output* and appended to the existing thread.
+
+    Args:
+        session: The :class:`Session` to update in-place and persist.
+        prompt: The user prompt that was just run.
+        output: The assistant's final output for this turn.
+        execution_id: The engine's ``execution_id`` for the run (may be
+                      ``None`` for the in-process path which generates one
+                      internally).
+        full_messages: The full ``messages`` list from the durable engine's
+                       terminal state, or ``None`` for the in-process path.
+        store: :class:`SessionStore` to call ``save()`` on after updating.
+    """
+    if full_messages is not None:
+        # Durable path: replace thread with full message ledger, strip system.
+        session.messages = [m for m in full_messages if m.get("role") != "system"]
+    else:
+        # In-process path: append the new user+assistant turn.
+        session.append_message("user", prompt)
+        session.append_message("assistant", output)
+
+    if execution_id is not None:
+        session.latest_execution_id = execution_id
+
+    store.save(session)

--- a/sdk/python/jamjet/agents/session.py
+++ b/sdk/python/jamjet/agents/session.py
@@ -200,16 +200,31 @@ class SessionStore:
     # ------------------------------------------------------------------
 
     def create(self, id: str | None = None) -> Session:
-        """Create and persist a new empty :class:`Session`.
+        """Get-or-create a :class:`Session` by id (never clobbers an existing one).
+
+        :meth:`save` is an ``INSERT OR REPLACE``, so creating over an existing id
+        would WIPE that session's thread + metadata.  To avoid silent data loss
+        ``create`` is get-or-create: if a session with *id* already exists it is
+        loaded and RETURNED UNCHANGED (no overwrite).  Only a genuinely new id is
+        persisted as an empty session.  To deliberately reset an existing session,
+        call :meth:`save` with a fresh :class:`Session` (the explicit overwrite).
 
         Args:
-            id: Optional session id.  If ``None`` a UUID4 is generated.
+            id: Optional session id.  If ``None`` a UUID4 is generated (always new).
 
         Returns:
-            The freshly-created :class:`Session` (already saved).
+            The existing :class:`Session` if *id* is already known, otherwise a
+            freshly-created empty one (already saved).
         """
+        if id is not None:
+            existing = self.load(id)
+            if existing is not None:
+                return existing
         session = Session(id=id if id is not None else str(uuid.uuid4()))
         self.save(session)
+        # Tag the originating store so a later run persists back HERE, not to the
+        # agent's default store (see Agent._store_for_session).
+        session._store = self
         return session
 
     def load(self, id: str) -> Session | None:
@@ -228,12 +243,16 @@ class SessionStore:
             row = cur.fetchone()
         if row is None:
             return None
-        return Session(
+        session = Session(
             id=row[0],
             messages=json.loads(row[1]),
             latest_execution_id=row[2],
             metadata=json.loads(row[3]),
         )
+        # Tag the originating store so a run that mutates this session persists it
+        # back HERE, not to the agent's default store (see Agent._store_for_session).
+        session._store = self
+        return session
 
     def save(self, session: Session) -> None:
         """Upsert a :class:`Session` (persist messages, latest_execution_id, metadata).

--- a/sdk/python/jamjet/agents/session.py
+++ b/sdk/python/jamjet/agents/session.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from jamjet.agents.agent import Agent, AgentResult
+    from jamjet.agents.artifacts import ArtifactStore
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS sessions (
@@ -68,6 +69,41 @@ class Session:
     def append_message(self, role: str, content: str) -> None:
         """Append a ``{"role", "content"}`` dict to the message thread."""
         self.messages.append({"role": role, "content": content})
+
+    def attach_client(self, client: Any) -> ArtifactStore:
+        """Bind a :class:`~jamjet.client.JamjetClient` (or compatible object)
+        so :attr:`artifacts` stores/fetches through *client*.
+
+        Returns the :class:`~jamjet.agents.artifacts.ArtifactStore` now backing
+        :attr:`artifacts`.
+        """
+        from jamjet.agents.artifacts import ArtifactStore
+
+        store = ArtifactStore(client)
+        self._artifacts = store
+        return store
+
+    @property
+    def artifacts(self) -> ArtifactStore:
+        """Artifact namespace for this session.
+
+        ``await session.artifacts.put(data, media_type)`` stores bytes and
+        returns an :class:`~jamjet.client.ArtifactRef`;
+        ``await session.artifacts.get(hash)`` fetches them back.
+
+        Lazily builds an :class:`~jamjet.agents.artifacts.ArtifactStore` over a
+        default :class:`~jamjet.client.JamjetClient` (``http://localhost:7700``)
+        on first use; call :meth:`attach_client` first to target a specific
+        runtime (or to inject a stub in tests).
+        """
+        store = getattr(self, "_artifacts", None)
+        if store is None:
+            from jamjet.agents.artifacts import ArtifactStore
+            from jamjet.client import JamjetClient
+
+            store = ArtifactStore(JamjetClient())
+            self._artifacts = store
+        return store
 
     async def run(
         self,

--- a/sdk/python/jamjet/agents/session.py
+++ b/sdk/python/jamjet/agents/session.py
@@ -56,6 +56,24 @@ class Session:
             ``{"role": str, "content": str}`` dicts.  System messages are
             **not** stored here; they are always re-injected from the
             agent's current ``instructions`` at seed time.
+
+            Persistence asymmetry (I2 — the documented contract).  What lands
+            in this thread depends on which run path produced the turn:
+
+            - ``Agent.run()`` (in-process) persists the user prompt + the
+              FINAL assistant output for the turn.  Strategy runners own their
+              multi-phase message lists internally and do not surface a single
+              tool-interleaved thread, so intermediate tool turns are NOT
+              stored.
+            - ``Agent.run_durable()`` (durable engine) persists the FULL
+              tool-interleaved ledger from the engine's terminal
+              ``current_state["messages"]`` (assistant tool-call turns + tool
+              results + final answer), system messages stripped.
+
+            Both paths always persist the user prompt and the final assistant
+            turn, so re-seeding never DROPS a user/assistant turn; durable
+            additionally carries the intermediate tool turns.  Within a single
+            path the thread is consistent across runs.
         latest_execution_id: The engine's internal lineage id for the most
             recent run started under this session.  Distinct from ``id``.
         metadata: Arbitrary caller-supplied key/value data.
@@ -91,18 +109,21 @@ class Session:
         returns an :class:`~jamjet.client.ArtifactRef`;
         ``await session.artifacts.get(hash)`` fetches them back.
 
-        Lazily builds an :class:`~jamjet.agents.artifacts.ArtifactStore` over a
-        default :class:`~jamjet.client.JamjetClient` (``http://localhost:7700``)
-        on first use; call :meth:`attach_client` first to target a specific
-        runtime (or to inject a stub in tests).
+        Requires a client: call :meth:`attach_client` first to bind a
+        :class:`~jamjet.client.JamjetClient` (or a compatible stub in tests).
+        Accessing this property before a client is attached raises
+        ``RuntimeError`` — rather than silently defaulting to a
+        ``http://localhost:7700`` runtime, which would mask a missing-client
+        misconfiguration as confusing connection errors at call time.
         """
         store = getattr(self, "_artifacts", None)
         if store is None:
-            from jamjet.agents.artifacts import ArtifactStore
-            from jamjet.client import JamjetClient
-
-            store = ArtifactStore(JamjetClient())
-            self._artifacts = store
+            raise RuntimeError(
+                f"Session {self.id!r}: no artifact client attached. Call "
+                "session.attach_client(JamjetClient(<runtime_url>)) before using "
+                "session.artifacts (it stores/fetches content-addressed bytes "
+                "through that client)."
+            )
         return store
 
     async def run(
@@ -142,6 +163,13 @@ class SessionStore:
     row per session.  Multiple ``SessionStore`` instances pointing at the
     same path share the same data — a fresh instance sees sessions saved by
     a previous instance (survives restart).
+
+    Concurrency contract (v1): SINGLE WRITER PER SESSION ID.  :meth:`save` is a
+    whole-row ``INSERT OR REPLACE`` (last-writer-wins), so two runs racing on the
+    SAME ``session.id`` would clobber each other's thread — the loser's turn is
+    lost.  Concurrent runs on ONE session are NOT supported in v1; serialize them
+    (or use distinct session ids).  Different session ids are independent rows and
+    are safe to run concurrently.
 
     Args:
         path: Path to the SQLite database file.  ``None`` uses the default
@@ -212,6 +240,11 @@ class SessionStore:
 
         Idempotent — calling ``save`` twice with the same session updates
         the existing row.
+
+        Last-writer-wins: this replaces the whole row, so it assumes a SINGLE
+        WRITER PER SESSION ID (see the class docstring).  Two concurrent runs on
+        the same session would overwrite each other's thread; serialize runs on a
+        given session id in v1.
         """
         with sqlite3.connect(self._db_path) as conn:
             conn.execute(
@@ -306,13 +339,26 @@ def persist_session_turn(
     Called after BOTH ``Agent.run()`` and ``Agent.run_durable()`` so the
     session thread is updated regardless of which path ran.
 
-    When *full_messages* is provided (the durable engine's
-    ``current_state["messages"]``), the session thread is replaced with those
-    messages minus any system messages (the full, tool-interleaved thread).
+    Persistence asymmetry (I2 — the documented contract).  The two paths persist
+    threads of DIFFERENT granularity, and this asymmetry is intentional and
+    contractual (see :class:`Session`'s ``messages`` docstring):
 
-    When *full_messages* is ``None`` (in-process path; strategy runners own
-    their message list internally), the turn is reconstructed from *prompt* +
-    *output* and appended to the existing thread.
+    - When *full_messages* is provided (the durable engine's
+      ``current_state["messages"]``), the session thread is REPLACED with those
+      messages minus any system messages — the full, tool-interleaved ledger
+      (assistant tool-call turns + tool results + final answer).
+    - When *full_messages* is ``None`` (in-process path; strategy runners own
+      their multi-phase message lists internally and do not surface a single
+      tool-interleaved thread), the turn is reconstructed from *prompt* +
+      *output* and appended to the existing thread — user prompt + final
+      assistant output only, no intermediate tool turns.
+
+    Both paths always persist the user prompt and the final assistant turn, so
+    re-seeding the thread on the next run never drops a user/assistant turn;
+    durable additionally carries the intermediate tool turns.  Aligning the
+    in-process path to also emit the tool-interleaved thread would require every
+    strategy runner to surface its internal messages (tracked as a follow-up);
+    until then this documented asymmetry IS the contract.
 
     Args:
         session: The :class:`Session` to update in-place and persist.

--- a/sdk/python/jamjet/agents/session.py
+++ b/sdk/python/jamjet/agents/session.py
@@ -1,0 +1,158 @@
+"""Session abstraction + persistent SessionStore.
+
+A Session is a stable user-owned conversation thread that persists across
+runs.  The user ``session.id`` is DISTINCT from the engine's internal
+``execution_id``/segment-lineage id (``latest_execution_id``).
+
+Storage: a single SQLite file at ``~/.jamjet/sessions.db`` (one row per
+session), reusing the same ``~/.jamjet/`` directory convention as the
+CheckpointStore.  All public methods are synchronous; no async overhead
+for simple session state.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id          TEXT PRIMARY KEY,
+    messages_json       TEXT NOT NULL DEFAULT '[]',
+    latest_execution_id TEXT,
+    metadata_json       TEXT NOT NULL DEFAULT '{}',
+    updated_at          TEXT NOT NULL
+);
+"""
+
+_DEFAULT_DB_PATH = Path.home() / ".jamjet" / "sessions.db"
+
+
+@dataclass
+class Session:
+    """A persistent conversation thread.
+
+    Attributes:
+        id: Stable user-assigned or auto-generated session identifier.
+            This is NOT the engine's internal ``execution_id``; the two
+            are explicitly separate (see ``latest_execution_id``).
+        messages: The running conversation thread — a list of
+            ``{"role": str, "content": str}`` dicts, the same shape that
+            ``build_initial_state`` emits.
+        latest_execution_id: The engine's internal lineage id for the most
+            recent run started under this session.  Distinct from ``id``.
+        metadata: Arbitrary caller-supplied key/value data.
+    """
+
+    id: str
+    messages: list[dict] = field(default_factory=list)
+    latest_execution_id: str | None = None
+    metadata: dict = field(default_factory=dict)
+
+    def append_message(self, role: str, content: str) -> None:
+        """Append a ``{"role", "content"}`` dict to the message thread."""
+        self.messages.append({"role": role, "content": content})
+
+
+class SessionStore:
+    """SQLite-backed persistent store for :class:`Session` objects.
+
+    Uses a single shared DB file (default ``~/.jamjet/sessions.db``), one
+    row per session.  Multiple ``SessionStore`` instances pointing at the
+    same path share the same data — a fresh instance sees sessions saved by
+    a previous instance (survives restart).
+
+    Args:
+        path: Path to the SQLite database file.  ``None`` uses the default
+              ``~/.jamjet/sessions.db``.
+    """
+
+    def __init__(self, path: str | None = None) -> None:
+        db_path = Path(path) if path is not None else _DEFAULT_DB_PATH
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db_path = str(db_path)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self._db_path) as conn:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create(self, id: str | None = None) -> Session:
+        """Create and persist a new empty :class:`Session`.
+
+        Args:
+            id: Optional session id.  If ``None`` a UUID4 is generated.
+
+        Returns:
+            The freshly-created :class:`Session` (already saved).
+        """
+        session = Session(id=id if id is not None else str(uuid.uuid4()))
+        self.save(session)
+        return session
+
+    def load(self, id: str) -> Session | None:
+        """Load a :class:`Session` by id.
+
+        Returns:
+            The :class:`Session`, or ``None`` if no session with that id
+            exists in the store.
+        """
+        with sqlite3.connect(self._db_path) as conn:
+            cur = conn.execute(
+                "SELECT session_id, messages_json, latest_execution_id, metadata_json"
+                " FROM sessions WHERE session_id = ?",
+                (id,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return Session(
+            id=row[0],
+            messages=json.loads(row[1]),
+            latest_execution_id=row[2],
+            metadata=json.loads(row[3]),
+        )
+
+    def save(self, session: Session) -> None:
+        """Upsert a :class:`Session` (persist messages, latest_execution_id, metadata).
+
+        Idempotent — calling ``save`` twice with the same session updates
+        the existing row.
+        """
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO sessions
+                   (session_id, messages_json, latest_execution_id, metadata_json, updated_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    session.id,
+                    json.dumps(session.messages),
+                    session.latest_execution_id,
+                    json.dumps(session.metadata),
+                    self._now(),
+                ),
+            )
+            conn.commit()
+
+    def list(self) -> list[str]:
+        """Return all known session ids ordered by last-updated time."""
+        with sqlite3.connect(self._db_path) as conn:
+            cur = conn.execute("SELECT session_id FROM sessions ORDER BY updated_at")
+            return [row[0] for row in cur.fetchall()]

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -7,9 +7,27 @@ Used by the CLI and the SDK to communicate with a running JamJet runtime.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """A reference to a content-addressed artifact in the JamJet CAS.
+
+    Mirrors the Rust ``ArtifactRef`` returned by ``POST /artifacts``.
+
+    Attributes:
+        hash: SHA-256 hex of the stored bytes (64 lowercase hex chars).
+        size: Byte length of the stored content.
+        media_type: Optional MIME type recorded at store time.
+    """
+
+    hash: str
+    size: int
+    media_type: str | None = None
 
 
 class JamjetClient:
@@ -166,6 +184,39 @@ class JamjetClient:
         )
         r.raise_for_status()
         return r.json()
+
+    # ── Artifacts (content-addressed store) ───────────────────────────────
+
+    async def put_artifact(
+        self,
+        data: bytes,
+        media_type: str | None = None,
+    ) -> ArtifactRef:
+        """Store raw bytes in the tenant-scoped CAS and return an ``ArtifactRef``.
+
+        The bytes are content-addressed: storing identical bytes twice yields
+        the same ``hash``. ``media_type`` is sent as the request ``Content-Type``
+        and echoed back on the returned ref.
+        """
+        headers = {"Content-Type": media_type} if media_type else None
+        r = await self._client.post("/artifacts", content=data, headers=headers)
+        r.raise_for_status()
+        j = r.json()
+        return ArtifactRef(
+            hash=j["hash"],
+            size=int(j["size"]),
+            media_type=j.get("media_type"),
+        )
+
+    async def get_artifact(self, hash: str) -> bytes:
+        """Fetch artifact bytes by hash from the tenant-scoped CAS.
+
+        Raises ``httpx.HTTPStatusError`` (404) when no artifact with that hash
+        exists for the caller's tenant.
+        """
+        r = await self._client.get(f"/artifacts/{hash}")
+        r.raise_for_status()
+        return r.content
 
     # ── Agents ────────────────────────────────────────────────────────────
 

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -389,19 +389,34 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
     return ir
 
 
-def build_initial_state(agent: Agent, prompt: str) -> dict[str, Any]:
+def build_initial_state(
+    agent: Agent,
+    prompt: str,
+    initial_messages: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """The execution ``initial_input`` for a compiled agent-loop IR.
 
     Seeds the running ``messages`` (system + user) and the
     ``{name: "module:function"}`` tool resolver map into workflow state, so the
     first model node and every ``dispatch_tool_calls`` node find them. The
     durable run entrypoint (Track 2j-4) passes this to ``start_execution``.
+
+    When *initial_messages* is provided (T4-2 session continuation), those
+    messages are used verbatim as the seed instead of the default
+    ``[system, user: prompt]`` pair.  The caller (``Agent.run_durable``) is
+    responsible for building ``initial_messages`` via
+    :func:`~jamjet.agents.session.seed_messages_for_run` so the session
+    thread is carried forward correctly.
     """
-    return {
-        "messages": [
+    if initial_messages is not None:
+        messages: list[dict[str, Any]] = initial_messages
+    else:
+        messages = [
             {"role": "system", "content": agent.instructions or "You are a helpful assistant."},
             {"role": "user", "content": prompt},
-        ],
+        ]
+    return {
+        "messages": messages,
         "tools": _tools_map(agent),
     }
 

--- a/sdk/python/jamjet/memory/engram_bridge.py
+++ b/sdk/python/jamjet/memory/engram_bridge.py
@@ -138,13 +138,26 @@ class AgentMemory:
 
     @contextmanager
     def as_scope(self, *, user_id: str | None = None, org_id: str | None = None) -> Any:
-        old = self._scope
-        new = EngramScope(
-            org_id=org_id if org_id is not None else old.org_id,
-            user_id=user_id if user_id is not None else old.user_id,
+        """Yield a memory view bound to an overridden scope for the duration of
+        the block.
+
+        Concurrency (I3): this yields a NEW ``AgentMemory`` bound to the new scope
+        rather than mutating ``self._scope`` around the ``await`` inside the
+        block.  The agent caches ONE ``AgentMemory`` for ``memory=True`` and
+        scopes every retrieve/record by the per-run ``session.id`` via this
+        method; if it mutated shared state around the await, two concurrent runs
+        on different sessions would read each other's scope mid-flight and
+        record/retrieve under the WRONG session.  Returning a per-call view keeps
+        each run's scope local, so concurrent sessions never cross.  The new view
+        shares the same underlying Engram, config, and session id.
+        """
+        new_scope = EngramScope(
+            org_id=org_id if org_id is not None else self._scope.org_id,
+            user_id=user_id if user_id is not None else self._scope.user_id,
         )
-        self._scope = new
-        try:
-            yield self
-        finally:
-            self._scope = old
+        yield AgentMemory(
+            self._engram,
+            scope=new_scope,
+            config=self._config,
+            session_id=self._session_id,
+        )

--- a/sdk/python/jamjet/runtime/local/executor.py
+++ b/sdk/python/jamjet/runtime/local/executor.py
@@ -42,6 +42,7 @@ class LocalRuntime:
         scope: Scope | None = None,
         on_event: Callable[[RuntimeEvent], None] | None = None,
         governance: GovernanceConfig | None = None,
+        initial_messages: list[dict[str, Any]] | None = None,
     ) -> RuntimeResult:
         eid = execution_id or str(uuid.uuid4())
         t0 = time.perf_counter()
@@ -61,6 +62,7 @@ class LocalRuntime:
                 eid,
                 on_event,
                 governance,
+                initial_messages=initial_messages,
             )
         elif isinstance(spec, WorkflowSpec):
             output, steps, tool_calls, llm_calls = await self._run_workflow(
@@ -100,6 +102,8 @@ class LocalRuntime:
         eid: str,
         on_event: Any,
         governance: GovernanceConfig | None = None,
+        *,
+        initial_messages: list[dict[str, Any]] | None = None,
     ) -> tuple[Any, list[StepRecord], list[ToolCallRecord], list[LLMCallRecord]]:
         # T3-7: thread the agent's GovernanceConfig into the seam-backed adapter
         # so budget / allowlist / PII enforce on the in-process path (agent.run),
@@ -116,6 +120,7 @@ class LocalRuntime:
             prompt=prompt,
             tools=openai_tools,
             tool_calls_log=tool_calls_log,
+            initial_messages=initial_messages,
         )
         tool_calls = [
             ToolCallRecord(

--- a/sdk/python/jamjet/runtime/local/strategies/base.py
+++ b/sdk/python/jamjet/runtime/local/strategies/base.py
@@ -11,6 +11,13 @@ from typing import Any, Protocol, runtime_checkable
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
 from jamjet.spec import AgentSpec, ToolSpec
 
+# Leading text of the retrieved-memory system block injected by
+# ``Agent._inject_memory_block`` (T4-3).  ``seed_history`` uses it to tell the
+# injected memory block apart from the agent-instruction system slot so it never
+# clobbers recall.  Kept here (the lowest-level consumer) so both sides share one
+# definition; ``_inject_memory_block`` imports it to BUILD the block.
+MEMORY_BLOCK_PREFIX = "Relevant memory from prior sessions:"
+
 
 @runtime_checkable
 class StrategyRunner(Protocol):
@@ -105,9 +112,20 @@ def seed_history(
 
     1. The **trailing new-user prompt is dropped** — the strategy re-frames it
        into its own phase prompt and appends that itself.
-    2. The **leading system block is swapped for *system*** — so a phase's role
-       augmentation ("You are the proposer", "agent N of M") is preserved, while
-       any injected memory block and every prior user/assistant turn are kept.
+    2. The **agent-instruction system slot is swapped for *system*** — so a
+       phase's role augmentation ("You are the proposer", "agent N of M") is
+       preserved, while any injected memory block and every prior user/assistant
+       turn are kept.
+
+    Distinguishing the instruction slot from the memory block (the Track-4 fix).
+    ``seed_messages_for_run`` only emits the instruction system slot when the
+    agent's instructions are NON-empty; for a memory-enabled run with EMPTY
+    instructions the FIRST system message is the injected memory block, not the
+    persona.  So we replace the leading system message ONLY when it is the
+    instruction slot (identified by NOT starting with
+    :data:`MEMORY_BLOCK_PREFIX`); otherwise we PREPEND *system*, keeping the
+    memory block intact.  Replacing blindly would drop recall for every non-react
+    strategy whenever instructions are empty.
 
     When *initial_messages* is ``None`` (a fresh, sessionless run) it returns the
     single default system block ``[{"role": "system", "content": system}]`` — the
@@ -123,8 +141,17 @@ def seed_history(
     # Copy each carried message so the strategy can append/extend freely without
     # mutating the caller's seed list.
     prefix = [dict(m) for m in initial_messages[:-1]]
-    if prefix and prefix[0].get("role") == "system":
+    leads_with_instruction_slot = (
+        bool(prefix)
+        and prefix[0].get("role") == "system"
+        and not str(prefix[0].get("content", "")).startswith(MEMORY_BLOCK_PREFIX)
+    )
+    if leads_with_instruction_slot:
+        # Swap the agent-instruction slot for the phase persona.
         prefix[0] = {"role": "system", "content": system}
     else:
+        # No instruction slot to swap (empty instructions, so the lead is the
+        # memory block, or no leading system at all): prepend the persona and keep
+        # the memory block / turns untouched.
         prefix.insert(0, {"role": "system", "content": system})
     return prefix

--- a/sdk/python/jamjet/runtime/local/strategies/base.py
+++ b/sdk/python/jamjet/runtime/local/strategies/base.py
@@ -80,3 +80,51 @@ def _last_assistant_content(messages: list[Any]) -> str:
         if role == "assistant" and content:
             return str(content)
     return ""
+
+
+def seed_history(
+    initial_messages: list[dict[str, Any]] | None,
+    system: str,
+) -> list[dict[str, Any]]:
+    """Leading messages a strategy's GENERATIVE phase should build on.
+
+    Session / memory continuity (C1).  When *initial_messages* is provided it is
+    the carried thread built by ``agents.session.seed_messages_for_run`` (and,
+    when memory is on, ``Agent._inject_memory_block``)::
+
+        [{"role": "system",    "content": <agent instructions>},
+         {"role": "system",    "content": "Relevant memory ..."},   # optional
+         {"role": "user",      "content": "<prior turn 1>"},
+         {"role": "assistant", "content": "<prior reply 1>"},
+         ...
+         {"role": "user",      "content": "<new prompt>"}]          # trailing
+
+    This returns that thread with two adjustments so a multi-phase strategy can
+    layer its own phase prompt on top while the model still sees the conversation
+    so far + any retrieved memory (matching ``react``'s behaviour):
+
+    1. The **trailing new-user prompt is dropped** — the strategy re-frames it
+       into its own phase prompt and appends that itself.
+    2. The **leading system block is swapped for *system*** — so a phase's role
+       augmentation ("You are the proposer", "agent N of M") is preserved, while
+       any injected memory block and every prior user/assistant turn are kept.
+
+    When *initial_messages* is ``None`` (a fresh, sessionless run) it returns the
+    single default system block ``[{"role": "system", "content": system}]`` — the
+    prior per-strategy behaviour, unchanged.
+
+    NOTE: meta phases that intentionally use a DIFFERENT system persona (critic,
+    judge, devil's-advocate, self-evaluator) do NOT call this — they evaluate the
+    draft text a generative phase already produced, so they keep their own system
+    and need no history.
+    """
+    if not initial_messages:
+        return [{"role": "system", "content": system}]
+    # Copy each carried message so the strategy can append/extend freely without
+    # mutating the caller's seed list.
+    prefix = [dict(m) for m in initial_messages[:-1]]
+    if prefix and prefix[0].get("role") == "system":
+        prefix[0] = {"role": "system", "content": system}
+    else:
+        prefix.insert(0, {"role": "system", "content": system})
+    return prefix

--- a/sdk/python/jamjet/runtime/local/strategies/base.py
+++ b/sdk/python/jamjet/runtime/local/strategies/base.py
@@ -22,6 +22,7 @@ class StrategyRunner(Protocol):
         prompt: str,
         tools: list[dict[str, Any]],
         tool_calls_log: list[dict[str, Any]],
+        initial_messages: list[dict[str, Any]] | None = None,
     ) -> str: ...
 
 

--- a/sdk/python/jamjet/runtime/local/strategies/consensus.py
+++ b/sdk/python/jamjet/runtime/local/strategies/consensus.py
@@ -16,6 +16,7 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)

--- a/sdk/python/jamjet/runtime/local/strategies/consensus.py
+++ b/sdk/python/jamjet/runtime/local/strategies/consensus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
-from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map
+from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map, seed_history
 from jamjet.spec import AgentSpec
 
 
@@ -23,13 +23,14 @@ async def run(
     system = spec.instructions or "You are a helpful assistant."
     n_agents = min(3, max_iter)
 
+    # Session/memory continuity (C1): each independent agent speaks as the agent,
+    # so it builds on the carried conversation history + retrieved memory before
+    # its prompt. The judge phase keeps its own persona and synthesizes the
+    # candidate responses, so it needs no history.
     responses: list[str] = []
     for i in range(n_agents):
         msgs: list[Any] = [
-            {
-                "role": "system",
-                "content": f"{system}\nYou are agent {i + 1} of {n_agents}. Think independently.",
-            },
+            *seed_history(initial_messages, f"{system}\nYou are agent {i + 1} of {n_agents}. Think independently."),
             {"role": "user", "content": prompt},
         ]
         for _ in range(max_iter):

--- a/sdk/python/jamjet/runtime/local/strategies/critic.py
+++ b/sdk/python/jamjet/runtime/local/strategies/critic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
-from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map
+from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map, seed_history
 from jamjet.spec import AgentSpec
 
 
@@ -33,8 +33,12 @@ async def run(
                 "Revise the draft to address the critic's feedback above. "
                 "Return only the improved draft."
             )
+        # Session/memory continuity (C1): the draft is the generative phase that
+        # speaks as the agent, so it builds on the carried conversation history +
+        # retrieved memory before the draft/revise prompt. The critic phase below
+        # keeps its own evaluator persona and operates on the produced draft.
         draft_messages: list[Any] = [
-            {"role": "system", "content": system},
+            *seed_history(initial_messages, system),
             {"role": "user", "content": draft_prompt},
         ]
         for _ in range(max_iter):

--- a/sdk/python/jamjet/runtime/local/strategies/critic.py
+++ b/sdk/python/jamjet/runtime/local/strategies/critic.py
@@ -16,6 +16,7 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)

--- a/sdk/python/jamjet/runtime/local/strategies/debate.py
+++ b/sdk/python/jamjet/runtime/local/strategies/debate.py
@@ -16,6 +16,7 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)

--- a/sdk/python/jamjet/runtime/local/strategies/debate.py
+++ b/sdk/python/jamjet/runtime/local/strategies/debate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
-from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map
+from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map, seed_history
 from jamjet.spec import AgentSpec
 
 
@@ -22,9 +22,13 @@ async def run(
     max_iter = spec.limits.get("max_iterations", 10)
     system = spec.instructions or "You are a helpful assistant."
 
+    # Session/memory continuity (C1): the proposer (and the reviser below) speak
+    # as the agent, so they build on the carried conversation history + retrieved
+    # memory. The devil's-advocate and judge phases keep their own personas and
+    # operate on the proposed/revised answer text, so they need no history.
     proposal = ""
     prop_msgs: list[Any] = [
-        {"role": "system", "content": f"{system}\nYou are the proposer. Give your best answer."},
+        *seed_history(initial_messages, f"{system}\nYou are the proposer. Give your best answer."),
         {"role": "user", "content": prompt},
     ]
     for _ in range(max_iter):
@@ -51,10 +55,7 @@ async def run(
         critique = counter_msg.content or ""
 
         revise_msgs: list[Any] = [
-            {
-                "role": "system",
-                "content": f"{system}\nRevise your answer addressing the critique.",
-            },
+            *seed_history(initial_messages, f"{system}\nRevise your answer addressing the critique."),
             {
                 "role": "user",
                 "content": f"Task: {prompt}\n\nYour answer:\n{counter}\n\nCritique:\n{critique}",

--- a/sdk/python/jamjet/runtime/local/strategies/plan_and_execute.py
+++ b/sdk/python/jamjet/runtime/local/strategies/plan_and_execute.py
@@ -16,6 +16,7 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)

--- a/sdk/python/jamjet/runtime/local/strategies/plan_and_execute.py
+++ b/sdk/python/jamjet/runtime/local/strategies/plan_and_execute.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
-from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map
+from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map, seed_history
 from jamjet.spec import AgentSpec
 
 
@@ -22,8 +22,13 @@ async def run(
     max_iter = spec.limits.get("max_iterations", 10)
     system = spec.instructions or "You are a helpful assistant."
 
+    # Session/memory continuity (C1): the plan, every step, and the synthesis are
+    # all generative phases that speak as the agent, so each builds on the carried
+    # conversation history + retrieved memory (seed_history) before its own phase
+    # prompt. Without this the model would never see prior turns and the plan
+    # would be drawn up — and executed — blind to the thread.
     plan_messages: list[Any] = [
-        {"role": "system", "content": system},
+        *seed_history(initial_messages, system),
         {
             "role": "user",
             "content": (
@@ -44,7 +49,7 @@ async def run(
     step_results: list[str] = []
     for step in steps[:max_iter]:
         step_messages: list[Any] = [
-            {"role": "system", "content": system},
+            *seed_history(initial_messages, system),
             {
                 "role": "user",
                 "content": (
@@ -66,7 +71,7 @@ async def run(
             step_results.append("")
 
     synthesis_messages: list[Any] = [
-        {"role": "system", "content": system},
+        *seed_history(initial_messages, system),
         {
             "role": "user",
             "content": (

--- a/sdk/python/jamjet/runtime/local/strategies/react.py
+++ b/sdk/python/jamjet/runtime/local/strategies/react.py
@@ -20,14 +20,20 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)
 
-    messages: list[Any] = []
-    if spec.instructions:
-        messages.append({"role": "system", "content": spec.instructions})
-    messages.append({"role": "user", "content": prompt})
+    if initial_messages is not None:
+        # Session continuation: initial_messages already contains the system
+        # message and all prior turns with the new user prompt appended.
+        messages: list[Any] = list(initial_messages)
+    else:
+        messages = []
+        if spec.instructions:
+            messages.append({"role": "system", "content": spec.instructions})
+        messages.append({"role": "user", "content": prompt})
 
     for _ in range(max_iter):
         msg = await adapter.generate(messages, tools=tools or None)

--- a/sdk/python/jamjet/runtime/local/strategies/reflection.py
+++ b/sdk/python/jamjet/runtime/local/strategies/reflection.py
@@ -16,6 +16,7 @@ async def run(
     prompt: str,
     tools: list[dict[str, Any]],
     tool_calls_log: list[dict[str, Any]],
+    initial_messages: list[dict[str, Any]] | None = None,
 ) -> str:
     tool_map = resolve_tool_map(spec.tools)
     max_iter = spec.limits.get("max_iterations", 10)

--- a/sdk/python/jamjet/runtime/local/strategies/reflection.py
+++ b/sdk/python/jamjet/runtime/local/strategies/reflection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from jamjet.runtime.local.llm_adapters.base import LLMAdapter
-from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map
+from jamjet.runtime.local.strategies.base import execute_tool_calls, resolve_tool_map, seed_history
 from jamjet.spec import AgentSpec
 
 
@@ -34,8 +34,12 @@ async def run(
                 f"Your self-reflection:\n{reflection}\n\n"
                 "Revise your answer based on the reflection. Return only the improved answer."
             )
+        # Session/memory continuity (C1): the execute phase speaks as the agent,
+        # so it builds on the carried conversation history + retrieved memory
+        # before its prompt. The self-evaluator phase keeps its own persona and
+        # reflects on the produced answer, so it needs no history.
         exec_msgs: list[Any] = [
-            {"role": "system", "content": system},
+            *seed_history(initial_messages, system),
             {"role": "user", "content": exec_prompt},
         ]
         for _ in range(max_iter):

--- a/sdk/python/tests/memory/test_engram_bridge_scope.py
+++ b/sdk/python/tests/memory/test_engram_bridge_scope.py
@@ -19,11 +19,33 @@ def test_scope_re_export():
 
 
 @pytest.mark.asyncio
-async def test_as_scope_overrides_then_restores(bridge):
+async def test_as_scope_yields_scoped_view_without_mutating_base(bridge):
+    """I3: ``as_scope`` yields a per-run scoped VIEW; it does not mutate the base.
+
+    A record made THROUGH the yielded view lands under the override scope, while
+    the base instance's scope is never touched — so concurrent runs that each
+    scope the one cached bridge by their own ``session.id`` cannot cross.  (The
+    pre-fix API mutated the shared scope around the await; recording on the base
+    instance inside the block leaked across sessions.)
+    """
+    # Base-scope (u1) record.
     await bridge.record("alice's secret", role="user")
-    with bridge.as_scope(user_id="other"):
-        await bridge.record("bob's secret", role="user")
+
+    # A record through the SCOPED VIEW lands under the override scope ("other"),
+    # and the base instance's scope is never mutated.
+    with bridge.as_scope(user_id="other") as scoped:
+        assert scoped is not bridge, "as_scope must yield a distinct per-run view"
+        await scoped.record("bob's secret", role="user")
+    assert bridge._scope.user_id == "u1", "base scope must not be mutated by as_scope"
+
+    # Recall under the base scope (u1) sees alice but NOT bob (bob is under "other").
     facts_u1 = await bridge.recall("secret")
     texts = [sf.fact.text for sf in facts_u1]
     assert any("alice" in t for t in texts)
     assert not any("bob" in t for t in texts)
+
+    # The scoped view retrieves bob under "other" (isolation holds both ways).
+    with bridge.as_scope(user_id="other") as scoped:
+        facts_other = await scoped.recall("secret")
+    texts_other = [sf.fact.text for sf in facts_other]
+    assert any("bob" in t for t in texts_other)

--- a/sdk/python/tests/runtime/local/test_executor.py
+++ b/sdk/python/tests/runtime/local/test_executor.py
@@ -9,7 +9,7 @@ from jamjet.spec import AgentSpec, AgentStrategy, LLMConfig
 async def test_local_runtime_executes_agent_spec(monkeypatch):
     """AgentSpec → strategy executor path. Uses fake LLM via monkeypatch."""
 
-    async def fake_runner(*, adapter, spec, prompt, tools, tool_calls_log):
+    async def fake_runner(*, adapter, spec, prompt, tools, tool_calls_log, initial_messages=None):
         return f"echo: {prompt}"
 
     monkeypatch.setattr(

--- a/sdk/python/tests/test_agent_memory.py
+++ b/sdk/python/tests/test_agent_memory.py
@@ -399,3 +399,48 @@ def test_as_scope_per_run_clone_no_cross_session_bleed() -> None:
     assert ("B", "B-second", "assistant") in probe.records, probe.records
     # The shared instance's scope is never mutated by as_scope.
     assert mem._scope.user_id == "base"
+
+
+# ---------------------------------------------------------------------------
+# 8. Finding 3 — two concurrent FIRST runs must open the embedded Engram ONCE
+#    (the lazy init is serialized with an asyncio.Lock + double-check).
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_first_memory_init_opens_engram_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two concurrent first ``_ensure_memory`` calls open Engram exactly once.
+
+    Without the lock both racing coroutines see ``_memory_resolved is None`` and
+    each ``await Engram.open(...)``, leaking a handle and breaking open-once.  We
+    patch ``Engram.open`` to count + yield (widening the race window) and assert
+    it ran once and both calls resolve to the SAME backend.
+
+    Skipped when the optional ``engram`` extra is absent (memory=True needs it).
+    """
+    pytest.importorskip("engram")
+    import engram as engram_mod  # noqa: PLC0415
+
+    calls = {"n": 0}
+
+    class _FakeHandle:
+        async def close(self) -> None:
+            return None
+
+    async def _fake_open(*_args: Any, path: str | None = None, **_kw: Any) -> _FakeHandle:
+        calls["n"] += 1
+        await asyncio.sleep(0.02)  # widen the window so a missing lock races
+        return _FakeHandle()
+
+    monkeypatch.setattr(engram_mod.Engram, "open", _fake_open)
+
+    agent = _agent(memory=True)  # import engram succeeds at __init__ (extra present)
+    assert agent._memory_enabled is True
+
+    async def _drive() -> tuple[Any, Any]:
+        return await asyncio.gather(agent._ensure_memory(), agent._ensure_memory())
+
+    a, b = asyncio.run(_drive())
+
+    assert calls["n"] == 1, f"Engram.open must be called exactly once, got {calls['n']}"
+    assert a is b, "both concurrent first inits must resolve to the same memory backend"
+    assert agent._memory_resolved is a

--- a/sdk/python/tests/test_agent_memory.py
+++ b/sdk/python/tests/test_agent_memory.py
@@ -1,0 +1,329 @@
+"""Tests for T4-3: the ``memory=`` knob wires Engram into the friendly Agent.
+
+The friendly :class:`~jamjet.agents.agent.Agent` gains a ``memory=`` knob and an
+AUTOMATIC, GOVERNED retrieve-at-start / record-at-end loop keyed by the stable
+``session.id``:
+
+- ``memory=True`` constructs the default embedded Engram bridge; if
+  ``jamjet-engram`` is not installed it FAILS LOUD (never a silent no-op).
+- ``memory=<AgentMemory>`` uses the injected bridge as-is (duck-typed, so a
+  fake can be injected in unit tests — no real Engram needed here).
+- Before a run the agent retrieves a context block keyed by ``session.id`` and
+  injects it into the model's messages; after the run it records the turn,
+  keyed by ``session.id``.
+- PII is REDACTED (the Track-3 redactor) before any memory write, so raw PII is
+  never written into the temporal KG.
+- Memory requires a session to key on (fail-loud if memory is on but no
+  session); memory is OFF by default (no behaviour change).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from jamjet import Agent, tool
+from jamjet.agents.session import SessionStore
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the input."""
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Capturing mock: records every messages list the model sees (so we can prove
+# the retrieved memory block was injected into the run).
+# ---------------------------------------------------------------------------
+
+
+class _CapturingMockClient:
+    def __init__(self) -> None:
+        self.calls: list[list[dict]] = []
+
+    async def _create(
+        self,
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        self.calls.append(
+            [
+                dict(m)
+                if isinstance(m, dict)
+                else {"role": getattr(m, "role", "?"), "content": getattr(m, "content", "")}
+                for m in messages
+            ]
+        )
+        last_user = ""
+        for m in reversed(messages):
+            role = m.get("role") if isinstance(m, dict) else getattr(m, "role", "")
+            content = m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+            if role == "user":
+                last_user = content or ""
+                break
+        msg = MagicMock()
+        msg.content = f"OK: {last_user}"
+        msg.role = "assistant"
+        msg.tool_calls = []
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=msg)]
+        return resp
+
+
+@pytest.fixture()
+def capturing_mock(monkeypatch: pytest.MonkeyPatch) -> _CapturingMockClient:
+    client = _CapturingMockClient()
+
+    async def _mock_acompletion(
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        return await client._create(model=model, messages=messages, tools=tools, **kwargs)
+
+    mock_litellm = types.ModuleType("litellm")
+    mock_litellm.acompletion = _mock_acompletion  # type: ignore[attr-defined]
+    mock_litellm.completion_cost = lambda *a, **kw: 0.0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+    return client
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "sessions_t43.db")
+
+
+# ---------------------------------------------------------------------------
+# Fake AgentMemory — duck-typed, captures the key (scope user_id) + calls.
+# No real Engram is opened in these unit tests.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMemory:
+    """A stand-in for :class:`AgentMemory`.
+
+    ``record`` / ``context`` / ``recall`` capture the *key* they were scoped to
+    (the session id, threaded via :meth:`as_scope`) plus their arguments, so a
+    test can assert the loop keyed memory by ``session.id``.
+    """
+
+    def __init__(self, context_reply: str = "") -> None:
+        # (key, text, role) tuples — the key is the scope user_id at call time.
+        self.records: list[tuple[str | None, str, str | None]] = []
+        # (key, query) tuples.
+        self.context_calls: list[tuple[str | None, str]] = []
+        self.context_reply = context_reply
+        self._scoped_user_id: str | None = None
+
+    @contextmanager
+    def as_scope(self, *, user_id: str | None = None, org_id: str | None = None) -> Any:
+        old = self._scoped_user_id
+        self._scoped_user_id = user_id
+        try:
+            yield self
+        finally:
+            self._scoped_user_id = old
+
+    async def record(
+        self,
+        text: str,
+        *,
+        role: str | None = None,
+        category: str | None = None,
+        confidence: float = 1.0,
+        metadata: dict | None = None,
+    ) -> None:
+        self.records.append((self._scoped_user_id, text, role))
+
+    async def context(
+        self,
+        query: str,
+        *,
+        token_budget: int | None = None,
+        role_filter: tuple[str, ...] | None = None,
+        decompose: bool | None = None,
+    ) -> str:
+        self.context_calls.append((self._scoped_user_id, query))
+        return self.context_reply
+
+
+def _agent(memory: Any = None, *, store: SessionStore | None = None) -> Agent:
+    return Agent(
+        "mem-tester",
+        model="gpt-4o-mini",
+        tools=[echo],
+        strategy="react",
+        memory=memory,
+        session_store=store,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. memory=True without the engram extra -> FAIL LOUD
+# ---------------------------------------------------------------------------
+
+
+def test_memory_true_without_engram_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``memory=True`` with engram missing raises a clear error naming the extra."""
+    # Setting sys.modules["engram"] = None makes ``import engram`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "engram", None)
+    with pytest.raises((ImportError, RuntimeError)) as exc_info:
+        _agent(memory=True)
+    assert "memory" in str(exc_info.value).lower()
+    assert "jamjet[memory]" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. Round-trip: record-at-end (run 1) -> retrieve-at-start + inject (run 2)
+# ---------------------------------------------------------------------------
+
+
+def test_memory_round_trip_record_then_retrieve(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    store = SessionStore(db_path)
+    s = store.create("mem-rt")
+    fake = _FakeMemory(context_reply="MEMORY-BLOCK: the user asked to remember X")
+    agent = _agent(memory=fake, store=store)
+
+    # Run 1: the turn is RECORDED, keyed by session.id.
+    asyncio.run(agent.run("remember X", session=s))
+    assert fake.records, "run 1 should record the turn"
+    # Every record is keyed by the stable session id (not an execution id).
+    assert all(key == "mem-rt" for (key, _text, _role) in fake.records), fake.records
+    # The user prompt was recorded.
+    assert any("remember X" in text for (_key, text, _role) in fake.records)
+
+    # Run 2: the context is RETRIEVED (keyed by session.id) and INJECTED.
+    capturing_mock.calls.clear()
+    asyncio.run(agent.run("recall X", session=s))
+
+    # context() was called keyed by the session id with the new prompt.
+    assert any(key == "mem-rt" and "recall X" in q for (key, q) in fake.context_calls), fake.context_calls
+
+    # The retrieved block reached the model on the 2nd run.
+    assert capturing_mock.calls, "run 2 should have hit the model"
+    second_run_msgs = capturing_mock.calls[0]
+    contents = " ".join(m.get("content", "") for m in second_run_msgs)
+    assert "MEMORY-BLOCK" in contents, f"retrieved memory not injected into run 2: {second_run_msgs}"
+
+
+# ---------------------------------------------------------------------------
+# 3. PII is REDACTED before a memory write
+# ---------------------------------------------------------------------------
+
+
+def test_pii_redacted_before_memory_write(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    store = SessionStore(db_path)
+    s = store.create("mem-pii")
+    fake = _FakeMemory()
+    agent = _agent(memory=fake, store=store)
+
+    asyncio.run(agent.run("my SSN is 123-45-6789", session=s))
+
+    assert fake.records, "the turn should have been recorded"
+    all_recorded = " ".join(text for (_key, text, _role) in fake.records)
+    # Raw SSN must NEVER be written into memory.
+    assert "123-45-6789" not in all_recorded, f"raw PII leaked into memory write: {fake.records}"
+    # The redaction placeholder proves the Track-3 redactor ran on the write.
+    assert "[REDACTED:US_SSN]" in all_recorded, f"expected redacted token in memory write: {fake.records}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Memory OFF by default -> no memory calls, behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_memory_off_by_default(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    store = SessionStore(db_path)
+    s = store.create("mem-off")
+    agent = _agent(memory=None, store=store)  # default
+
+    asyncio.run(agent.run("hello", session=s))
+
+    assert capturing_mock.calls, "the run should still hit the model"
+    first = capturing_mock.calls[0]
+    contents = " ".join(m.get("content", "") for m in first)
+    # No memory block is injected when memory is off.
+    assert "Relevant memory" not in contents, f"memory block injected with memory off: {first}"
+
+
+def test_memory_off_does_not_touch_injected_fake(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """A fake passed only as a sanity object is never used when memory is off.
+
+    (We cannot pass a fake via memory= and have it stay off — memory= IS the
+    switch — so this asserts the converse: a plain agent with no memory= makes
+    zero memory calls by construction.)
+    """
+    store = SessionStore(db_path)
+    s = store.create("mem-off2")
+    agent = _agent(memory=None, store=store)
+    # The agent holds no memory backend at all.
+    assert agent._memory_enabled is False
+    asyncio.run(agent.run("hello again", session=s))
+
+
+# ---------------------------------------------------------------------------
+# 5. Memory requires a session (fail-loud, never silently drop)
+# ---------------------------------------------------------------------------
+
+
+def test_memory_without_session_raises(capturing_mock: _CapturingMockClient) -> None:
+    fake = _FakeMemory()
+    agent = _agent(memory=fake)  # no session_store, and no session= on run
+    with pytest.raises(RuntimeError, match="session"):
+        asyncio.run(agent.run("hello"))
+    # Memory must not have been touched on the failed path.
+    assert fake.records == []
+    assert fake.context_calls == []
+
+
+def test_memory_without_session_raises_durable(capturing_mock: _CapturingMockClient) -> None:
+    """run_durable enforces the same session requirement (before any engine call)."""
+    fake = _FakeMemory()
+    agent = _agent(memory=fake)
+    with pytest.raises(RuntimeError, match="session"):
+        asyncio.run(agent.run_durable("hello"))
+    assert fake.records == []
+    assert fake.context_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 6. The injected AgentMemory is used as-is (duck-typed, no engram needed)
+# ---------------------------------------------------------------------------
+
+
+def test_injected_memory_is_used_directly(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    store = SessionStore(db_path)
+    s = store.create("mem-inject")
+    fake = _FakeMemory(context_reply="hi from memory")
+    agent = _agent(memory=fake, store=store)
+    assert agent._memory_enabled is True
+    asyncio.run(agent.run("ping", session=s))
+    # The injected fake (not a freshly-built Engram bridge) handled the calls.
+    assert fake.context_calls, "the injected memory should have served retrieval"
+    assert fake.records, "the injected memory should have served the record"

--- a/sdk/python/tests/test_agent_memory.py
+++ b/sdk/python/tests/test_agent_memory.py
@@ -327,3 +327,75 @@ def test_injected_memory_is_used_directly(
     # The injected fake (not a freshly-built Engram bridge) handled the calls.
     assert fake.context_calls, "the injected memory should have served retrieval"
     assert fake.records, "the injected memory should have served the record"
+
+
+# ---------------------------------------------------------------------------
+# 7. I3 — concurrent runs on ONE cached AgentMemory must not cross scopes
+# ---------------------------------------------------------------------------
+
+
+def test_as_scope_per_run_clone_no_cross_session_bleed() -> None:
+    """I3: ``as_scope`` yields a per-run view; concurrent sessions never cross.
+
+    The agent caches ONE :class:`AgentMemory` for ``memory=True`` and scopes
+    every retrieve/record by the per-run ``session.id`` via ``as_scope``.  The
+    pre-fix ``as_scope`` mutated a SHARED ``self._scope`` around the ``await``
+    inside the block, so two concurrent runs on different sessions could record
+    under the WRONG session.  This drives two concurrent record loops (mirroring
+    ``_record_turn``: two awaits in one ``as_scope`` block) on the SAME memory
+    with different scopes and asserts each run's SECOND record (written after the
+    interleaving await) is keyed by its OWN session.
+
+    Skipped when the optional ``engram`` extra is absent (the bridge imports it).
+    """
+    pytest.importorskip("engram")
+    from engram import Scope as EngramScope  # noqa: PLC0415
+
+    from jamjet.memory.engram_bridge import AgentMemory  # noqa: PLC0415
+    from jamjet.spec import MemoryConfig  # noqa: PLC0415
+
+    class _ProbeEngram:
+        """Stand-in Engram that records the scope it was called under, with an
+        await between calls so concurrent runs interleave."""
+
+        def __init__(self) -> None:
+            self.records: list[tuple[str, str, str | None]] = []
+
+        async def record(
+            self,
+            text: str,
+            *,
+            user_id: str,
+            org_id: str | None = None,
+            session_id: str | None = None,
+            role: str | None = None,
+            **_kw: Any,
+        ) -> None:
+            await asyncio.sleep(0.01)  # force the two runs to interleave
+            self.records.append((user_id, text, role))
+            return None
+
+    probe = _ProbeEngram()
+    mem = AgentMemory(
+        probe,  # type: ignore[arg-type]
+        scope=EngramScope(user_id="base", org_id="o"),
+        config=MemoryConfig(),
+    )
+
+    async def _two_records(sid: str) -> None:
+        with mem.as_scope(user_id=sid) as scoped:
+            await scoped.record(f"{sid}-first", role="user")
+            await scoped.record(f"{sid}-second", role="assistant")
+
+    async def _drive() -> None:
+        await asyncio.gather(_two_records("A"), _two_records("B"))
+
+    asyncio.run(_drive())
+
+    # Each run's SECOND record (after the interleaving await) is keyed by its OWN
+    # session — never the other run's.  Pre-fix, one of these landed under the
+    # other scope.
+    assert ("A", "A-second", "assistant") in probe.records, probe.records
+    assert ("B", "B-second", "assistant") in probe.records, probe.records
+    # The shared instance's scope is never mutated by as_scope.
+    assert mem._scope.user_id == "base"

--- a/sdk/python/tests/test_agent_receipts.py
+++ b/sdk/python/tests/test_agent_receipts.py
@@ -23,7 +23,9 @@ class FakeLocalRuntime:
     name = "local"
     supported_ir_versions = ("1.0",)
 
-    async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None):
+    async def execute(
+        self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None, initial_messages=None
+    ):
         return RuntimeResult(
             output=_OUTPUT,
             execution_id="ex1",

--- a/sdk/python/tests/test_agent_session.py
+++ b/sdk/python/tests/test_agent_session.py
@@ -350,17 +350,97 @@ def test_persist_session_turn_with_full_messages(db_path: str) -> None:
     assert loaded.latest_execution_id == "exec-002"
 
 
-def test_parity_seed_same_for_both_paths() -> None:
-    """The seed helper is path-agnostic: same output regardless of path."""
-    s = Session("z")
-    s.messages = [
-        {"role": "user", "content": "prior"},
-        {"role": "assistant", "content": "prior-reply"},
-    ]
-    # Both run() and run_durable() call the same function.
-    msgs_run = seed_messages_for_run(s, "system", "new")
-    msgs_durable = seed_messages_for_run(s, "system", "new")
-    assert msgs_run == msgs_durable
+class _FakeDurableClient:
+    """Async-context-manager fake of JamjetClient for the run_durable seam test.
+
+    Captures the ``initial_input`` passed to ``start_execution`` (so a test can
+    assert the session thread was SEEDED) and returns a terminal execution whose
+    ``current_state.messages`` is the durable ledger (so the persist seam runs).
+    """
+
+    def __init__(self, execution: dict[str, Any]) -> None:
+        self._execution = execution
+        self.started: list[tuple[str, dict[str, Any]]] = []
+
+    async def __aenter__(self) -> _FakeDurableClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        return {"workflow_id": ir["workflow_id"]}
+
+    async def start_execution(
+        self, workflow_id: str, input: dict[str, Any], workflow_version: str | None = None
+    ) -> dict[str, Any]:
+        self.started.append((workflow_id, input))
+        return {"execution_id": "exec-durable-1"}
+
+    async def get_execution(self, execution_id: str) -> dict[str, Any]:
+        return self._execution
+
+    async def get_events(self, execution_id: str) -> dict[str, Any]:
+        return {"events": []}
+
+
+def test_run_durable_seeds_and_persists_session_thread(
+    db_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The REAL run_durable() path seeds the carried thread + persists the ledger.
+
+    Drives ``Agent.run_durable`` against a mocked durable engine (no live engine)
+    and asserts BOTH ends of the carried-state seam: the prior session thread is
+    seeded into the execution's ``initial_input``, and the durable ledger is
+    persisted back to the session.  Unlike the old test (which called
+    ``seed_messages_for_run`` directly and stayed green even if run_durable
+    stopped seeding/persisting), this exercises the actual run_durable seam.
+    """
+    store = SessionStore(db_path)
+    s = store.create("durable-seam")
+    s.append_message("user", "my name is Alice")
+    s.append_message("assistant", "your name is Alice")
+    store.save(s)
+
+    completed = {
+        "execution_id": "exec-durable-1",
+        "status": "completed",
+        "current_state": {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "my name is Alice"},
+                {"role": "assistant", "content": "your name is Alice"},
+                {"role": "user", "content": "what is my name?"},
+                {"role": "assistant", "content": "Your name is Alice."},
+            ],
+            "last_model_output": "Your name is Alice.",
+        },
+    }
+    fake = _FakeDurableClient(completed)
+    # run_durable does `from jamjet.client import JamjetClient` at call time, so
+    # patching the module attribute swaps in our fake (mirrors run_durable tests).
+    monkeypatch.setattr("jamjet.client.JamjetClient", lambda *a, **k: fake)
+
+    agent = Agent("d", model="gpt-4o-mini", tools=[echo], session_store=store)
+    result = asyncio.run(agent.run_durable("what is my name?", session=s))
+
+    # SEED: the prior session thread reached start_execution's initial_input.
+    assert fake.started, "run_durable must have started an execution"
+    _wf_id, initial_input = fake.started[0]
+    seeded = " ".join(str(m.get("content", "")) for m in initial_input["messages"])
+    assert "my name is Alice" in seeded, initial_input["messages"]
+    assert "what is my name?" in seeded, initial_input["messages"]
+
+    # PERSIST: the session now carries the durable ledger (system stripped) and
+    # the execution id — written through the real run_durable persist seam.
+    reloaded = store.load("durable-seam")
+    assert reloaded is not None
+    assert all(m["role"] != "system" for m in reloaded.messages)
+    assert {"role": "user", "content": "what is my name?"} in reloaded.messages
+    assert {"role": "assistant", "content": "Your name is Alice."} in reloaded.messages
+    assert reloaded.latest_execution_id == "exec-durable-1"
+    assert result.output == "Your name is Alice."
 
 
 # ---------------------------------------------------------------------------
@@ -417,3 +497,70 @@ def test_str_session_id_not_found(db_path: str) -> None:
     agent = Agent("err", model="gpt-4o-mini", tools=[echo], session_store=store)
     with pytest.raises(ValueError, match="not found"):
         asyncio.run(agent.run("hello", session="no-such-session"))
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — create() is get-or-create; it must never clobber an existing
+# session (save() is INSERT OR REPLACE, so a naive create() wiped the thread).
+# ---------------------------------------------------------------------------
+
+
+def test_create_does_not_clobber_existing_session(db_path: str) -> None:
+    """create() over an existing id returns it UNCHANGED (no silent data loss)."""
+    store = SessionStore(db_path)
+    s = store.create("s1")
+    s.append_message("user", "remember me")
+    s.append_message("assistant", "noted")
+    s.metadata["k"] = "v"
+    store.save(s)
+
+    # create("s1") again must NOT wipe the thread/metadata.
+    again = store.create("s1")
+    assert again.messages == [
+        {"role": "user", "content": "remember me"},
+        {"role": "assistant", "content": "noted"},
+    ], "create() clobbered the existing thread (silent data loss)"
+    assert again.metadata == {"k": "v"}
+
+    # The persisted row is intact too (not just the returned object).
+    reloaded = store.load("s1")
+    assert reloaded is not None
+    assert reloaded.messages == again.messages
+    assert reloaded.metadata == {"k": "v"}
+
+
+def test_create_new_id_still_creates_empty_session(db_path: str) -> None:
+    """create() for a genuinely new id still creates+persists an empty session."""
+    store = SessionStore(db_path)
+    s = store.create("fresh")
+    assert s.messages == []
+    assert store.load("fresh") is not None
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — a session loaded from store X is persisted back to X, not to the
+# agent's default store.
+# ---------------------------------------------------------------------------
+
+
+def test_session_persists_back_to_its_originating_store(
+    capturing_mock: _CapturingMockClient,
+    tmp_path: Path,
+) -> None:
+    """A Session loaded from store A is saved back to A, never the agent's store B."""
+    store_a = SessionStore(str(tmp_path / "store_a.db"))  # the session's origin
+    store_b = SessionStore(str(tmp_path / "store_b.db"))  # the agent's default store
+    store_a.create("cross")
+
+    loaded = store_a.load("cross")  # carries a back-ref to store_a
+    assert loaded is not None
+    agent = Agent("x", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store_b)
+
+    asyncio.run(agent.run("my name is Alice", session=loaded))
+
+    # The turn landed in store A (the originating store) ...
+    from_a = store_a.load("cross")
+    assert from_a is not None
+    assert any(m["role"] == "user" for m in from_a.messages), "run did not persist to the originating store A"
+    # ... and NOT in the agent's default store B.
+    assert store_b.load("cross") is None, "run leaked the session into the agent's default store B"

--- a/sdk/python/tests/test_agent_session.py
+++ b/sdk/python/tests/test_agent_session.py
@@ -1,0 +1,419 @@
+"""Tests for T4-2: Agent.run / run_durable continue a Session thread.
+
+Tests:
+- thread_continues: the second run's input messages contain the first turn.
+- survives_restart: a fresh Agent + fresh SessionStore loads the session and
+  the third run sees the first two turns (restart across process boundary).
+- no_session: agent.run() without session= behaves exactly as before.
+- parity: seed_messages_for_run + persist_session_turn helpers are the same
+  for both run() and run_durable() (unit-tested directly).
+- session_run_method: Session.run(agent, prompt) ergonomic form.
+- str_session_id: session= may be a str; the agent resolves via the store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from jamjet import Agent, tool
+from jamjet.agents.session import (
+    Session,
+    SessionStore,
+    persist_session_turn,
+    seed_messages_for_run,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal tool for all tests
+# ---------------------------------------------------------------------------
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the input."""
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Capturing mock: records every messages list the model sees
+# ---------------------------------------------------------------------------
+
+
+class _CapturingMockClient:
+    """Mock OpenAI client that records the messages list for every call.
+
+    On each call it returns a simple text reply (no tool calls) so the
+    react strategy terminates immediately.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.chat = MagicMock()
+        self.chat.completions = MagicMock()
+        self.chat.completions.create = self._create
+        self.calls: list[list[dict]] = []
+
+    async def _create(
+        self,
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        # Record a deep copy of the messages for inspection.
+        self.calls.append(
+            [
+                dict(m)
+                if isinstance(m, dict)
+                else {"role": getattr(m, "role", "?"), "content": getattr(m, "content", "")}
+                for m in messages
+            ]
+        )
+
+        # Determine a canned reply based on the last user message.
+        last_user = ""
+        for m in reversed(messages):
+            role = m.get("role") if isinstance(m, dict) else getattr(m, "role", "")
+            content = m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+            if role == "user":
+                last_user = content or ""
+                break
+
+        # Map prompts to canned replies for determinism.
+        if "alice" in last_user.lower() or "my name is" in last_user.lower():
+            reply = "Got it — your name is Alice."
+        elif "what is my name" in last_user.lower():
+            reply = "Your name is Alice."
+        elif "third" in last_user.lower():
+            reply = "This is the third turn."
+        else:
+            reply = f"OK: {last_user}"
+
+        msg = MagicMock()
+        msg.content = reply
+        msg.role = "assistant"
+        msg.tool_calls = []
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=msg)]
+        return resp
+
+
+# ---------------------------------------------------------------------------
+# Fixture: replace litellm.acompletion with the capturing client for a test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def capturing_mock(monkeypatch: pytest.MonkeyPatch) -> _CapturingMockClient:
+    """Patch litellm.acompletion so we can inspect the messages per call."""
+    client = _CapturingMockClient()
+
+    async def _mock_acompletion(
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        return await client._create(model=model, messages=messages, tools=tools, **kwargs)
+
+    mock_litellm = types.ModuleType("litellm")
+    mock_litellm.acompletion = _mock_acompletion  # type: ignore[attr-defined]
+    mock_litellm.completion_cost = lambda *a, **kw: 0.0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+    return client
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "sessions_t42.db")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(strategy: str = "react") -> Agent:
+    return Agent("tester", model="gpt-4o-mini", tools=[echo], strategy=strategy)
+
+
+# ---------------------------------------------------------------------------
+# T4-2 core: thread continues
+# ---------------------------------------------------------------------------
+
+
+def test_thread_continues_second_run_sees_first_turn(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """Second agent.run() with session= must send prior turns to the model."""
+    store = SessionStore(db_path)
+    s = store.create("s1")
+    agent = Agent("tester", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store)
+
+    asyncio.run(agent.run("my name is Alice", session=s))
+    asyncio.run(agent.run("what is my name?", session=s))
+
+    # The capturing mock should have at least two calls.
+    assert len(capturing_mock.calls) >= 2
+
+    # The SECOND call's messages must contain a turn about "Alice".
+    second_call_messages = capturing_mock.calls[1]
+    roles = [m["role"] for m in second_call_messages]
+    contents = " ".join(m.get("content", "") for m in second_call_messages)
+
+    # Prior user prompt must appear in the second run's input.
+    assert "alice" in contents.lower() or "my name is" in contents.lower(), (
+        f"Expected 'alice' in second call messages, got: {second_call_messages}"
+    )
+    # The second run's prompt also appears.
+    assert "what is my name" in contents.lower(), (
+        f"Expected 'what is my name' in second call, got: {second_call_messages}"
+    )
+    # There's at least one prior assistant turn in the messages.
+    assert "assistant" in roles, f"Expected prior assistant turn in second call: {second_call_messages}"
+
+
+def test_session_messages_after_both_runs(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """After two runs the session contains both turns (user+assistant each)."""
+    store = SessionStore(db_path)
+    s = store.create("s2")
+    agent = Agent("tester", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store)
+
+    asyncio.run(agent.run("my name is Alice", session=s))
+    asyncio.run(agent.run("what is my name?", session=s))
+
+    # Reload from store to verify persistence.
+    reloaded = store.load("s2")
+    assert reloaded is not None
+    roles = [m["role"] for m in reloaded.messages]
+    # Must have at least two user turns and two assistant turns.
+    assert roles.count("user") >= 2, f"Expected >=2 user turns, got: {roles}"
+    assert roles.count("assistant") >= 2, f"Expected >=2 assistant turns, got: {roles}"
+
+
+# ---------------------------------------------------------------------------
+# T4-2: survives restart
+# ---------------------------------------------------------------------------
+
+
+def test_survives_restart(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """A fresh Agent + fresh SessionStore load continues the thread correctly.
+
+    Run 1 + 2: first Agent instance.
+    Run 3: brand-new Agent + brand-new SessionStore pointing at same db.
+    The third run's messages must contain turns from runs 1 and 2.
+    """
+    store1 = SessionStore(db_path)
+    s = store1.create("restart-1")
+    agent1 = Agent("a1", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store1)
+
+    asyncio.run(agent1.run("my name is Alice", session=s))
+    asyncio.run(agent1.run("what is my name?", session=s))
+
+    # Simulate a process restart: discard agent1 + store1, create fresh instances.
+    del agent1
+    del store1
+
+    store2 = SessionStore(db_path)  # same db path
+    s_reloaded = store2.load("restart-1")
+    assert s_reloaded is not None, "Session not found after restart"
+
+    agent2 = Agent("a2", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store2)
+
+    # Reset the capturing mock's call log before the third run.
+    capturing_mock.calls.clear()
+    asyncio.run(agent2.run("this is the third turn", session=s_reloaded))
+
+    assert len(capturing_mock.calls) >= 1
+    third_call_messages = capturing_mock.calls[0]
+    contents = " ".join(m.get("content", "") for m in third_call_messages)
+
+    # The third run must see the prior "Alice" turns from runs 1 and 2.
+    assert "alice" in contents.lower() or "my name is" in contents.lower(), (
+        f"Third run did not see prior turns. Messages: {third_call_messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4-2: no session — default run path unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_no_session_default_path_unchanged(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """agent.run() without session= sends only the system + user prompt."""
+    agent = Agent("tester", model="gpt-4o-mini", tools=[echo], strategy="react")
+    asyncio.run(agent.run("hello world"))
+
+    assert len(capturing_mock.calls) >= 1
+    first_call = capturing_mock.calls[0]
+    roles = [m["role"] for m in first_call]
+    # No prior assistant turns — fresh seed.
+    assert "assistant" not in roles, f"No-session run should not have assistant messages: {first_call}"
+    assert roles.count("user") == 1, f"No-session run should have exactly 1 user message: {first_call}"
+
+
+# ---------------------------------------------------------------------------
+# T4-2: parity — shared helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_seed_messages_no_session() -> None:
+    """seed_messages_for_run without a session returns the default scratch seed."""
+    msgs = seed_messages_for_run(None, "Be helpful.", "hello")
+    assert msgs == [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+def test_seed_messages_with_session() -> None:
+    """seed_messages_for_run with a session prepends prior non-system turns."""
+    s = Session("x")
+    s.messages = [
+        {"role": "user", "content": "turn 1"},
+        {"role": "assistant", "content": "reply 1"},
+    ]
+    msgs = seed_messages_for_run(s, "Be helpful.", "turn 2")
+    assert msgs == [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": "turn 1"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "turn 2"},
+    ]
+
+
+def test_seed_messages_strips_stale_system() -> None:
+    """seed_messages_for_run drops any system messages stored in the session."""
+    s = Session("y")
+    s.messages = [
+        {"role": "system", "content": "OLD instructions"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    msgs = seed_messages_for_run(s, "NEW instructions", "next")
+    roles = [m["role"] for m in msgs]
+    assert roles.count("system") == 1, "Should have exactly one system message"
+    assert msgs[0]["content"] == "NEW instructions", "System must come from current instructions"
+
+
+def test_persist_session_turn_no_full_messages(db_path: str) -> None:
+    """persist_session_turn with full_messages=None appends user+assistant."""
+    store = SessionStore(db_path)
+    s = store.create("p1")
+
+    persist_session_turn(s, "hello", "hi there", "exec-001", full_messages=None, store=store)
+
+    loaded = store.load("p1")
+    assert loaded is not None
+    assert loaded.messages == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    assert loaded.latest_execution_id == "exec-001"
+
+
+def test_persist_session_turn_with_full_messages(db_path: str) -> None:
+    """persist_session_turn with full_messages uses them (strips system)."""
+    store = SessionStore(db_path)
+    s = store.create("p2")
+
+    full_msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+        {"role": "tool", "content": "tool result"},
+        {"role": "assistant", "content": "final"},
+    ]
+    persist_session_turn(s, "hello", "final", "exec-002", full_messages=full_msgs, store=store)
+
+    loaded = store.load("p2")
+    assert loaded is not None
+    # System stripped; the rest preserved.
+    assert all(m["role"] != "system" for m in loaded.messages)
+    assert loaded.messages[0] == {"role": "user", "content": "hello"}
+    assert loaded.latest_execution_id == "exec-002"
+
+
+def test_parity_seed_same_for_both_paths() -> None:
+    """The seed helper is path-agnostic: same output regardless of path."""
+    s = Session("z")
+    s.messages = [
+        {"role": "user", "content": "prior"},
+        {"role": "assistant", "content": "prior-reply"},
+    ]
+    # Both run() and run_durable() call the same function.
+    msgs_run = seed_messages_for_run(s, "system", "new")
+    msgs_durable = seed_messages_for_run(s, "system", "new")
+    assert msgs_run == msgs_durable
+
+
+# ---------------------------------------------------------------------------
+# T4-2: Session.run() ergonomic method
+# ---------------------------------------------------------------------------
+
+
+def test_session_run_method(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """Session.run(agent, prompt) is equivalent to agent.run(prompt, session=self)."""
+    store = SessionStore(db_path)
+    s = store.create("erg-1")
+    agent = Agent("erg", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store)
+
+    result = asyncio.run(s.run(agent, "my name is Alice"))
+    assert result.output  # non-empty
+
+    # Session should be updated.
+    loaded = store.load("erg-1")
+    assert loaded is not None
+    roles = [m["role"] for m in loaded.messages]
+    assert "user" in roles
+    assert "assistant" in roles
+
+
+# ---------------------------------------------------------------------------
+# T4-2: str session id form
+# ---------------------------------------------------------------------------
+
+
+def test_str_session_id(
+    capturing_mock: _CapturingMockClient,
+    db_path: str,
+) -> None:
+    """session= may be a str; the agent resolves it from the session_store."""
+    store = SessionStore(db_path)
+    store.create("str-session-1")
+
+    agent = Agent("str-test", model="gpt-4o-mini", tools=[echo], strategy="react", session_store=store)
+
+    result = asyncio.run(agent.run("my name is Alice", session="str-session-1"))
+    assert result.output
+
+    loaded = store.load("str-session-1")
+    assert loaded is not None
+    assert any(m["role"] == "user" for m in loaded.messages)
+
+
+def test_str_session_id_not_found(db_path: str) -> None:
+    """str session id not in store raises ValueError (fail-loud)."""
+    store = SessionStore(db_path)
+    agent = Agent("err", model="gpt-4o-mini", tools=[echo], session_store=store)
+    with pytest.raises(ValueError, match="not found"):
+        asyncio.run(agent.run("hello", session="no-such-session"))

--- a/sdk/python/tests/test_artifacts.py
+++ b/sdk/python/tests/test_artifacts.py
@@ -1,0 +1,172 @@
+"""Tests for T4-4: the Python artifact API.
+
+Covers three layers:
+- ``JamjetClient.put_artifact`` / ``get_artifact`` against a mock HTTP transport
+  (no live runtime) — a real round-trip through the HTTP serialization.
+- ``ArtifactStore`` over a fake client.
+- ``Session.artifacts`` namespace round-trip via an attached fake client.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import httpx
+import pytest
+
+from jamjet import ArtifactRef, ArtifactStore, Session
+from jamjet.client import JamjetClient
+
+# ---------------------------------------------------------------------------
+# Mock HTTP transport — a content-addressed artifact store in a dict
+# ---------------------------------------------------------------------------
+
+
+def _mock_client() -> JamjetClient:
+    """A JamjetClient whose transport implements the artifact routes in memory.
+
+    POST /artifacts hashes the body and stores it; GET /artifacts/:hash returns
+    the bytes (404 when absent) — mirroring the Rust routes.
+    """
+    store: dict[str, bytes] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path == "/artifacts":
+            data = request.content
+            digest = hashlib.sha256(data).hexdigest()
+            store[digest] = data
+            media_type = request.headers.get("content-type")
+            # Match the runtime: an explicit ?media_type= query wins.
+            media_type = request.url.params.get("media_type", media_type)
+            return httpx.Response(
+                200,
+                json={"hash": digest, "size": len(data), "media_type": media_type},
+            )
+        if request.method == "GET" and path.startswith("/artifacts/"):
+            digest = path.rsplit("/", 1)[-1]
+            data = store.get(digest)
+            if data is None:
+                return httpx.Response(404, json={"error": f"artifact {digest}"})
+            return httpx.Response(
+                200,
+                content=data,
+                headers={"content-type": "application/octet-stream"},
+            )
+        return httpx.Response(404, json={"error": "not found"})
+
+    client = JamjetClient(base_url="http://test")
+    client._client = httpx.AsyncClient(base_url="http://test", transport=httpx.MockTransport(handler))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# ArtifactRef dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_ref_fields():
+    ref = ArtifactRef(hash="a" * 64, size=12, media_type="text/plain")
+    assert ref.hash == "a" * 64
+    assert ref.size == 12
+    assert ref.media_type == "text/plain"
+
+
+def test_artifact_ref_media_type_optional():
+    ref = ArtifactRef(hash="b" * 64, size=3)
+    assert ref.media_type is None
+
+
+# ---------------------------------------------------------------------------
+# JamjetClient.put_artifact / get_artifact (mock HTTP)
+# ---------------------------------------------------------------------------
+
+
+async def test_client_put_artifact_returns_ref():
+    client = _mock_client()
+    try:
+        ref = await client.put_artifact(b"hello", media_type="text/plain")
+        assert isinstance(ref, ArtifactRef)
+        assert ref.hash == hashlib.sha256(b"hello").hexdigest()
+        assert ref.size == 5
+        assert ref.media_type == "text/plain"
+    finally:
+        await client._client.aclose()
+
+
+async def test_client_round_trips_blob_by_hash():
+    client = _mock_client()
+    try:
+        ref = await client.put_artifact(b"hello")
+        got = await client.get_artifact(ref.hash)
+        assert got == b"hello"
+    finally:
+        await client._client.aclose()
+
+
+async def test_client_get_unknown_hash_raises_404():
+    client = _mock_client()
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            await client.get_artifact("0" * 64)
+        assert exc.value.response.status_code == 404
+    finally:
+        await client._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Fake client — duck-typed for ArtifactStore / Session.artifacts
+# ---------------------------------------------------------------------------
+
+
+class _FakeArtifactClient:
+    """In-memory stand-in exposing the client's artifact methods."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    async def put_artifact(self, data: bytes, media_type: str | None = None) -> ArtifactRef:
+        digest = hashlib.sha256(data).hexdigest()
+        self.store[digest] = data
+        return ArtifactRef(hash=digest, size=len(data), media_type=media_type)
+
+    async def get_artifact(self, hash: str) -> bytes:
+        return self.store[hash]
+
+
+async def test_artifact_store_put_get_round_trip():
+    store = ArtifactStore(_FakeArtifactClient())
+    ref = await store.put(b"report bytes", "text/markdown")
+    assert ref.size == len(b"report bytes")
+    assert ref.media_type == "text/markdown"
+    assert await store.get(ref.hash) == b"report bytes"
+
+
+# ---------------------------------------------------------------------------
+# Session.artifacts namespace
+# ---------------------------------------------------------------------------
+
+
+async def test_session_artifacts_round_trip():
+    session = Session(id="s-1")
+    session.attach_client(_FakeArtifactClient())
+
+    ref = await session.artifacts.put(b"hello session", "text/plain")
+    assert ref.hash == hashlib.sha256(b"hello session").hexdigest()
+    assert await session.artifacts.get(ref.hash) == b"hello session"
+
+
+def test_session_artifacts_property_is_lazy_store():
+    """Without attach_client, .artifacts builds a default ArtifactStore."""
+    session = Session(id="s-2")
+    assert isinstance(session.artifacts, ArtifactStore)
+    # Memoised: the same store instance is returned on repeat access.
+    assert session.artifacts is session.artifacts
+
+
+def test_session_artifacts_does_not_break_equality_or_persistence():
+    """Attaching a client must not affect Session value-equality or saved state."""
+    a = Session(id="s-3", messages=[{"role": "user", "content": "hi"}])
+    b = Session(id="s-3", messages=[{"role": "user", "content": "hi"}])
+    a.attach_client(_FakeArtifactClient())
+    assert a == b  # _artifacts is not a compared field

--- a/sdk/python/tests/test_artifacts.py
+++ b/sdk/python/tests/test_artifacts.py
@@ -22,7 +22,7 @@ from jamjet.client import JamjetClient
 # ---------------------------------------------------------------------------
 
 
-def _mock_client() -> JamjetClient:
+async def _mock_client() -> JamjetClient:
     """A JamjetClient whose transport implements the artifact routes in memory.
 
     POST /artifacts hashes the body and stores it; GET /artifacts/:hash returns
@@ -56,6 +56,9 @@ def _mock_client() -> JamjetClient:
         return httpx.Response(404, json={"error": "not found"})
 
     client = JamjetClient(base_url="http://test")
+    # JamjetClient.__init__ eagerly opens an AsyncClient; close it before swapping
+    # in the mock-transport one so the original is not leaked (ResourceWarning).
+    await client._client.aclose()
     client._client = httpx.AsyncClient(base_url="http://test", transport=httpx.MockTransport(handler))
     return client
 
@@ -77,13 +80,20 @@ def test_artifact_ref_media_type_optional():
     assert ref.media_type is None
 
 
+def test_artifact_ref_reexported_from_agents():
+    """ArtifactRef is re-exported from jamjet.agents (alongside ArtifactStore)."""
+    from jamjet.agents import ArtifactRef as AgentsArtifactRef
+
+    assert AgentsArtifactRef is ArtifactRef
+
+
 # ---------------------------------------------------------------------------
 # JamjetClient.put_artifact / get_artifact (mock HTTP)
 # ---------------------------------------------------------------------------
 
 
 async def test_client_put_artifact_returns_ref():
-    client = _mock_client()
+    client = await _mock_client()
     try:
         ref = await client.put_artifact(b"hello", media_type="text/plain")
         assert isinstance(ref, ArtifactRef)
@@ -95,7 +105,7 @@ async def test_client_put_artifact_returns_ref():
 
 
 async def test_client_round_trips_blob_by_hash():
-    client = _mock_client()
+    client = await _mock_client()
     try:
         ref = await client.put_artifact(b"hello")
         got = await client.get_artifact(ref.hash)
@@ -105,7 +115,7 @@ async def test_client_round_trips_blob_by_hash():
 
 
 async def test_client_get_unknown_hash_raises_404():
-    client = _mock_client()
+    client = await _mock_client()
     try:
         with pytest.raises(httpx.HTTPStatusError) as exc:
             await client.get_artifact("0" * 64)

--- a/sdk/python/tests/test_artifacts.py
+++ b/sdk/python/tests/test_artifacts.py
@@ -156,9 +156,17 @@ async def test_session_artifacts_round_trip():
     assert await session.artifacts.get(ref.hash) == b"hello session"
 
 
-def test_session_artifacts_property_is_lazy_store():
-    """Without attach_client, .artifacts builds a default ArtifactStore."""
+def test_session_artifacts_without_client_raises():
+    """Without attach_client, .artifacts fails loud (no silent localhost default)."""
     session = Session(id="s-2")
+    with pytest.raises(RuntimeError, match="no artifact client attached"):
+        _ = session.artifacts
+
+
+def test_session_artifacts_memoised_after_attach():
+    """After attach_client, .artifacts returns the same store on repeat access."""
+    session = Session(id="s-2b")
+    session.attach_client(_FakeArtifactClient())
     assert isinstance(session.artifacts, ArtifactStore)
     # Memoised: the same store instance is returned on repeat access.
     assert session.artifacts is session.artifacts

--- a/sdk/python/tests/test_public_surface.py
+++ b/sdk/python/tests/test_public_surface.py
@@ -28,6 +28,8 @@ def test_public_surface_complete():
         "deploy",
         "Session",
         "SessionStore",
+        "ArtifactRef",
+        "ArtifactStore",
     }
     public_attrs = {n for n in dir(jamjet) if not n.startswith("_")}
     missing = expected - public_attrs

--- a/sdk/python/tests/test_public_surface.py
+++ b/sdk/python/tests/test_public_surface.py
@@ -26,6 +26,8 @@ def test_public_surface_complete():
         "run",
         "resume",
         "deploy",
+        "Session",
+        "SessionStore",
     }
     public_attrs = {n for n in dir(jamjet) if not n.startswith("_")}
     missing = expected - public_attrs

--- a/sdk/python/tests/test_run_through_local_runtime.py
+++ b/sdk/python/tests/test_run_through_local_runtime.py
@@ -12,7 +12,9 @@ async def test_agent_run_dispatches_to_local_runtime(monkeypatch):
         name = "local"
         supported_ir_versions = ("1.0",)
 
-        async def execute(self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None):
+        async def execute(
+            self, spec, input, *, execution_id=None, scope=None, on_event=None, governance=None, initial_messages=None
+        ):
             seen["spec"] = spec
             seen["input"] = input
             seen["governance"] = governance

--- a/sdk/python/tests/test_session.py
+++ b/sdk/python/tests/test_session.py
@@ -1,0 +1,248 @@
+"""Tests for Session + SessionStore (T4-1).
+
+All tests use a temporary file path so they do not touch ~/.jamjet/sessions.db.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from jamjet.agents.session import Session, SessionStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a fresh, unique SQLite path inside pytest's tmp_path."""
+    return str(tmp_path / "sessions.db")
+
+
+# ---------------------------------------------------------------------------
+# Session dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_session_defaults():
+    s = Session(id="abc")
+    assert s.id == "abc"
+    assert s.messages == []
+    assert s.latest_execution_id is None
+    assert s.metadata == {}
+
+
+def test_session_append_message():
+    s = Session(id="abc")
+    s.append_message("user", "hello")
+    s.append_message("assistant", "hi there")
+    assert len(s.messages) == 2
+    assert s.messages[0] == {"role": "user", "content": "hello"}
+    assert s.messages[1] == {"role": "assistant", "content": "hi there"}
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.create
+# ---------------------------------------------------------------------------
+
+
+def test_create_generates_id(db_path: str):
+    store = SessionStore(db_path)
+    s = store.create()
+    assert s.id  # non-empty
+    # Should be a valid UUID4
+    parsed = uuid.UUID(s.id)
+    assert str(parsed) == s.id
+
+
+def test_create_with_explicit_id(db_path: str):
+    store = SessionStore(db_path)
+    s = store.create("s1")
+    assert s.id == "s1"
+
+
+def test_create_returns_empty_session(db_path: str):
+    store = SessionStore(db_path)
+    s = store.create("s2")
+    assert s.messages == []
+    assert s.latest_execution_id is None
+    assert s.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.load
+# ---------------------------------------------------------------------------
+
+
+def test_load_unknown_returns_none(db_path: str):
+    store = SessionStore(db_path)
+    result = store.load("does-not-exist")
+    assert result is None
+
+
+def test_load_after_create(db_path: str):
+    store = SessionStore(db_path)
+    store.create("x")
+    loaded = store.load("x")
+    assert loaded is not None
+    assert loaded.id == "x"
+
+
+# ---------------------------------------------------------------------------
+# Save / load round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_roundtrip_messages(db_path: str):
+    store = SessionStore(db_path)
+    s = Session(id="rt1")
+    s.messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+    ]
+    store.save(s)
+
+    loaded = store.load("rt1")
+    assert loaded is not None
+    assert loaded.messages == s.messages
+
+
+def test_save_load_roundtrip_latest_execution_id(db_path: str):
+    store = SessionStore(db_path)
+    s = Session(id="rt2", latest_execution_id="exec-abc-123")
+    store.save(s)
+
+    loaded = store.load("rt2")
+    assert loaded is not None
+    # user session id is distinct from engine lineage id
+    assert loaded.id == "rt2"
+    assert loaded.latest_execution_id == "exec-abc-123"
+    assert loaded.id != loaded.latest_execution_id
+
+
+def test_save_load_roundtrip_metadata(db_path: str):
+    store = SessionStore(db_path)
+    s = Session(id="rt3", metadata={"agent": "my-agent", "version": 2})
+    store.save(s)
+
+    loaded = store.load("rt3")
+    assert loaded is not None
+    assert loaded.metadata == {"agent": "my-agent", "version": 2}
+
+
+def test_save_upserts(db_path: str):
+    """Saving the same session twice keeps the latest state."""
+    store = SessionStore(db_path)
+    s = Session(id="upsert-1")
+    s.messages = [{"role": "user", "content": "v1"}]
+    store.save(s)
+
+    s.messages.append({"role": "assistant", "content": "v2"})
+    s.latest_execution_id = "exec-v2"
+    store.save(s)
+
+    loaded = store.load("upsert-1")
+    assert loaded is not None
+    assert len(loaded.messages) == 2
+    assert loaded.latest_execution_id == "exec-v2"
+
+
+# ---------------------------------------------------------------------------
+# append_message + save/load
+# ---------------------------------------------------------------------------
+
+
+def test_append_message_then_save_load(db_path: str):
+    store = SessionStore(db_path)
+    s = store.create("am-1")
+    s.append_message("user", "question")
+    s.append_message("assistant", "answer")
+    store.save(s)
+
+    loaded = store.load("am-1")
+    assert loaded is not None
+    assert loaded.messages == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Survives restart
+# ---------------------------------------------------------------------------
+
+
+def test_survives_restart(db_path: str):
+    """Persist a session, then a FRESH store instance must load it correctly."""
+    # First store instance saves a 2-message thread
+    store1 = SessionStore(db_path)
+    s = store1.create("persist-1")
+    s.append_message("user", "turn one")
+    s.append_message("assistant", "reply one")
+    s.latest_execution_id = "exec-restart-001"
+    s.metadata = {"key": "val"}
+    store1.save(s)
+
+    # Discard store1 — simulate process restart with a new store instance
+    store2 = SessionStore(db_path)
+    loaded = store2.load("persist-1")
+
+    assert loaded is not None
+    assert loaded.id == "persist-1"
+    assert len(loaded.messages) == 2
+    assert loaded.messages[0] == {"role": "user", "content": "turn one"}
+    assert loaded.messages[1] == {"role": "assistant", "content": "reply one"}
+    assert loaded.latest_execution_id == "exec-restart-001"
+    assert loaded.metadata == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# SessionStore.list
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty(db_path: str):
+    store = SessionStore(db_path)
+    assert store.list() == []
+
+
+def test_list_returns_saved_ids(db_path: str):
+    store = SessionStore(db_path)
+    store.create("a")
+    store.create("b")
+    store.create("c")
+    ids = store.list()
+    assert set(ids) == {"a", "b", "c"}
+
+
+def test_list_excludes_unsaved(db_path: str):
+    store = SessionStore(db_path)
+    store.create("saved")
+    # create a Session object in memory but never save it
+    _ = Session(id="not-saved")
+    ids = store.list()
+    assert "not-saved" not in ids
+    assert "saved" in ids
+
+
+# ---------------------------------------------------------------------------
+# Top-level import
+# ---------------------------------------------------------------------------
+
+
+def test_importable_from_jamjet():
+    import jamjet
+
+    assert jamjet.Session is Session
+    assert jamjet.SessionStore is SessionStore
+
+
+def test_importable_from_jamjet_agents():
+    import jamjet.agents
+
+    assert jamjet.agents.Session is Session
+    assert jamjet.agents.SessionStore is SessionStore

--- a/sdk/python/tests/test_session_integration.py
+++ b/sdk/python/tests/test_session_integration.py
@@ -1,0 +1,305 @@
+"""Consolidated integration test for T4-5: session + memory + artifact together.
+
+One test drives a single agent + session through ALL THREE headline guarantees
+across a simulated process restart, using scripted fakes (no real model, no real
+Engram, no real runtime):
+
+  Guarantee 1 — Thread continuity
+    Run 2 (after restart) receives the full thread from run 1 so the model sees
+    prior turns.
+
+  Guarantee 2 — Memory recall across restart
+    The fake AgentMemory records after run 1; run 2 retrieves the context block
+    keyed by session.id and it is injected into the model's messages.
+
+  Guarantee 3 — Artifact round-trip
+    Bytes stored via session.artifacts.put() before restart are fetched by hash
+    from the same fake client after restart.
+
+This test does NOT duplicate:
+  - test_session.py          (T4-1: Session/SessionStore unit tests)
+  - test_agent_session.py    (T4-2: thread-continues / survives-restart / parity)
+  - test_agent_memory.py     (T4-3: memory round-trip / PII / fail-loud)
+  - test_artifacts.py        (T4-4: ArtifactRef / ArtifactStore / Session.artifacts)
+
+All three harnesses (capturing model, fake memory, fake artifact client) are
+defined inline so this file is self-contained.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import types
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from jamjet import Agent, ArtifactRef, tool
+from jamjet.agents.session import SessionStore
+
+# ---------------------------------------------------------------------------
+# Tool (minimal — just needs a defined @tool for Agent to accept)
+# ---------------------------------------------------------------------------
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the input."""
+    return text
+
+
+# ---------------------------------------------------------------------------
+# _CapturingModel — records every messages list the model receives
+# ---------------------------------------------------------------------------
+
+
+class _CapturingModel:
+    """Scripted LLM stand-in that records calls and returns canned replies."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[dict]] = []
+
+    async def _acompletion(
+        self,
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        self.calls.append(
+            [
+                dict(m)
+                if isinstance(m, dict)
+                else {"role": getattr(m, "role", "?"), "content": getattr(m, "content", "")}
+                for m in messages
+            ]
+        )
+        last_user = ""
+        for m in reversed(messages):
+            role = m.get("role") if isinstance(m, dict) else getattr(m, "role", "")
+            content = m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+            if role == "user":
+                last_user = content or ""
+                break
+
+        if "alice" in last_user.lower() or "my name is" in last_user.lower():
+            reply = "Got it — your name is Alice."
+        elif "what is my name" in last_user.lower():
+            reply = "Your name is Alice."
+        else:
+            reply = f"OK: {last_user}"
+
+        msg = MagicMock()
+        msg.content = reply
+        msg.role = "assistant"
+        msg.tool_calls = []
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=msg)]
+        return resp
+
+
+# ---------------------------------------------------------------------------
+# _FakeMemory — duck-typed AgentMemory that captures record/context calls
+# ---------------------------------------------------------------------------
+
+
+class _FakeMemory:
+    """Stand-in for AgentMemory; no real Engram required.
+
+    Captures (scoped_user_id, text, role) tuples in .records so a test can
+    assert the loop keyed memory by session.id.
+    """
+
+    def __init__(self, context_reply: str = "") -> None:
+        self.records: list[tuple[str | None, str, str | None]] = []
+        self.context_calls: list[tuple[str | None, str]] = []
+        self.context_reply = context_reply
+        self._scoped_user_id: str | None = None
+
+    @contextmanager
+    def as_scope(
+        self,
+        *,
+        user_id: str | None = None,
+        org_id: str | None = None,
+    ) -> Generator[_FakeMemory, None, None]:
+        old = self._scoped_user_id
+        self._scoped_user_id = user_id
+        try:
+            yield self
+        finally:
+            self._scoped_user_id = old
+
+    async def record(
+        self,
+        text: str,
+        *,
+        role: str | None = None,
+        category: str | None = None,
+        confidence: float = 1.0,
+        metadata: dict | None = None,
+    ) -> None:
+        self.records.append((self._scoped_user_id, text, role))
+
+    async def context(
+        self,
+        query: str,
+        *,
+        token_budget: int | None = None,
+        role_filter: tuple[str, ...] | None = None,
+        decompose: bool | None = None,
+    ) -> str:
+        self.context_calls.append((self._scoped_user_id, query))
+        return self.context_reply
+
+
+# ---------------------------------------------------------------------------
+# _FakeArtifactClient — in-memory content-addressed artifact backend
+# ---------------------------------------------------------------------------
+
+
+class _FakeArtifactClient:
+    """In-memory stand-in exposing the JamjetClient artifact surface."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    async def put_artifact(self, data: bytes, media_type: str | None = None) -> ArtifactRef:
+        digest = hashlib.sha256(data).hexdigest()
+        self._store[digest] = data
+        return ArtifactRef(hash=digest, size=len(data), media_type=media_type)
+
+    async def get_artifact(self, hash: str) -> bytes:
+        return self._store[hash]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def capturing_model(monkeypatch: pytest.MonkeyPatch) -> _CapturingModel:
+    """Patch litellm.acompletion with a capturing scripted model."""
+    m = _CapturingModel()
+
+    async def _acompletion(
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        return await m._acompletion(model=model, messages=messages, tools=tools, **kwargs)
+
+    mock_litellm = types.ModuleType("litellm")
+    mock_litellm.acompletion = _acompletion  # type: ignore[attr-defined]
+    mock_litellm.completion_cost = lambda *a, **kw: 0.0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# The consolidated integration test
+# ---------------------------------------------------------------------------
+
+
+async def test_combined_session_memory_artifact(
+    capturing_model: _CapturingModel,
+    tmp_path: Path,
+) -> None:
+    """Three headline guarantees exercised together across a simulated restart.
+
+    Flow
+    ----
+    1. Run 1  — creates session "si-1", runs agent, persists thread + memory.
+    2. Restart — discards first Agent + store instances (simulating a new process).
+    3. Run 2  — fresh Agent + fresh SessionStore; continues the session.
+    4. Assertions — model received (a) prior thread AND (b) memory block; artifact
+                    stored before restart is retrievable by hash after.
+    """
+    db_path = str(tmp_path / "integration.db")
+    fake_mem = _FakeMemory(context_reply="MEMORY-BLOCK: user mentioned their name is Alice")
+    fake_artifacts = _FakeArtifactClient()
+
+    # ---- Run 1 ---------------------------------------------------------- #
+    store1 = SessionStore(db_path)
+    s1 = store1.create("si-1")
+    s1.attach_client(fake_artifacts)  # wire artifact backend before the run
+
+    agent1 = Agent(
+        "si-agent",
+        model="gpt-4o-mini",
+        tools=[echo],
+        strategy="react",
+        memory=fake_mem,
+        session_store=store1,
+    )
+
+    r1 = await agent1.run("my name is Alice", session=s1)
+    assert r1.output, "run 1 must produce output"
+
+    # Memory loop ran: record-at-end was called, keyed by the stable session.id
+    assert fake_mem.records, "run 1 must record the turn to memory"
+    record_keys = [k for k, _, _ in fake_mem.records]
+    assert all(k == "si-1" for k in record_keys), (
+        f"memory records must be keyed by session.id 'si-1', got: {record_keys}"
+    )
+
+    # Store an artifact (the in-process 'si-1' session carries the fake client)
+    ref = await s1.artifacts.put(b"run-1-summary", "text/plain")
+    assert ref.hash, "artifact put must return a non-empty hash"
+    assert ref.size == len(b"run-1-summary")
+
+    # ---- Restart -------------------------------------------------------- #
+    # Discard the first Agent + SessionStore — simulates a new process startup.
+    del agent1, store1
+    capturing_model.calls.clear()  # reset call log; only run-2 calls matter
+
+    store2 = SessionStore(db_path)  # same db path -> same sessions
+    s2 = store2.load("si-1")
+    assert s2 is not None, "session 'si-1' must survive the simulated restart"
+    s2.attach_client(fake_artifacts)  # rewire to the same in-memory artifact backend
+
+    agent2 = Agent(
+        "si-agent",
+        model="gpt-4o-mini",
+        tools=[echo],
+        strategy="react",
+        memory=fake_mem,
+        session_store=store2,
+    )
+
+    # ---- Run 2 ---------------------------------------------------------- #
+    r2 = await agent2.run("what is my name?", session=s2)
+    assert r2.output, "run 2 must produce output"
+
+    # ---- Guarantee 1: thread continuity --------------------------------- #
+    assert capturing_model.calls, "run 2 must hit the model"
+    run2_msgs = capturing_model.calls[0]
+    run2_content = " ".join(m.get("content", "") or "" for m in run2_msgs)
+    run2_roles = [m.get("role", "") for m in run2_msgs]
+
+    assert "alice" in run2_content.lower() or "my name is" in run2_content.lower(), (
+        f"Thread continuity FAILED: run 2 did not receive run 1 turns.\nmessages={run2_msgs}"
+    )
+    assert "assistant" in run2_roles, (
+        f"Thread continuity FAILED: no prior assistant turn in run 2 messages.\nmessages={run2_msgs}"
+    )
+
+    # ---- Guarantee 2: memory recall across restart ---------------------- #
+    assert "MEMORY-BLOCK" in run2_content, (
+        f"Memory recall FAILED: retrieved context block not injected into run 2.\nmessages={run2_msgs}"
+    )
+    assert any(k == "si-1" and "what is my name" in q for k, q in fake_mem.context_calls), (
+        f"Memory recall FAILED: context() was not called with session key 'si-1'.\n"
+        f"context_calls={fake_mem.context_calls}"
+    )
+
+    # ---- Guarantee 3: artifact round-trip ------------------------------- #
+    fetched = await s2.artifacts.get(ref.hash)
+    assert fetched == b"run-1-summary", f"Artifact round-trip FAILED: expected b'run-1-summary', got {fetched!r}"

--- a/sdk/python/tests/test_strategy_session_continuity.py
+++ b/sdk/python/tests/test_strategy_session_continuity.py
@@ -178,3 +178,111 @@ def test_non_react_strategies_continue_thread(
     store = SessionStore(db_path)
     calls = _run_two_turns(capturing_model, store, strategy=strategy)
     _assert_secret_in_some_call(calls, strategy=strategy)
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — seed_history must preserve the injected MEMORY block when the
+# instruction slot is absent (empty instructions).  seed_messages_for_run emits
+# the instruction system slot ONLY for non-empty instructions; for a
+# memory-enabled run with EMPTY instructions the FIRST system message is the
+# retrieved-memory block.  The pre-fix seed_history blindly REPLACED the leading
+# system message with the strategy persona, dropping recall for every non-react
+# strategy.  These pin the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_seed_history_preserves_memory_block_when_it_leads() -> None:
+    """seed_history: a leading MEMORY block (empty instructions) is NOT clobbered.
+
+    Pre-fix, prefix[0] (the memory block, role=system) was replaced with the
+    persona and recall was lost.  Post-fix the persona is PREPENDED and the memory
+    block survives.
+    """
+    from jamjet.runtime.local.strategies.base import MEMORY_BLOCK_PREFIX, seed_history
+
+    memory_block = {"role": "system", "content": f"{MEMORY_BLOCK_PREFIX}\nThe codeword is {SECRET}."}
+    initial_messages = [
+        memory_block,
+        {"role": "user", "content": "earlier turn"},
+        {"role": "assistant", "content": "earlier reply"},
+        {"role": "user", "content": "new prompt"},  # trailing, dropped by seed_history
+    ]
+    out = seed_history(initial_messages, "You are the proposer.")
+
+    # The persona is present as the FIRST system message ...
+    assert out[0] == {"role": "system", "content": "You are the proposer."}
+    # ... and the memory block is preserved (not clobbered).
+    assert any(m.get("role") == "system" and str(m.get("content", "")).startswith(MEMORY_BLOCK_PREFIX) for m in out), (
+        f"memory block dropped by seed_history: {out}"
+    )
+    assert SECRET in " ".join(m.get("content", "") for m in out)
+
+
+def test_seed_history_swaps_instruction_slot_keeps_memory() -> None:
+    """seed_history: with an instruction slot present it is swapped (not duplicated)
+    for the persona, and the memory block right after it is kept."""
+    from jamjet.runtime.local.strategies.base import MEMORY_BLOCK_PREFIX, seed_history
+
+    initial_messages = [
+        {"role": "system", "content": "Original agent instructions."},
+        {"role": "system", "content": f"{MEMORY_BLOCK_PREFIX}\nremember {SECRET}"},
+        {"role": "user", "content": "earlier"},
+        {"role": "user", "content": "new prompt"},  # trailing, dropped
+    ]
+    out = seed_history(initial_messages, "You are agent 1 of 3. Think independently.")
+
+    systems = [m for m in out if m.get("role") == "system"]
+    # Exactly the persona + the memory block (instruction slot swapped, not duplicated).
+    assert systems[0]["content"] == "You are agent 1 of 3. Think independently."
+    assert "Original agent instructions." not in " ".join(m.get("content", "") for m in out)
+    assert any(str(m["content"]).startswith(MEMORY_BLOCK_PREFIX) for m in systems), out
+
+
+def test_non_react_strategy_carries_memory_block_with_empty_instructions() -> None:
+    """End-to-end through a non-react strategy: a memory-first seed (empty
+    instructions) carries the memory block INTO the model call.
+
+    Drives the real ``plan_and_execute`` generative phase with a memory-first
+    seed and a capturing adapter; asserts the retrieved-memory block reached the
+    model.  Fails pre-fix (seed_history dropped the leading memory block).
+    """
+    from jamjet.runtime.local.strategies import plan_and_execute
+    from jamjet.runtime.local.strategies.base import MEMORY_BLOCK_PREFIX
+
+    captured: list[list[dict]] = []
+
+    class _FakeAdapter:
+        async def generate(self, messages: list[dict[str, Any]], *, tools: Any = None) -> Any:
+            captured.append([dict(m) if isinstance(m, dict) else m for m in messages])
+            msg = MagicMock()
+            msg.content = _GENERIC_REPLY
+            msg.role = "assistant"
+            msg.tool_calls = []
+            return msg
+
+    # Build a valid spec with EMPTY instructions via the real compile path.
+    spec = Agent("m", model="gpt-4o-mini", tools=[echo], instructions="", strategy="plan-and-execute").compile()
+
+    memory_block = {"role": "system", "content": f"{MEMORY_BLOCK_PREFIX}\nThe codeword is {SECRET}."}
+    initial_messages = [
+        memory_block,  # leads (no instruction slot — empty instructions)
+        {"role": "user", "content": "earlier turn"},
+        {"role": "assistant", "content": "earlier reply"},
+        {"role": "user", "content": "what is my codeword?"},
+    ]
+
+    asyncio.run(
+        plan_and_execute.run(
+            adapter=_FakeAdapter(),
+            spec=spec,
+            prompt="what is my codeword?",
+            tools=[],
+            tool_calls_log=[],
+            initial_messages=initial_messages,
+        )
+    )
+
+    assert captured, "the strategy must have hit the model"
+    joined = "\n".join(" ".join((m.get("content") or "") for m in call if isinstance(m, dict)) for call in captured)
+    assert MEMORY_BLOCK_PREFIX in joined, f"memory block never reached the model: {captured}"
+    assert SECRET in joined, f"recalled secret dropped before the model call: {captured}"

--- a/sdk/python/tests/test_strategy_session_continuity.py
+++ b/sdk/python/tests/test_strategy_session_continuity.py
@@ -1,0 +1,180 @@
+"""C1 regression: EVERY strategy seeds a session run from the carried thread.
+
+The whole-branch review found that ``Agent.run(prompt, session=s)`` only threaded
+the prior conversation into the ``react`` strategy.  The DEFAULT strategy is
+``plan-and-execute``, and it (plus ``critic`` / ``debate`` / ``consensus`` /
+``reflection``) accepted ``initial_messages`` and IGNORED it — so a default-agent
+session run was AMNESIAC: the model never saw turn N-1 (or the retrieved memory
+block) even though persistence kept running, making storage look continuous while
+inference was not.
+
+These tests assert the model INPUT on the SECOND turn carries the first turn's
+content for the default strategy and every non-react strategy.  They FAIL before
+the fix (the strategies build messages from ``prompt`` + ``instructions`` only)
+and PASS after (each generative phase seeds from the carried thread).
+
+Design notes
+------------
+- The secret marker (``SECRET``) appears ONLY in the user's first prompt.  The
+  scripted model NEVER echoes it (replies are constant), so the marker can reach
+  a second-turn model call ONLY via the seeded conversation history — not via a
+  canned reply leaking back in.  This is what makes the test fail pre-fix.
+- The model returns a terminating verdict for the two meta personas (critic
+  "strict critic" -> ``PASS``; reflection "self-evaluator" -> ``SATISFIED``) so
+  those review loops stop after one round; every other phase gets a generic
+  reply with no tool calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from jamjet import Agent, tool
+from jamjet.agents.session import SessionStore
+
+SECRET = "Zorblax"
+_GENERIC_REPLY = "Understood; proceeding."
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the input."""
+    return text
+
+
+class _CapturingModel:
+    """Records every messages list the model sees; never echoes the secret.
+
+    Returns a terminating verdict for the two review personas so critic /
+    reflection loops stop after one round; otherwise a constant generic reply
+    with no tool calls.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[dict]] = []
+
+    async def acompletion(
+        self,
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        self.calls.append(
+            [
+                dict(m)
+                if isinstance(m, dict)
+                else {"role": getattr(m, "role", "?"), "content": getattr(m, "content", "")}
+                for m in messages
+            ]
+        )
+
+        systems = " ".join(
+            (m.get("content") if isinstance(m, dict) else getattr(m, "content", "")) or ""
+            for m in messages
+            if (m.get("role") if isinstance(m, dict) else getattr(m, "role", "")) == "system"
+        ).lower()
+        if "strict critic" in systems:
+            reply = "PASS"
+        elif "self-evaluator" in systems:
+            reply = "SATISFIED"
+        else:
+            reply = _GENERIC_REPLY
+
+        msg = MagicMock()
+        msg.content = reply
+        msg.role = "assistant"
+        msg.tool_calls = []
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=msg)]
+        return resp
+
+
+@pytest.fixture()
+def capturing_model(monkeypatch: pytest.MonkeyPatch) -> _CapturingModel:
+    _model = _CapturingModel()
+
+    async def _acompletion(
+        model: str,
+        messages: list,
+        tools: list | None = None,
+        **kwargs: object,
+    ) -> Any:
+        return await _model.acompletion(model=model, messages=messages, tools=tools, **kwargs)
+
+    mock_litellm = types.ModuleType("litellm")
+    mock_litellm.acompletion = _acompletion  # type: ignore[attr-defined]
+    mock_litellm.completion_cost = lambda *a, **kw: 0.0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", mock_litellm)
+    return _model
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "sessions_c1.db")
+
+
+def _run_two_turns(model: _CapturingModel, store: SessionStore, *, strategy: str | None) -> list[list[dict]]:
+    """Run two turns on one session; return ONLY the second turn's model calls."""
+    s = store.create("c1")
+    kwargs: dict[str, Any] = {"session_store": store}
+    if strategy is not None:
+        kwargs["strategy"] = strategy
+    agent = Agent("c1-agent", model="gpt-4o-mini", tools=[echo], **kwargs)
+
+    asyncio.run(agent.run(f"my codeword is {SECRET}", session=s))
+    model.calls.clear()  # only the SECOND turn's inputs matter
+    asyncio.run(agent.run("what is my codeword?", session=s))
+    return model.calls
+
+
+def _assert_secret_in_some_call(calls: list[list[dict]], *, strategy: str) -> None:
+    assert calls, f"[{strategy}] second turn must hit the model"
+    joined = "\n".join(" ".join((m.get("content") or "") for m in call if isinstance(m, dict)) for call in calls)
+    assert SECRET.lower() in joined.lower(), (
+        f"[{strategy}] AMNESIAC: the prior turn's secret {SECRET!r} never reached the "
+        f"model on the second turn — the session thread was dropped.\ncalls={calls}"
+    )
+
+
+def test_default_strategy_is_plan_and_execute() -> None:
+    """The default Agent strategy is plan-and-execute (the one C1 was about)."""
+    agent = Agent("d", model="gpt-4o-mini", tools=[echo])
+    assert agent.strategy == "plan-and-execute"
+
+
+def test_default_strategy_session_continues_thread(
+    capturing_model: _CapturingModel,
+    db_path: str,
+) -> None:
+    """DEFAULT-strategy (plan-and-execute) agent continues a session thread.
+
+    Constructs ``Agent(...)`` with NO ``strategy=`` so the default plan-and-execute
+    runner is exercised.  The second run's model input MUST contain the first
+    turn's secret.  Fails before the C1 fix; passes after.
+    """
+    store = SessionStore(db_path)
+    calls = _run_two_turns(capturing_model, store, strategy=None)
+    _assert_secret_in_some_call(calls, strategy="plan-and-execute (default)")
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    ["plan-and-execute", "critic", "debate", "consensus", "reflection"],
+)
+def test_non_react_strategies_continue_thread(
+    capturing_model: _CapturingModel,
+    db_path: str,
+    strategy: str,
+) -> None:
+    """Every non-react strategy seeds the session thread into its generative phase."""
+    store = SessionStore(db_path)
+    calls = _run_two_turns(capturing_model, store, strategy=strategy)
+    _assert_secret_in_some_call(calls, strategy=strategy)


### PR DESCRIPTION
## What

Track 4 of the 9-track ADK plan (M2). The friendly `Agent` gets first-class sessions, opt-in memory, and a developer artifact API.

- **Sessions**: `Session` + a persistent `SessionStore`. `agent.run(prompt, session=s)` (and `run_durable`) continue the conversation thread across separate runs and survive a restart. The user `session.id` is stable and distinct from the engine execution lineage.
- **Memory**: a `memory=` knob wires the Engram bridge into the friendly `Agent` with an automatic, governed loop — retrieve relevant context at the start of a run (keyed by `session.id`), record the turn after, with PII redacted before every memory write. Fail-loud if the `jamjet[memory]` extra is missing or memory is used without a session.
- **Artifacts**: `POST /artifacts` and `GET /artifacts/:hash` over the tenant-scoped backend, plus `JamjetClient.put_artifact`/`get_artifact` and `session.artifacts`.

## Safety

A whole-branch adversarial review caught and forced a fix for a Critical the tests had masked: session and memory history was silently dropped for every in-process strategy except `react`, and the `Agent` default is `plan-and-execute` — so a default-agent session run looked continuous in storage but was amnesiac at inference. Every strategy runner now seeds its generative phases from the prior thread, and a new test proves it on the default strategy and all the others (a secret placed only in turn 1 reaches turn 2 solely via seeded history, asserted against the model's input). Also fixed: a concurrent memory-scope bleed (the scope is now a per-run clone), the artifact body limit, and the no-client / fail-loud-order guards. The review confirmed no PII leaks into memory, no cross-tenant artifact reads, and no regression of the Track-3 governance.

## Tests

1180 Python passed and the Rust workspace green, including session-survives-restart, the per-strategy continuity test, the memory round-trip with PII redaction, artifact tenant isolation, and a consolidated integration test exercising all three together across a restart.

## Follow-ups

F-t4-segment-session (an engine-owned session as a 2g segment chain), F-t4-thread-window (token cost of re-sending history per generative phase), F-t4-memory-synthesis, F-t4-aclose, F-2i-media-type (media type on artifact GET).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session continuity support so conversations can be resumed across runs.
  * Added optional memory recall and artifact storage/retrieval for agents and sessions.
  * Exposed new session and artifact utilities in the Python SDK.

* **Documentation**
  * Added a new session-memory demo guide and expanded example documentation.

* **Bug Fixes**
  * Improved consistency of multi-turn behavior across supported agent strategies.
  * Enforced artifact size limits and clearer missing-artifact responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->