### PR TITLE
feat(track-5): devtools + trajectory eval (jamjet create/dev + TrajectoryScorer)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to the JamJet documentation. Use the table below to find what you need.
 | Guide | Description |
 |-------|-------------|
 | [Quickstart](guides/quickstart.md) | Running your first workflow in under 10 minutes |
+| [Five-Minute Dev Loop](guides/dev-loop.md) | `jamjet create` + `jamjet dev` + trajectory eval from scratch |
 | [Core Concepts](guides/concepts.md) | Agents, workflows, nodes, state, durability explained |
 | [Workflow Authoring](guides/workflow-authoring.md) | YAML and Python authoring — everything you need to know |
 | [Python SDK](guides/python-sdk.md) | Full Python SDK reference with examples |

--- a/docs/guides/dev-loop.md
+++ b/docs/guides/dev-loop.md
@@ -1,0 +1,154 @@
+# Five-Minute Dev Loop
+
+Get a new agent running locally and scoring its tool trajectory in about five minutes.
+
+---
+
+## Prerequisites
+
+- Python 3.11+
+- `pip install 'jamjet[sidecar]'` -- the sidecar extra brings in uvicorn, which `jamjet dev` needs by default
+- A model provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or similar) for live model calls
+- The `jamjet-server` binary -- `jamjet dev` downloads it on first run
+
+---
+
+## 1. Scaffold a project
+
+```bash
+jamjet create myagent
+cd myagent
+```
+
+Creates `myagent/` with a minimal, runnable agent:
+
+```
+myagent/
+  agent.py       # Agent + one @tool function; calls agent.run("Hello")
+  pyproject.toml # declares jamjet as a dependency
+  README.md
+```
+
+To use a different template or list all available templates:
+
+```bash
+jamjet create myagent --template quickstart   # explicit (same as default)
+jamjet init --list-templates                  # list every template
+```
+
+---
+
+## 2. Start the local dev stack
+
+```bash
+jamjet dev
+```
+
+This brings up three processes in order:
+
+1. **Model sidecar** (`http://127.0.0.1:4280`) -- the governed model seam that
+   fronts the AI provider. Health-gated: the engine does not start until the
+   sidecar's `/health` endpoint returns `{"ok": true}`.
+2. **Engine** (`http://localhost:7700`) -- the durable, event-sourced runtime,
+   started with `JAMJET_MODEL_SEAM_URL` wired to the sidecar so every model call
+   flows through the governed seam.
+3. **Worker** -- drains the `python_tool` queue so your `@tool` functions execute.
+
+Press **Ctrl+C** to stop the entire stack (graceful group teardown, no orphaned
+processes).
+
+### Dev stack flags
+
+| Flag | Effect |
+|------|--------|
+| `--modules myagent.agent` | Worker pre-imports this module so `@tool` decorators register before polling |
+| `--sidecar-port 4281` | Use a different sidecar port |
+| `--no-sidecar` | Engine + worker only; providers are called directly (no governed seam) |
+| `--no-worker` | Sidecar + engine only; `@tool` functions will not execute |
+| `--engine-only` | Just the engine, legacy mode (no sidecar, no worker) |
+| `--port 7701` | Engine port (default 7700) |
+
+Example -- pre-import your tools so `@tool` functions register before the worker polls:
+
+```bash
+jamjet dev --modules myagent.agent
+```
+
+---
+
+## 3. Run the agent
+
+Open a second terminal (the dev stack occupies the first):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+python agent.py
+```
+
+The scaffolded `agent.py` runs in-process via `agent.run(...)`. To run on the
+durable engine (event log, replay, approvals, trajectory scoring), switch to
+`agent.run_durable(...)` -- see [`react-agent-durable/`](../../examples/react-agent-durable/)
+for the full durable pattern.
+
+---
+
+## 4. Inspect what happened
+
+```bash
+# List recent executions
+jamjet inspect <execution-id>
+
+# See the full event timeline (tool calls, node transitions)
+jamjet events <execution-id>
+```
+
+---
+
+## 5. Score the agent's trajectory
+
+Create a small evalset (JSONL) that asserts which tools the agent should call:
+
+```jsonl
+{"id": "smoke", "input": {"query": "Hello"}, "expected_trajectory": {"used_tool": "greet", "max_turns": 3}}
+```
+
+Run it:
+
+```bash
+jamjet eval run evalset.jsonl --workflow myagent
+```
+
+The runner scores each row's output AND its tool trajectory. A row passes only
+when both the output scorer and all trajectory assertions pass.
+
+For a full worked example with multiple assertion types, see
+[`examples/trajectory-eval/`](../../examples/trajectory-eval/).
+
+### Trajectory-diff (replay-regression gate)
+
+After a model or prompt change, diff the tool sequences between two runs to
+catch unexpected behavior:
+
+```bash
+# Compare two event-log files
+jamjet eval trajectory-diff before.json after.json
+
+# CI: exit 1 if the trajectory changed
+jamjet eval trajectory-diff v1.json v2.json --fail-on-change
+
+# Report only, no exit code change
+jamjet eval trajectory-diff a.json b.json --no-fail-on-change
+
+# Output as JSON
+jamjet eval trajectory-diff a.json b.json --format json
+```
+
+---
+
+## Next steps
+
+- [Python SDK guide](python-sdk.md) -- `Agent`, `@tool`, `run_durable`, sessions
+- [eval harness example](../../examples/eval-harness/) -- output-only eval with LLM judge + assertions
+- [trajectory-eval example](../../examples/trajectory-eval/) -- evalset with `expected_trajectory`
+- [react-agent-durable](../../examples/react-agent-durable/) -- durable engine, event log, replay
+- [Human-in-the-loop](hitl.md) -- gating agent actions on human approval

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,15 @@ Numbered examples in this directory:
 Each example is self-contained. The fifth example includes its own virtual
 environment setup script and runs without a model API key.
 
+## Five-minute dev loop and eval
+
+- `trajectory-eval/` - A trajectory evalset (`evalset.jsonl`) with `expected_trajectory`
+  assertions on tool sequences. Shows `jamjet eval run evalset.jsonl --workflow <name>` for
+  batch trajectory scoring and `jamjet eval trajectory-diff` for replay-regression detection.
+  See [`trajectory-eval/README.md`](./trajectory-eval/README.md) and
+  [`docs/guides/dev-loop.md`](../docs/guides/dev-loop.md) for the full five-minute loop
+  starting from `jamjet create myagent`.
+
 ## Sessions, memory, artifacts
 
 - `session-memory/` - An agent with a persistent `Session` running across two turns. The second turn receives the full prior thread (session continuity), a retrieved memory block (Engram recall), and fetches an artifact stored before a simulated restart. Demo mode requires no API key. See `session-memory/README.md`.

--- a/examples/trajectory-eval/README.md
+++ b/examples/trajectory-eval/README.md
@@ -16,8 +16,8 @@ result, always. No model calls are made unless you opt in with `judge=True`.
 
 ## Dataset (`evalset.jsonl`)
 
-```
-search-then-calc   expects ["web_search", "calculator"] in order, max 4 steps
+```text
+search-then-calc   expects ["web_search", "calculator"] in order, max 4 model turns
 search-only        expects web_search was used; calculator was NOT used
 no-trajectory      no expected_trajectory -- output scoring only (backward compatible)
 ```
@@ -90,7 +90,7 @@ EvalRunner.print_summary(results)
 | `expected_tools` | `list[str]` | All these tools appear (subset; add `"expected_tools_exact": true` to forbid extras) |
 | `used_tool` | `str` or `list[str]` | Each named tool appears at least once |
 | `did_not_use` | `str` or `list[str]` | None of these tools appear |
-| `max_turns` | `int` | Total step count is at most this value |
+| `max_turns` | `int` | Model turn count is at most this value (a turn may emit several parallel tool calls) |
 | `step_count` | `int` | Total step count equals this value exactly |
 
 All keys are optional. Only the keys that are present in `expected_trajectory` are checked.

--- a/examples/trajectory-eval/README.md
+++ b/examples/trajectory-eval/README.md
@@ -1,0 +1,96 @@
+# trajectory-eval
+
+A runnable evalset that shows how to add `expected_trajectory` assertions to
+`jamjet eval run` cases, and how to use `jamjet eval trajectory-diff` as a
+replay-regression gate.
+
+## What trajectory eval does
+
+When an `EvalRow` carries an `expected_trajectory` key, the runner scores the
+run's tool sequence (the ordered list of tools the agent called) in addition to
+the final output. A row passes only when both the output scorer and every
+trajectory assertion pass.
+
+Trajectory assertions are **deterministic** -- same event log, same spec, same
+result, always. No model calls are made unless you opt in with `judge=True`.
+
+## Dataset (`evalset.jsonl`)
+
+```
+search-then-calc   expects ["web_search", "calculator"] in order, max 4 steps
+search-only        expects web_search was used; calculator was NOT used
+no-trajectory      no expected_trajectory -- output scoring only (backward compatible)
+```
+
+## Run the eval
+
+```bash
+# Score outputs with an assertion + check trajectories
+jamjet eval run evalset.jsonl \
+  --workflow my-research-agent \
+  --assert "'answer' in output" \
+  --output results.json
+
+# CI: fail if pass rate drops below 80%
+jamjet eval run evalset.jsonl \
+  --workflow my-research-agent \
+  --fail-below 80 \
+  --output results.json
+```
+
+The summary table includes a `Trajectory` column showing pass/fail for each
+trajectory assertion alongside the output scorer.
+
+## Replay-regression diff
+
+After a model or prompt change, diff two runs' tool sequences to catch unexpected
+behavioral shifts:
+
+```bash
+# Compare two event-log files (before and after a model change)
+jamjet eval trajectory-diff before_events.json after_events.json
+
+# Compare results files from two eval runs, scoped to one row
+jamjet eval trajectory-diff v1_results.json v2_results.json --row-id search-then-calc
+
+# CI gate: exit 1 if the trajectory changed
+jamjet eval trajectory-diff v1.json v2.json --fail-on-change
+
+# Just report, do not fail
+jamjet eval trajectory-diff a.json b.json --no-fail-on-change
+
+# Machine-readable output
+jamjet eval trajectory-diff a.json b.json --format json
+```
+
+## Python API
+
+```python
+import asyncio
+from pathlib import Path
+from jamjet.eval.dataset import EvalDataset
+from jamjet.eval.runner import EvalRunner
+from jamjet.eval.scorers import AssertionScorer
+
+ds = EvalDataset.from_file(Path(__file__).parent / "evalset.jsonl")
+
+runner = EvalRunner(
+    workflow_id="my-research-agent",
+    scorers=[AssertionScorer(checks=["'answer' in output"])],
+)
+results = asyncio.run(runner.run(ds))
+EvalRunner.print_summary(results)
+```
+
+## expected_trajectory spec keys
+
+| Key | Type | Assertion |
+|-----|------|-----------|
+| `tool_sequence` | `list[str]` | Tools appear in this order (ordered subsequence; extras allowed in between) |
+| `expected_tools` | `list[str]` | All these tools appear (subset; add `"expected_tools_exact": true` to forbid extras) |
+| `used_tool` | `str` or `list[str]` | Each named tool appears at least once |
+| `did_not_use` | `str` or `list[str]` | None of these tools appear |
+| `max_turns` | `int` | Total step count is at most this value |
+| `step_count` | `int` | Total step count equals this value exactly |
+
+All keys are optional. Only the keys that are present in `expected_trajectory` are checked.

--- a/examples/trajectory-eval/evalset.jsonl
+++ b/examples/trajectory-eval/evalset.jsonl
@@ -1,0 +1,14 @@
+# Trajectory evalset for jamjet eval run
+# Each row carries an optional expected_trajectory spec that the TrajectoryScorer checks
+# in addition to the final output.
+#
+# Spec keys (all optional; only present keys are checked):
+#   tool_sequence:  list[str] -- tools must appear in this order (ordered subsequence)
+#   expected_tools: list[str] -- all these tools must appear (subset check)
+#   used_tool:      str | list[str] -- each named tool must appear
+#   did_not_use:    str | list[str] -- each named tool must NOT appear
+#   max_turns:      int -- step count must be <= this value
+#   step_count:     int -- step count must equal this value exactly
+{"id": "search-then-calc", "input": {"query": "What is the population of France divided by 2?"}, "expected": "approximately 33 million", "expected_trajectory": {"tool_sequence": ["web_search", "calculator"], "max_turns": 4}, "metadata": {"category": "math+research"}}
+{"id": "search-only", "input": {"query": "Who is the current CEO of Anthropic?"}, "expected": "Dario Amodei", "expected_trajectory": {"used_tool": "web_search", "did_not_use": "calculator"}, "metadata": {"category": "lookup"}}
+{"id": "no-trajectory", "input": {"query": "Say hello"}, "expected": "hello", "metadata": {"category": "trivial"}}

--- a/examples/trajectory-eval/evalset.jsonl
+++ b/examples/trajectory-eval/evalset.jsonl
@@ -9,6 +9,6 @@
 #   did_not_use:    str | list[str] -- each named tool must NOT appear
 #   max_turns:      int -- step count must be <= this value
 #   step_count:     int -- step count must equal this value exactly
-{"id": "search-then-calc", "input": {"query": "What is the population of France divided by 2?"}, "expected": "approximately 33 million", "expected_trajectory": {"tool_sequence": ["web_search", "calculator"], "max_turns": 4}, "metadata": {"category": "math+research"}}
-{"id": "search-only", "input": {"query": "Who is the current CEO of Anthropic?"}, "expected": "Dario Amodei", "expected_trajectory": {"used_tool": "web_search", "did_not_use": "calculator"}, "metadata": {"category": "lookup"}}
+{"id": "search-then-calc", "input": {"query": "Look up the speed of light in km/s, then divide it by 2."}, "expected": "approximately 149896 km/s", "expected_trajectory": {"tool_sequence": ["web_search", "calculator"], "max_turns": 4}, "metadata": {"category": "math+research"}}
+{"id": "search-only", "input": {"query": "In what year did the Apollo 11 mission first land humans on the Moon?"}, "expected": "1969", "expected_trajectory": {"used_tool": "web_search", "did_not_use": "calculator"}, "metadata": {"category": "lookup"}}
 {"id": "no-trajectory", "input": {"query": "Say hello"}, "expected": "hello", "metadata": {"category": "trivial"}}

--- a/sdk/python/jamjet/__main__.py
+++ b/sdk/python/jamjet/__main__.py
@@ -1,0 +1,13 @@
+"""Enable `python -m jamjet ...` as an alias for the `jamjet` console script.
+
+This makes `jamjet dev` able to spawn the worker as a subprocess using the same
+interpreter/venv (`python -m jamjet worker ...`) without relying on the console
+script being on PATH.
+"""
+
+from __future__ import annotations
+
+from jamjet.cli.main import app
+
+if __name__ == "__main__":
+    app()

--- a/sdk/python/jamjet/cli/dev_stack.py
+++ b/sdk/python/jamjet/cli/dev_stack.py
@@ -1,0 +1,387 @@
+"""Local-stack orchestration for `jamjet dev`.
+
+`jamjet dev` brings up the whole durable dev loop with one command:
+
+  1. the model **sidecar** (`uvicorn jamjet.model.sidecar_server:app`) FIRST,
+     health-gated on `GET /health` — the engine fails closed at startup if
+     ``JAMJET_MODEL_SEAM_URL`` is set but the sidecar is unreachable, so the
+     sidecar must be up and healthy BEFORE the engine starts;
+  2. the **engine** (`jamjet-server`) with ``JAMJET_MODEL_SEAM_URL`` wired to the
+     sidecar so durable model calls route through the governed seam;
+  3. a **worker** (`jamjet worker`) draining the ``python_tool`` queue.
+
+On Ctrl+C (or SIGTERM) every child is torn down as a group — SIGTERM, then
+SIGKILL after a grace period — leaving no orphans.
+
+The orchestration LOGIC (start order, env wiring, the health-gate, teardown) is
+factored into :class:`DevStack`, which takes an injectable process *spawner* and
+a *health probe* so it can be unit-tested without starting real processes.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class DevStackError(RuntimeError):
+    """A managed process failed to start (names the failing process)."""
+
+
+@dataclass
+class ProcessSpec:
+    """How to launch one managed process, plus how to know it is ready."""
+
+    name: str
+    argv: list[str]
+    env: dict[str, str]
+    health_url: str | None = None
+
+
+class ManagedProcess(Protocol):
+    """The subset of a spawned process the orchestrator relies on."""
+
+    name: str
+
+    def poll(self) -> int | None: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+
+Spawner = Callable[[ProcessSpec], ManagedProcess]
+HealthProbe = Callable[[str], bool]
+Logger = Callable[..., None]
+
+
+# ── Real process + spawner ────────────────────────────────────────────────────
+
+
+class _GroupProcess:
+    """Wrap ``subprocess.Popen`` so terminate/kill hit the whole process group.
+
+    Each child is started in its own session (``start_new_session=True``) so a
+    single ``killpg`` reaps the child *and* anything it forked (uvicorn workers,
+    cargo, etc.). Falls back to per-process signalling where process groups are
+    unavailable (e.g. Windows).
+    """
+
+    def __init__(self, popen: subprocess.Popen, name: str) -> None:
+        self._p = popen
+        self.name = name
+        self.stdout = popen.stdout  # piped; read by the log-prefixing thread
+
+    @property
+    def pid(self) -> int:
+        return self._p.pid
+
+    def poll(self) -> int | None:
+        return self._p.poll()
+
+    def _signal_group(self, sig: int) -> None:
+        killpg = getattr(os, "killpg", None)
+        getpgid = getattr(os, "getpgid", None)
+        if killpg is not None and getpgid is not None:
+            try:
+                killpg(getpgid(self._p.pid), sig)
+                return
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        try:
+            self._p.send_signal(sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+    def terminate(self) -> None:
+        self._signal_group(signal.SIGTERM)
+
+    def kill(self) -> None:
+        self._signal_group(getattr(signal, "SIGKILL", signal.SIGTERM))
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._p.wait(timeout=timeout)
+
+
+def real_spawn(spec: ProcessSpec) -> ManagedProcess:
+    """Spawn a process in its own session, piping stdout/stderr for log-prefixing."""
+    popen = subprocess.Popen(  # noqa: S603 - argv is built from trusted internal values
+        spec.argv,
+        env=spec.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        bufsize=1,
+        text=True,
+    )
+    return _GroupProcess(popen, spec.name)
+
+
+def http_health_probe(url: str) -> bool:
+    """Return True iff ``GET url`` answers 200 (a healthy ``/health`` endpoint)."""
+    try:
+        with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310 - fixed localhost URL
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+# ── Log prefixing ─────────────────────────────────────────────────────────────
+
+_ANSI = {
+    "sidecar": "\033[36m",  # cyan
+    "engine": "\033[32m",  # green
+    "worker": "\033[35m",  # magenta
+}
+_ANSI_RESET = "\033[0m"
+
+
+def _prefix(name: str) -> str:
+    if sys.stdout.isatty() and name in _ANSI:
+        return f"{_ANSI[name]}[{name}]{_ANSI_RESET} "
+    return f"[{name}] "
+
+
+# ── The orchestrator ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class DevStack:
+    """Start order + env wiring + health-gate + graceful teardown for `jamjet dev`.
+
+    The spawner and health probe are injectable so the sequencing can be tested
+    without real processes (see ``tests/test_cli_dev.py``).
+    """
+
+    binary: str
+    base_env: Mapping[str, str]
+    port: int = 7700
+    sidecar_port: int = 4280
+    db_url: str | None = None
+    modules: str | None = None
+    runtime_url: str | None = None
+    enable_sidecar: bool = True
+    enable_worker: bool = True
+    # Injectables (defaulted to the real implementations).
+    spawn: Spawner = real_spawn
+    health_probe: HealthProbe = http_health_probe
+    sleep: Callable[[float], None] = time.sleep
+    monotonic: Callable[[], float] = time.monotonic
+    log: Logger = print
+    # Tunables.
+    health_timeout: float = 30.0
+    poll_interval: float = 0.25
+    readiness_wait: float = 0.5
+    shutdown_grace: float = 5.0
+    rust_log: str = "info"
+    # Internal state.
+    _started: list[tuple[ManagedProcess, ProcessSpec]] = field(default_factory=list, init=False)
+    _log_threads: list[threading.Thread] = field(default_factory=list, init=False)
+    _shut_down: bool = field(default=False, init=False)
+
+    # -- spec building (pure; observable through the injected spawner) ----------
+
+    def _seam_url(self) -> str:
+        return f"http://127.0.0.1:{self.sidecar_port}"
+
+    def _runtime_url(self) -> str:
+        return self.runtime_url or f"http://127.0.0.1:{self.port}"
+
+    def build_specs(self) -> list[ProcessSpec]:
+        """Build the ordered process specs with all env wiring resolved."""
+        specs: list[ProcessSpec] = []
+
+        if self.enable_sidecar:
+            specs.append(
+                ProcessSpec(
+                    name="sidecar",
+                    argv=[
+                        sys.executable,
+                        "-m",
+                        "uvicorn",
+                        "jamjet.model.sidecar_server:app",
+                        "--host",
+                        "127.0.0.1",
+                        "--port",
+                        str(self.sidecar_port),
+                    ],
+                    env=dict(self.base_env),
+                    health_url=f"{self._seam_url()}/health",
+                )
+            )
+
+        engine_env = dict(self.base_env)
+        engine_env["PORT"] = str(self.port)
+        engine_env["JAMJET_PORT"] = str(self.port)
+        engine_env["JAMJET_DEV_MODE"] = "1"
+        engine_env.setdefault("RUST_LOG", self.rust_log)
+        if self.db_url:
+            engine_env["DATABASE_URL"] = self.db_url
+        if self.enable_sidecar:
+            # Route durable model calls through the governed seam.
+            engine_env["JAMJET_MODEL_SEAM_URL"] = self._seam_url()
+        else:
+            # Never let a stale exported seam URL make the engine fail closed
+            # when we are NOT managing a sidecar.
+            engine_env.pop("JAMJET_MODEL_SEAM_URL", None)
+        specs.append(
+            ProcessSpec(
+                name="engine",
+                argv=[self.binary],
+                env=engine_env,
+                health_url=f"http://127.0.0.1:{self.port}/health",
+            )
+        )
+
+        if self.enable_worker:
+            worker_argv = [
+                sys.executable,
+                "-m",
+                "jamjet",
+                "worker",
+                "--runtime",
+                self._runtime_url(),
+                "--queue",
+                "python_tool",
+            ]
+            if self.modules:
+                worker_argv += ["--modules", self.modules]
+            specs.append(
+                ProcessSpec(
+                    name="worker",
+                    argv=worker_argv,
+                    env=dict(self.base_env),
+                    health_url=None,
+                )
+            )
+
+        return specs
+
+    # -- lifecycle --------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start every process in order, health-gating each before the next.
+
+        Fails LOUD (``DevStackError`` naming the process) and tears down anything
+        already started if a process never becomes ready.
+        """
+        try:
+            for spec in self.build_specs():
+                self.log(f"Starting {spec.name}...")
+                proc = self.spawn(spec)
+                self._started.append((proc, spec))
+                self._attach_logs(proc, spec.name)
+                if spec.health_url is not None:
+                    self._health_gate(proc, spec)
+                else:
+                    self._readiness_check(proc, spec)
+                self.log(f"  {spec.name} ready.")
+        except BaseException:
+            # Includes DevStackError and KeyboardInterrupt during startup.
+            self.shutdown()
+            raise
+
+    def _health_gate(self, proc: ManagedProcess, spec: ProcessSpec) -> None:
+        assert spec.health_url is not None
+        deadline = self.monotonic() + self.health_timeout
+        while True:
+            rc = proc.poll()
+            if rc is not None:
+                raise DevStackError(f"{spec.name} exited before it was ready (exit code {rc}).")
+            if self.health_probe(spec.health_url):
+                return
+            if self.monotonic() >= deadline:
+                raise DevStackError(
+                    f"{spec.name} failed to start: {spec.health_url} did not become healthy "
+                    f"within {self.health_timeout:.0f}s."
+                )
+            self.sleep(self.poll_interval)
+
+    def _readiness_check(self, proc: ManagedProcess, spec: ProcessSpec) -> None:
+        """For processes with no health endpoint (the worker): a short settle then
+        confirm it did not die immediately."""
+        self.sleep(self.readiness_wait)
+        rc = proc.poll()
+        if rc is not None:
+            raise DevStackError(f"{spec.name} exited immediately (exit code {rc}).")
+
+    def shutdown(self) -> None:
+        """Terminate every started process as a group, SIGKILL stragglers."""
+        if self._shut_down:
+            return
+        self._shut_down = True
+
+        # SIGTERM all live children (reverse start order).
+        for proc, spec in reversed(self._started):
+            if proc.poll() is None:
+                self.log(f"Stopping {spec.name}...")
+                try:
+                    proc.terminate()
+                except Exception:  # noqa: BLE001 - best-effort teardown
+                    pass
+
+        # Wait up to the grace period (shared deadline), then SIGKILL survivors.
+        deadline = self.monotonic() + self.shutdown_grace
+        for proc, spec in reversed(self._started):
+            remaining = max(0.0, deadline - self.monotonic())
+            try:
+                proc.wait(timeout=remaining if remaining > 0 else None)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=self.shutdown_grace)
+                except Exception:  # noqa: BLE001 - best-effort teardown
+                    pass
+            except Exception:  # noqa: BLE001 - never let teardown raise
+                pass
+
+    def run(self) -> None:
+        """Start the stack, then block until a child exits or Ctrl+C, then tear down."""
+        self.start()
+        try:
+            self._wait_for_exit()
+        except KeyboardInterrupt:
+            self.log("\nShutting down JamJet dev stack...")
+        finally:
+            self.shutdown()
+
+    def _wait_for_exit(self) -> None:
+        while True:
+            for proc, spec in self._started:
+                rc = proc.poll()
+                if rc is not None:
+                    self.log(f"{spec.name} exited (code {rc}); shutting down the stack.")
+                    return
+            self.sleep(0.5)
+
+    # -- log prefixing ----------------------------------------------------------
+
+    def _attach_logs(self, proc: ManagedProcess, name: str) -> None:
+        stdout = getattr(proc, "stdout", None)
+        if stdout is None:
+            return
+        prefix = _prefix(name)
+
+        def _pump() -> None:
+            try:
+                for line in iter(stdout.readline, ""):
+                    if line == "":
+                        break
+                    self.log(prefix + line.rstrip("\n"))
+            except Exception:  # noqa: BLE001 - reader thread must never crash the stack
+                pass
+
+        thread = threading.Thread(target=_pump, name=f"logs-{name}", daemon=True)
+        thread.start()
+        self._log_threads.append(thread)

--- a/sdk/python/jamjet/cli/dev_stack.py
+++ b/sdk/python/jamjet/cli/dev_stack.py
@@ -20,6 +20,7 @@ a *health probe* so it can be unit-tested without starting real processes.
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import subprocess
@@ -129,12 +130,29 @@ def real_spawn(spec: ProcessSpec) -> ManagedProcess:
 
 
 def http_health_probe(url: str) -> bool:
-    """Return True iff ``GET url`` answers 200 (a healthy ``/health`` endpoint)."""
+    """Return True iff ``GET url`` answers 2xx AND its body affirms health.
+
+    The ``/health`` contract promises a healthy JSON body, so a 2xx alone is not
+    enough -- a 200 with a wrong, absent, or non-JSON body is NOT healthy (fail
+    closed). Both probed services are accepted in their real documented shapes:
+    the model sidecar returns ``{"ok": true}`` and the engine returns
+    ``{"status": "ok", ...}``. Total: never raises -- any error (unreachable,
+    non-JSON, non-dict body) returns False.
+    """
     try:
         with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310 - fixed localhost URL
-            return 200 <= resp.status < 300
+            if not (200 <= resp.status < 300):
+                return False
+            body = resp.read()
     except (urllib.error.URLError, OSError, ValueError):
         return False
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return payload.get("ok") is True or payload.get("status") == "ok"
 
 
 # ── Log prefixing ─────────────────────────────────────────────────────────────
@@ -317,12 +335,19 @@ class DevStack:
             raise DevStackError(f"{spec.name} exited immediately (exit code {rc}).")
 
     def shutdown(self) -> None:
-        """Terminate every started process as a group, SIGKILL stragglers."""
+        """Terminate every started process as a group, SIGKILL stragglers.
+
+        Guarantees termination with no infinite block and no orphan: every live
+        child gets a SIGTERM, a bounded shared grace wait (the wait timeout is
+        ALWAYS floored above zero, so a SIGTERM-ignoring child can never make
+        ``wait()`` block forever), then a final UNCONDITIONAL SIGKILL sweep with
+        a short bounded wait over anything still alive.
+        """
         if self._shut_down:
             return
         self._shut_down = True
 
-        # SIGTERM all live children (reverse start order).
+        # Phase 1: SIGTERM all live children (reverse start order).
         for proc, spec in reversed(self._started):
             if proc.poll() is None:
                 self.log(f"Stopping {spec.name}...")
@@ -331,20 +356,34 @@ class DevStack:
                 except Exception:  # noqa: BLE001 - best-effort teardown
                     pass
 
-        # Wait up to the grace period (shared deadline), then SIGKILL survivors.
+        # Phase 2: bounded grace wait for clean SIGTERM exits (shared deadline).
+        # The timeout is ALWAYS floored above zero: once an earlier child has
+        # exhausted the shared deadline, later children still get a tiny bounded
+        # wait (never timeout=None), so wait() can never block forever on a
+        # SIGTERM-ignoring child.
         deadline = self.monotonic() + self.shutdown_grace
         for proc, spec in reversed(self._started):
-            remaining = max(0.0, deadline - self.monotonic())
+            remaining = deadline - self.monotonic()
             try:
-                proc.wait(timeout=remaining if remaining > 0 else None)
+                proc.wait(timeout=max(remaining, 0.1))
             except subprocess.TimeoutExpired:
-                try:
-                    proc.kill()
-                    proc.wait(timeout=self.shutdown_grace)
-                except Exception:  # noqa: BLE001 - best-effort teardown
-                    pass
+                pass
             except Exception:  # noqa: BLE001 - never let teardown raise
                 pass
+
+        # Phase 3: UNCONDITIONAL SIGKILL sweep over anything still alive, then a
+        # short bounded wait so every survivor is reaped (no orphan, no hang).
+        # This is what fires for a child that ignored SIGTERM during Phase 2.
+        for proc, spec in reversed(self._started):
+            if proc.poll() is None:
+                try:
+                    proc.kill()
+                except Exception:  # noqa: BLE001 - best-effort teardown
+                    pass
+                try:
+                    proc.wait(timeout=max(self.shutdown_grace, 1.0))
+                except Exception:  # noqa: BLE001 - never let teardown raise (incl. TimeoutExpired)
+                    pass
 
     def run(self) -> None:
         """Start the stack, then block until a child exits or Ctrl+C, then tear down."""

--- a/sdk/python/jamjet/cli/dev_stack.py
+++ b/sdk/python/jamjet/cli/dev_stack.py
@@ -297,7 +297,18 @@ class DevStack:
         try:
             for spec in self.build_specs():
                 self.log(f"Starting {spec.name}...")
-                proc = self.spawn(spec)
+                try:
+                    proc = self.spawn(spec)
+                except DevStackError:
+                    raise
+                except Exception as e:  # noqa: BLE001 - normalize ANY spawn failure
+                    # The spawner failed to even start the process (e.g. the server
+                    # binary is missing -> FileNotFoundError, or an OSError from the
+                    # OS). Re-raise as DevStackError so the CLI -- which only catches
+                    # DevStackError -- prints the intended dev-stack failure message
+                    # instead of a raw traceback. Already-started children are torn
+                    # down by the outer handler below.
+                    raise DevStackError(f"{spec.name} failed to spawn: {e}") from e
                 self._started.append((proc, spec))
                 self._attach_logs(proc, spec.name)
                 if spec.health_url is not None:

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -248,6 +248,69 @@ def init(
     console.print("  jamjet run workflow.yaml  [dim]# run in another terminal[/dim]")
 
 
+# ── create ───────────────────────────────────────────────────────────────────
+
+
+@app.command()
+def create(
+    name: str = typer.Argument(..., help="Name for the new agent project (creates a directory <name>/)."),
+    template: str = typer.Option(
+        "quickstart",
+        "--template",
+        "-t",
+        help="Starter template. Run `jamjet init --list-templates` to see all options.",
+    ),
+) -> None:
+    """Scaffold a new agent project directory from a template.
+
+    Creates <name>/ and writes the template files into it. Fails if the directory
+    already exists so you never overwrite existing work.
+
+    Example:
+        jamjet create my-agent
+        cd my-agent
+        jamjet dev
+    """
+    import os
+
+    from jamjet.templates import AVAILABLE_TEMPLATES, render_template
+
+    if template not in AVAILABLE_TEMPLATES:
+        console.print(
+            f"[red]Error:[/red] unknown template '{template}'. "
+            f"Run [bold]jamjet init --list-templates[/bold] to see options."
+        )
+        raise typer.Exit(1)
+
+    project_dir = os.path.join(os.getcwd(), name)
+    if os.path.exists(project_dir):
+        console.print(
+            f"[red]Error:[/red] directory '{name}' already exists. "
+            "Choose a different name or remove the existing directory."
+        )
+        raise typer.Exit(1)
+
+    os.makedirs(project_dir)
+
+    files = render_template(template, name)
+    written: list[str] = []
+    for rel_path, content in files.items():
+        abs_path = os.path.join(project_dir, rel_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        with open(abs_path, "w") as fh:
+            fh.write(content)
+        written.append(rel_path)
+
+    console.print(f"[green]✓[/green] Created [bold]{name}[/bold] from template [bold]{template}[/bold]")
+    for rel_path in written:
+        console.print(f"  [dim]{rel_path}[/dim]")
+    console.print()
+    console.print("[bold]Next steps:[/bold]")
+    console.print(f"  cd {name}")
+    console.print("  jamjet dev               [dim]# start the runtime[/dim]")
+    console.print("  python agent.py          [dim]# run your agent[/dim]")
+
+
 # ── dev ──────────────────────────────────────────────────────────────────────
 
 

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -2241,7 +2241,21 @@ def _load_trajectory_from_file(path: str, *, row_id: str | None = None) -> Traje
                 if match is None:
                     raise ValueError(f"row_id {row_id!r} not found in {path}")
                 chosen = match
-            return Trajectory.from_tool_sequence(chosen.get("trajectory") or [])
+            # Require a real trajectory field. A missing trajectory means this is
+            # NOT a trajectory-bearing results artifact (e.g. an old/malformed
+            # `jamjet eval run --output` file). Defaulting it to [] would forge a
+            # bogus "no tools used" baseline and emit fake added/removed diffs, so
+            # fail fast instead. An explicit empty list (the agent used no tools)
+            # is legitimate and accepted.
+            traj = chosen.get("trajectory")
+            if not isinstance(traj, list):
+                row_label = f"row_id {row_id!r}" if row_id is not None else "the first row"
+                raise ValueError(
+                    f"{path}: {row_label} has no 'trajectory' field -- this is not a "
+                    "trajectory-bearing eval-results file. Re-run `jamjet eval run` with a "
+                    "build that records trajectories, or pass an event-log JSON instead."
+                )
+            return Trajectory.from_tool_sequence(traj)
         # Shape 4: bare list of tool-name strings.
         if all(isinstance(x, str) for x in data):
             return Trajectory.from_tool_sequence(data)

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -458,14 +458,40 @@ def _download_server_binary(cache_dir: str) -> str:
 
 @app.command()
 def dev(
-    port: int = typer.Option(7700, help="Port to run the runtime on"),
+    port: int = typer.Option(7700, help="Port to run the engine on"),
     db: str | None = typer.Option(None, "--db", help="SQLite database path (default: .jamjet/runtime.db)"),
     build: bool = typer.Option(False, "--build", help="Build the runtime binary before starting"),
+    sidecar_port: int = typer.Option(4280, "--sidecar-port", help="Port for the model sidecar"),
+    modules: str | None = typer.Option(
+        None, "--modules", help="Comma-separated Python modules for the worker to pre-import (your @tool code)"
+    ),
+    engine_only: bool = typer.Option(
+        False, "--engine-only", help="Start ONLY the engine (the legacy behavior; no sidecar, no worker)"
+    ),
+    no_sidecar: bool = typer.Option(
+        False, "--no-sidecar", help="Do not start the model sidecar (engine talks to providers directly)"
+    ),
+    no_worker: bool = typer.Option(False, "--no-worker", help="Do not start the python_tool worker"),
 ) -> None:
-    """Start the local dev runtime (SQLite mode)."""
+    """Start the whole local dev stack with one command.
+
+    Brings up, in order, the model sidecar (health-gated), the durable engine
+    (with the model seam wired to the sidecar) and the python_tool worker. Press
+    Ctrl+C to stop the whole stack gracefully — no orphaned processes.
+
+    \b
+    Examples:
+      jamjet dev                          # sidecar + engine + worker
+      jamjet dev --modules myapp.tools    # worker pre-imports your @tool module
+      jamjet dev --no-sidecar             # engine + worker, providers called directly
+      jamjet dev --engine-only            # just the engine (legacy)
+    """
+    import importlib.util
     import os
     import signal
     import subprocess
+
+    from jamjet.cli import dev_stack
 
     if build:
         console.print("[dim]Building jamjet-server...[/dim]")
@@ -483,36 +509,76 @@ def dev(
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 
+    enable_sidecar = not (engine_only or no_sidecar)
+    enable_worker = not (engine_only or no_worker)
+
+    # The sidecar needs the optional `sidecar` extra (starlette + uvicorn). Fail
+    # with a clear hint rather than a cryptic "sidecar exited" later.
+    if enable_sidecar and importlib.util.find_spec("uvicorn") is None:
+        console.print(
+            "[red]Error:[/red] the model sidecar needs uvicorn.\n"
+            "  Install it:   [bold]pip install 'jamjet[sidecar]'[/bold]\n"
+            "  Or skip it:   [bold]jamjet dev --no-sidecar[/bold]"
+        )
+        raise typer.Exit(1)
+
     db_url = f"sqlite://{db}" if db else None
-    env = os.environ.copy()
-    env["PORT"] = str(port)
-    env["JAMJET_PORT"] = str(port)
-    env["JAMJET_DEV_MODE"] = "1"
-    env["RUST_LOG"] = env.get("RUST_LOG", "info")
-    if db_url:
-        env["DATABASE_URL"] = db_url
 
     _print_logo()
-    console.rule("[bold green]JamJet Dev Runtime[/bold green]")
-    console.print(f"  [bold]Binary:[/bold] {binary}")
-    console.print(f"  [bold]Port:[/bold]   {port}")
-    console.print("  [bold]Mode:[/bold]   local (SQLite)")
-    console.print(f"  [bold]API:[/bold]    http://localhost:{port}")
+    console.rule("[bold green]JamJet Dev Stack[/bold green]")
+    console.print(f"  [bold]Binary:[/bold]  {binary}")
+    console.print(f"  [bold]Engine:[/bold]  http://localhost:{port}")
+    if enable_sidecar:
+        console.print(f"  [bold]Sidecar:[/bold] http://127.0.0.1:{sidecar_port}  [dim](governed model seam)[/dim]")
+    else:
+        console.print("  [bold]Sidecar:[/bold] [dim]disabled (engine calls providers directly)[/dim]")
+    console.print(f"  [bold]Worker:[/bold]  {'python_tool' if enable_worker else '[dim]disabled[/dim]'}")
+    console.print("  [bold]Mode:[/bold]    local (SQLite)")
     console.print()
-    console.print("[dim]Press Ctrl+C to stop.[/dim]")
+    console.print("[dim]Press Ctrl+C to stop the whole stack.[/dim]")
     console.rule()
 
-    proc = subprocess.Popen([binary], env=env)
+    def _log(msg: str = "") -> None:
+        # markup=False so subprocess log lines (which may contain '[...]') are
+        # printed verbatim and never interpreted as Rich markup.
+        console.print(msg, markup=False, highlight=False)
+
+    stack = dev_stack.DevStack(
+        binary=binary,
+        base_env=os.environ.copy(),
+        port=port,
+        sidecar_port=sidecar_port,
+        db_url=db_url,
+        modules=modules,
+        enable_sidecar=enable_sidecar,
+        enable_worker=enable_worker,
+        log=_log,
+    )
+
+    # Route SIGTERM through the same graceful path as Ctrl+C (SIGINT).
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def _on_sigterm(_signum: int, _frame: object) -> None:
+        raise KeyboardInterrupt
+
     try:
-        proc.wait()
-    except KeyboardInterrupt:
-        console.print("\n[yellow]Stopping runtime...[/yellow]")
-        proc.send_signal(signal.SIGTERM)
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-    console.print("[green]Runtime stopped.[/green]")
+        signal.signal(signal.SIGTERM, _on_sigterm)
+    except (ValueError, OSError):
+        previous_sigterm = None  # not in the main thread; rely on SIGINT only
+
+    try:
+        stack.run()
+    except dev_stack.DevStackError as e:
+        console.print(f"[red]Dev stack failed to start:[/red] {e}")
+        raise typer.Exit(1)
+    finally:
+        if previous_sigterm is not None:
+            try:
+                signal.signal(signal.SIGTERM, previous_sigterm)
+            except (ValueError, OSError):
+                pass
+
+    console.print("[green]Dev stack stopped.[/green]")
 
 
 # ── validate ─────────────────────────────────────────────────────────────────

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -17,6 +17,7 @@ Commands:
   jamjet eval run       Run batch evaluation of a workflow
   jamjet eval export    Export eval results as LaTeX, CSV, or JSON
   jamjet eval compare   Compare two conditions with statistical tests
+  jamjet eval trajectory-diff  Diff two runs' tool sequences (replay-regression)
   jamjet demo unsafe-tool-call    Show how JamJet blocks destructive tool calls
   jamjet demo approval            Show pause-for-approval flow
   jamjet demo budget-cap          Show budget enforcement
@@ -39,6 +40,7 @@ import yaml
 
 if TYPE_CHECKING:
     from jamjet.eval.grid import ComparisonResult
+    from jamjet.eval.trajectory import Trajectory
 
 import typer
 from rich.console import Console
@@ -1998,6 +2000,7 @@ def eval_run(
                 "output": r.output,
                 "input": r.input,
                 "expected": r.expected,
+                "trajectory": r.trajectory,
             }
             for r in results
         ]
@@ -2202,6 +2205,105 @@ def eval_compare(
         typer.echo(json.dumps(dataclasses.asdict(result), indent=2, default=str))
     else:
         _print_comparison_table(result, alpha=alpha)
+
+
+def _load_trajectory_from_file(path: str, *, row_id: str | None = None) -> Trajectory:
+    """Load a Trajectory from one of the accepted replay-regression inputs.
+
+    Accepts:
+    - a ``{"events": [...]}`` dict (a get_events / `jamjet events --json` dump)
+    - a raw list of event dicts (each item has a ``"kind"``)
+    - an eval-run results list (each item has ``row_id``/``trajectory``); pass
+      ``row_id`` to select the case, else the first row is used
+    - a bare list of tool-name strings (an explicit tool sequence)
+    """
+    from jamjet.eval.trajectory import Trajectory
+
+    with open(path) as f:
+        data = json.load(f)
+
+    # Shape 1: {"events": [...]} -- a get_events() dump.
+    if isinstance(data, dict) and "events" in data:
+        return Trajectory.from_events(data)
+
+    if isinstance(data, list):
+        if not data:
+            return Trajectory.from_events([])
+        first = data[0]
+        # Shape 2: raw event list (each item carries a "kind").
+        if isinstance(first, dict) and "kind" in first:
+            return Trajectory.from_events(data)
+        # Shape 3: eval-run results list (each item has row_id/trajectory).
+        if isinstance(first, dict) and ("row_id" in first or "trajectory" in first):
+            chosen = data[0]
+            if row_id is not None:
+                match = next((r for r in data if r.get("row_id") == row_id), None)
+                if match is None:
+                    raise ValueError(f"row_id {row_id!r} not found in {path}")
+                chosen = match
+            return Trajectory.from_tool_sequence(chosen.get("trajectory") or [])
+        # Shape 4: bare list of tool-name strings.
+        if all(isinstance(x, str) for x in data):
+            return Trajectory.from_tool_sequence(data)
+
+    raise ValueError(f"Unrecognized trajectory/event-log shape in {path}")
+
+
+@eval_app.command("trajectory-diff")
+def eval_trajectory_diff(
+    before: str = typer.Argument(
+        ..., help="Baseline run: an event-log JSON, an eval-run results JSON, or a tool-name list"
+    ),
+    after: str = typer.Argument(..., help="New run: same accepted shapes as <before>"),
+    row_id: str | None = typer.Option(
+        None, "--row-id", help="When the inputs are eval-run results files, the case row_id to diff"
+    ),
+    fail_on_change: bool = typer.Option(  # noqa: FBT001
+        True,
+        "--fail-on-change/--no-fail-on-change",
+        help="Exit 1 if the tool sequence changed (replay-regression gate; default on)",
+    ),
+    fmt: str = typer.Option("table", "--format", "-f", help="Output format: table (default) or json"),
+) -> None:
+    """Diff two runs' TRAJECTORIES (tool sequences) for replay-regression.
+
+    Reconstructs each run's tool sequence from its event log and reports whether
+    tools were added, removed, or reordered between the two runs -- the signal
+    for "did a model/prompt change alter HOW the agent used its tools?".
+
+    \b
+    Examples:
+      jamjet eval trajectory-diff before_events.json after_events.json
+      jamjet eval trajectory-diff v1_results.json v2_results.json --row-id q1
+      jamjet eval trajectory-diff a.json b.json --no-fail-on-change --format json
+    """
+    from jamjet.eval.trajectory import diff_trajectories
+
+    try:
+        before_traj = _load_trajectory_from_file(before, row_id=row_id)
+        after_traj = _load_trajectory_from_file(after, row_id=row_id)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] file not found: {e.filename}")
+        raise typer.Exit(1)
+    except (json.JSONDecodeError, ValueError) as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    diff = diff_trajectories(before_traj, after_traj)
+
+    if fmt.lower() == "json":
+        import dataclasses
+
+        typer.echo(json.dumps(dataclasses.asdict(diff), indent=2, default=str))
+    else:
+        if diff.changed:
+            console.print("[bold red]REGRESSION:[/bold red] trajectory changed")
+        else:
+            console.print("[green]OK:[/green] trajectory unchanged")
+        console.print(diff.render())
+
+    if fail_on_change and diff.changed:
+        raise typer.Exit(1)
 
 
 def _resolve_condition(name: str, agg: Mapping[str, object]) -> str | None:

--- a/sdk/python/jamjet/eval/__init__.py
+++ b/sdk/python/jamjet/eval/__init__.py
@@ -35,9 +35,11 @@ from jamjet.eval.scorers import (
 from jamjet.eval.trajectory import (
     Trajectory,
     TrajectoryAssertionResult,
+    TrajectoryDiff,
     TrajectoryResult,
     TrajectoryScorer,
     TrajectoryStep,
+    diff_trajectories,
 )
 
 __all__ = [
@@ -60,9 +62,11 @@ __all__ = [
     "ScorerResult",
     "Trajectory",
     "TrajectoryAssertionResult",
+    "TrajectoryDiff",
     "TrajectoryResult",
     "TrajectoryScorer",
     "TrajectoryStep",
+    "diff_trajectories",
     "get_scorer_registry",
     "invoke_scorer",
     "scorer",

--- a/sdk/python/jamjet/eval/__init__.py
+++ b/sdk/python/jamjet/eval/__init__.py
@@ -32,6 +32,13 @@ from jamjet.eval.scorers import (
     LlmJudgeScorer,
     ScorerResult,
 )
+from jamjet.eval.trajectory import (
+    Trajectory,
+    TrajectoryAssertionResult,
+    TrajectoryResult,
+    TrajectoryScorer,
+    TrajectoryStep,
+)
 
 __all__ = [
     "AgentEvalRunner",
@@ -51,6 +58,11 @@ __all__ = [
     "ScorerDefinition",
     "ScorerRegistry",
     "ScorerResult",
+    "Trajectory",
+    "TrajectoryAssertionResult",
+    "TrajectoryResult",
+    "TrajectoryScorer",
+    "TrajectoryStep",
     "get_scorer_registry",
     "invoke_scorer",
     "scorer",

--- a/sdk/python/jamjet/eval/dataset.py
+++ b/sdk/python/jamjet/eval/dataset.py
@@ -12,6 +12,12 @@ Fields:
 - `expected` (optional) — expected output (for assertion scorers)
 - `metadata` (optional) — arbitrary tags, passed through to results
 - `id` (optional) — row identifier; auto-assigned if absent
+- `expected_trajectory` (optional) — the TrajectoryScorer spec for this case
+  (e.g. ``{"tool_sequence": ["search", "calc"]}``). When present, the runner
+  scores the run's trajectory IN ADDITION to the final output.
+
+Datasets load from `.json` (top-level array), `.yaml`/`.yml` (top-level list),
+or JSONL (one object per line).
 """
 
 from __future__ import annotations
@@ -29,6 +35,9 @@ class EvalRow:
     input: dict[str, Any]
     expected: Any | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Optional TrajectoryScorer spec (tool_sequence / expected_tools / used_tool /
+    # did_not_use / max_turns / step_count). None -> output-only scoring.
+    expected_trajectory: dict[str, Any] | None = None
 
 
 class EvalDataset:
@@ -39,7 +48,7 @@ class EvalDataset:
 
     @classmethod
     def from_file(cls, path: str | Path) -> EvalDataset:
-        """Load a dataset from a JSONL or JSON file."""
+        """Load a dataset from a JSON array, a YAML list, or a JSONL file."""
         path = Path(path)
         if not path.exists():
             raise FileNotFoundError(f"Dataset file not found: {path}")
@@ -51,6 +60,13 @@ class EvalDataset:
             data = json.loads(text)
             if not isinstance(data, list):
                 raise ValueError("JSON dataset must be a top-level array")
+            raw_rows = data
+        elif path.suffix in (".yaml", ".yml"):
+            import yaml
+
+            data = yaml.safe_load(text)
+            if not isinstance(data, list):
+                raise ValueError("YAML dataset must be a top-level list")
             raw_rows = data
         else:
             # JSONL: one JSON object per line, skip blanks and comments
@@ -67,6 +83,7 @@ class EvalDataset:
                     input=raw["input"],
                     expected=raw.get("expected"),
                     metadata=raw.get("metadata", {}),
+                    expected_trajectory=raw.get("expected_trajectory"),
                 )
             )
 

--- a/sdk/python/jamjet/eval/runner.py
+++ b/sdk/python/jamjet/eval/runner.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from jamjet.eval.dataset import EvalDataset, EvalRow
 from jamjet.eval.scorers import BaseScorer, ScorerResult
+from jamjet.eval.trajectory import Trajectory, TrajectoryScorer
 
 
 @dataclass
@@ -39,9 +40,15 @@ class EvalResult:
     duration_ms: float
     cost_usd: float | None
     error: str | None = None
+    # Ordered tool names the run actually called (captured for inspection and
+    # replay-regression diffing). None when no trajectory could be reconstructed.
+    trajectory: list[str] | None = None
 
     @property
     def passed(self) -> bool:
+        # A case passes only when it has no error AND every scorer passed. The
+        # TrajectoryScorer (when a case carries an expected_trajectory) is one of
+        # those scorers, so a case passes only if output AND trajectory pass.
         return self.error is None and all(s.passed for s in self.scorers)
 
     @property
@@ -50,6 +57,100 @@ class EvalResult:
         if not numeric:
             return None
         return sum(numeric) / len(numeric)
+
+
+async def _score_trajectory(
+    row: EvalRow,
+    trajectory: Trajectory,
+    output: Any,
+    scorer_results: list[ScorerResult],
+) -> None:
+    """Score the run's trajectory IN ADDITION to the output scorers.
+
+    When ``row.expected_trajectory`` is set, a TrajectoryScorer scores the
+    reconstructed trajectory and its result is appended to ``scorer_results``
+    (alongside, not replacing, the output scorers). A row with no
+    expected_trajectory is left output-only (no-op).
+    """
+    if row.expected_trajectory is None:
+        return
+    tscorer = TrajectoryScorer(expected=row.expected_trajectory)
+    try:
+        scorer_results.append(await tscorer.score(output, trajectory=trajectory))
+    except Exception as e:
+        scorer_results.append(
+            ScorerResult(
+                scorer=tscorer.name,
+                passed=False,
+                score=None,
+                message=f"scorer error: {e}",
+            )
+        )
+
+
+def _trajectory_cell(result: EvalResult) -> str:
+    """Render the trajectory scorer's pass/fail (+ failed assertions) for summaries."""
+    for s in result.scorers:
+        if s.scorer == "trajectory":
+            icon = "[green]✓[/green]" if s.passed else "[red]✗[/red]"
+            if s.passed:
+                return icon
+            failed = [a.name for a in getattr(s, "assertions", []) if not a.passed]
+            return f"{icon} {', '.join(failed)}" if failed else f"{icon} {s.message}"
+    return "—"
+
+
+def _print_summary_table(results: list[EvalResult], *, console: Any = None) -> None:
+    """Print a Rich summary table of eval results.
+
+    The per-case row shows the overall pass/fail (output AND trajectory), the
+    output-scorer score, a dedicated Trajectory column (pass/fail + the failed
+    trajectory assertions), and the per-scorer detail string.
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    if console is None:
+        console = Console()
+
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    failed = total - passed
+    pass_rate = passed / total * 100 if total else 0
+
+    console.rule(f"[bold]Eval Results — {passed}/{total} passed ({pass_rate:.1f}%)[/bold]")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Row", style="dim")
+    table.add_column("Passed")
+    table.add_column("Score")
+    table.add_column("Trajectory")
+    table.add_column("Duration (ms)", justify="right")
+    table.add_column("Cost (USD)", justify="right")
+    table.add_column("Scorer Details")
+
+    for r in results:
+        passed_icon = "[green]✓[/green]" if r.passed else "[red]✗[/red]"
+        score_str = f"{r.overall_score:.2f}" if r.overall_score is not None else "—"
+        cost_str = f"${r.cost_usd:.6f}" if r.cost_usd is not None else "—"
+        details = "; ".join(f"{s.scorer}={'✓' if s.passed else '✗'}({s.message})" for s in r.scorers)
+        if r.error:
+            details = f"[red]{r.error}[/red]"
+
+        table.add_row(
+            r.row_id,
+            passed_icon,
+            score_str,
+            _trajectory_cell(r),
+            f"{r.duration_ms:.0f}",
+            cost_str,
+            details,
+        )
+
+    console.print(table)
+    console.print(
+        f"[bold]Pass rate:[/bold] {pass_rate:.1f}%  [bold]Passed:[/bold] {passed}  [bold]Failed:[/bold] {failed}"
+    )
 
 
 class EvalRunner:
@@ -90,6 +191,7 @@ class EvalRunner:
         output = None
         cost_usd = None
         error = None
+        events_list: list[dict[str, Any]] | None = None
 
         try:
             async with JamjetClient(base_url=self.runtime) as client:
@@ -118,10 +220,12 @@ class EvalRunner:
                     else:
                         error = f"execution {status}: {state.get('error', '')}"
 
-                    # Extract cost from events if available.
+                    # Fetch the event log once: reused for both cost extraction
+                    # and trajectory reconstruction (the trajectory-eval hook).
                     try:
                         events_data = await client.get_events(exec_id)
-                        for evt in events_data.get("events", []):
+                        events_list = events_data.get("events", [])
+                        for evt in events_list:
                             kind = evt.get("kind", {})
                             if kind.get("type") == "node_completed":
                                 cost = kind.get("cost_usd")
@@ -158,6 +262,16 @@ class EvalRunner:
                         )
                     )
 
+        # Trajectory scoring (T5-4): reconstruct the run's trajectory from the
+        # event log and, when the row carries an expected_trajectory, score it
+        # IN ADDITION to the output scorers. tool_sequence is captured regardless
+        # for inspection / replay-regression diffing.
+        trajectory_seq: list[str] | None = None
+        if events_list is not None:
+            traj = Trajectory.from_events(events_list)
+            trajectory_seq = traj.tool_sequence
+            await _score_trajectory(row, traj, output, scorer_results)
+
         return EvalResult(
             row_id=row.id,
             input=row.input,
@@ -167,53 +281,13 @@ class EvalRunner:
             duration_ms=duration_ms,
             cost_usd=cost_usd,
             error=error,
+            trajectory=trajectory_seq,
         )
 
     @staticmethod
     def print_summary(results: list[EvalResult], *, console: Any = None) -> None:
         """Print a Rich summary table of eval results."""
-        from rich.console import Console
-        from rich.table import Table
-
-        if console is None:
-            console = Console()
-
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        failed = total - passed
-        pass_rate = passed / total * 100 if total else 0
-
-        console.rule(f"[bold]Eval Results — {passed}/{total} passed ({pass_rate:.1f}%)[/bold]")
-
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("Row", style="dim")
-        table.add_column("Passed")
-        table.add_column("Score")
-        table.add_column("Duration (ms)", justify="right")
-        table.add_column("Cost (USD)", justify="right")
-        table.add_column("Scorer Details")
-
-        for r in results:
-            passed_icon = "[green]✓[/green]" if r.passed else "[red]✗[/red]"
-            score_str = f"{r.overall_score:.2f}" if r.overall_score is not None else "—"
-            cost_str = f"${r.cost_usd:.6f}" if r.cost_usd is not None else "—"
-            details = "; ".join(f"{s.scorer}={'✓' if s.passed else '✗'}({s.message})" for s in r.scorers)
-            if r.error:
-                details = f"[red]{r.error}[/red]"
-
-            table.add_row(
-                r.row_id,
-                passed_icon,
-                score_str,
-                f"{r.duration_ms:.0f}",
-                cost_str,
-                details,
-            )
-
-        console.print(table)
-        console.print(
-            f"[bold]Pass rate:[/bold] {pass_rate:.1f}%  [bold]Passed:[/bold] {passed}  [bold]Failed:[/bold] {failed}"
-        )
+        _print_summary_table(results, console=console)
 
 
 class AgentEvalRunner:
@@ -267,6 +341,7 @@ class AgentEvalRunner:
         output = None
         cost_usd = None
         error = None
+        agent_result_obj: Any = None
 
         condition = row.input.get("_condition", {})
         strategy = condition.get("strategy", "plan-and-execute")
@@ -288,6 +363,7 @@ class AgentEvalRunner:
                 agent.run(task_text),
                 timeout=self.timeout_s,
             )
+            agent_result_obj = agent_result
             output = agent_result.output
         except TimeoutError:
             error = f"timeout after {self.timeout_s}s"
@@ -318,6 +394,15 @@ class AgentEvalRunner:
                         )
                     )
 
+        # Trajectory scoring (T5-4): build the trajectory from the in-process
+        # AgentResult.tool_calls and score it IN ADDITION to the output scorers
+        # when the row carries an expected_trajectory.
+        trajectory_seq: list[str] | None = None
+        if agent_result_obj is not None:
+            traj = Trajectory.from_agent_result(agent_result_obj)
+            trajectory_seq = traj.tool_sequence
+            await _score_trajectory(row, traj, output, scorer_results)
+
         return EvalResult(
             row_id=row.id,
             input=row.input,
@@ -327,50 +412,10 @@ class AgentEvalRunner:
             duration_ms=duration_ms,
             cost_usd=cost_usd,
             error=error,
+            trajectory=trajectory_seq,
         )
 
     @staticmethod
     def print_summary(results: list[EvalResult], *, console: Any = None) -> None:
         """Print a Rich summary table of eval results."""
-        from rich.console import Console
-        from rich.table import Table
-
-        if console is None:
-            console = Console()
-
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        failed = total - passed
-        pass_rate = passed / total * 100 if total else 0
-
-        console.rule(f"[bold]Eval Results — {passed}/{total} passed ({pass_rate:.1f}%)[/bold]")
-
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("Row", style="dim")
-        table.add_column("Passed")
-        table.add_column("Score")
-        table.add_column("Duration (ms)", justify="right")
-        table.add_column("Cost (USD)", justify="right")
-        table.add_column("Scorer Details")
-
-        for r in results:
-            passed_icon = "[green]✓[/green]" if r.passed else "[red]✗[/red]"
-            score_str = f"{r.overall_score:.2f}" if r.overall_score is not None else "—"
-            cost_str = f"${r.cost_usd:.6f}" if r.cost_usd is not None else "—"
-            details = "; ".join(f"{s.scorer}={'✓' if s.passed else '✗'}({s.message})" for s in r.scorers)
-            if r.error:
-                details = f"[red]{r.error}[/red]"
-
-            table.add_row(
-                r.row_id,
-                passed_icon,
-                score_str,
-                f"{r.duration_ms:.0f}",
-                cost_str,
-                details,
-            )
-
-        console.print(table)
-        console.print(
-            f"[bold]Pass rate:[/bold] {pass_rate:.1f}%  [bold]Passed:[/bold] {passed}  [bold]Failed:[/bold] {failed}"
-        )
+        _print_summary_table(results, console=console)

--- a/sdk/python/jamjet/eval/trajectory.py
+++ b/sdk/python/jamjet/eval/trajectory.py
@@ -9,7 +9,9 @@ calls in the default path.
 Trajectory sources
 ------------------
 - ``Trajectory.from_agent_result(result)`` -- in-process AgentResult.tool_calls
-- ``Trajectory.from_events(events)`` -- event log from get_events() (ToolCalled events)
+- ``Trajectory.from_events(events)`` -- durable event log from get_events(): the
+  tool calls the model requested, read off each model ``NodeCompleted`` event's
+  ``output.tool_calls`` (the shape the durable engine actually emits)
 
 Both sources produce the same Trajectory shape; the tool_sequence and step_count
 are identical for the same run.
@@ -80,6 +82,34 @@ class TrajectoryResult(ScorerResult):
     assertions: list[TrajectoryAssertionResult] = field(default_factory=list)
 
 
+def _tool_calls_from_node_completed(kind: dict[str, Any]) -> list[Any]:
+    """Extract the model's requested tool calls from a ``node_completed`` event kind.
+
+    The durable model-node executor (``runtime/workers/src/executors/model_node.rs``)
+    writes the model turn's tool calls to TWO places on its ``NodeCompleted`` event:
+
+    - ``output.tool_calls`` -- ``[{"id", "name", "arguments"}, ...]`` (authoritative)
+    - ``state_patch.last_model_tool_calls`` -- the SAME list, written inline so it
+      is never spilled to the artifact store.
+
+    ``output`` is preferred; ``state_patch.last_model_tool_calls`` is the fallback
+    for the rare case where ``output`` was artifact-spilled and could not be
+    resolved on read. A non-model ``NodeCompleted`` (a tool-dispatch node, a plain
+    node) carries neither and contributes no tool calls.
+    """
+    output = kind.get("output")
+    if isinstance(output, dict):
+        tcs = output.get("tool_calls")
+        if isinstance(tcs, list):
+            return tcs
+    state_patch = kind.get("state_patch")
+    if isinstance(state_patch, dict):
+        tcs = state_patch.get("last_model_tool_calls")
+        if isinstance(tcs, list):
+            return tcs
+    return []
+
+
 class Trajectory:
     """Ordered sequence of steps (tool calls) in an agent run.
 
@@ -144,8 +174,19 @@ class Trajectory:
         - A raw list of event dicts (the ``events`` list from get_events)
         - The wrapped ``{"events": [...]}`` dict returned by get_events()
 
-        Only ``ToolCalled`` events (``kind.type == "tool_called"``) contribute
-        steps; all other event kinds are ignored.
+        Reconstructs the tool trajectory from what a durable run ACTUALLY emits:
+        the tool calls the model requested across the run's model
+        ``NodeCompleted`` events. Each model ``NodeCompleted`` carries the turn's
+        tool calls in ``output.tool_calls``
+        (``[{"id", "name", "arguments"}, ...]`` -- see
+        ``runtime/workers/src/executors/model_node.rs``); every such tool call,
+        in event order, contributes one step (the tool name). Tool-dispatch and
+        plain node completions carry no ``tool_calls`` and add nothing.
+
+        Legacy ``ToolCalled`` events (``kind.type == "tool_called"``) are still
+        honored if present, but the durable engine does not emit them -- the
+        model-node ``tool_calls`` is the authoritative "tools the agent called"
+        source.
         """
         if isinstance(events, dict):
             event_list: list[dict[str, Any]] = events.get("events", [])
@@ -155,15 +196,40 @@ class Trajectory:
         steps: list[TrajectoryStep] = []
         for evt in event_list:
             kind = evt.get("kind", {})
-            if kind.get("type") == "tool_called":
-                steps.append(
-                    TrajectoryStep(
-                        tool=kind.get("tool"),
-                        node_id=kind.get("node_id"),
-                        args={},
-                        output=None,
+            if not isinstance(kind, dict):
+                continue
+            ktype = kind.get("type")
+            if ktype == "node_completed":
+                # Authoritative durable source: the model node's requested tool
+                # calls. Non-model completions carry no tool_calls -> no steps.
+                node_id = kind.get("node_id")
+                for tc in _tool_calls_from_node_completed(kind):
+                    if not isinstance(tc, dict):
+                        continue
+                    name = tc.get("name")
+                    if not name:
+                        continue
+                    steps.append(
+                        TrajectoryStep(
+                            tool=name,
+                            node_id=node_id,
+                            args=tc.get("arguments") or {},
+                            output=None,
+                        )
                     )
-                )
+            elif ktype == "tool_called":
+                # Legacy/secondary: defined + consumed but not produced by the
+                # durable model loop. Honored for hand-built or strategy logs.
+                name = kind.get("tool")
+                if name:
+                    steps.append(
+                        TrajectoryStep(
+                            tool=name,
+                            node_id=kind.get("node_id"),
+                            args={},
+                            output=None,
+                        )
+                    )
         return cls(steps)
 
     @classmethod

--- a/sdk/python/jamjet/eval/trajectory.py
+++ b/sdk/python/jamjet/eval/trajectory.py
@@ -1,0 +1,423 @@
+"""
+TrajectoryScorer -- deterministic assertions over an agent run's step sequence.
+
+A Trajectory is the ordered list of steps (tools called, nodes, turns) an agent
+took during a run. TrajectoryScorer scores a trajectory against an
+expected-trajectory spec using deterministic structural assertions with no LLM
+calls in the default path.
+
+Trajectory sources
+------------------
+- ``Trajectory.from_agent_result(result)`` -- in-process AgentResult.tool_calls
+- ``Trajectory.from_events(events)`` -- event log from get_events() (ToolCalled events)
+
+Both sources produce the same Trajectory shape; the tool_sequence and step_count
+are identical for the same run.
+
+Spec keys (all optional -- only keys present are checked)
+---------------------------------------------------------
+- ``expected_tools``: list[str] -- all these tools must appear (subset check)
+- ``expected_tools_exact``: bool -- if True, tool set must match exactly (default: False)
+- ``tool_sequence``: list[str] -- tools must appear in this order (ordered subsequence)
+- ``used_tool``: str | list[str] -- each named tool must appear
+- ``did_not_use``: str | list[str] -- each named tool must NOT appear
+- ``max_turns``: int -- step count must be <= this value
+- ``step_count``: int -- step count must equal this value exactly
+
+Determinism guarantee
+---------------------
+The score() method is a pure function of the trajectory and the expected spec.
+Same trajectory + same spec -> identical ScorerResult, always. No wall-clock,
+random, or external state is read in the deterministic path.
+
+Optional LLM judge
+------------------
+Pass ``judge=True`` at construction to also run an LLM-as-judge over the rendered
+trajectory trace. This is NON-DETERMINISTIC and OFF by default. The judge result
+is appended to the message but does NOT override the structural pass/fail. Enable
+only when you understand and accept the non-determinism.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from jamjet.eval.scorers import BaseScorer, ScorerResult
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class TrajectoryStep:
+    """A single step in an agent trajectory."""
+
+    tool: str | None = None
+    node_id: str | None = None
+    args: dict[str, Any] = field(default_factory=dict)
+    output: Any = None
+
+
+@dataclass
+class TrajectoryAssertionResult:
+    """Result of a single named trajectory assertion."""
+
+    name: str
+    passed: bool
+    message: str
+
+
+@dataclass
+class TrajectoryResult(ScorerResult):
+    """ScorerResult extended with a per-assertion breakdown.
+
+    Fully compatible with ScorerResult -- all standard fields are present.
+    The ``assertions`` list carries the fine-grained pass/fail detail per
+    configured assertion.
+    """
+
+    assertions: list[TrajectoryAssertionResult] = field(default_factory=list)
+
+
+class Trajectory:
+    """Ordered sequence of steps (tool calls) in an agent run.
+
+    Construct via the class methods rather than directly:
+
+    - :meth:`from_agent_result` -- in-process Agent.run() result
+    - :meth:`from_events` -- durable event log from get_events()
+    """
+
+    def __init__(self, steps: list[TrajectoryStep]) -> None:
+        self._steps = list(steps)
+
+    # ── Properties ───────────────────────────────────────────────────────────
+
+    @property
+    def steps(self) -> list[TrajectoryStep]:
+        """Ordered list of all steps (copy)."""
+        return list(self._steps)
+
+    @property
+    def tool_sequence(self) -> list[str]:
+        """Ordered list of tool names called (steps without a tool name skipped)."""
+        return [s.tool for s in self._steps if s.tool is not None]
+
+    @property
+    def tool_set(self) -> set[str]:
+        """Set of distinct tool names used across all steps."""
+        return set(self.tool_sequence)
+
+    @property
+    def step_count(self) -> int:
+        """Total number of steps (including non-tool steps)."""
+        return len(self._steps)
+
+    # ── Constructors ──────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_agent_result(cls, result: Any) -> Trajectory:
+        """Build a Trajectory from AgentResult.tool_calls (in-process path).
+
+        Each element of ``result.tool_calls`` is a dict with keys:
+        ``tool``, ``input``, ``output``, ``duration_us`` (as produced by
+        ``Agent._tool_calls_from_messages`` and in-process ToolCallRecord.model_dump()).
+        """
+        steps: list[TrajectoryStep] = []
+        for tc in result.tool_calls or []:
+            steps.append(
+                TrajectoryStep(
+                    tool=tc.get("tool"),
+                    node_id=None,  # not available in-process
+                    args=tc.get("input") or {},
+                    output=tc.get("output"),
+                )
+            )
+        return cls(steps)
+
+    @classmethod
+    def from_events(cls, events: list[dict[str, Any]] | dict[str, Any]) -> Trajectory:
+        """Build a Trajectory from the durable event log (event log path).
+
+        Accepts either:
+        - A raw list of event dicts (the ``events`` list from get_events)
+        - The wrapped ``{"events": [...]}`` dict returned by get_events()
+
+        Only ``ToolCalled`` events (``kind.type == "tool_called"``) contribute
+        steps; all other event kinds are ignored.
+        """
+        if isinstance(events, dict):
+            event_list: list[dict[str, Any]] = events.get("events", [])
+        else:
+            event_list = events
+
+        steps: list[TrajectoryStep] = []
+        for evt in event_list:
+            kind = evt.get("kind", {})
+            if kind.get("type") == "tool_called":
+                steps.append(
+                    TrajectoryStep(
+                        tool=kind.get("tool"),
+                        node_id=kind.get("node_id"),
+                        args={},
+                        output=None,
+                    )
+                )
+        return cls(steps)
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def render(self) -> str:
+        """Human-readable trace for debugging or LLM judge input."""
+        lines = [f"Trajectory ({self.step_count} steps):"]
+        for i, step in enumerate(self._steps, 1):
+            tool_part = step.tool or "(no tool)"
+            node_part = f" [node={step.node_id}]" if step.node_id else ""
+            lines.append(f"  {i}. {tool_part}{node_part}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"Trajectory(steps={self.step_count}, tools={self.tool_sequence!r})"
+
+
+class TrajectoryScorer(BaseScorer):
+    """Scores an agent run's trajectory with DETERMINISTIC structural assertions.
+
+    Configured by an ``expected`` spec dict (see module docstring for all keys).
+    Returns a :class:`TrajectoryResult` (a ScorerResult subclass) with overall
+    pass/fail, a fractional score (passed_assertions / total_assertions), and a
+    per-assertion breakdown in ``result.assertions``.
+
+    All assertions are independent -- each is checked and reported separately.
+    The overall result passes only when every configured assertion passes.
+
+    DETERMINISM: the score is a pure function of the trajectory and the spec.
+    Same inputs -> same outputs, always. No model calls are made by default.
+
+    Optional LLM judge: pass ``judge=True`` to enable non-deterministic
+    LLM-as-judge scoring over the rendered trace (see module docstring).
+
+    Usage::
+
+        scorer = TrajectoryScorer(expected={
+            "tool_sequence": ["search", "calculate"],
+            "did_not_use": "dangerous_tool",
+            "max_turns": 5,
+        })
+        result = await scorer.score(output, trajectory=trajectory)
+        assert result.passed          # overall
+        for a in result.assertions:   # per-assertion breakdown
+            print(a.name, a.passed, a.message)
+    """
+
+    name = "trajectory"
+
+    def __init__(
+        self,
+        expected: dict[str, Any],
+        *,
+        judge: bool = False,
+        judge_rubric: str = "Rate whether the agent followed an appropriate tool-use trajectory (1-5).",
+        judge_model: str = "claude-haiku-4-5-20251001",
+        judge_model_fn: Any | None = None,
+    ) -> None:
+        self.expected = expected
+        self._judge_enabled = judge
+        self._judge_rubric = judge_rubric
+        self._judge_model = judge_model
+        self._judge_model_fn = judge_model_fn
+
+    async def score(  # type: ignore[override]
+        self,
+        output: Any,
+        *,
+        expected: Any | None = None,
+        duration_ms: float | None = None,
+        cost_usd: float | None = None,
+        input_data: Any | None = None,
+        trajectory: Trajectory | None = None,
+    ) -> TrajectoryResult:
+        """Score the trajectory against the configured expected-trajectory spec.
+
+        Args:
+            output: The agent's final output (passed through from scorer interface;
+                not used for trajectory scoring but kept for interface compatibility).
+            trajectory: The :class:`Trajectory` to score. If ``None`` (e.g. when
+                called from an existing runner that does not yet pass a trajectory),
+                all assertions are skipped and the result is passed with no breakdown.
+            expected: Not used (trajectory spec is in ``self.expected``).
+            duration_ms, cost_usd, input_data: Standard scorer kwargs; not used.
+
+        Returns:
+            :class:`TrajectoryResult` with ``passed``, ``score`` (fraction of
+            assertions that passed), ``message``, and per-assertion ``assertions``.
+            Scoring is deterministic unless ``judge=True`` was set at construction.
+        """
+        if trajectory is None:
+            return TrajectoryResult(
+                scorer=self.name,
+                passed=True,
+                score=None,
+                message="no trajectory provided; skipping trajectory assertions",
+                assertions=[],
+            )
+
+        assertions: list[TrajectoryAssertionResult] = []
+
+        # Run each configured assertion in the order they appear in the spec.
+        if "expected_tools" in self.expected:
+            assertions.append(self._check_expected_tools(trajectory))
+
+        if "tool_sequence" in self.expected:
+            assertions.append(self._check_tool_sequence(trajectory))
+
+        if "used_tool" in self.expected:
+            assertions.append(self._check_used_tool(trajectory))
+
+        if "did_not_use" in self.expected:
+            assertions.append(self._check_did_not_use(trajectory))
+
+        if "max_turns" in self.expected:
+            assertions.append(self._check_max_turns(trajectory))
+
+        if "step_count" in self.expected:
+            assertions.append(self._check_step_count(trajectory))
+
+        total = len(assertions)
+        passed_count = sum(1 for a in assertions if a.passed)
+        all_passed = passed_count == total
+        score = float(passed_count) / total if total > 0 else 1.0
+
+        if all_passed:
+            message = f"all {total} assertion(s) passed"
+        else:
+            failed_names = [a.name for a in assertions if not a.passed]
+            message = f"failed ({total - passed_count}/{total}): {', '.join(failed_names)}"
+
+        # Optional LLM judge -- OFF by default; non-deterministic.
+        # Gate is explicit: judge must be True at construction. When enabled, the
+        # judge result is appended to the message for transparency but does NOT
+        # override the structural pass/fail (which remains the source of truth).
+        if self._judge_enabled:
+            judge_result = await self._run_judge(trajectory)
+            message += f"; judge: {judge_result.message}"
+
+        return TrajectoryResult(
+            scorer=self.name,
+            passed=all_passed,
+            score=score,
+            message=message,
+            assertions=assertions,
+        )
+
+    # ── Deterministic assertion implementations ───────────────────────────────
+
+    def _check_expected_tools(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """All expected tools must appear (subset check by default; exact if flag set)."""
+        expected_set = set(self.expected["expected_tools"])
+        actual_set = trajectory.tool_set
+        exact = bool(self.expected.get("expected_tools_exact", False))
+
+        if exact:
+            passed = actual_set == expected_set
+            missing = sorted(expected_set - actual_set)
+            extra = sorted(actual_set - expected_set)
+            if passed:
+                msg = f"tool set matches exactly: {sorted(expected_set)}"
+            else:
+                parts = []
+                if missing:
+                    parts.append(f"missing {missing}")
+                if extra:
+                    parts.append(f"unexpected {extra}")
+                msg = f"tool set mismatch: {'; '.join(parts)}"
+        else:
+            missing = sorted(expected_set - actual_set)
+            passed = not missing
+            msg = f"all expected tools present: {sorted(expected_set)}" if passed else f"missing tools: {missing}"
+
+        return TrajectoryAssertionResult(name="expected_tools", passed=passed, message=msg)
+
+    def _check_tool_sequence(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """Tools must appear in the specified order (ordered subsequence check).
+
+        Extra tools between required steps are allowed. For example, the sequence
+        ["search", "calculate"] passes for ["search", "fetch", "calculate"] (fetch
+        is permitted in between). Use ``expected_tools_exact=True`` with
+        ``expected_tools`` if you also want to forbid extras.
+        """
+        expected_seq: list[str] = self.expected["tool_sequence"]
+        actual_seq = trajectory.tool_sequence
+
+        # Greedy subsequence matching.
+        expected_iter = iter(expected_seq)
+        current = next(expected_iter, None)
+        for tool in actual_seq:
+            if current is None:
+                break
+            if tool == current:
+                current = next(expected_iter, None)
+
+        passed = current is None  # consumed all expected elements
+        if passed:
+            msg = f"tool sequence satisfied: {expected_seq}"
+        else:
+            msg = f"tool sequence not satisfied: expected {expected_seq}, got {actual_seq}"
+
+        return TrajectoryAssertionResult(name="tool_sequence", passed=passed, message=msg)
+
+    def _check_used_tool(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """Each named tool (or all tools in a list) must appear in the trajectory."""
+        required = self.expected["used_tool"]
+        if isinstance(required, str):
+            required = [required]
+        missing = [t for t in required if t not in trajectory.tool_set]
+        passed = not missing
+        msg = f"required tool(s) used: {required}" if passed else f"required tool(s) not used: {missing}"
+        return TrajectoryAssertionResult(name="used_tool", passed=passed, message=msg)
+
+    def _check_did_not_use(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """Each named forbidden tool must NOT appear in the trajectory."""
+        forbidden = self.expected["did_not_use"]
+        if isinstance(forbidden, str):
+            forbidden = [forbidden]
+        used = [t for t in forbidden if t in trajectory.tool_set]
+        passed = not used
+        msg = f"forbidden tool(s) not used: {list(forbidden)}" if passed else f"forbidden tool(s) were used: {used}"
+        return TrajectoryAssertionResult(name="did_not_use", passed=passed, message=msg)
+
+    def _check_max_turns(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """Step count must not exceed the configured limit."""
+        limit: int = self.expected["max_turns"]
+        actual = trajectory.step_count
+        passed = actual <= limit
+        msg = f"{actual} step(s) (max {limit})"
+        return TrajectoryAssertionResult(name="max_turns", passed=passed, message=msg)
+
+    def _check_step_count(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
+        """Step count must equal the configured value exactly."""
+        expected_count: int = self.expected["step_count"]
+        actual = trajectory.step_count
+        passed = actual == expected_count
+        msg = f"step count: {actual} (expected {expected_count})"
+        return TrajectoryAssertionResult(name="step_count", passed=passed, message=msg)
+
+    # ── Optional LLM judge (non-deterministic; off by default) ───────────────
+
+    async def _run_judge(self, trajectory: Trajectory) -> ScorerResult:
+        """Run an LLM judge over the rendered trajectory trace.
+
+        NON-DETERMINISTIC. Called only when ``judge=True`` was passed at
+        construction. Reuses :class:`~jamjet.eval.scorers.LlmJudgeScorer` so
+        provider detection (Anthropic / OpenAI / Ollama) is shared.
+        """
+        from jamjet.eval.scorers import LlmJudgeScorer  # noqa: PLC0415
+
+        judge = LlmJudgeScorer(
+            rubric=self._judge_rubric,
+            model=self._judge_model,
+            model_fn=self._judge_model_fn,
+        )
+        trace_text = trajectory.render()
+        return await judge.score(trace_text, expected=None)

--- a/sdk/python/jamjet/eval/trajectory.py
+++ b/sdk/python/jamjet/eval/trajectory.py
@@ -16,6 +16,15 @@ Trajectory sources
 Both sources produce the same Trajectory shape; the tool_sequence and step_count
 are identical for the same run.
 
+Turns vs steps
+--------------
+A TURN is one model call. A STEP is one tool call. A single model turn may emit
+several tool calls (parallel tool-calling), so ``turn_count`` and ``step_count``
+differ. ``max_turns`` is checked against ``turn_count``; ``step_count`` against
+the flattened tool steps. ``from_events`` counts one turn per model
+``NodeCompleted`` event; sources with no turn signal (``from_agent_result``,
+``from_tool_sequence``) fall back to one turn per step.
+
 Spec keys (all optional -- only keys present are checked)
 ---------------------------------------------------------
 - ``expected_tools``: list[str] -- all these tools must appear (subset check)
@@ -23,8 +32,10 @@ Spec keys (all optional -- only keys present are checked)
 - ``tool_sequence``: list[str] -- tools must appear in this order (ordered subsequence)
 - ``used_tool``: str | list[str] -- each named tool must appear
 - ``did_not_use``: str | list[str] -- each named tool must NOT appear
-- ``max_turns``: int -- step count must be <= this value
-- ``step_count``: int -- step count must equal this value exactly
+- ``max_turns``: int -- model TURN count must be <= this value (a turn = one model
+  call; a single turn may emit several parallel tool calls)
+- ``step_count``: int -- tool-step count must equal this value exactly (one step
+  per tool call)
 
 Determinism guarantee
 ---------------------
@@ -110,6 +121,25 @@ def _tool_calls_from_node_completed(kind: dict[str, Any]) -> list[Any]:
     return []
 
 
+def _is_model_node_completed(kind: dict[str, Any]) -> bool:
+    """True iff a ``node_completed`` event kind is a MODEL turn (one model call).
+
+    A model node writes ``output.tool_calls`` (an empty list when the model stops
+    without calling a tool) and ``state_patch.last_model_tool_calls``; a
+    tool-dispatch or plain node writes neither. Either marker identifies a model
+    turn -- so the empty-tool-calls final turn (``finish_reason="stop"``) still
+    counts as a turn, and the artifact-spilled-output case is covered by the
+    ``state_patch`` fallback.
+    """
+    output = kind.get("output")
+    if isinstance(output, dict) and "tool_calls" in output:
+        return True
+    state_patch = kind.get("state_patch")
+    if isinstance(state_patch, dict) and "last_model_tool_calls" in state_patch:
+        return True
+    return False
+
+
 class Trajectory:
     """Ordered sequence of steps (tool calls) in an agent run.
 
@@ -119,8 +149,13 @@ class Trajectory:
     - :meth:`from_events` -- durable event log from get_events()
     """
 
-    def __init__(self, steps: list[TrajectoryStep]) -> None:
+    def __init__(self, steps: list[TrajectoryStep], *, turns: int | None = None) -> None:
         self._steps = list(steps)
+        # Number of model TURNS (model calls), distinct from the flattened tool
+        # step count. ``None`` means "no turn signal available" -> turn_count
+        # falls back to step_count (one turn per tool step). ``from_events``
+        # supplies a real turn count from the model NodeCompleted events.
+        self._turns = turns
 
     # ── Properties ───────────────────────────────────────────────────────────
 
@@ -141,8 +176,21 @@ class Trajectory:
 
     @property
     def step_count(self) -> int:
-        """Total number of steps (including non-tool steps)."""
+        """Total number of tool steps (one step per tool call)."""
         return len(self._steps)
+
+    @property
+    def turn_count(self) -> int:
+        """Number of model TURNS (model calls) in the run.
+
+        A turn is one model call; a single turn may emit several tool calls
+        (parallel tool-calling), so this is distinct from :attr:`step_count`.
+        ``from_events`` counts one turn per model ``NodeCompleted`` event. When no
+        turn signal is available (in-process ``from_agent_result`` or a bare
+        ``from_tool_sequence``) this falls back to ``step_count`` -- one turn per
+        tool step.
+        """
+        return self._turns if self._turns is not None else self.step_count
 
     # ── Constructors ──────────────────────────────────────────────────────────
 
@@ -194,12 +242,19 @@ class Trajectory:
             event_list = events
 
         steps: list[TrajectoryStep] = []
+        model_turns = 0
         for evt in event_list:
             kind = evt.get("kind", {})
             if not isinstance(kind, dict):
                 continue
             ktype = kind.get("type")
             if ktype == "node_completed":
+                # A model NodeCompleted is one TURN (one model call); count it
+                # whether or not it emitted tool calls -- the final stop turn emits
+                # none but is still a turn. Non-model completions (tool dispatch,
+                # plain nodes) are not turns and carry no tool_calls -> no steps.
+                if _is_model_node_completed(kind):
+                    model_turns += 1
                 # Authoritative durable source: the model node's requested tool
                 # calls. Non-model completions carry no tool_calls -> no steps.
                 node_id = kind.get("node_id")
@@ -230,7 +285,10 @@ class Trajectory:
                             output=None,
                         )
                     )
-        return cls(steps)
+        # A real durable log carries model NodeCompleted turns; a legacy or
+        # hand-built tool_called-only log has no turn signal, so fall back to step
+        # count (turns=None) -- one turn per tool step.
+        return cls(steps, turns=model_turns if model_turns > 0 else None)
 
     @classmethod
     def from_tool_sequence(cls, tools: list[str]) -> Trajectory:
@@ -464,11 +522,16 @@ class TrajectoryScorer(BaseScorer):
         return TrajectoryAssertionResult(name="did_not_use", passed=passed, message=msg)
 
     def _check_max_turns(self, trajectory: Trajectory) -> TrajectoryAssertionResult:
-        """Step count must not exceed the configured limit."""
+        """Model TURN count must not exceed the configured limit.
+
+        A turn is one model call; a single turn may emit several parallel tool
+        calls. This checks ``turn_count`` (NOT the flattened tool-step count), so a
+        one-turn run that calls two tools satisfies ``max_turns: 1``.
+        """
         limit: int = self.expected["max_turns"]
-        actual = trajectory.step_count
+        actual = trajectory.turn_count
         passed = actual <= limit
-        msg = f"{actual} step(s) (max {limit})"
+        msg = f"{actual} turn(s) (max {limit})"
         return TrajectoryAssertionResult(name="max_turns", passed=passed, message=msg)
 
     def _check_step_count(self, trajectory: Trajectory) -> TrajectoryAssertionResult:

--- a/sdk/python/jamjet/eval/trajectory.py
+++ b/sdk/python/jamjet/eval/trajectory.py
@@ -166,6 +166,16 @@ class Trajectory:
                 )
         return cls(steps)
 
+    @classmethod
+    def from_tool_sequence(cls, tools: list[str]) -> Trajectory:
+        """Build a Trajectory from a bare ordered list of tool names.
+
+        Handy for reconstructing a trajectory from a persisted ``tool_sequence``
+        (e.g. the ``trajectory`` field of an eval-run results file) for
+        replay-regression diffing.
+        """
+        return cls([TrajectoryStep(tool=t) for t in tools])
+
     # ── Rendering ─────────────────────────────────────────────────────────────
 
     def render(self) -> str:
@@ -421,3 +431,70 @@ class TrajectoryScorer(BaseScorer):
         )
         trace_text = trajectory.render()
         return await judge.score(trace_text, expected=None)
+
+
+# ── Replay-regression trajectory diff ─────────────────────────────────────────
+
+
+@dataclass
+class TrajectoryDiff:
+    """Difference between two trajectories' tool sequences (replay-regression).
+
+    ``changed`` is True whenever the ordered tool sequences differ at all. The
+    ``added`` / ``removed`` lists are the multiset difference of tools (so a pure
+    reordering reports neither), and ``reordered`` is True when the two runs used
+    the same multiset of tools in a different order.
+    """
+
+    before: list[str]
+    after: list[str]
+    added: list[str]
+    removed: list[str]
+    reordered: bool
+    changed: bool
+
+    def render(self) -> str:
+        """Human-readable summary of the diff."""
+        if not self.changed:
+            return f"No trajectory change: {self.before}"
+        lines = ["Trajectory CHANGED:"]
+        lines.append(f"  before: {self.before}")
+        lines.append(f"  after:  {self.after}")
+        if self.added:
+            lines.append(f"  + added:    {self.added}")
+        if self.removed:
+            lines.append(f"  - removed:  {self.removed}")
+        if self.reordered:
+            lines.append("  ~ reordered (same tools, different order)")
+        return "\n".join(lines)
+
+
+def diff_trajectories(before: Trajectory, after: Trajectory) -> TrajectoryDiff:
+    """Diff two trajectories' tool sequences for replay-regression detection.
+
+    Reuses the event-sourced trajectory: pass two :class:`Trajectory` objects
+    (e.g. ``Trajectory.from_events(...)`` over two runs of the SAME case) and get
+    back which tools were added, removed, or merely reordered between the runs.
+    Deterministic: the result is a pure function of the two tool sequences.
+    """
+    from collections import Counter  # noqa: PLC0415
+
+    before_seq = before.tool_sequence
+    after_seq = after.tool_sequence
+
+    before_counts = Counter(before_seq)
+    after_counts = Counter(after_seq)
+    added = sorted((after_counts - before_counts).elements())
+    removed = sorted((before_counts - after_counts).elements())
+
+    changed = before_seq != after_seq
+    reordered = changed and before_counts == after_counts
+
+    return TrajectoryDiff(
+        before=before_seq,
+        after=after_seq,
+        added=added,
+        removed=removed,
+        reordered=reordered,
+        changed=changed,
+    )

--- a/sdk/python/jamjet/templates/__init__.py
+++ b/sdk/python/jamjet/templates/__init__.py
@@ -1422,6 +1422,99 @@ nodes:
     type: end
 """,
     },
+    # ── quickstart ────────────────────────────────────────────────────────────
+    "quickstart": {
+        "agent.py": """\
+\"\"\"
+{name} -- a minimal JamJet agent.
+
+Run in-process (no dev server needed):
+    python agent.py
+\"\"\"
+
+from __future__ import annotations
+
+import asyncio
+
+from jamjet import Agent, tool
+
+
+@tool
+async def add(a: float, b: float) -> str:
+    \"\"\"Add two numbers and return the sum.\"\"\"
+    return f"{{a + b:g}}"
+
+
+agent = Agent(
+    "{name}",
+    model="anthropic/claude-sonnet-4-6",
+    tools=[add],
+    instructions="You are a helpful assistant. Use the add tool when asked to sum numbers.",
+    strategy="react",
+)
+
+
+async def main() -> None:
+    result = await agent.run("What is 7 plus 35?")
+    print(result.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+""",
+        "pyproject.toml": """\
+[project]
+name = "{name}"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["jamjet>=0.10.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""",
+        "README.md": """\
+# {name}
+
+A minimal JamJet agent built with the `quickstart` template.
+
+## Prerequisites
+
+```bash
+pip install jamjet
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Run in-process
+
+```bash
+python agent.py
+```
+
+Runs the agent via `LocalRuntime` -- no server needed.
+
+## Run with the durable engine
+
+Start the local stack:
+
+```bash
+jamjet dev
+```
+
+Then in a second terminal:
+
+```bash
+python agent.py
+```
+
+The durable engine records every turn to SQLite so you can inspect, replay, and fork runs.
+
+```bash
+jamjet inspect <execution-id>
+jamjet events  <execution-id>
+```
+""",
+    },
 }
 
 # ── Public API ────────────────────────────────────────────────────────────────

--- a/sdk/python/jamjet/templates/__init__.py
+++ b/sdk/python/jamjet/templates/__init__.py
@@ -1467,7 +1467,10 @@ if __name__ == "__main__":
 name = "{name}"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["jamjet>=0.10.0"]
+# The [model] extra pulls in litellm, which the in-process model seam uses to
+# call the agent's "anthropic/claude-sonnet-4-6" model. Without it `agent.run()`
+# raises at the first model call.
+dependencies = ["jamjet[model]>=0.10.0"]
 
 [build-system]
 requires = ["hatchling"]
@@ -1481,7 +1484,7 @@ A minimal JamJet agent built with the `quickstart` template.
 ## Prerequisites
 
 ```bash
-pip install jamjet
+pip install 'jamjet[model]'
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 

--- a/sdk/python/tests/test_cli_create.py
+++ b/sdk/python/tests/test_cli_create.py
@@ -83,6 +83,18 @@ def test_quickstart_pyproject_has_jamjet_dependency():
     assert "jamjet" in toml
 
 
+def test_quickstart_pyproject_dependency_includes_model_extra():
+    """The generated dependency must carry the [model] extra: the quickstart's
+    "anthropic/claude-sonnet-4-6" model is called through the in-process litellm
+    seam, which the [model] extra provides. A bare `jamjet` dep cannot run it."""
+    files = render_template("quickstart", "myagent")
+    toml = files["pyproject.toml"]
+    assert "jamjet[model]" in toml
+    # The README install command must match the dependency so a fresh project runs.
+    readme = files["README.md"]
+    assert "jamjet[model]" in readme
+
+
 # ---------------------------------------------------------------------------
 # `jamjet create` CLI tests
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_cli_create.py
+++ b/sdk/python/tests/test_cli_create.py
@@ -1,0 +1,188 @@
+"""Tests for `jamjet create` and the quickstart template."""
+
+from __future__ import annotations
+
+import ast
+
+from typer.testing import CliRunner
+
+from jamjet.cli.main import app
+from jamjet.templates import AVAILABLE_TEMPLATES, render_template
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Template unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_quickstart_in_available_templates():
+    assert "quickstart" in AVAILABLE_TEMPLATES
+
+
+def test_quickstart_renders_three_files():
+    files = render_template("quickstart", "myagent")
+    assert "agent.py" in files
+    assert "README.md" in files
+    assert "pyproject.toml" in files
+
+
+def test_quickstart_substitutes_name():
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    assert "myagent" in agent_src
+    # Placeholder must be replaced -- no literal {name} left
+    assert "{name}" not in agent_src
+
+    readme = files["README.md"]
+    assert "myagent" in readme
+    assert "{name}" not in readme
+
+    toml = files["pyproject.toml"]
+    assert "myagent" in toml
+    assert "{name}" not in toml
+
+
+def test_quickstart_agent_py_is_valid_python():
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    # Must parse without SyntaxError
+    tree = ast.parse(agent_src)
+    assert tree is not None
+
+
+def test_quickstart_agent_py_imports_jamjet():
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    # Must import Agent and tool from jamjet
+    assert "from jamjet import Agent, tool" in agent_src
+
+
+def test_quickstart_agent_py_has_tool_decorator():
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    assert "@tool" in agent_src
+
+
+def test_quickstart_agent_py_has_agent_constructor():
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    assert "Agent(" in agent_src
+
+
+def test_quickstart_agent_py_uses_real_model_string():
+    """The scaffold must reference the real model string, not a placeholder."""
+    files = render_template("quickstart", "myagent")
+    agent_src = files["agent.py"]
+    assert "anthropic/claude-sonnet-4-6" in agent_src
+
+
+def test_quickstart_pyproject_has_jamjet_dependency():
+    files = render_template("quickstart", "myagent")
+    toml = files["pyproject.toml"]
+    assert "jamjet" in toml
+
+
+# ---------------------------------------------------------------------------
+# `jamjet create` CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_writes_expected_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "myagent"])
+    assert result.exit_code == 0, result.output
+
+    assert (tmp_path / "myagent" / "agent.py").exists()
+    assert (tmp_path / "myagent" / "README.md").exists()
+    assert (tmp_path / "myagent" / "pyproject.toml").exists()
+
+
+def test_create_substitutes_name_in_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["create", "myagent"])
+
+    agent_src = (tmp_path / "myagent" / "agent.py").read_text()
+    assert "myagent" in agent_src
+    assert "{name}" not in agent_src
+
+
+def test_create_rendered_agent_is_valid_python(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["create", "myagent"])
+
+    agent_src = (tmp_path / "myagent" / "agent.py").read_text()
+    tree = ast.parse(agent_src)
+    assert tree is not None
+
+
+def test_create_fails_if_directory_exists(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "myagent").mkdir()
+
+    result = runner.invoke(app, ["create", "myagent"])
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+
+
+def test_create_does_not_overwrite_existing_dir(tmp_path, monkeypatch):
+    """Files in an existing directory must not be touched."""
+    monkeypatch.chdir(tmp_path)
+    existing_dir = tmp_path / "myagent"
+    existing_dir.mkdir()
+    sentinel = existing_dir / "sentinel.txt"
+    sentinel.write_text("do not overwrite")
+
+    runner.invoke(app, ["create", "myagent"])
+
+    assert sentinel.read_text() == "do not overwrite"
+
+
+def test_create_prints_cd_hint(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "myagent"])
+    assert result.exit_code == 0
+    assert "cd myagent" in result.output
+
+
+def test_create_default_template_is_quickstart(tmp_path, monkeypatch):
+    """create with no --template flag uses quickstart."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "myagent"])
+    assert result.exit_code == 0
+    assert "quickstart" in result.output
+
+
+def test_create_with_explicit_template(tmp_path, monkeypatch):
+    """create --template hello-agent should work."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "myproj", "--template", "hello-agent"])
+    assert result.exit_code == 0
+    assert (tmp_path / "myproj" / "workflow.yaml").exists()
+
+
+def test_create_unknown_template_fails(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "myagent", "--template", "nonexistent"])
+    assert result.exit_code != 0
+    assert "unknown template" in result.output.lower() or "unknown template" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Confirm `init` still works (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_init_still_works(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "myproj"])
+    assert result.exit_code == 0
+    assert (tmp_path / "myproj" / "workflow.yaml").exists()
+
+
+def test_init_list_templates_still_works(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--list-templates"])
+    assert result.exit_code == 0
+    assert "hello-agent" in result.output
+    assert "quickstart" in result.output

--- a/sdk/python/tests/test_cli_dev.py
+++ b/sdk/python/tests/test_cli_dev.py
@@ -7,9 +7,11 @@ health probe injected. No real processes are started.
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
-from jamjet.cli.dev_stack import DevStack, DevStackError
+from jamjet.cli.dev_stack import DevStack, DevStackError, ProcessSpec, http_health_probe
 
 # ---------------------------------------------------------------------------
 # Test doubles
@@ -328,6 +330,190 @@ def test_keyboard_interrupt_during_start_tears_down():
 
     # The sidecar (first spawned) must be torn down.
     assert rec.procs[0].terminated or rec.procs[0].killed
+
+
+# ---------------------------------------------------------------------------
+# Teardown — SIGTERM-ignoring child is SIGKILLed (no hang, no orphan) [I2]
+# ---------------------------------------------------------------------------
+
+
+class _WouldBlockForeverError(Exception):
+    """Raised by the stubborn fake when wait(timeout=None) is called — the buggy
+    path where a real Popen.wait() would block forever on a live child."""
+
+
+class StubbornProcess:
+    """A child that IGNORES SIGTERM.
+
+    ``terminate()`` has no effect on liveness; the first bounded ``wait()``
+    consumes its whole timeout (advancing the shared clock) and then times out;
+    it only dies after ``kill()``. ``wait(timeout=None)`` is the buggy path and
+    raises ``_WouldBlockForeverError`` (instead of hanging) so the old behavior is
+    caught deterministically rather than freezing the test.
+    """
+
+    def __init__(self, name: str, clock: FakeClock) -> None:
+        self.name = name
+        self.clock = clock
+        self.stdout = None
+        self.terminated = False
+        self.killed = False
+        self.wait_calls = 0
+        self.blocked_forever = False  # set if wait(timeout=None) is ever called
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        if self.killed:
+            self.returncode = -9
+            return -9
+        return None  # SIGTERM ignored -> stays alive until killed
+
+    def terminate(self) -> None:
+        self.terminated = True  # no effect on liveness (SIGTERM ignored)
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        if self.killed:
+            self.returncode = -9
+            return -9
+        if timeout is None:
+            # A real Popen.wait(None) BLOCKS FOREVER on a live child.
+            self.blocked_forever = True
+            raise _WouldBlockForeverError(self.name)
+        # Alive + bounded wait: consume the timeout (advance the shared clock),
+        # then report the timeout, exactly like a stubborn child.
+        self.clock.sleep(timeout)
+        raise subprocess.TimeoutExpired(cmd=self.name, timeout=timeout)
+
+
+def _spec(name: str) -> ProcessSpec:
+    return ProcessSpec(name=name, argv=[name], env={})
+
+
+def test_shutdown_sigkills_sigterm_ignoring_child_no_hang():
+    """A child that ignores SIGTERM is still SIGKILLed and wait() returns.
+
+    Two stubborn children: the first consumes the WHOLE shared grace deadline in
+    its wait, so the second sees remaining == 0. The old code passed
+    ``timeout=None`` there and blocked forever; the fix floors the wait and runs
+    a final unconditional SIGKILL sweep. Asserts both are SIGKILLed, the
+    wait(timeout=None) hang path is never taken, and shutdown() returns.
+    """
+    clock = FakeClock()
+    rec = Recorder()
+    stack = _make_stack(rec, clock, shutdown_grace=5.0)
+
+    first = StubbornProcess("engine", clock)
+    second = StubbornProcess("worker", clock)
+    # _started order is [engine, worker]; shutdown walks it in reverse, so worker
+    # is waited first and exhausts the deadline, leaving engine at remaining == 0.
+    stack._started = [(first, _spec("engine")), (second, _spec("worker"))]
+
+    stack.shutdown()  # must RETURN — not hang
+
+    for p in (first, second):
+        assert p.terminated, f"{p.name} was not SIGTERMed"
+        assert p.killed, f"{p.name} was not SIGKILLed (escalation must fire)"
+        assert p.blocked_forever is False, f"{p.name} hit the wait(timeout=None) hang path"
+
+
+def test_shutdown_sigkills_single_child_when_grace_already_zero():
+    """Degenerate deadline (grace == 0 -> remaining == 0 immediately) still
+    escalates to SIGKILL instead of blocking on wait(timeout=None)."""
+    clock = FakeClock()
+    rec = Recorder()
+    stack = _make_stack(rec, clock, shutdown_grace=0.0)
+
+    proc = StubbornProcess("engine", clock)
+    stack._started = [(proc, _spec("engine"))]
+
+    stack.shutdown()
+
+    assert proc.terminated
+    assert proc.killed
+    assert proc.blocked_forever is False
+
+
+# ---------------------------------------------------------------------------
+# Health probe — body must affirm health, not just HTTP 200 [M3]
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+
+def _patch_urlopen(monkeypatch, status: int, body: bytes) -> None:
+    import jamjet.cli.dev_stack as ds
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", lambda url, timeout=2: _FakeResp(status, body))
+
+
+def test_health_probe_ok_true_body_is_healthy(monkeypatch):
+    """Sidecar shape {"ok": true} -> healthy."""
+    _patch_urlopen(monkeypatch, 200, b'{"ok": true}')
+    assert http_health_probe("http://x/health") is True
+
+
+def test_health_probe_status_ok_body_is_healthy(monkeypatch):
+    """Engine shape {"status": "ok", ...} -> healthy (the probe gates BOTH)."""
+    _patch_urlopen(monkeypatch, 200, b'{"status": "ok", "version": "0.10.2"}')
+    assert http_health_probe("http://x/health") is True
+
+
+def test_health_probe_200_wrong_body_not_healthy(monkeypatch):
+    """A 200 with {"ok": false} is NOT healthy."""
+    _patch_urlopen(monkeypatch, 200, b'{"ok": false}')
+    assert http_health_probe("http://x/health") is False
+
+
+def test_health_probe_200_absent_body_not_healthy(monkeypatch):
+    """A 200 with an empty/absent health field is NOT healthy."""
+    _patch_urlopen(monkeypatch, 200, b"{}")
+    assert http_health_probe("http://x/health") is False
+
+
+def test_health_probe_200_non_json_body_not_healthy_no_crash(monkeypatch):
+    """A 200 with a non-JSON body is NOT healthy and does not crash (total)."""
+    _patch_urlopen(monkeypatch, 200, b"not json at all")
+    assert http_health_probe("http://x/health") is False
+
+
+def test_health_probe_200_non_dict_json_not_healthy(monkeypatch):
+    """A 200 whose JSON body is not an object (e.g. a bare ``true``) is NOT healthy."""
+    _patch_urlopen(monkeypatch, 200, b"true")
+    assert http_health_probe("http://x/health") is False
+
+
+def test_health_probe_non_2xx_not_healthy(monkeypatch):
+    """A non-2xx status is NOT healthy even with an otherwise-healthy body."""
+    _patch_urlopen(monkeypatch, 503, b'{"ok": true}')
+    assert http_health_probe("http://x/health") is False
+
+
+def test_health_probe_unreachable_not_healthy(monkeypatch):
+    """An unreachable endpoint is NOT healthy and does not raise."""
+    import jamjet.cli.dev_stack as ds
+
+    def _boom(url, timeout=2):
+        raise ds.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", _boom)
+    assert http_health_probe("http://x/health") is False
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_cli_dev.py
+++ b/sdk/python/tests/test_cli_dev.py
@@ -1,0 +1,390 @@
+"""Tests for `jamjet dev` full-stack orchestration (DevStack).
+
+These exercise the orchestration LOGIC in isolation — start order, env wiring,
+the health-gate and graceful teardown — with a fake process spawner and a fake
+health probe injected. No real processes are started.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.cli.dev_stack import DevStack, DevStackError
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeProcess:
+    """A stand-in for a spawned process exposing the ManagedProcess surface."""
+
+    def __init__(self, name: str, *, dies: bool = False) -> None:
+        self.name = name
+        self.stdout = None  # no log pump in tests
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+        self.returncode: int | None = None
+        self._dies = dies
+
+    def poll(self) -> int | None:
+        if self.terminated:
+            self.returncode = 0
+            return 0
+        if self.killed:
+            self.returncode = -9
+            return -9
+        if self._dies:
+            self.returncode = 1
+            return 1
+        return None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.waited = True
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+class FakeClock:
+    """Deterministic monotonic clock advanced only by sleep()."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def sleep(self, dt: float) -> None:
+        self.t += dt
+
+
+class Recorder:
+    """A fake spawner + health-probe that records an ordered event log."""
+
+    def __init__(
+        self,
+        *,
+        healthy_after: dict[str, int] | None = None,
+        never_healthy: list[str] | None = None,
+        die: set[str] | None = None,
+    ) -> None:
+        self.events: list[tuple[str, str]] = []
+        self.specs: dict[str, object] = {}
+        self.procs: list[FakeProcess] = []
+        self.healthy_after = healthy_after or {}
+        self.never_healthy = list(never_healthy or [])
+        self.die = die or set()
+        self._probe_counts: dict[str, int] = {}
+
+    def spawn(self, spec) -> FakeProcess:  # noqa: ANN001
+        self.events.append(("spawn", spec.name))
+        self.specs[spec.name] = spec
+        proc = FakeProcess(spec.name, dies=spec.name in self.die)
+        self.procs.append(proc)
+        return proc
+
+    def probe(self, url: str) -> bool:
+        self.events.append(("probe", url))
+        for frag in self.never_healthy:
+            if frag in url:
+                return False
+        n = self._probe_counts.get(url, 0) + 1
+        self._probe_counts[url] = n
+        for frag, need in self.healthy_after.items():
+            if frag in url:
+                if n >= need:
+                    self.events.append(("healthy", url))
+                    return True
+                return False
+        self.events.append(("healthy", url))
+        return True
+
+
+def _make_stack(rec: Recorder, clock: FakeClock, **kw) -> DevStack:
+    defaults = dict(
+        binary="/fake/jamjet-server",
+        base_env={"PATH": "/usr/bin"},
+        spawn=rec.spawn,
+        health_probe=rec.probe,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+        log=lambda *_a, **_k: None,
+        health_timeout=30.0,
+        poll_interval=0.25,
+        readiness_wait=0.0,
+        shutdown_grace=5.0,
+    )
+    defaults.update(kw)
+    return DevStack(**defaults)
+
+
+def _spawn_order(rec: Recorder) -> list[str]:
+    return [name for (kind, name) in rec.events if kind == "spawn"]
+
+
+def _first_index(rec: Recorder, pred) -> int:
+    return next(i for i, e in enumerate(rec.events) if pred(e))
+
+
+# ---------------------------------------------------------------------------
+# Start order + env wiring
+# ---------------------------------------------------------------------------
+
+
+def test_start_order_sidecar_health_gated_before_engine_then_worker():
+    # Sidecar reports healthy only after a few polls, so we can assert the
+    # gate completes BEFORE the engine is spawned.
+    rec = Recorder(healthy_after={":4280/health": 3})
+    clock = FakeClock()
+    _make_stack(rec, clock, sidecar_port=4280).start()
+
+    assert _spawn_order(rec) == ["sidecar", "engine", "worker"]
+
+    sidecar_healthy = _first_index(rec, lambda e: e[0] == "healthy" and ":4280" in e[1])
+    engine_spawn = _first_index(rec, lambda e: e == ("spawn", "engine"))
+    worker_spawn = _first_index(rec, lambda e: e == ("spawn", "worker"))
+    assert sidecar_healthy < engine_spawn < worker_spawn
+
+
+def test_engine_env_carries_model_seam_url():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, sidecar_port=4280).start()
+    engine_env = rec.specs["engine"].env
+    assert engine_env["JAMJET_MODEL_SEAM_URL"] == "http://127.0.0.1:4280"
+
+
+def test_engine_env_has_port_and_dev_mode():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, port=7799).start()
+    env = rec.specs["engine"].env
+    assert env["PORT"] == "7799"
+    assert env["JAMJET_PORT"] == "7799"
+    assert env["JAMJET_DEV_MODE"] == "1"
+
+
+def test_engine_is_health_gated():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, port=7700).start()
+    assert any(k == "probe" and ":7700/health" in u for (k, u) in rec.events)
+
+
+def test_worker_argv_includes_modules_passthrough():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, modules="weather_agent").start()
+    argv = rec.specs["worker"].argv
+    assert "worker" in argv
+    assert "--modules" in argv
+    assert argv[argv.index("--modules") + 1] == "weather_agent"
+
+
+def test_worker_argv_omits_modules_when_none():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, modules=None).start()
+    argv = rec.specs["worker"].argv
+    assert "--modules" not in argv
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — fail loud + tear down
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_never_healthy_fails_loud_and_tears_down():
+    rec = Recorder(never_healthy=[":4280/health"])
+    clock = FakeClock()
+    stack = _make_stack(rec, clock, sidecar_port=4280)
+
+    with pytest.raises(DevStackError) as exc_info:
+        stack.start()
+
+    assert "sidecar" in str(exc_info.value).lower()
+    # Engine + worker must NOT have been started after the sidecar failed.
+    assert _spawn_order(rec) == ["sidecar"]
+    # The half-started sidecar must have been torn down (no orphan).
+    assert rec.procs[0].terminated or rec.procs[0].killed
+
+
+def test_engine_dies_before_healthy_fails_loud_and_tears_down_sidecar():
+    rec = Recorder(die={"engine"})
+    clock = FakeClock()
+    stack = _make_stack(rec, clock)
+
+    with pytest.raises(DevStackError) as exc_info:
+        stack.start()
+
+    assert "engine" in str(exc_info.value).lower()
+    # The healthy sidecar that was already up must be torn down.
+    sidecar_proc = next(p for p in rec.procs if p.name == "sidecar")
+    assert sidecar_proc.terminated or sidecar_proc.killed
+    # Worker never started.
+    assert "worker" not in _spawn_order(rec)
+
+
+# ---------------------------------------------------------------------------
+# Flags: --no-sidecar / --no-worker / --engine-only
+# ---------------------------------------------------------------------------
+
+
+def test_no_sidecar_skips_sidecar_and_does_not_set_seam_env():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, enable_sidecar=False).start()
+
+    assert "sidecar" not in _spawn_order(rec)
+    assert "JAMJET_MODEL_SEAM_URL" not in rec.specs["engine"].env
+
+
+def test_no_sidecar_pops_inherited_seam_env():
+    """A stale exported JAMJET_MODEL_SEAM_URL must not leak through to the engine
+    when we are not managing a sidecar — else the engine fails closed."""
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(
+        rec,
+        clock,
+        enable_sidecar=False,
+        base_env={"JAMJET_MODEL_SEAM_URL": "http://stale:1234"},
+    ).start()
+    assert "JAMJET_MODEL_SEAM_URL" not in rec.specs["engine"].env
+
+
+def test_no_worker_skips_worker():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, enable_worker=False).start()
+    spawned = _spawn_order(rec)
+    assert "worker" not in spawned
+    assert "sidecar" in spawned
+    assert "engine" in spawned
+
+
+def test_engine_only_starts_only_the_engine():
+    rec = Recorder()
+    clock = FakeClock()
+    _make_stack(rec, clock, enable_sidecar=False, enable_worker=False).start()
+    assert _spawn_order(rec) == ["engine"]
+    assert "JAMJET_MODEL_SEAM_URL" not in rec.specs["engine"].env
+
+
+# ---------------------------------------------------------------------------
+# Teardown — no orphans
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_terminates_all_started_processes():
+    rec = Recorder()
+    clock = FakeClock()
+    stack = _make_stack(rec, clock)
+    stack.start()
+
+    stack.shutdown()
+
+    assert len(rec.procs) == 3
+    for proc in rec.procs:
+        assert proc.terminated, f"{proc.name} was not terminated"
+        assert proc.waited, f"{proc.name} was not waited on"
+
+
+def test_shutdown_is_idempotent():
+    rec = Recorder()
+    clock = FakeClock()
+    stack = _make_stack(rec, clock)
+    stack.start()
+    stack.shutdown()
+    # Second call must not raise and must not double-terminate.
+    stack.shutdown()
+    assert all(p.terminated for p in rec.procs)
+
+
+def test_keyboard_interrupt_during_start_tears_down():
+    """If startup is interrupted (Ctrl+C), already-started processes are torn down."""
+
+    class Boom:
+        calls = 0
+
+        def __call__(self, url: str) -> bool:
+            Boom.calls += 1
+            raise KeyboardInterrupt
+
+    rec = Recorder()
+    clock = FakeClock()
+    stack = _make_stack(rec, clock, health_probe=Boom())
+
+    with pytest.raises(KeyboardInterrupt):
+        stack.start()
+
+    # The sidecar (first spawned) must be torn down.
+    assert rec.procs[0].terminated or rec.procs[0].killed
+
+
+# ---------------------------------------------------------------------------
+# CLI command wiring
+# ---------------------------------------------------------------------------
+
+
+def test_dev_command_engine_only_wires_flags(monkeypatch):
+    import jamjet.cli.dev_stack as dev_stack
+    import jamjet.cli.main as cli
+
+    captured: dict = {}
+
+    class FakeStack:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self) -> None:
+            return None
+
+    monkeypatch.setattr(cli, "_find_server_binary", lambda: "/fake/jamjet-server")
+    monkeypatch.setattr(dev_stack, "DevStack", FakeStack)
+
+    from typer.testing import CliRunner
+
+    result = CliRunner().invoke(cli.app, ["dev", "--engine-only"])
+    assert result.exit_code == 0, result.output
+    assert captured["enable_sidecar"] is False
+    assert captured["enable_worker"] is False
+
+
+def test_dev_command_passes_sidecar_port_and_modules(monkeypatch):
+    import jamjet.cli.dev_stack as dev_stack
+    import jamjet.cli.main as cli
+
+    captured: dict = {}
+
+    class FakeStack:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self) -> None:
+            return None
+
+    monkeypatch.setattr(cli, "_find_server_binary", lambda: "/fake/jamjet-server")
+    monkeypatch.setattr(dev_stack, "DevStack", FakeStack)
+    # Pretend uvicorn is importable so the sidecar path is taken without a warning exit.
+    monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+
+    from typer.testing import CliRunner
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["dev", "--sidecar-port", "4999", "--modules", "myapp.tools"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["sidecar_port"] == 4999
+    assert captured["modules"] == "myapp.tools"
+    assert captured["enable_sidecar"] is True
+    assert captured["enable_worker"] is True

--- a/sdk/python/tests/test_cli_dev.py
+++ b/sdk/python/tests/test_cli_dev.py
@@ -235,6 +235,35 @@ def test_engine_dies_before_healthy_fails_loud_and_tears_down_sidecar():
     assert "worker" not in _spawn_order(rec)
 
 
+def test_spawn_failure_is_wrapped_in_devstackerror_and_tears_down():
+    """A spawner that RAISES (e.g. the server binary is missing -> FileNotFoundError)
+    surfaces as DevStackError -- the only exception the CLI catches -- with the raw
+    error chained, and the already-started sidecar is torn down (CodeRabbit #6)."""
+    rec = Recorder()
+    clock = FakeClock()
+    real_spawn = rec.spawn
+
+    def failing_spawn(spec):  # noqa: ANN001, ANN202
+        if spec.name == "engine":
+            raise FileNotFoundError(2, "No such file or directory", "/fake/jamjet-server")
+        return real_spawn(spec)
+
+    stack = _make_stack(rec, clock, spawn=failing_spawn)
+
+    with pytest.raises(DevStackError) as exc_info:
+        stack.start()
+
+    # The intended dev-stack message names the failing process; the raw
+    # FileNotFoundError is wrapped (chained), not surfaced to the CLI.
+    assert "engine" in str(exc_info.value).lower()
+    assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+    # The already-started sidecar must be torn down (no orphan).
+    sidecar_proc = next(p for p in rec.procs if p.name == "sidecar")
+    assert sidecar_proc.terminated or sidecar_proc.killed
+    # Worker never started.
+    assert "worker" not in _spawn_order(rec)
+
+
 # ---------------------------------------------------------------------------
 # Flags: --no-sidecar / --no-worker / --engine-only
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_trajectory_eval.py
+++ b/sdk/python/tests/test_trajectory_eval.py
@@ -1,0 +1,627 @@
+"""
+Tests for TrajectoryScorer and Trajectory -- T5-3.
+
+Coverage:
+- Trajectory.from_agent_result + from_events produce the same tool sequence
+- TrajectoryScorer with tool_sequence -> PASS on match, FAIL on missing/wrong order
+- used_tool / did_not_use / max_turns duals (positive and negative)
+- Per-assertion breakdown (which assertions passed/failed)
+- DETERMINISM: same trajectory + same spec -> identical result
+- LLM judge is OFF by default (no model call unless judge=True)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jamjet.eval.trajectory import (
+    Trajectory,
+    TrajectoryAssertionResult,
+    TrajectoryResult,
+    TrajectoryScorer,
+    TrajectoryStep,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _fake_result(tool_calls: list[dict]) -> MagicMock:
+    """Minimal fake AgentResult with the given tool_calls list."""
+    r = MagicMock()
+    r.tool_calls = tool_calls
+    return r
+
+
+def _tool_event(tool: str, node_id: str = "n1") -> dict:
+    """Minimal ToolCalled event dict."""
+    return {"kind": {"type": "tool_called", "node_id": node_id, "tool": tool}}
+
+
+def _other_event(kind_type: str) -> dict:
+    """Non-tool event (NodeStarted, NodeCompleted, etc.)."""
+    return {"kind": {"type": kind_type, "node_id": "n1"}}
+
+
+# ── Trajectory construction ───────────────────────────────────────────────────
+
+
+def test_trajectory_from_agent_result_tools():
+    tc = [
+        {"tool": "search", "input": {"q": "foo"}, "output": "results", "duration_us": 100},
+        {"tool": "calculate", "input": {"x": 1}, "output": "42", "duration_us": 50},
+    ]
+    traj = Trajectory.from_agent_result(_fake_result(tc))
+    assert traj.tool_sequence == ["search", "calculate"]
+    assert traj.step_count == 2
+    assert traj.tool_set == {"search", "calculate"}
+
+
+def test_trajectory_from_agent_result_args_preserved():
+    tc = [{"tool": "search", "input": {"q": "foo"}, "output": "r", "duration_us": 0}]
+    traj = Trajectory.from_agent_result(_fake_result(tc))
+    assert traj.steps[0].args == {"q": "foo"}
+    assert traj.steps[0].output == "r"
+    assert traj.steps[0].node_id is None  # not available in-process
+
+
+def test_trajectory_from_agent_result_empty():
+    traj = Trajectory.from_agent_result(_fake_result([]))
+    assert traj.tool_sequence == []
+    assert traj.step_count == 0
+    assert traj.tool_set == set()
+
+
+def test_trajectory_from_events_raw_list():
+    events = [
+        _other_event("node_started"),
+        _tool_event("search"),
+        _tool_event("calculate"),
+        _other_event("node_completed"),
+    ]
+    traj = Trajectory.from_events(events)
+    assert traj.tool_sequence == ["search", "calculate"]
+    assert traj.step_count == 2
+
+
+def test_trajectory_from_events_wrapped_dict():
+    """from_events accepts the {'events': [...]} dict from get_events()."""
+    events_data = {
+        "events": [
+            _tool_event("search"),
+            _tool_event("calculate"),
+        ]
+    }
+    traj = Trajectory.from_events(events_data)
+    assert traj.tool_sequence == ["search", "calculate"]
+
+
+def test_trajectory_from_events_skips_non_tool():
+    """Non-tool events (node_started, node_completed, etc.) are ignored."""
+    events = [
+        _other_event("workflow_started"),
+        _other_event("node_started"),
+        _tool_event("search"),
+        _other_event("node_completed"),
+    ]
+    traj = Trajectory.from_events(events)
+    assert traj.tool_sequence == ["search"]
+    assert traj.step_count == 1
+
+
+def test_trajectory_sources_agree():
+    """from_agent_result and from_events produce the same tool sequence."""
+    tc = [
+        {"tool": "search", "input": {}, "output": "", "duration_us": 0},
+        {"tool": "calculate", "input": {}, "output": "", "duration_us": 0},
+    ]
+    events = [_tool_event("search"), _tool_event("calculate")]
+
+    t1 = Trajectory.from_agent_result(_fake_result(tc))
+    t2 = Trajectory.from_events(events)
+    assert t1.tool_sequence == t2.tool_sequence
+    assert t1.tool_set == t2.tool_set
+    assert t1.step_count == t2.step_count
+
+
+def test_trajectory_node_id_from_events():
+    """node_id is populated from events but not from in-process tool_calls."""
+    events = [{"kind": {"type": "tool_called", "node_id": "agent-node-1", "tool": "search"}}]
+    traj = Trajectory.from_events(events)
+    assert traj.steps[0].node_id == "agent-node-1"
+
+
+def test_trajectory_render():
+    traj = Trajectory(
+        [
+            TrajectoryStep(tool="search", node_id="n1"),
+            TrajectoryStep(tool="calculate"),
+        ]
+    )
+    text = traj.render()
+    assert "search" in text
+    assert "calculate" in text
+    assert "2 steps" in text
+
+
+# ── tool_sequence assertion ───────────────────────────────────────────────────
+
+
+async def test_tool_sequence_exact_pass():
+    """Matching tool sequence -> PASS."""
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("calculate")])
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert isinstance(result, TrajectoryResult)
+    assert result.passed is True
+    assert result.score == pytest.approx(1.0)
+    assert len(result.assertions) == 1
+    assert result.assertions[0].name == "tool_sequence"
+    assert result.assertions[0].passed is True
+
+
+async def test_tool_sequence_subsequence_pass():
+    """Extra tool between required steps is allowed (subsequence)."""
+    traj = Trajectory.from_events(
+        [
+            _tool_event("search"),
+            _tool_event("fetch"),  # extra -- allowed
+            _tool_event("calculate"),
+        ]
+    )
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.assertions[0].passed is True
+
+
+async def test_tool_sequence_fail_missing_tool():
+    """Missing tool in sequence -> FAIL with breakdown showing which failed."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert result.score == pytest.approx(0.0)
+    assert result.assertions[0].name == "tool_sequence"
+    assert result.assertions[0].passed is False
+    assert "calculate" in result.assertions[0].message
+
+
+async def test_tool_sequence_fail_wrong_order():
+    """Both tools present but wrong order -> FAIL."""
+    traj = Trajectory.from_events([_tool_event("calculate"), _tool_event("search")])
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert result.assertions[0].passed is False
+
+
+async def test_tool_sequence_empty_expected_passes():
+    """Empty expected sequence -> always passes."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"tool_sequence": []})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+# ── expected_tools assertion ──────────────────────────────────────────────────
+
+
+async def test_expected_tools_subset_pass():
+    """All listed tools appear (subset check -- extras OK)."""
+    traj = Trajectory.from_events(
+        [
+            _tool_event("search"),
+            _tool_event("calculate"),
+            _tool_event("extra"),
+        ]
+    )
+    scorer = TrajectoryScorer(expected={"expected_tools": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+async def test_expected_tools_subset_fail():
+    """Missing required tool -> FAIL."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"expected_tools": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+    assert "calculate" in result.assertions[0].message
+
+
+async def test_expected_tools_exact_pass():
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("calculate")])
+    scorer = TrajectoryScorer(
+        expected={
+            "expected_tools": ["search", "calculate"],
+            "expected_tools_exact": True,
+        }
+    )
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+async def test_expected_tools_exact_fail_extra():
+    """Extra tool with exact=True -> FAIL."""
+    traj = Trajectory.from_events(
+        [
+            _tool_event("search"),
+            _tool_event("calculate"),
+            _tool_event("extra"),
+        ]
+    )
+    scorer = TrajectoryScorer(
+        expected={
+            "expected_tools": ["search", "calculate"],
+            "expected_tools_exact": True,
+        }
+    )
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+    assert "extra" in result.assertions[0].message
+
+
+# ── used_tool assertion ───────────────────────────────────────────────────────
+
+
+async def test_used_tool_string_pass():
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"used_tool": "search"})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.assertions[0].name == "used_tool"
+    assert result.assertions[0].passed is True
+
+
+async def test_used_tool_string_fail():
+    """used_tool: required tool absent -> FAIL (negative dual)."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"used_tool": "calculate"})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert result.assertions[0].name == "used_tool"
+    assert result.assertions[0].passed is False
+    assert "calculate" in result.assertions[0].message
+
+
+async def test_used_tool_list_pass():
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("calculate")])
+    scorer = TrajectoryScorer(expected={"used_tool": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+async def test_used_tool_list_partial_fail():
+    """One of several required tools missing -> FAIL."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"used_tool": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+
+
+# ── did_not_use assertion ─────────────────────────────────────────────────────
+
+
+async def test_did_not_use_string_pass():
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"did_not_use": "dangerous_tool"})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.assertions[0].name == "did_not_use"
+    assert result.assertions[0].passed is True
+
+
+async def test_did_not_use_string_fail():
+    """Forbidden tool was used -> FAIL (negative dual)."""
+    traj = Trajectory.from_events([_tool_event("dangerous_tool")])
+    scorer = TrajectoryScorer(expected={"did_not_use": "dangerous_tool"})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert result.assertions[0].name == "did_not_use"
+    assert result.assertions[0].passed is False
+    assert "dangerous_tool" in result.assertions[0].message
+
+
+async def test_did_not_use_list_fail():
+    """Any forbidden tool present -> FAIL."""
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("bad_tool")])
+    scorer = TrajectoryScorer(expected={"did_not_use": ["bad_tool", "evil_tool"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+    assert "bad_tool" in result.assertions[0].message
+
+
+async def test_did_not_use_list_pass_when_none_used():
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"did_not_use": ["bad_tool", "evil_tool"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+# ── max_turns assertion ───────────────────────────────────────────────────────
+
+
+async def test_max_turns_pass():
+    traj = Trajectory.from_events([_tool_event("a"), _tool_event("b")])
+    scorer = TrajectoryScorer(expected={"max_turns": 3})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.assertions[0].name == "max_turns"
+
+
+async def test_max_turns_exact_boundary_pass():
+    traj = Trajectory.from_events([_tool_event("a"), _tool_event("b"), _tool_event("c")])
+    scorer = TrajectoryScorer(expected={"max_turns": 3})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True  # <= is the check
+
+
+async def test_max_turns_fail():
+    """Exceeding max_turns -> FAIL (negative dual)."""
+    traj = Trajectory.from_events(
+        [
+            _tool_event("a"),
+            _tool_event("b"),
+            _tool_event("c"),
+            _tool_event("d"),
+        ]
+    )
+    scorer = TrajectoryScorer(expected={"max_turns": 3})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert result.assertions[0].name == "max_turns"
+    assert result.assertions[0].passed is False
+    assert "4" in result.assertions[0].message
+
+
+# ── step_count assertion ──────────────────────────────────────────────────────
+
+
+async def test_step_count_exact_pass():
+    traj = Trajectory.from_events([_tool_event("a"), _tool_event("b")])
+    scorer = TrajectoryScorer(expected={"step_count": 2})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+
+
+async def test_step_count_exact_fail():
+    traj = Trajectory.from_events([_tool_event("a")])
+    scorer = TrajectoryScorer(expected={"step_count": 2})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+    assert result.assertions[0].name == "step_count"
+
+
+# ── Per-assertion breakdown ───────────────────────────────────────────────────
+
+
+async def test_multiple_assertions_breakdown_mixed():
+    """Multiple assertions: breakdown shows which passed and which failed."""
+    traj = Trajectory.from_events([_tool_event("search")])  # 'calculate' missing
+
+    scorer = TrajectoryScorer(
+        expected={
+            "expected_tools": ["search", "calculate"],  # FAIL (missing calculate)
+            "did_not_use": "dangerous",  # PASS
+            "max_turns": 5,  # PASS
+        }
+    )
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is False
+    assert len(result.assertions) == 3
+
+    by_name = {a.name: a for a in result.assertions}
+    assert "expected_tools" in by_name
+    assert "did_not_use" in by_name
+    assert "max_turns" in by_name
+    assert by_name["expected_tools"].passed is False
+    assert by_name["did_not_use"].passed is True
+    assert by_name["max_turns"].passed is True
+
+    # Score: 2 of 3 passed
+    assert result.score == pytest.approx(2.0 / 3.0)
+
+
+async def test_all_assertions_pass_score_is_one():
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("calculate")])
+    scorer = TrajectoryScorer(
+        expected={
+            "used_tool": "search",
+            "did_not_use": "bad",
+            "max_turns": 5,
+        }
+    )
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.score == pytest.approx(1.0)
+
+
+async def test_message_lists_failed_assertions():
+    """Message names the failed assertions when not all pass."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(
+        expected={
+            "used_tool": "calculate",  # FAIL
+            "did_not_use": "bad",  # PASS
+        }
+    )
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is False
+    assert "used_tool" in result.message
+
+
+# ── No trajectory provided ────────────────────────────────────────────────────
+
+
+async def test_no_trajectory_skips_gracefully():
+    """If no trajectory kwarg is given, scorer skips all assertions."""
+    scorer = TrajectoryScorer(expected={"used_tool": "search"})
+    result = await scorer.score("some output")  # no trajectory= kwarg
+
+    assert result.passed is True
+    assert result.score is None
+    assert len(result.assertions) == 0
+    assert "no trajectory" in result.message
+
+
+async def test_no_assertions_in_spec_passes():
+    """Empty spec -> passes with score 1.0."""
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.score == pytest.approx(1.0)
+    assert len(result.assertions) == 0
+
+
+# ── DETERMINISM ───────────────────────────────────────────────────────────────
+
+
+async def test_scoring_deterministic_same_result_twice():
+    """Same trajectory + same spec -> identical result, both calls."""
+    traj = Trajectory.from_events([_tool_event("search"), _tool_event("calculate")])
+    scorer = TrajectoryScorer(
+        expected={
+            "tool_sequence": ["search", "calculate"],
+            "max_turns": 5,
+        }
+    )
+
+    r1 = await scorer.score(None, trajectory=traj)
+    r2 = await scorer.score(None, trajectory=traj)
+
+    assert r1.passed == r2.passed
+    assert r1.score == r2.score
+    assert r1.message == r2.message
+    assert len(r1.assertions) == len(r2.assertions)
+    for a1, a2 in zip(r1.assertions, r2.assertions):
+        assert a1.name == a2.name
+        assert a1.passed == a2.passed
+        assert a1.message == a2.message
+
+
+async def test_scoring_deterministic_pass_then_fail():
+    """Determinism holds across different trajectories (not just same)."""
+    traj_pass = Trajectory.from_events([_tool_event("search"), _tool_event("calc")])
+    traj_fail = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calc"]})
+
+    r_pass = await scorer.score(None, trajectory=traj_pass)
+    r_fail = await scorer.score(None, trajectory=traj_fail)
+    # Scoring same passing trajectory again -- must equal first result
+    r_pass2 = await scorer.score(None, trajectory=traj_pass)
+
+    assert r_pass.passed is True
+    assert r_fail.passed is False
+    assert r_pass2.passed == r_pass.passed
+    assert r_pass2.score == r_pass.score
+
+
+# ── LLM judge: OFF by default ─────────────────────────────────────────────────
+
+
+async def test_judge_off_by_default_no_model_call(monkeypatch):
+    """No model call is made when judge=False (the default)."""
+    calls: list[str] = []
+
+    async def spy_model(prompt: str) -> str:
+        calls.append(prompt)
+        return '{"score": 5, "reason": "great"}'
+
+    # Monkeypatch LlmJudgeScorer._call_model to detect any invocation.
+    from jamjet.eval import scorers as scorers_mod
+
+    monkeypatch.setattr(scorers_mod.LlmJudgeScorer, "_call_model", spy_model)
+
+    traj = Trajectory.from_events([_tool_event("search")])
+    # Default: no judge flag
+    scorer = TrajectoryScorer(expected={"used_tool": "search"})
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is True
+    assert len(calls) == 0, "LLM judge must NOT be called when judge=False"
+
+
+async def test_judge_enabled_calls_model():
+    """When judge=True, the model_fn is called exactly once."""
+    calls: list[str] = []
+
+    async def fake_model(prompt: str) -> str:
+        calls.append(prompt)
+        return '{"score": 4, "reason": "good trajectory"}'
+
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(
+        expected={"used_tool": "search"},
+        judge=True,
+        judge_model_fn=fake_model,
+    )
+    result = await scorer.score(None, trajectory=traj)
+
+    assert result.passed is True  # structural assertion passes
+    assert len(calls) == 1, "LLM judge SHOULD be called once when judge=True"
+    assert "judge" in result.message  # judge result appended to message
+
+
+async def test_judge_enabled_but_structural_fails():
+    """Even with judge enabled, structural failure dominates passed=False."""
+
+    async def fake_model(prompt: str) -> str:
+        return '{"score": 5, "reason": "great"}'
+
+    traj = Trajectory.from_events([_tool_event("search")])
+    scorer = TrajectoryScorer(
+        expected={"used_tool": "calculate"},  # FAIL structurally
+        judge=True,
+        judge_model_fn=fake_model,
+    )
+    result = await scorer.score(None, trajectory=traj)
+
+    # Structural assertion failed -- overall result is False
+    assert result.passed is False
+
+
+# ── Public surface via jamjet.eval ────────────────────────────────────────────
+
+
+def test_exports_from_jamjet_eval():
+    """Trajectory, TrajectoryScorer etc. are accessible from jamjet.eval."""
+    from jamjet.eval import (
+        Trajectory,
+        TrajectoryAssertionResult,
+        TrajectoryResult,
+        TrajectoryScorer,
+        TrajectoryStep,
+    )
+
+    assert Trajectory is not None
+    assert TrajectoryScorer is not None
+    assert TrajectoryResult is not None
+    assert TrajectoryStep is not None
+    assert TrajectoryAssertionResult is not None
+
+
+def test_trajectory_result_is_scorer_result():
+    """TrajectoryResult is a ScorerResult subclass."""
+    from jamjet.eval.scorers import ScorerResult
+
+    result = TrajectoryResult(
+        scorer="trajectory",
+        passed=True,
+        score=1.0,
+        message="ok",
+        assertions=[],
+    )
+    assert isinstance(result, ScorerResult)
+    assert result.scorer == "trajectory"
+    assert result.passed is True

--- a/sdk/python/tests/test_trajectory_eval.py
+++ b/sdk/python/tests/test_trajectory_eval.py
@@ -12,18 +12,16 @@ Coverage:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from jamjet.eval.trajectory import (
     Trajectory,
-    TrajectoryAssertionResult,
     TrajectoryResult,
     TrajectoryScorer,
     TrajectoryStep,
 )
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -43,6 +41,141 @@ def _tool_event(tool: str, node_id: str = "n1") -> dict:
 def _other_event(kind_type: str) -> dict:
     """Non-tool event (NodeStarted, NodeCompleted, etc.)."""
     return {"kind": {"type": kind_type, "node_id": "n1"}}
+
+
+def _model_node_completed(
+    tool_calls: list[str],
+    *,
+    node_id: str = "model",
+    finish_reason: str = "tool_calls",
+    seq: int = 0,
+) -> dict:
+    """A model-node ``NodeCompleted`` event in the SHAPE the durable engine emits.
+
+    Mirrors ``runtime/workers/src/executors/model_node.rs`` +
+    ``runtime/state/src/event.rs``: the EventKind serializes with
+    ``serde(tag="type", rename_all="snake_case")``, so the variant nests under
+    ``kind`` with ``type="node_completed"``; ``output`` carries
+    ``content/model/finish_reason/tool_calls`` and ``state_patch`` carries
+    ``last_model_tool_calls``. Each tool_call entry is ``{id, name, arguments}``.
+    """
+    tc = [{"id": f"call_{i}", "name": name, "arguments": {}} for i, name in enumerate(tool_calls)]
+    return {
+        "id": f"evt-{seq}",
+        "execution_id": "exec-1",
+        "sequence": seq,
+        "kind": {
+            "type": "node_completed",
+            "node_id": node_id,
+            "output": {
+                "content": "",
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": finish_reason,
+                "tool_calls": tc,
+            },
+            "state_patch": {
+                "last_model_output": "",
+                "last_model_finish_reason": finish_reason,
+                "last_model_tool_calls": tc,
+            },
+            "duration_ms": 7,
+            "gen_ai_system": "anthropic",
+            "gen_ai_model": "anthropic/claude-sonnet-4-6",
+        },
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+
+def _dispatch_node_completed(node_id: str, result: object) -> dict:
+    """A tool-dispatch PythonFn ``NodeCompleted``: result payload, NO tool_calls."""
+    return {
+        "kind": {
+            "type": "node_completed",
+            "node_id": node_id,
+            "output": {"result": result},
+            "state_patch": {},
+            "duration_ms": 2,
+        }
+    }
+
+
+# ── Realistic durable event log (the SHAPE the engine actually emits) ──────────
+
+
+def test_from_events_realistic_durable_node_completed():
+    """A real durable run reconstructs its tool trajectory from model
+    ``NodeCompleted.output.tool_calls`` -- NOT from never-emitted ``tool_called``
+    events.
+
+    C1 regression guard: this FAILS against ``tool_called``-keyed code (which
+    finds zero tool calls in a real durable log) and passes once ``from_events``
+    reads the model node's ``tool_calls``.
+    """
+    # A two-turn durable run: model asks for search, a dispatch node runs it,
+    # model asks for calculate, a dispatch node runs it, model stops.
+    events = {
+        "events": [
+            {
+                "kind": {
+                    "type": "workflow_started",
+                    "workflow_id": "wf",
+                    "workflow_version": "1",
+                    "initial_input": {},
+                }
+            },
+            {"kind": {"type": "node_started", "node_id": "model", "worker_id": "w1", "attempt": 1}},
+            _model_node_completed(["search"], node_id="model_turn_1", seq=1),
+            _dispatch_node_completed("dispatch_1", "hits"),
+            _model_node_completed(["calculate"], node_id="model_turn_2", seq=3),
+            _dispatch_node_completed("dispatch_2", "42"),
+            _model_node_completed([], node_id="model_turn_3", finish_reason="stop", seq=5),
+        ]
+    }
+    traj = Trajectory.from_events(events)
+    assert traj.tool_sequence == ["search", "calculate"]
+    assert traj.step_count == 2
+    # node_id is carried from the model node that requested the tool.
+    assert traj.steps[0].node_id == "model_turn_1"
+    assert traj.steps[1].node_id == "model_turn_2"
+
+
+def test_from_events_durable_parallel_tool_calls_in_one_turn():
+    """A single model turn that requests two tools (parallel tool-calling)
+    contributes both, in order."""
+    events = [_model_node_completed(["search", "calculate"], node_id="model_turn_1", seq=1)]
+    traj = Trajectory.from_events(events)
+    assert traj.tool_sequence == ["search", "calculate"]
+    assert traj.steps[0].node_id == "model_turn_1"
+
+
+def test_from_events_durable_falls_back_to_state_patch():
+    """When ``output.tool_calls`` is unavailable (e.g. output artifact-spilled and
+    unresolved), the always-inline ``state_patch.last_model_tool_calls`` is used."""
+    evt = _model_node_completed(["search"], node_id="m", seq=1)
+    # Simulate an unresolved artifact sentinel output (no tool_calls in output).
+    evt["kind"]["output"] = {"$artifact": {"ref": "blob://x", "unresolved": True}}
+    traj = Trajectory.from_events([evt])
+    assert traj.tool_sequence == ["search"]
+
+
+def test_from_events_durable_plain_node_completed_contributes_nothing():
+    """A ``node_completed`` with no model tool_calls (dispatch / plain node) adds
+    no steps -- so a did_not_use / max_turns-only spec is NOT falsely satisfied."""
+    events = [_dispatch_node_completed("dispatch_1", "x"), _other_event("node_completed")]
+    traj = Trajectory.from_events(events)
+    assert traj.tool_sequence == []
+    assert traj.step_count == 0
+
+
+async def test_from_events_durable_trajectory_scores_tool_sequence():
+    """End-to-end: a realistic durable log scores a ``tool_sequence`` spec
+    correctly (the path ``jamjet eval run`` exercises via the durable runner)."""
+    events = {"events": [_model_node_completed(["search"], seq=1), _model_node_completed(["calculate"], seq=2)]}
+    traj = Trajectory.from_events(events)
+    scorer = TrajectoryScorer(expected={"tool_sequence": ["search", "calculate"]})
+    result = await scorer.score(None, trajectory=traj)
+    assert result.passed is True
+    assert result.assertions[0].passed is True
 
 
 # ── Trajectory construction ───────────────────────────────────────────────────

--- a/sdk/python/tests/test_trajectory_eval.py
+++ b/sdk/python/tests/test_trajectory_eval.py
@@ -516,6 +516,66 @@ async def test_max_turns_fail():
     assert "4" in result.assertions[0].message
 
 
+async def test_max_turns_counts_model_turns_not_tool_calls():
+    """One model turn that emits TWO parallel tool calls is ONE turn, not two.
+
+    Regression guard for CodeRabbit #1: max_turns must count model TURNS, so a
+    single turn calling two tools satisfies {max_turns: 1} (it used to fail
+    because the two flattened tool steps were miscounted as two turns). The same
+    trajectory has step_count 2.
+    """
+    events = [_model_node_completed(["search", "calculate"], node_id="model_turn_1", seq=1)]
+    traj = Trajectory.from_events(events)
+    assert traj.turn_count == 1
+    assert traj.step_count == 2
+
+    # max_turns: 1 PASSES (one model turn), step_count: 2 PASSES (two tool steps).
+    r_turns = await TrajectoryScorer(expected={"max_turns": 1}).score(None, trajectory=traj)
+    assert r_turns.passed is True, "1 model turn with 2 tool calls must satisfy max_turns: 1"
+    r_steps = await TrajectoryScorer(expected={"step_count": 2}).score(None, trajectory=traj)
+    assert r_steps.passed is True
+
+
+async def test_max_turns_two_model_turns_fails_max_turns_one():
+    """Two model turns -> turn_count 2 -> fails {max_turns: 1} (the negative dual)."""
+    events = [
+        _model_node_completed(["search"], node_id="m1", seq=1),
+        _model_node_completed(["calculate"], node_id="m2", seq=2),
+    ]
+    traj = Trajectory.from_events(events)
+    assert traj.turn_count == 2
+    result = await TrajectoryScorer(expected={"max_turns": 1}).score(None, trajectory=traj)
+    assert result.passed is False
+    assert result.assertions[0].name == "max_turns"
+    assert "turn" in result.assertions[0].message
+
+
+async def test_max_turns_final_stop_turn_counts_as_a_turn():
+    """A final model turn with no tool calls (finish_reason=stop) still counts."""
+    events = [
+        _model_node_completed(["search"], node_id="m1", seq=1),
+        _model_node_completed([], node_id="m2", finish_reason="stop", seq=2),
+    ]
+    traj = Trajectory.from_events(events)
+    assert traj.turn_count == 2  # both model calls are turns
+    assert traj.step_count == 1  # only one tool call
+
+
+def test_turn_count_falls_back_to_step_count_in_process():
+    """In-process AgentResult has no turn signal -> turn_count falls back to steps."""
+    tc = [
+        {"tool": "search", "input": {}, "output": "", "duration_us": 0},
+        {"tool": "calculate", "input": {}, "output": "", "duration_us": 0},
+    ]
+    from unittest.mock import MagicMock
+
+    r = MagicMock()
+    r.tool_calls = tc
+    traj = Trajectory.from_agent_result(r)
+    assert traj.turn_count == 2  # == step_count (no turn signal)
+    assert traj.step_count == 2
+
+
 # ── step_count assertion ──────────────────────────────────────────────────────
 
 

--- a/sdk/python/tests/test_trajectory_eval_fixture.py
+++ b/sdk/python/tests/test_trajectory_eval_fixture.py
@@ -1,0 +1,60 @@
+"""
+Smoke test: the trajectory-eval example evalset loads without error via the
+real dataset loader (eval/dataset.py) and has the expected shape.
+
+This is the T5-6 fixture-validity gate: if the example file is malformed the
+loader raises, failing the suite and preventing broken example files from
+landing on main.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jamjet.eval.dataset import EvalDataset
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EVALSET = REPO_ROOT / "examples" / "trajectory-eval" / "evalset.jsonl"
+
+
+def test_trajectory_eval_fixture_exists():
+    """The evalset file ships alongside the example."""
+    assert EVALSET.exists(), f"evalset.jsonl missing at {EVALSET}"
+
+
+def test_trajectory_eval_fixture_loads():
+    """EvalDataset.from_file parses the evalset without error."""
+    ds = EvalDataset.from_file(EVALSET)
+    assert len(ds) == 3, f"expected 3 rows, got {len(ds)}"
+
+
+def test_trajectory_eval_fixture_row_ids():
+    """Each row has the expected id."""
+    ds = EvalDataset.from_file(EVALSET)
+    ids = [row.id for row in ds]
+    assert "search-then-calc" in ids
+    assert "search-only" in ids
+    assert "no-trajectory" in ids
+
+
+def test_trajectory_eval_fixture_expected_trajectory_shape():
+    """Rows with expected_trajectory carry the right spec keys."""
+    ds = EvalDataset.from_file(EVALSET)
+    rows_by_id = {row.id: row for row in ds}
+
+    # search-then-calc: tool_sequence + max_turns
+    r = rows_by_id["search-then-calc"]
+    assert r.expected_trajectory is not None
+    assert "tool_sequence" in r.expected_trajectory
+    assert r.expected_trajectory["tool_sequence"] == ["web_search", "calculator"]
+    assert r.expected_trajectory["max_turns"] == 4
+
+    # search-only: used_tool + did_not_use
+    r = rows_by_id["search-only"]
+    assert r.expected_trajectory is not None
+    assert r.expected_trajectory["used_tool"] == "web_search"
+    assert r.expected_trajectory["did_not_use"] == "calculator"
+
+    # no-trajectory: backward-compatible -- expected_trajectory is None
+    r = rows_by_id["no-trajectory"]
+    assert r.expected_trajectory is None

--- a/sdk/python/tests/test_trajectory_eval_runner.py
+++ b/sdk/python/tests/test_trajectory_eval_runner.py
@@ -1,0 +1,340 @@
+"""
+Tests for trajectory eval wiring + replay-regression diff -- T5-4.
+
+Coverage:
+- EvalRow.expected_trajectory: default None; loader parses it (JSONL / JSON / YAML)
+- EvalRunner (durable, mocked client): a case whose events match expected_trajectory
+  scores the trajectory PASS and the case passes
+- EvalRunner: a case whose agent uses the WRONG tools scores the trajectory FAIL and
+  the case FAILS even though the output scorer matched (output AND trajectory)
+- EvalRow with no expected_trajectory -> output-only, unchanged (no trajectory scorer)
+- AgentEvalRunner (in-process, mocked Agent): trajectory built from tool_calls
+- diff_trajectories: an added tool is flagged as a regression; reorder + identical
+- jamjet eval trajectory-diff CLI: detects the regression and exits 1
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jamjet.eval.dataset import EvalDataset, EvalRow
+from jamjet.eval.runner import AgentEvalRunner, EvalRunner
+from jamjet.eval.scorers import AssertionScorer
+from jamjet.eval.trajectory import Trajectory, diff_trajectories
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _tool_event(tool: str, node_id: str = "n1") -> dict:
+    return {"kind": {"type": "tool_called", "node_id": node_id, "tool": tool}}
+
+
+def _mock_client(*, output: dict, events: list[dict]) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.start_execution = AsyncMock(return_value={"execution_id": "exec-1"})
+    client.get_execution = AsyncMock(return_value={"status": "completed", "output": output})
+    client.get_events = AsyncMock(return_value={"events": events})
+    return client
+
+
+# ── EvalRow.expected_trajectory + loader ──────────────────────────────────────
+
+
+def test_evalrow_expected_trajectory_default_none():
+    row = EvalRow(id="r1", input={"q": "x"})
+    assert row.expected_trajectory is None
+
+
+def test_loader_parses_expected_trajectory_jsonl(tmp_path):
+    path = tmp_path / "data.jsonl"
+    path.write_text(
+        '{"id": "q1", "input": {"q": "a"}, "expected_trajectory": {"tool_sequence": ["search", "calc"]}}\n'
+        '{"id": "q2", "input": {"q": "b"}}\n'
+    )
+    ds = EvalDataset.from_file(path)
+    assert ds[0].expected_trajectory == {"tool_sequence": ["search", "calc"]}
+    assert ds[1].expected_trajectory is None  # backward compatible
+
+
+def test_loader_parses_expected_trajectory_json(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"input": {"q": "a"}, "expected_trajectory": {"used_tool": "search"}},
+            ]
+        )
+    )
+    ds = EvalDataset.from_file(path)
+    assert ds[0].expected_trajectory == {"used_tool": "search"}
+
+
+def test_loader_parses_expected_trajectory_yaml(tmp_path):
+    path = tmp_path / "data.yaml"
+    path.write_text("- input:\n    q: a\n  expected_trajectory:\n    tool_sequence: [search, calc]\n")
+    ds = EvalDataset.from_file(path)
+    assert ds[0].expected_trajectory == {"tool_sequence": ["search", "calc"]}
+
+
+# ── EvalRunner: trajectory scored IN ADDITION to output ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_trajectory_pass(monkeypatch):
+    """A case whose events match expected_trajectory -> trajectory PASS, case passes."""
+    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search"), _tool_event("calc")])
+    import jamjet.client as client_mod
+
+    monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)
+
+    row = EvalRow(
+        id="r1",
+        input={"q": "hi"},
+        expected_trajectory={"tool_sequence": ["search", "calc"]},
+    )
+    runner = EvalRunner("wf", [AssertionScorer(checks=["'answer' in output"])], poll_interval_s=0.0)
+    [result] = await runner.run(EvalDataset([row]))
+
+    assert result.passed is True
+    # output AND trajectory scorers both present
+    names = {s.scorer for s in result.scorers}
+    assert "assertion" in names
+    assert "trajectory" in names
+    traj_scorer = next(s for s in result.scorers if s.scorer == "trajectory")
+    assert traj_scorer.passed is True
+    assert result.trajectory == ["search", "calc"]
+
+
+@pytest.mark.asyncio
+async def test_runner_trajectory_fail_even_if_output_matches(monkeypatch):
+    """Wrong tools -> trajectory FAIL and the case FAILS even though output matched."""
+    # Output matches the assertion, but the agent used the wrong tools.
+    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search"), _tool_event("web")])
+    import jamjet.client as client_mod
+
+    monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)
+
+    row = EvalRow(
+        id="r1",
+        input={"q": "hi"},
+        expected_trajectory={"tool_sequence": ["search", "calc"]},  # expects calc, got web
+    )
+    runner = EvalRunner("wf", [AssertionScorer(checks=["'answer' in output"])], poll_interval_s=0.0)
+    [result] = await runner.run(EvalDataset([row]))
+
+    # Output scorer passes ...
+    output_scorer = next(s for s in result.scorers if s.scorer == "assertion")
+    assert output_scorer.passed is True
+    # ... trajectory scorer fails ...
+    traj_scorer = next(s for s in result.scorers if s.scorer == "trajectory")
+    assert traj_scorer.passed is False
+    # ... so the overall case fails (output AND trajectory).
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_runner_no_expected_trajectory_is_output_only(monkeypatch):
+    """expected_trajectory=None -> output-only, unchanged (no trajectory scorer)."""
+    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search")])
+    import jamjet.client as client_mod
+
+    monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)
+
+    row = EvalRow(id="r1", input={"q": "hi"})  # no expected_trajectory
+    runner = EvalRunner("wf", [AssertionScorer(checks=["'answer' in output"])], poll_interval_s=0.0)
+    [result] = await runner.run(EvalDataset([row]))
+
+    assert result.passed is True
+    names = {s.scorer for s in result.scorers}
+    assert names == {"assertion"}  # NO trajectory scorer appended
+    # trajectory tool_sequence still captured for inspection / regression diffing
+    assert result.trajectory == ["search"]
+
+
+# ── AgentEvalRunner: trajectory from in-process tool_calls ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_runner_trajectory_from_tool_calls(monkeypatch):
+    """AgentEvalRunner builds the trajectory from AgentResult.tool_calls."""
+
+    class _FakeAgentResult:
+        output = {"answer": "ok"}
+        tool_calls = [
+            {"tool": "search", "input": {}, "output": "", "duration_us": 0},
+            {"tool": "calc", "input": {}, "output": "", "duration_us": 0},
+        ]
+
+    class _FakeAgent:
+        def __init__(self, *a, **k):
+            pass
+
+        async def run(self, task):
+            return _FakeAgentResult()
+
+    import jamjet.agents.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "Agent", _FakeAgent)
+
+    row = EvalRow(
+        id="r1",
+        input={"task": "do it"},
+        expected_trajectory={"tool_sequence": ["search", "calc"]},
+    )
+    runner = AgentEvalRunner([AssertionScorer(checks=["'answer' in output"])])
+    [result] = await runner.run(EvalDataset([row]))
+
+    assert result.passed is True
+    traj_scorer = next(s for s in result.scorers if s.scorer == "trajectory")
+    assert traj_scorer.passed is True
+    assert result.trajectory == ["search", "calc"]
+
+
+@pytest.mark.asyncio
+async def test_agent_runner_trajectory_fail(monkeypatch):
+    """AgentEvalRunner trajectory failure fails the case even when output matches."""
+
+    class _FakeAgentResult:
+        output = {"answer": "ok"}
+        tool_calls = [{"tool": "search", "input": {}, "output": "", "duration_us": 0}]  # missing calc
+
+    class _FakeAgent:
+        def __init__(self, *a, **k):
+            pass
+
+        async def run(self, task):
+            return _FakeAgentResult()
+
+    import jamjet.agents.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "Agent", _FakeAgent)
+
+    row = EvalRow(
+        id="r1",
+        input={"task": "do it"},
+        expected_trajectory={"tool_sequence": ["search", "calc"]},
+    )
+    runner = AgentEvalRunner([AssertionScorer(checks=["'answer' in output"])])
+    [result] = await runner.run(EvalDataset([row]))
+
+    assert result.passed is False
+
+
+# ── Replay-regression trajectory diff ─────────────────────────────────────────
+
+
+def test_diff_flags_added_tool_regression():
+    """before [search, calc] vs after [search, web, calc] -> 'web' added (regression)."""
+    before = Trajectory.from_events([_tool_event("search"), _tool_event("calc")])
+    after = Trajectory.from_events([_tool_event("search"), _tool_event("web"), _tool_event("calc")])
+
+    diff = diff_trajectories(before, after)
+
+    assert diff.changed is True
+    assert diff.added == ["web"]
+    assert diff.removed == []
+    assert diff.reordered is False
+    assert diff.before == ["search", "calc"]
+    assert diff.after == ["search", "web", "calc"]
+
+
+def test_diff_flags_removed_tool():
+    before = Trajectory.from_events([_tool_event("search"), _tool_event("web"), _tool_event("calc")])
+    after = Trajectory.from_events([_tool_event("search"), _tool_event("calc")])
+    diff = diff_trajectories(before, after)
+    assert diff.changed is True
+    assert diff.removed == ["web"]
+    assert diff.added == []
+
+
+def test_diff_detects_reorder():
+    before = Trajectory.from_events([_tool_event("a"), _tool_event("b")])
+    after = Trajectory.from_events([_tool_event("b"), _tool_event("a")])
+    diff = diff_trajectories(before, after)
+    assert diff.changed is True
+    assert diff.reordered is True
+    assert diff.added == []
+    assert diff.removed == []
+
+
+def test_diff_identical_no_change():
+    before = Trajectory.from_events([_tool_event("search"), _tool_event("calc")])
+    after = Trajectory.from_events([_tool_event("search"), _tool_event("calc")])
+    diff = diff_trajectories(before, after)
+    assert diff.changed is False
+    assert diff.added == []
+    assert diff.removed == []
+    assert diff.reordered is False
+
+
+def test_diff_render_mentions_added():
+    before = Trajectory.from_tool_sequence(["search", "calc"])
+    after = Trajectory.from_tool_sequence(["search", "web", "calc"])
+    text = diff_trajectories(before, after).render()
+    assert "web" in text
+    assert "CHANGED" in text
+
+
+# ── CLI: jamjet eval trajectory-diff ──────────────────────────────────────────
+
+
+def test_cli_trajectory_diff_detects_regression(tmp_path):
+    from typer.testing import CliRunner
+
+    from jamjet.cli.main import app
+
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    before.write_text(json.dumps({"events": [_tool_event("search"), _tool_event("calc")]}))
+    after.write_text(json.dumps({"events": [_tool_event("search"), _tool_event("web"), _tool_event("calc")]}))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["eval", "trajectory-diff", str(before), str(after)])
+
+    assert result.exit_code == 1  # fail-on-change is the default (regression gate)
+    assert "web" in result.stdout
+    assert "REGRESSION" in result.stdout
+
+
+def test_cli_trajectory_diff_no_change_exits_zero(tmp_path):
+    from typer.testing import CliRunner
+
+    from jamjet.cli.main import app
+
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    same = json.dumps({"events": [_tool_event("search"), _tool_event("calc")]})
+    before.write_text(same)
+    after.write_text(same)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["eval", "trajectory-diff", str(before), str(after)])
+
+    assert result.exit_code == 0
+    assert "unchanged" in result.stdout.lower()
+
+
+def test_cli_trajectory_diff_json_format(tmp_path):
+    from typer.testing import CliRunner
+
+    from jamjet.cli.main import app
+
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    before.write_text(json.dumps([_tool_event("search")]))  # raw event list shape
+    after.write_text(json.dumps([_tool_event("search"), _tool_event("web")]))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["eval", "trajectory-diff", str(before), str(after), "--no-fail-on-change", "--format", "json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["added"] == ["web"]
+    assert payload["changed"] is True

--- a/sdk/python/tests/test_trajectory_eval_runner.py
+++ b/sdk/python/tests/test_trajectory_eval_runner.py
@@ -377,3 +377,54 @@ def test_cli_trajectory_diff_json_format(tmp_path):
     payload = json.loads(result.stdout)
     assert payload["added"] == ["web"]
     assert payload["changed"] is True
+
+
+# ── CodeRabbit #3: reject eval-results rows that carry no real trajectory ──────
+
+
+def test_load_trajectory_rejects_results_row_without_trajectory(tmp_path):
+    """An eval-results row with row_id but NO trajectory field fails fast with a
+    clear error -- it must NOT default to [] and forge a bogus 'no tools' baseline."""
+    from jamjet.cli.main import _load_trajectory_from_file
+
+    p = tmp_path / "results.json"
+    # Old/malformed `jamjet eval run --output` artifact: rows lack `trajectory`.
+    p.write_text(json.dumps([{"row_id": "q1", "passed": True}, {"row_id": "q2", "passed": False}]))
+
+    with pytest.raises(ValueError, match="trajectory"):
+        _load_trajectory_from_file(str(p), row_id="q1")
+
+
+def test_load_trajectory_accepts_explicit_empty_trajectory(tmp_path):
+    """An explicit empty trajectory (the agent legitimately used no tools) is
+    accepted -- only a MISSING trajectory field is an error."""
+    from jamjet.cli.main import _load_trajectory_from_file
+
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps([{"row_id": "q1", "trajectory": []}]))
+
+    traj = _load_trajectory_from_file(str(p), row_id="q1")
+    assert traj.tool_sequence == []
+
+
+def test_cli_trajectory_diff_rejects_results_without_trajectory(tmp_path):
+    """End-to-end: diffing a results file whose rows lack `trajectory` exits 1 with
+    an error, NOT a bogus 'OK / unchanged' empty-trajectory diff."""
+    from typer.testing import CliRunner
+
+    from jamjet.cli.main import app
+
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    rows = json.dumps([{"row_id": "q1", "passed": True}])
+    before.write_text(rows)
+    after.write_text(rows)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["eval", "trajectory-diff", str(before), str(after), "--row-id", "q1"])
+
+    assert result.exit_code == 1
+    assert "Error" in result.stdout
+    # Must not have produced a bogus baseline diff.
+    assert "OK:" not in result.stdout
+    assert "unchanged" not in result.stdout.lower()

--- a/sdk/python/tests/test_trajectory_eval_runner.py
+++ b/sdk/python/tests/test_trajectory_eval_runner.py
@@ -32,6 +32,34 @@ def _tool_event(tool: str, node_id: str = "n1") -> dict:
     return {"kind": {"type": "tool_called", "node_id": node_id, "tool": tool}}
 
 
+def _model_turn(tool: str, *, node_id: str = "model", seq: int = 0) -> dict:
+    """A model-node ``NodeCompleted`` event in the SHAPE a real durable run emits.
+
+    This is what ``client.get_events`` actually returns for a durable agent run
+    (per ``runtime/workers/src/executors/model_node.rs``): the model's requested
+    tool calls live on ``kind.output.tool_calls`` as ``{id, name, arguments}``,
+    NOT in a (never-emitted) ``tool_called`` event. The runner reconstructs the
+    trajectory from these.
+    """
+    tc = [{"id": f"call_{seq}", "name": tool, "arguments": {}}]
+    return {
+        "id": f"evt-{seq}",
+        "sequence": seq,
+        "kind": {
+            "type": "node_completed",
+            "node_id": node_id,
+            "output": {
+                "content": "",
+                "model": "anthropic/claude-sonnet-4-6",
+                "finish_reason": "tool_calls",
+                "tool_calls": tc,
+            },
+            "state_patch": {"last_model_tool_calls": tc, "last_model_finish_reason": "tool_calls"},
+            "duration_ms": 5,
+        },
+    }
+
+
 def _mock_client(*, output: dict, events: list[dict]) -> MagicMock:
     client = MagicMock()
     client.__aenter__ = AsyncMock(return_value=client)
@@ -86,8 +114,16 @@ def test_loader_parses_expected_trajectory_yaml(tmp_path):
 
 @pytest.mark.asyncio
 async def test_runner_trajectory_pass(monkeypatch):
-    """A case whose events match expected_trajectory -> trajectory PASS, case passes."""
-    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search"), _tool_event("calc")])
+    """A case whose events match expected_trajectory -> trajectory PASS, case passes.
+
+    Events are the REAL durable shape (model ``node_completed`` with
+    ``output.tool_calls``), so this also guards C1: the runner reconstructs the
+    trajectory from what the engine actually emits, not from ``tool_called``.
+    """
+    client = _mock_client(
+        output={"answer": "42"},
+        events=[_model_turn("search", node_id="m1", seq=1), _model_turn("calc", node_id="m2", seq=2)],
+    )
     import jamjet.client as client_mod
 
     monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)
@@ -114,7 +150,10 @@ async def test_runner_trajectory_pass(monkeypatch):
 async def test_runner_trajectory_fail_even_if_output_matches(monkeypatch):
     """Wrong tools -> trajectory FAIL and the case FAILS even though output matched."""
     # Output matches the assertion, but the agent used the wrong tools.
-    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search"), _tool_event("web")])
+    client = _mock_client(
+        output={"answer": "42"},
+        events=[_model_turn("search", node_id="m1", seq=1), _model_turn("web", node_id="m2", seq=2)],
+    )
     import jamjet.client as client_mod
 
     monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)
@@ -140,7 +179,7 @@ async def test_runner_trajectory_fail_even_if_output_matches(monkeypatch):
 @pytest.mark.asyncio
 async def test_runner_no_expected_trajectory_is_output_only(monkeypatch):
     """expected_trajectory=None -> output-only, unchanged (no trajectory scorer)."""
-    client = _mock_client(output={"answer": "42"}, events=[_tool_event("search")])
+    client = _mock_client(output={"answer": "42"}, events=[_model_turn("search", node_id="m1", seq=1)])
     import jamjet.client as client_mod
 
     monkeypatch.setattr(client_mod, "JamjetClient", lambda **kw: client)


### PR DESCRIPTION
## What

Track 5 of the 9-track ADK plan (M2) — the five-minute dev loop and trajectory evaluation. All Python.

- **`jamjet create <name>`** scaffolds a runnable quickstart project (an `Agent` + a `@tool` + a `main.py`, using the real API).
- **`jamjet dev`** now orchestrates the whole local stack with one command: the model sidecar (started first and health-gated, so the engine never hits its fail-closed seam path), the engine (with `JAMJET_MODEL_SEAM_URL` wired), and a worker — with graceful process-group teardown (no orphans). Flags: `--engine-only`, `--no-sidecar`, `--no-worker`, `--sidecar-port`, `--modules`.
- **Trajectory eval**: a deterministic `TrajectoryScorer` (tool set/sequence/used/not-used/max-turns) over the run's trajectory, an `expected_trajectory` field on eval cases (a case passes only if output and trajectory both pass), and a `jamjet eval trajectory-diff` regression gate. The LLM-judge-over-trajectory is off by default.

## Safety

A whole-branch adversarial review caught and forced a fix for a Critical the tests had masked: durable trajectory eval was vacuous because `Trajectory.from_events` keyed on a `tool_called` event the engine never emits — so a real durable run scored an empty trajectory (correct runs false-failing, forbidden-tool runs false-passing), and the runner test hid it by feeding hand-built events to a mocked `get_events`. It now reconstructs the trajectory from the real emitted `NodeCompleted.output.tool_calls` (cross-checked against the model executor and its Rust tests), with a test over a realistic durable event log. Also fixed: a `jamjet dev` teardown path that could hang and skip SIGKILL on a SIGTERM-ignoring child (now an unconditional kill sweep), and the health probe now checks the body. The re-review confirmed the durable trajectory is non-vacuous, teardown leaves no orphan, and there is no double-counting on retries.

## Tests

1304 Python passed, including the dev-stack orchestration (start-order, health-gate, fail-loud, SIGKILL teardown), trajectory determinism and the realistic-durable-log reconstruction, the eval gating (a wrong-tools case fails even when output matched), the regression diff, and the scaffold compiling.

## Follow-ups

F-t5-dev-tui, F-t5-judge-eval (LLM-judge trajectory scoring + recall metrics), F-t5-remote-eval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new project scaffolding command with a built-in quickstart template.
  * Added trajectory evaluation support, including scoring, result export, and trajectory comparison tools.
  * Improved the local dev command with sidecar/worker controls and a clearer startup flow.

* **Bug Fixes**
  * Dev shutdown is now more reliable and avoids leaving orphaned processes behind.
  * Evaluation results now include trajectory details for easier inspection.

* **Documentation**
  * Added a new trajectory evaluation guide and expanded dev-loop docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->