### PR TITLE
feat(track-6): Team multi-agent sugar (Sequential/Parallel/Team/Loop over the durable path)

### DIFF
--- a/examples/team-multi-agent/README.md
+++ b/examples/team-multi-agent/README.md
@@ -1,0 +1,73 @@
+# team-multi-agent
+
+Compose several `Agent`s into a coordinated multi-agent workflow with the `Team`
+API. Two patterns over the same two specialists (a researcher and a writer):
+
+- A coordinator `Team`: a router agent picks one specialist to handle each
+  request.
+- A `Sequential` pipeline: the researcher's output feeds the writer.
+
+## How it works (Path A)
+
+A team is plain Python orchestration over the single-agent path. Each sub-agent
+runs as its own independent execution via `Agent.run` (in-process) or
+`Agent.run_durable` (durable), and the team composes the results. There is no
+custom orchestration to write and no Rust involved. Because each sub-agent is its
+own execution, a failing sub-agent is isolated: its error lands in
+`TeamResult.per_agent`, and the team does not crash.
+
+```python
+from jamjet import Team, Sequential
+
+desk = Team([researcher, writer], coordinator=router)   # router picks one
+result = await desk.run("Find the latest on agent runtimes")
+print(result.output)            # the chosen specialist's answer
+print(list(result.per_agent))   # ['router', 'researcher']
+
+pipeline = Sequential([researcher, writer])             # research then write
+result = await pipeline.run("agent runtimes")
+```
+
+The coordinator's `coordinator=` is either a router `Agent` whose output names the
+specialist (as here), or a plain Python routing callable
+`(input, agents) -> Agent | name | index`.
+
+## Files
+
+- `specialists.py` - the `@tool` functions, the three Agent factories
+  (`researcher`, `writer`, `router`), and the two team factories (`build_desk`,
+  `build_pipeline`). Imported by both the runner and, on the durable path, the
+  worker.
+- `main.py` - runs the coordinator team and the sequential pipeline with `.run()`.
+
+## Governance inheritance
+
+`build_desk()` sets a team governance default (`governance={"budget": 0.50}`).
+The specialists set no budget of their own, so they inherit the team cap and each
+one enforces it. A team never bypasses governance: a sub-agent that sets its own
+budget, policy, PII, or allowlist keeps it, and a governed sub-agent in a team
+still denies an over-budget call.
+
+## Sessions
+
+Pass `session=` to a team to give each sub-agent its own persistent thread. The
+team namespaces a distinct child session per sub-agent, so concurrent sub-agents
+never write the same row.
+
+## Run it (in-process)
+
+The in-process path needs only a model provider key.
+
+```bash
+export ANTHROPIC_API_KEY=sk-...
+python main.py
+```
+
+## Run it durable
+
+Swap `.run(...)` for `.run_durable(...)` in `main.py`. The durable path runs each
+sub-agent as a durable, event-sourced execution, so every sub-agent gets the event
+log, replay, idempotency, and artifacts. It needs the engine, a `jamjet worker`
+draining the tool queue, and the model sidecar running. See the
+`react-agent-durable` example for the four-terminal setup; a team simply starts
+one such execution per sub-agent.

--- a/examples/team-multi-agent/README.md
+++ b/examples/team-multi-agent/README.md
@@ -71,3 +71,8 @@ log, replay, idempotency, and artifacts. It needs the engine, a `jamjet worker`
 draining the tool queue, and the model sidecar running. See the
 `react-agent-durable` example for the four-terminal setup; a team simply starts
 one such execution per sub-agent.
+
+The worker has to import the `specialists` module to run the tools. Each compiled
+agent records its tools as `specialists:<fn>` refs, and the worker resolves those
+by importing the module. Start `jamjet worker` from `examples/team-multi-agent/`,
+or add that directory to `PYTHONPATH`, so the import resolves.

--- a/examples/team-multi-agent/main.py
+++ b/examples/team-multi-agent/main.py
@@ -26,7 +26,10 @@ async def main() -> None:
     # ── Pattern 1: coordinator routing ────────────────────────────────────────
     desk = build_desk()
 
-    fact_task = "Find the latest on durable agent runtimes."
+    # A timeless explainer (not a freshness query): the example's web_search tool
+    # is a canned stub, so the prompt asks for a definition that does not change
+    # rather than implying live, up-to-the-minute data.
+    fact_task = "Explain what a durable agent runtime is and why it matters."
     routed = await desk.run(fact_task)
     print(f"[desk] {fact_task}")
     print(f"  routed to: {', '.join(k for k in routed.per_agent if k != 'router')}")

--- a/examples/team-multi-agent/main.py
+++ b/examples/team-multi-agent/main.py
@@ -1,0 +1,50 @@
+"""Run the multi-agent team example.
+
+Two patterns over the same two specialists:
+
+1. A coordinator ``Team``: a router picks ONE specialist (researcher or writer)
+   to handle each request.
+2. A ``Sequential`` pipeline: the researcher's output feeds the writer.
+
+Each sub-agent runs as its own execution (Path A). This file uses the in-process
+``.run()`` path, which needs only a model provider key (for example
+``ANTHROPIC_API_KEY``). For the durable path, swap ``.run(...)`` for
+``.run_durable(...)`` and start the engine + a worker + the model sidecar (see
+README.md); the API is identical.
+
+    python main.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from specialists import build_desk, build_pipeline
+
+
+async def main() -> None:
+    # ── Pattern 1: coordinator routing ────────────────────────────────────────
+    desk = build_desk()
+
+    fact_task = "Find the latest on durable agent runtimes."
+    routed = await desk.run(fact_task)
+    print(f"[desk] {fact_task}")
+    print(f"  routed to: {', '.join(k for k in routed.per_agent if k != 'router')}")
+    print(f"  answer:    {routed.output}\n")
+
+    write_task = "Write a one-line teaser for our new agent runtime."
+    routed2 = await desk.run(write_task)
+    print(f"[desk] {write_task}")
+    print(f"  routed to: {', '.join(k for k in routed2.per_agent if k != 'router')}")
+    print(f"  answer:    {routed2.output}\n")
+
+    # ── Pattern 2: sequential pipeline ────────────────────────────────────────
+    pipeline = build_pipeline()
+    result = await pipeline.run("agent runtimes")
+    print("[pipeline] research-then-write")
+    print(f"  steps:  {' -> '.join(result.per_agent)}")
+    print(f"  output: {result.output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/team-multi-agent/specialists.py
+++ b/examples/team-multi-agent/specialists.py
@@ -1,0 +1,101 @@
+"""Specialists + a router + the team factories for the multi-agent example.
+
+This module is imported by BOTH the runner (``main.py``) and (on the durable
+path) the ``jamjet worker`` that executes the ``@tool`` functions, so the tools
+and the Agent factories live HERE, not in ``__main__`` — the compiled agent-loop
+IR records each tool as ``{name: "specialists:<fn>"}`` (module + qualname), and
+the worker resolves it by importing this module.
+
+The team is pure Python orchestration over the single-agent path (Path A): each
+sub-agent runs as its OWN execution via ``Agent.run`` / ``Agent.run_durable`` and
+the team composes the results. No custom orchestration code, no Rust.
+"""
+
+from __future__ import annotations
+
+from jamjet import Agent, Sequential, Team, tool
+
+_MODEL = "anthropic/claude-sonnet-4-6"
+
+
+# ── Tools ──────────────────────────────────────────────────────────────────────
+
+
+@tool
+async def web_search(query: str) -> str:
+    """Look up background facts for a topic (stubbed for the example)."""
+    return f"Background facts about: {query}"
+
+
+@tool
+async def word_count(text: str) -> str:
+    """Count the words in a piece of text."""
+    return str(len(text.split()))
+
+
+# ── Specialists ─────────────────────────────────────────────────────────────────
+
+
+def build_researcher() -> Agent:
+    """A fact-finder: searches, then summarizes what it found."""
+    return Agent(
+        "researcher",
+        model=_MODEL,
+        tools=[web_search],
+        instructions="You are a researcher. Use web_search to gather facts, then give a tight factual summary.",
+        strategy="react",
+    )
+
+
+def build_writer() -> Agent:
+    """A drafter: turns notes into a short, clear piece of writing."""
+    return Agent(
+        "writer",
+        model=_MODEL,
+        tools=[word_count],
+        instructions="You are a writer. Turn the input into a short, clear paragraph. Keep it under 80 words.",
+        strategy="react",
+    )
+
+
+def build_router() -> Agent:
+    """A dispatcher whose OUTPUT names the specialist to run.
+
+    The coordinator Team matches the router's output against the specialist names,
+    so the router is instructed to answer with exactly one name.
+    """
+    return Agent(
+        "router",
+        model=_MODEL,
+        tools=[],
+        instructions=(
+            "You are a dispatcher for a content desk. Reply with EXACTLY one word and nothing else: "
+            "'researcher' if the request needs fact-finding, or 'writer' if it needs drafting or editing."
+        ),
+    )
+
+
+# ── Teams ────────────────────────────────────────────────────────────────────────
+
+
+def build_desk() -> Team:
+    """A coordinator team: the router picks ONE specialist to handle the request.
+
+    The team carries a governance default (a per-sub-agent budget cap). Because the
+    specialists set no budget of their own, they INHERIT this cap and each enforces
+    it — a team never bypasses governance.
+    """
+    return Team(
+        [build_researcher(), build_writer()],
+        coordinator=build_router(),
+        name="content-desk",
+        governance={"budget": 0.50},
+    )
+
+
+def build_pipeline() -> Sequential:
+    """A sequential pipeline: research first, then write up the findings.
+
+    The researcher's output is fed straight into the writer as its input.
+    """
+    return Sequential([build_researcher(), build_writer()], name="research-then-write")

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -60,6 +60,7 @@ from jamjet.spec import (  # noqa: F401
     ToolSpec,
     WorkflowSpec,
 )
+from jamjet.team import Loop, Parallel, Sequential, Team, TeamResult
 from jamjet.tools.decorators import tool
 from jamjet.workflow.workflow import Workflow
 from jamjet.decorators import DurableAgent, workflow  # noqa: F401, E402
@@ -85,10 +86,15 @@ __all__ = [
     "MemoryConfig",
     "ProtocolAdapter",
     "ProtocolRegistry",
+    "Loop",
+    "Parallel",
     "Runtime",
     "RuntimeEvent",
     "RuntimeResult",
     "Scope",
+    "Sequential",
+    "Team",
+    "TeamResult",
     "ToolSpec",
     "Workflow",
     "WorkflowSpec",

--- a/sdk/python/jamjet/compiler/team_ir.py
+++ b/sdk/python/jamjet/compiler/team_ir.py
@@ -1,0 +1,127 @@
+"""Compile a Team to per-sub-agent IRs + a composition plan (Track 6, Path A).
+
+A ``Team`` is **N independent agent IRs orchestrated in Python**, NOT one fused
+multi-agent IR. Each sub-agent compiles via the already-shipped single-agent
+:func:`~jamjet.compiler.agent_ir.compile_agent_to_ir` (Track 2j), so each carries
+its OWN governance (budget / policy / PII) and the durable run path can start one
+execution per sub-agent. We deliberately do NOT emit the in-IR
+``coordinator`` / ``agent_tool`` / ``subgraph`` node kinds — they are unwired in
+the running runtime (a silent no-op stub) per the track grounding.
+
+:func:`compile_team_to_ir` returns a small :class:`TeamPlan` describing the
+composition (the ordered per-sub-agent IRs, the router IR when the coordinator is
+an Agent, and the merge name for a parallel fan-out) — the plan the Python
+orchestrator in :mod:`jamjet.team` executes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from jamjet.compiler.agent_ir import compile_agent_to_ir
+from jamjet.team.team import Collect, Custom, First, MergeStrategy, Parallel, Team
+
+if TYPE_CHECKING:
+    from jamjet.agents.agent import Agent
+    from jamjet.team.team import _TeamBase
+
+# The prompt is per-run and private; compile_agent_to_ir does NOT embed it in the
+# IR (it only seeds build_initial_state), so a placeholder is correct here. Each
+# sub-agent's real prompt is supplied at run time by the orchestrator.
+_PLAN_PROMPT = ""
+
+
+@dataclass
+class CompiledSubAgent:
+    """One sub-agent and its compiled durable agent-loop IR."""
+
+    agent: Agent
+    ir: dict[str, Any]
+
+
+@dataclass
+class TeamPlan:
+    """The composition plan for a team: the per-sub-agent IRs + how to combine them.
+
+    Attributes:
+        pattern: ``"sequential"`` | ``"parallel"`` | ``"coordinator"`` | ``"loop"``.
+        sub_agents: the specialist sub-agents, each with its OWN compiled IR, in
+            declared order (the sequential pipeline order / the parallel fan-out set
+            / the coordinator's candidate specialists / the single looped agent).
+        coordinator: the router's :class:`CompiledSubAgent` when the team's
+            coordinator is itself an Agent; ``None`` for a routing-callable
+            coordinator or a non-coordinator pattern.
+        merge: the merge-strategy name (``"collect"`` / ``"first"`` / ``"custom"``)
+            for a parallel team; ``None`` otherwise.
+    """
+
+    pattern: str
+    sub_agents: list[CompiledSubAgent]
+    coordinator: CompiledSubAgent | None = None
+    merge: str | None = None
+
+    @property
+    def irs(self) -> list[dict[str, Any]]:
+        """Every sub-agent's IR, in order — the N independent IRs of the team."""
+        return [c.ir for c in self.sub_agents]
+
+
+def merge_name(merge: MergeStrategy) -> str:
+    """A stable name for a :class:`~jamjet.team.team.MergeStrategy` instance."""
+    if isinstance(merge, Collect):
+        return "collect"
+    if isinstance(merge, First):
+        return "first"
+    if isinstance(merge, Custom):
+        return "custom"
+    return type(merge).__name__.lower()
+
+
+def compile_team_to_ir(team: _TeamBase, max_turns: int = 8) -> TeamPlan:
+    """Compile *team* into a :class:`TeamPlan` of per-sub-agent IRs.
+
+    Each sub-agent is compiled independently with
+    :func:`~jamjet.compiler.agent_ir.compile_agent_to_ir`, so each IR carries its
+    own governance and is a complete, runnable durable agent-loop — the team is the
+    Python composition OVER these N IRs, never a single merged IR.
+
+    Parameters
+    ----------
+    team:
+        A :class:`~jamjet.team.team.Sequential` / ``Parallel`` / ``Team`` / ``Loop``.
+    max_turns:
+        Static-unroll bound forwarded to each sub-agent's compile.
+    """
+    sub_agents = [
+        CompiledSubAgent(agent=agent, ir=compile_agent_to_ir(agent, _PLAN_PROMPT, max_turns)) for agent in team.agents
+    ]
+
+    coordinator: CompiledSubAgent | None = None
+    if isinstance(team, Team) and _is_agent(team.coordinator):
+        coordinator = CompiledSubAgent(
+            agent=team.coordinator,  # type: ignore[arg-type]
+            ir=compile_agent_to_ir(team.coordinator, _PLAN_PROMPT, max_turns),  # type: ignore[arg-type]
+        )
+
+    merge: str | None = None
+    if isinstance(team, Parallel):
+        merge = merge_name(team.merge)
+
+    return TeamPlan(
+        pattern=team.pattern,
+        sub_agents=sub_agents,
+        coordinator=coordinator,
+        merge=merge,
+    )
+
+
+def _is_agent(obj: Any) -> bool:
+    if obj is None:
+        return False
+    from jamjet.agents.agent import Agent  # noqa: PLC0415 - avoid import cycle
+
+    return isinstance(obj, Agent)
+
+
+__all__ = ["CompiledSubAgent", "TeamPlan", "compile_team_to_ir", "merge_name"]

--- a/sdk/python/jamjet/team/__init__.py
+++ b/sdk/python/jamjet/team/__init__.py
@@ -1,0 +1,43 @@
+"""Team — multi-agent composition for JamJet (Track 6, Path A).
+
+Compose several :class:`~jamjet.agents.agent.Agent` objects into a coordinated
+multi-agent workflow. Each sub-agent runs as its OWN independent execution over
+the already-shipped single-agent path (:meth:`Agent.run` / :meth:`Agent.run_durable`)
+— Python orchestration, zero Rust.
+
+    from jamjet import Sequential, Parallel, Team, Loop
+
+    pipeline = Sequential([researcher, writer])
+    result = await pipeline.run("Write a brief on agent runtimes")
+
+    fanout = Parallel([a, b, c], merge="collect")
+    desk = Team([researcher, writer], coordinator=router)
+"""
+
+from __future__ import annotations
+
+from jamjet.team.team import (
+    Collect,
+    Custom,
+    First,
+    Loop,
+    MergeStrategy,
+    Parallel,
+    Sequential,
+    Team,
+    TeamResult,
+    derive_child_session,
+)
+
+__all__ = [
+    "Collect",
+    "Custom",
+    "First",
+    "Loop",
+    "MergeStrategy",
+    "Parallel",
+    "Sequential",
+    "Team",
+    "TeamResult",
+    "derive_child_session",
+]

--- a/sdk/python/jamjet/team/team.py
+++ b/sdk/python/jamjet/team/team.py
@@ -31,10 +31,14 @@ the run was ``durable``.
 Governance + sessions (T6-5)
 ----------------------------
 Each sub-agent compiles and enforces its OWN governance (budget / PII / policy /
-allowlist) — a team adds no enforcement layer and removes none, so there is **no
-governance bypass**. A team may carry a ``governance=`` default that is applied
-only to sub-agents built with all-default governance (an explicitly-governed
-sub-agent is never overridden). A team may carry a ``session=`` that namespaces a
+allowlist); a team adds no enforcement layer, so a sub-agent's own explicit
+governance is never bypassed. A team may carry a ``governance=`` default applied
+ONLY to a sub-agent that set no explicit governance (all-default); it never
+overrides a sub-agent's own explicit knob, so a governed sub-agent is never
+weakened by the team (explicit beats inherited). The default is not a
+tighten-only knob: applied to an all-default sub-agent it may turn a
+framework-default-on protection (such as PII) off, which is the team author's
+deliberate choice, not a bypass. A team may carry a ``session=`` that namespaces a
 per-sub-agent child session so concurrent sub-agents never race on one SQLite row
 (see :func:`derive_child_session`).
 """
@@ -42,6 +46,7 @@ per-sub-agent child session so concurrent sub-agents never race on one SQLite ro
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -228,15 +233,19 @@ _DEFAULT_GOVERNANCE = GovernanceConfig()
 
 
 def _apply_governance_default(agents: list[Agent], team_governance: GovernanceConfig | None) -> None:
-    """Apply the team governance default to un-governed sub-agents (in place).
+    """Apply the team governance default to all-default sub-agents (in place).
 
     A sub-agent whose ``governance`` is the all-default sentinel set no explicit
     knob, so it INHERITS the team default (its compiled IR then carries the team's
     budget / policy / PII and enforces it). A sub-agent that set ANY governance
-    knob keeps its own config wholesale — explicit beats inherited, and an
-    explicitly-governed sub-agent is never weakened (no bypass). This mutates the
-    sub-agent's ``governance`` attribute; it only ever happens when the team
-    carries a default AND the sub-agent was un-governed.
+    knob keeps its own config wholesale (explicit beats inherited), so a governed
+    sub-agent is never overridden or weakened by the team. The default is applied
+    ONLY to an all-default sub-agent and NEVER overrides a sub-agent's own explicit
+    knob; it does not only tighten, since for an all-default sub-agent a team
+    default such as ``pii=False`` turns a framework-default-on protection off (the
+    team author's deliberate choice, not a bypass). This mutates the sub-agent's
+    ``governance`` attribute; it only happens when the team carries a default AND
+    the sub-agent was all-default.
     """
     if team_governance is None:
         return
@@ -269,8 +278,9 @@ class _TeamBase:
         self.name = name
         self.session = session
         self.governance = _resolve_team_governance(governance)
-        # T6-5: push the team governance default into un-governed sub-agents so
-        # each sub-agent compiles + enforces it (no bypass; explicit wins).
+        # T6-5: push the team governance default into all-default sub-agents so
+        # each sub-agent compiles + enforces it (explicit knobs always win; the
+        # default never overrides a sub-agent's own governance).
         _apply_governance_default(self.agents, self.governance)
 
     async def run(self, input: str) -> TeamResult:
@@ -471,21 +481,27 @@ class Team(_TeamBase):
             return self._match_specialist(router_result.output)
 
         # A routing callable: (input, agents) -> Agent | name | index (maybe async).
+        # Coercion runs INSIDE the try so a misuse (unknown name, out-of-range
+        # index, foreign Agent) becomes an ISOLATED recorded error and a clean
+        # empty TeamResult, not an opaque team crash.
         try:
             choice = coord(input, self.agents)
             if asyncio.iscoroutine(choice):
                 choice = await choice
+            return self._coerce_choice(choice)
         except Exception as exc:  # noqa: BLE001 - isolate routing-callable failure
             per_agent[f"{self.name}:coordinator"] = exc
             return None
-        return self._coerce_choice(choice)
 
     def _match_specialist(self, router_output: str) -> Agent:
         """Match a router's free-text output to a specialist by name.
 
-        Exact name match wins; otherwise the first agent whose name appears
-        (case-insensitive) in the output; otherwise the first agent (a safe,
-        documented fallback so an ambiguous router never crashes the team).
+        Exact name match wins; otherwise the first agent whose name appears as a
+        WHOLE WORD (case-insensitive, word-boundary) in the output; otherwise the
+        first agent (a safe, documented fallback so an ambiguous router never
+        crashes the team). The word-boundary pass avoids mis-routing overlapping
+        names: output "rewriter" matches ``rewriter`` and not the substring
+        ``writer``.
         """
         text = (router_output or "").strip()
         for agent in self.agents:
@@ -493,16 +509,28 @@ class Team(_TeamBase):
                 return agent
         low = text.lower()
         for agent in self.agents:
-            if agent.name.lower() in low:
+            if re.search(rf"\b{re.escape(agent.name.lower())}\b", low):
                 return agent
         return self.agents[0]
 
     def _coerce_choice(self, choice: Agent | str | int) -> Agent:
-        """Coerce a routing callable's return (Agent / name / index) to an Agent."""
+        """Coerce a routing callable's return (Agent / name / index) to an Agent.
+
+        A misuse (a foreign Agent, an out-of-range index, or an unknown name)
+        raises a clear ValueError/TypeError; the caller (_route) catches it so the
+        error is isolated and recorded rather than crashing the team opaquely.
+        """
         if _is_agent(choice):
+            if choice not in self.agents:
+                raise ValueError("coordinator returned an Agent that is not a member of this team")
             return choice  # type: ignore[return-value]
         if isinstance(choice, int):
-            return self.agents[choice]
+            try:
+                return self.agents[choice]
+            except IndexError:
+                raise ValueError(
+                    f"coordinator returned out-of-range agent index {choice}; team has {len(self.agents)} agents"
+                ) from None
         if isinstance(choice, str):
             for agent in self.agents:
                 if agent.name == choice:

--- a/sdk/python/jamjet/team/team.py
+++ b/sdk/python/jamjet/team/team.py
@@ -46,6 +46,7 @@ per-sub-agent child session so concurrent sub-agents never race on one SQLite ro
 from __future__ import annotations
 
 import asyncio
+import inspect
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -275,6 +276,17 @@ class _TeamBase:
         if not agents:
             raise ValueError("a team needs at least one agent")
         self.agents = list(agents)
+        # Names must be unique: per_agent keys by agent.name and the coordinator
+        # routes by name, so two members sharing a name would silently overwrite a
+        # result and make routing ambiguous. Catch it at construction.
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for agent in self.agents:
+            if agent.name in seen:
+                dupes.add(agent.name)
+            seen.add(agent.name)
+        if dupes:
+            raise ValueError(f"team members must have unique names; duplicates: {sorted(dupes)}")
         self.name = name
         self.session = session
         self.governance = _resolve_team_governance(governance)
@@ -486,7 +498,9 @@ class Team(_TeamBase):
         # empty TeamResult, not an opaque team crash.
         try:
             choice = coord(input, self.agents)
-            if asyncio.iscoroutine(choice):
+            # Await ANY awaitable (a coroutine, a Future/Task, or a custom
+            # __await__), not just a coroutine, before coercing the choice.
+            if inspect.isawaitable(choice):
                 choice = await choice
             return self._coerce_choice(choice)
         except Exception as exc:  # noqa: BLE001 - isolate routing-callable failure

--- a/sdk/python/jamjet/team/team.py
+++ b/sdk/python/jamjet/team/team.py
@@ -1,0 +1,590 @@
+"""Team — friendly multi-agent composition over the single-agent durable path.
+
+Track 6 (Path A). A ``Team`` composes several :class:`~jamjet.agents.agent.Agent`
+objects into a coordinated multi-agent workflow WITHOUT writing orchestration.
+The load-bearing decision: **Python orchestration over the already-working
+single-agent path**. Each sub-agent runs as its OWN independent execution via the
+shipped :meth:`Agent.run` (in-process) / :meth:`Agent.run_durable` (durable);
+a team simply composes N such runs in Python. We do NOT touch Rust and we do NOT
+use the in-IR ``coordinator`` / ``agent_tool`` / ``subgraph`` nodes (they hit a
+silent no-op stub in the running runtime — see the track grounding).
+
+Four patterns, each a thin Python orchestrator over that primitive:
+
+- :class:`Sequential` — a pipeline ``a -> b -> c``; each agent's output is the
+  next agent's input. Halts on the first failing step (a broken upstream output
+  cannot sensibly feed downstream); the error lands in ``TeamResult.per_agent``.
+- :class:`Parallel` — fan the SAME input out to every agent concurrently
+  (``asyncio.gather(..., return_exceptions=True)``), then aggregate via a
+  :class:`MergeStrategy`. A failing sub-agent is isolated (its error is recorded;
+  siblings are unaffected).
+- :class:`Team` — a coordinator routes the input to ONE specialist. The
+  coordinator is either a *router* :class:`~jamjet.agents.agent.Agent` (its output
+  names the specialist) or a plain Python routing callable.
+- :class:`Loop` — re-run a single agent until a predicate holds (or a max-iters
+  bound), threading each output into the next iteration (a refinement loop).
+
+Every pattern returns a common :class:`TeamResult` carrying the combined
+``output``, the per-sub-agent results/errors, the ``pattern`` name, and whether
+the run was ``durable``.
+
+Governance + sessions (T6-5)
+----------------------------
+Each sub-agent compiles and enforces its OWN governance (budget / PII / policy /
+allowlist) — a team adds no enforcement layer and removes none, so there is **no
+governance bypass**. A team may carry a ``governance=`` default that is applied
+only to sub-agents built with all-default governance (an explicitly-governed
+sub-agent is never overridden). A team may carry a ``session=`` that namespaces a
+per-sub-agent child session so concurrent sub-agents never race on one SQLite row
+(see :func:`derive_child_session`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from jamjet.agents.governance import GovernanceConfig, normalize_governance
+from jamjet.agents.session import Session, SessionStore
+
+if TYPE_CHECKING:
+    from jamjet.agents.agent import Agent, AgentResult
+
+# A sub-agent run can succeed (AgentResult) or fail (the exception is captured so
+# one failing sub-agent never crashes the team — child-crash isolation).
+PerAgent = dict[str, "AgentResult | BaseException"]
+
+# Default durable engine URL, matching Agent.run_durable's default.
+_DEFAULT_RUNTIME_URL = "http://127.0.0.1:7700"
+
+
+# ── Merge strategies (the parallel aggregation vocabulary) ─────────────────────
+
+
+class MergeStrategy:
+    """How a :class:`Parallel` team combines its sub-agents' results into one
+    ``output`` string. Subclasses implement :meth:`merge` over the ordered
+    per-agent mapping (insertion order == declared agent order)."""
+
+    def merge(self, per_agent: PerAgent) -> str:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class Collect(MergeStrategy):
+    """Combine every SUCCESSFUL output into a labeled, newline-joined block.
+
+    Failures (captured exceptions) are skipped. The result is ``"[name] output"``
+    lines in declared agent order — a readable digest of the fan-out.
+    """
+
+    def merge(self, per_agent: PerAgent) -> str:
+        parts: list[str] = []
+        for name, result in per_agent.items():
+            if isinstance(result, BaseException):
+                continue
+            parts.append(f"[{name}] {result.output}")
+        return "\n".join(parts)
+
+
+class First(MergeStrategy):
+    """The first SUCCESSFUL sub-agent's output, in declared agent order.
+
+    Deterministic: because the parallel pattern gathers ALL results (for
+    child-crash isolation), "first" means the first agent in declaration order
+    that succeeded, not the first to finish on the wall clock (a true race +
+    cancel is a follow-up). Returns ``""`` when every sub-agent failed.
+    """
+
+    def merge(self, per_agent: PerAgent) -> str:
+        for result in per_agent.values():
+            if not isinstance(result, BaseException):
+                return result.output
+        return ""
+
+
+class Custom(MergeStrategy):
+    """Aggregate via a caller-supplied callable over the per-agent mapping.
+
+    The callable receives the ordered ``{name: AgentResult | exception}`` dict and
+    returns the combined ``output`` string.
+    """
+
+    def __init__(self, fn: Callable[[PerAgent], str]) -> None:
+        self._fn = fn
+
+    def merge(self, per_agent: PerAgent) -> str:
+        return self._fn(per_agent)
+
+
+def _resolve_merge(merge: MergeStrategy | Callable[[PerAgent], str] | str | None) -> MergeStrategy:
+    """Coerce the ``merge=`` argument into a :class:`MergeStrategy`."""
+    if merge is None:
+        return Collect()
+    if isinstance(merge, MergeStrategy):
+        return merge
+    if isinstance(merge, str):
+        key = merge.strip().lower()
+        if key == "collect":
+            return Collect()
+        if key == "first":
+            return First()
+        raise ValueError(f"unknown merge strategy {merge!r}; use 'collect', 'first', a MergeStrategy, or a callable")
+    if callable(merge):
+        return Custom(merge)
+    raise TypeError(f"merge must be a MergeStrategy, a callable, or a string — got {type(merge).__name__!r}")
+
+
+# ── The combined result ────────────────────────────────────────────────────────
+
+
+@dataclass
+class TeamResult:
+    """The result of running a team.
+
+    Attributes:
+        output: The combined output (the merged string for parallel, the last
+            successful output for sequential / loop, the chosen specialist's
+            output for a coordinator).
+        per_agent: Per-sub-agent result keyed by name. A value is an
+            :class:`~jamjet.agents.agent.AgentResult` on success or the captured
+            exception on failure — a failing sub-agent is isolated here, never a
+            team crash. Keys preserve run order.
+        pattern: ``"sequential"`` | ``"parallel"`` | ``"coordinator"`` | ``"loop"``.
+        durable: ``True`` when each sub-agent ran as a durable execution
+            (:meth:`Team.run_durable`); ``False`` for the in-process
+            :meth:`Team.run`.
+    """
+
+    output: str
+    per_agent: PerAgent
+    pattern: str
+    durable: bool
+
+    def __str__(self) -> str:
+        return self.output
+
+    @property
+    def errors(self) -> dict[str, BaseException]:
+        """The subset of ``per_agent`` whose runs failed (exception values)."""
+        return {name: r for name, r in self.per_agent.items() if isinstance(r, BaseException)}
+
+    @property
+    def ok(self) -> bool:
+        """True when no sub-agent failed."""
+        return not self.errors
+
+
+# ── Session derivation (race-safe per-sub-agent threads) ───────────────────────
+
+
+def derive_child_session(
+    team_session: Session | str | None,
+    index: int,
+    agent_name: str,
+) -> Session | None:
+    """Derive a per-sub-agent child :class:`Session` from a team-level session.
+
+    Returns ``None`` when the team carries no session (sub-agents run stateless).
+
+    Each sub-agent gets its OWN session id ``"{team_id}::{index}-{name}"`` so a
+    sub-agent has a persistent, independent thread that survives across team runs
+    WITHOUT racing siblings. This matters because :class:`SessionStore` is
+    single-writer-per-id (last-writer-wins): the parallel pattern runs siblings
+    concurrently, so they MUST write distinct rows. The ``index`` keeps ids unique
+    even when two sub-agents share a name. The child is loaded get-or-create from
+    the team session's originating store (or a default store), so threads persist.
+    """
+    if team_session is None:
+        return None
+    if isinstance(team_session, Session):
+        base_id = team_session.id
+        store = getattr(team_session, "_store", None) or SessionStore()
+    else:
+        base_id = team_session
+        store = SessionStore()
+    child_id = f"{base_id}::{index}-{agent_name}"
+    return store.create(child_id)
+
+
+# ── Governance inheritance ──────────────────────────────────────────────────────
+
+
+def _resolve_team_governance(governance: GovernanceConfig | dict | None) -> GovernanceConfig | None:
+    """Coerce the team's ``governance=`` default into a :class:`GovernanceConfig`."""
+    if governance is None:
+        return None
+    if isinstance(governance, GovernanceConfig):
+        return governance
+    if isinstance(governance, dict):
+        return normalize_governance(**governance)
+    raise TypeError(f"governance must be a GovernanceConfig, dict, or None — got {type(governance).__name__!r}")
+
+
+# The all-default sentinel: a sub-agent whose governance equals this set NO
+# explicit governance knob, so a team default may be inherited into it.
+_DEFAULT_GOVERNANCE = GovernanceConfig()
+
+
+def _apply_governance_default(agents: list[Agent], team_governance: GovernanceConfig | None) -> None:
+    """Apply the team governance default to un-governed sub-agents (in place).
+
+    A sub-agent whose ``governance`` is the all-default sentinel set no explicit
+    knob, so it INHERITS the team default (its compiled IR then carries the team's
+    budget / policy / PII and enforces it). A sub-agent that set ANY governance
+    knob keeps its own config wholesale — explicit beats inherited, and an
+    explicitly-governed sub-agent is never weakened (no bypass). This mutates the
+    sub-agent's ``governance`` attribute; it only ever happens when the team
+    carries a default AND the sub-agent was un-governed.
+    """
+    if team_governance is None:
+        return
+    for agent in agents:
+        if agent.governance == _DEFAULT_GOVERNANCE:
+            agent.governance = team_governance
+
+
+# ── The base team ──────────────────────────────────────────────────────────────
+
+
+class _TeamBase:
+    """Shared machinery for the four patterns: governance/session inheritance,
+    the per-sub-agent run primitive, and the ``run`` / ``run_durable`` entry
+    points (each delegating to the subclass's :meth:`_orchestrate`)."""
+
+    pattern: str = "team"
+
+    def __init__(
+        self,
+        agents: list[Agent],
+        *,
+        name: str = "team",
+        governance: GovernanceConfig | dict | None = None,
+        session: Session | str | None = None,
+    ) -> None:
+        if not agents:
+            raise ValueError("a team needs at least one agent")
+        self.agents = list(agents)
+        self.name = name
+        self.session = session
+        self.governance = _resolve_team_governance(governance)
+        # T6-5: push the team governance default into un-governed sub-agents so
+        # each sub-agent compiles + enforces it (no bypass; explicit wins).
+        _apply_governance_default(self.agents, self.governance)
+
+    async def run(self, input: str) -> TeamResult:
+        """Run the team in-process (each sub-agent via :meth:`Agent.run`)."""
+        return await self._orchestrate(input, durable=False, runtime_url=_DEFAULT_RUNTIME_URL)
+
+    async def run_durable(self, input: str, *, runtime_url: str = _DEFAULT_RUNTIME_URL) -> TeamResult:
+        """Run the team durably (each sub-agent its own :meth:`Agent.run_durable`
+        execution, polled to a terminal state)."""
+        return await self._orchestrate(input, durable=True, runtime_url=runtime_url)
+
+    # -- the per-sub-agent run primitive --------------------------------------
+
+    async def _run_one(
+        self,
+        agent: Agent,
+        prompt: str,
+        *,
+        index: int,
+        durable: bool,
+        runtime_url: str,
+    ) -> AgentResult:
+        """Run a single sub-agent as its own independent execution.
+
+        In-process (:meth:`Agent.run`) or durable (:meth:`Agent.run_durable`),
+        matching the team's run mode. When the team carries a session, the
+        sub-agent runs with a derived per-sub-agent child session so siblings
+        never race. Exceptions propagate to the caller, which isolates them.
+        """
+        child = derive_child_session(self.session, index, agent.name)
+        if durable:
+            return await agent.run_durable(prompt, runtime_url=runtime_url, session=child)
+        return await agent.run(prompt, session=child)
+
+    async def _orchestrate(self, input: str, *, durable: bool, runtime_url: str) -> TeamResult:  # pragma: no cover
+        raise NotImplementedError("subclasses implement the pattern orchestration")
+
+
+# ── Sequential ──────────────────────────────────────────────────────────────────
+
+
+class Sequential(_TeamBase):
+    """A pipeline: each agent's output is the next agent's input.
+
+    ``Sequential([a, b, c]).run("go")`` runs ``a("go") -> b(a.out) -> c(b.out)``
+    and returns the last agent's output. Halts on the first failing step (a broken
+    upstream output cannot feed downstream); the failure is recorded in
+    ``TeamResult.per_agent`` and no later agent runs.
+    """
+
+    pattern = "sequential"
+
+    def __init__(
+        self,
+        agents: list[Agent],
+        *,
+        name: str = "sequential",
+        governance: GovernanceConfig | dict | None = None,
+        session: Session | str | None = None,
+    ) -> None:
+        super().__init__(agents, name=name, governance=governance, session=session)
+
+    async def _orchestrate(self, input: str, *, durable: bool, runtime_url: str) -> TeamResult:
+        per_agent: PerAgent = {}
+        current = input
+        last_output = ""
+        for i, agent in enumerate(self.agents):
+            try:
+                result = await self._run_one(agent, current, index=i, durable=durable, runtime_url=runtime_url)
+            except Exception as exc:  # noqa: BLE001 - isolate any sub-agent failure
+                per_agent[agent.name] = exc
+                break  # halt-on-error: do not feed a broken output downstream
+            per_agent[agent.name] = result
+            last_output = result.output
+            current = result.output  # thread the output forward
+        return TeamResult(output=last_output, per_agent=per_agent, pattern=self.pattern, durable=durable)
+
+
+# ── Parallel ────────────────────────────────────────────────────────────────────
+
+
+class Parallel(_TeamBase):
+    """Fan the same input out to every agent concurrently, then aggregate.
+
+    ``Parallel([a, b], merge=Collect()).run("go")`` runs ``a("go")`` and
+    ``b("go")`` concurrently (``asyncio.gather(..., return_exceptions=True)``) and
+    merges the results. A failing sub-agent is isolated — its exception is captured
+    in ``per_agent`` and siblings are unaffected.
+    """
+
+    pattern = "parallel"
+
+    def __init__(
+        self,
+        agents: list[Agent],
+        *,
+        merge: MergeStrategy | Callable[[PerAgent], str] | str | None = None,
+        name: str = "parallel",
+        governance: GovernanceConfig | dict | None = None,
+        session: Session | str | None = None,
+    ) -> None:
+        super().__init__(agents, name=name, governance=governance, session=session)
+        self.merge = _resolve_merge(merge)
+
+    async def _orchestrate(self, input: str, *, durable: bool, runtime_url: str) -> TeamResult:
+        tasks = [
+            self._run_one(agent, input, index=i, durable=durable, runtime_url=runtime_url)
+            for i, agent in enumerate(self.agents)
+        ]
+        # return_exceptions=True => one failed child never corrupts siblings; each
+        # sub-agent is its own execution, so isolation is natural under Path A.
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        per_agent: PerAgent = {agent.name: result for agent, result in zip(self.agents, results)}
+        output = self.merge.merge(per_agent)
+        return TeamResult(output=output, per_agent=per_agent, pattern=self.pattern, durable=durable)
+
+
+# ── Team (coordinator / router) ─────────────────────────────────────────────────
+
+# A routing callable: given the input and the candidate agents, return the chosen
+# Agent, its name, or its index.
+RoutingFn = Callable[[str, "list[Agent]"], "Agent | str | int | Awaitable[Agent | str | int]"]
+
+
+class Team(_TeamBase):
+    """A coordinator routes the input to ONE specialist, then that one runs.
+
+    The ``coordinator`` is either:
+
+    - a *router* :class:`~jamjet.agents.agent.Agent` whose OUTPUT names the chosen
+      specialist (matched against the sub-agents by name), or
+    - a Python routing callable ``(input, agents) -> Agent | name | index`` (may be
+      async), or
+    - ``None`` — routes to the first agent (a single-specialist degenerate team).
+
+    The router (when an Agent) and the chosen specialist both appear in
+    ``per_agent``; ``output`` is the specialist's output.
+    """
+
+    pattern = "coordinator"
+
+    def __init__(
+        self,
+        agents: list[Agent],
+        *,
+        coordinator: Agent | RoutingFn | None = None,
+        name: str = "team",
+        governance: GovernanceConfig | dict | None = None,
+        session: Session | str | None = None,
+    ) -> None:
+        super().__init__(agents, name=name, governance=governance, session=session)
+        self.coordinator = coordinator
+
+    async def _orchestrate(self, input: str, *, durable: bool, runtime_url: str) -> TeamResult:
+        per_agent: PerAgent = {}
+        specialist = await self._route(input, per_agent, durable=durable, runtime_url=runtime_url)
+        if specialist is None:
+            # Routing itself failed (the router crashed); the error is already in
+            # per_agent. Return an empty combined output rather than crashing.
+            return TeamResult(output="", per_agent=per_agent, pattern=self.pattern, durable=durable)
+
+        # The specialist's index in self.agents keeps its child-session id stable.
+        idx = self.agents.index(specialist)
+        try:
+            result = await self._run_one(specialist, input, index=idx, durable=durable, runtime_url=runtime_url)
+        except Exception as exc:  # noqa: BLE001 - isolate the specialist failure
+            per_agent[specialist.name] = exc
+            return TeamResult(output="", per_agent=per_agent, pattern=self.pattern, durable=durable)
+        per_agent[specialist.name] = result
+        return TeamResult(output=result.output, per_agent=per_agent, pattern=self.pattern, durable=durable)
+
+    async def _route(
+        self,
+        input: str,
+        per_agent: PerAgent,
+        *,
+        durable: bool,
+        runtime_url: str,
+    ) -> Agent | None:
+        """Pick the specialist. Records a router-Agent's result in ``per_agent``.
+
+        Returns the chosen :class:`Agent`, or ``None`` if routing crashed.
+        """
+        coord = self.coordinator
+        if coord is None:
+            return self.agents[0]
+
+        # A router Agent: run it, then match its output to a specialist by name.
+        if _is_agent(coord):
+            # The router runs at index -1 so its derived child session never
+            # collides with a specialist's (which use 0..n-1).
+            try:
+                router_result = await self._run_one(coord, input, index=-1, durable=durable, runtime_url=runtime_url)
+            except Exception as exc:  # noqa: BLE001 - isolate router failure
+                per_agent[coord.name] = exc
+                return None
+            per_agent[coord.name] = router_result
+            return self._match_specialist(router_result.output)
+
+        # A routing callable: (input, agents) -> Agent | name | index (maybe async).
+        try:
+            choice = coord(input, self.agents)
+            if asyncio.iscoroutine(choice):
+                choice = await choice
+        except Exception as exc:  # noqa: BLE001 - isolate routing-callable failure
+            per_agent[f"{self.name}:coordinator"] = exc
+            return None
+        return self._coerce_choice(choice)
+
+    def _match_specialist(self, router_output: str) -> Agent:
+        """Match a router's free-text output to a specialist by name.
+
+        Exact name match wins; otherwise the first agent whose name appears
+        (case-insensitive) in the output; otherwise the first agent (a safe,
+        documented fallback so an ambiguous router never crashes the team).
+        """
+        text = (router_output or "").strip()
+        for agent in self.agents:
+            if agent.name == text:
+                return agent
+        low = text.lower()
+        for agent in self.agents:
+            if agent.name.lower() in low:
+                return agent
+        return self.agents[0]
+
+    def _coerce_choice(self, choice: Agent | str | int) -> Agent:
+        """Coerce a routing callable's return (Agent / name / index) to an Agent."""
+        if _is_agent(choice):
+            return choice  # type: ignore[return-value]
+        if isinstance(choice, int):
+            return self.agents[choice]
+        if isinstance(choice, str):
+            for agent in self.agents:
+                if agent.name == choice:
+                    return agent
+            raise ValueError(f"coordinator returned unknown agent name {choice!r}")
+        raise TypeError(f"coordinator must return an Agent, a name, or an index — got {type(choice).__name__!r}")
+
+
+# ── Loop ─────────────────────────────────────────────────────────────────────────
+
+# A loop predicate over the latest AgentResult: True => stop.
+LoopPredicate = Callable[["AgentResult"], bool]
+
+
+class Loop(_TeamBase):
+    """Re-run a single agent until a predicate holds (or a max-iters bound).
+
+    ``Loop(agent, until=is_done, max_iters=5).run("draft")`` runs the agent on the
+    input, then re-runs it on each previous output (a refinement loop), stopping
+    when ``until(result)`` is truthy or after ``max_iters`` iterations. Each
+    iteration is keyed ``"name#i"`` in ``per_agent``; ``output`` is the last
+    iteration's output. A failing iteration is isolated and stops the loop.
+    """
+
+    pattern = "loop"
+
+    def __init__(
+        self,
+        agent: Agent,
+        *,
+        until: LoopPredicate | None = None,
+        max_iters: int = 5,
+        name: str = "loop",
+        governance: GovernanceConfig | dict | None = None,
+        session: Session | str | None = None,
+    ) -> None:
+        if max_iters < 1:
+            raise ValueError("max_iters must be >= 1")
+        super().__init__([agent], name=name, governance=governance, session=session)
+        self.agent = agent
+        self.until = until
+        self.max_iters = max_iters
+
+    async def _orchestrate(self, input: str, *, durable: bool, runtime_url: str) -> TeamResult:
+        per_agent: PerAgent = {}
+        current = input
+        last_output = ""
+        for i in range(self.max_iters):
+            try:
+                result = await self._run_one(self.agent, current, index=0, durable=durable, runtime_url=runtime_url)
+            except Exception as exc:  # noqa: BLE001 - isolate the iteration failure
+                per_agent[f"{self.agent.name}#{i}"] = exc
+                break
+            per_agent[f"{self.agent.name}#{i}"] = result
+            last_output = result.output
+            current = result.output
+            if self.until is not None and self.until(result):
+                break
+        return TeamResult(output=last_output, per_agent=per_agent, pattern=self.pattern, durable=durable)
+
+
+# ── small helpers ────────────────────────────────────────────────────────────────
+
+
+def _is_agent(obj: Any) -> bool:
+    """True if *obj* is a :class:`~jamjet.agents.agent.Agent` (imported lazily to
+    avoid an import cycle: agent.py does not import team, and team is optional)."""
+    from jamjet.agents.agent import Agent  # noqa: PLC0415
+
+    return isinstance(obj, Agent)
+
+
+__all__ = [
+    "Collect",
+    "Custom",
+    "First",
+    "Loop",
+    "MergeStrategy",
+    "Parallel",
+    "RoutingFn",
+    "Sequential",
+    "Team",
+    "TeamResult",
+    "derive_child_session",
+]

--- a/sdk/python/tests/team_fakes.py
+++ b/sdk/python/tests/team_fakes.py
@@ -30,7 +30,8 @@ def scripted_agent(
     is observable). ``agent_kwargs`` (e.g. ``budget=``) flow to the real Agent ctor.
     """
     agent = Agent(name, model="anthropic/claude-sonnet-4-6", tools=[], **agent_kwargs)
-    agent.calls = []  # type: ignore[attr-defined]
+    agent.calls = []  # type: ignore[attr-defined]  # (mode, prompt, session) per run
+    agent.durable_runtime_urls = []  # type: ignore[attr-defined]  # runtime_url per durable run
 
     def _compute(prompt: str) -> str:
         if fail is not None:
@@ -53,8 +54,73 @@ def scripted_agent(
         **kw: Any,
     ) -> AgentResult:
         agent.calls.append(("run_durable", prompt, session))  # type: ignore[attr-defined]
+        agent.durable_runtime_urls.append(runtime_url)  # type: ignore[attr-defined]
         return AgentResult(output=_compute(prompt), tool_calls=[], ir={})
 
     agent.run = _run  # type: ignore[method-assign,assignment]
     agent.run_durable = _run_durable  # type: ignore[method-assign,assignment]
     return agent
+
+
+# ── Durable client fake (drives REAL Agent.run_durable, no engine) ─────────────
+
+
+def completed_terminal(answer: str) -> dict[str, Any]:
+    """A ``completed`` terminal execution whose final answer is *answer*."""
+    return {
+        "status": "completed",
+        "current_state": {
+            "messages": [{"role": "user", "content": "in"}],
+            "last_model_output": answer,
+            "last_model_finish_reason": "stop",
+        },
+    }
+
+
+def failed_terminal(status: str = "failed") -> dict[str, Any]:
+    """A non-``completed`` terminal (``failed`` / ``limit_exceeded`` / ``cancelled``)."""
+    return {"status": status, "current_state": {}}
+
+
+class MultiAgentFakeClient:
+    """An async-context fake of :class:`~jamjet.client.JamjetClient` serving MANY
+    sub-agents (one Team run starts several executions through one patched client).
+
+    Terminals are keyed by ``workflow_id`` (== the agent name), so different
+    sub-agents can be made to succeed or fail independently — exactly what the
+    durable child-crash-isolation tests need. The SAME instance is shared across
+    concurrent parallel sub-agent runs (single-threaded asyncio, distinct
+    workflow ids -> no collision).
+    """
+
+    def __init__(self, terminals: dict[str, dict[str, Any]]) -> None:
+        self._terminals = terminals
+        self._by_exec: dict[str, dict[str, Any]] = {}
+        self.created: list[str] = []
+        self.started: list[tuple[str, dict[str, Any]]] = []
+
+    async def __aenter__(self) -> MultiAgentFakeClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        self.created.append(ir["workflow_id"])
+        return {"workflow_id": ir["workflow_id"]}
+
+    async def start_execution(
+        self, workflow_id: str, input: dict[str, Any], workflow_version: str | None = None
+    ) -> dict[str, Any]:
+        exec_id = f"exec-{workflow_id}"
+        term = dict(self._terminals[workflow_id])
+        term.setdefault("execution_id", exec_id)
+        self._by_exec[exec_id] = term
+        self.started.append((workflow_id, input))
+        return {"execution_id": exec_id}
+
+    async def get_execution(self, execution_id: str) -> dict[str, Any]:
+        return self._by_exec[execution_id]
+
+    async def get_events(self, execution_id: str) -> dict[str, Any]:
+        return {"events": []}

--- a/sdk/python/tests/team_fakes.py
+++ b/sdk/python/tests/team_fakes.py
@@ -1,0 +1,60 @@
+"""Shared test helpers for the Team patterns (not collected by pytest).
+
+``scripted_agent`` builds a REAL :class:`~jamjet.agents.agent.Agent` (so the
+coordinator's ``isinstance(coord, Agent)`` router detection works and governance
+is real) but replaces its ``run`` / ``run_durable`` with scripted coroutines, so
+the patterns run with NO engine and NO network. Each call is recorded on
+``agent.calls`` as ``(mode, prompt, session)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from jamjet.agents.agent import Agent, AgentResult
+
+
+def scripted_agent(
+    name: str,
+    *,
+    transform: Callable[[str], str] | None = None,
+    output: str | None = None,
+    fail: BaseException | None = None,
+    **agent_kwargs: Any,
+) -> Agent:
+    """A real Agent whose ``run`` / ``run_durable`` are scripted (no engine).
+
+    Output precedence: ``fail`` (raise) > ``output`` (constant) > ``transform``
+    (``f(prompt)``) > the default ``f"{name}:{prompt}"`` (so sequential threading
+    is observable). ``agent_kwargs`` (e.g. ``budget=``) flow to the real Agent ctor.
+    """
+    agent = Agent(name, model="anthropic/claude-sonnet-4-6", tools=[], **agent_kwargs)
+    agent.calls = []  # type: ignore[attr-defined]
+
+    def _compute(prompt: str) -> str:
+        if fail is not None:
+            raise fail
+        if output is not None:
+            return output
+        if transform is not None:
+            return transform(prompt)
+        return f"{name}:{prompt}"
+
+    async def _run(prompt: str, *, session: Any = None) -> AgentResult:
+        agent.calls.append(("run", prompt, session))  # type: ignore[attr-defined]
+        return AgentResult(output=_compute(prompt), tool_calls=[], ir={})
+
+    async def _run_durable(
+        prompt: str,
+        *,
+        runtime_url: str = "http://127.0.0.1:7700",
+        session: Any = None,
+        **kw: Any,
+    ) -> AgentResult:
+        agent.calls.append(("run_durable", prompt, session))  # type: ignore[attr-defined]
+        return AgentResult(output=_compute(prompt), tool_calls=[], ir={})
+
+    agent.run = _run  # type: ignore[method-assign,assignment]
+    agent.run_durable = _run_durable  # type: ignore[method-assign,assignment]
+    return agent

--- a/sdk/python/tests/team_fakes.py
+++ b/sdk/python/tests/team_fakes.py
@@ -96,6 +96,10 @@ class MultiAgentFakeClient:
     def __init__(self, terminals: dict[str, dict[str, Any]]) -> None:
         self._terminals = terminals
         self._by_exec: dict[str, dict[str, Any]] = {}
+        # A deterministic, monotonically increasing counter so every
+        # start_execution call gets a UNIQUE exec_id (two starts of the same
+        # workflow_id never collide in _by_exec). No clock / randomness.
+        self._exec_seq = 0
         self.created: list[str] = []
         self.started: list[tuple[str, dict[str, Any]]] = []
 
@@ -112,9 +116,10 @@ class MultiAgentFakeClient:
     async def start_execution(
         self, workflow_id: str, input: dict[str, Any], workflow_version: str | None = None
     ) -> dict[str, Any]:
-        exec_id = f"exec-{workflow_id}"
+        self._exec_seq += 1
+        exec_id = f"exec-{workflow_id}-{self._exec_seq}"
         term = dict(self._terminals[workflow_id])
-        term.setdefault("execution_id", exec_id)
+        term["execution_id"] = exec_id
         self._by_exec[exec_id] = term
         self.started.append((workflow_id, input))
         return {"execution_id": exec_id}

--- a/sdk/python/tests/test_team_api.py
+++ b/sdk/python/tests/test_team_api.py
@@ -1,0 +1,168 @@
+"""T6-1 — the ``Team`` / ``Sequential`` / ``Parallel`` / ``Loop`` composition API.
+
+These tests assert ONLY construction + the composition shape (which agents, in
+what order, with what merge / coordinator). Orchestration (``run`` / ``run_durable``)
+is covered by the pattern tests (T6-3/T6-4). No engine, no network.
+"""
+
+from __future__ import annotations
+
+from jamjet.agents.agent import Agent
+from jamjet.team import (
+    Collect,
+    Custom,
+    First,
+    Loop,
+    MergeStrategy,
+    Parallel,
+    Sequential,
+    Team,
+    TeamResult,
+)
+
+
+def _agent(name: str) -> Agent:
+    return Agent(name, model="anthropic/claude-sonnet-4-6", tools=[])
+
+
+# ── Sequential ────────────────────────────────────────────────────────────────
+
+
+def test_sequential_constructs_and_carries_agents_in_order() -> None:
+    a, b, c = _agent("a"), _agent("b"), _agent("c")
+    seq = Sequential([a, b, c])
+    assert seq.agents == [a, b, c]
+    assert seq.pattern == "sequential"
+
+
+def test_sequential_rejects_empty() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="at least one"):
+        Sequential([])
+
+
+# ── Parallel ──────────────────────────────────────────────────────────────────
+
+
+def test_parallel_constructs_with_default_collect_merge() -> None:
+    a, b = _agent("a"), _agent("b")
+    par = Parallel([a, b])
+    assert par.agents == [a, b]
+    assert par.pattern == "parallel"
+    assert isinstance(par.merge, Collect)
+
+
+def test_parallel_accepts_merge_strategy_instance() -> None:
+    par = Parallel([_agent("a")], merge=First())
+    assert isinstance(par.merge, First)
+
+
+def test_parallel_accepts_string_merge_names() -> None:
+    assert isinstance(Parallel([_agent("a")], merge="collect").merge, Collect)
+    assert isinstance(Parallel([_agent("a")], merge="first").merge, First)
+
+
+def test_parallel_wraps_a_plain_callable_as_custom() -> None:
+    par = Parallel([_agent("a")], merge=lambda per_agent: "joined")
+    assert isinstance(par.merge, Custom)
+    assert par.merge.merge({}) == "joined"
+
+
+# ── Team (coordinator) ────────────────────────────────────────────────────────
+
+
+def test_team_constructs_with_router_agent_coordinator() -> None:
+    router, x, y = _agent("router"), _agent("x"), _agent("y")
+    team = Team([x, y], coordinator=router, name="desk")
+    assert team.agents == [x, y]
+    assert team.coordinator is router
+    assert team.pattern == "coordinator"
+    assert team.name == "desk"
+
+
+def test_team_constructs_with_callable_coordinator() -> None:
+    def route(input: str, agents: list[Agent]) -> Agent:
+        return agents[0]
+
+    team = Team([_agent("x")], coordinator=route)
+    assert team.coordinator is route
+
+
+def test_team_coordinator_optional() -> None:
+    team = Team([_agent("only")])
+    assert team.coordinator is None
+
+
+# ── Loop ──────────────────────────────────────────────────────────────────────
+
+
+def test_loop_constructs() -> None:
+    a = _agent("refiner")
+    loop = Loop(a, until=lambda r: True, max_iters=3)
+    assert loop.agent is a
+    assert loop.agents == [a]
+    assert loop.pattern == "loop"
+    assert loop.max_iters == 3
+
+
+# ── TeamResult ────────────────────────────────────────────────────────────────
+
+
+def test_team_result_str_is_output() -> None:
+    tr = TeamResult(output="hi", per_agent={}, pattern="sequential", durable=False)
+    assert str(tr) == "hi"
+    assert tr.pattern == "sequential"
+    assert tr.durable is False
+
+
+# ── MergeStrategy semantics ───────────────────────────────────────────────────
+
+
+class _Out:
+    """Minimal AgentResult stand-in: only ``.output`` is read by merges."""
+
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+
+def test_collect_joins_labeled_successful_outputs_in_order() -> None:
+    merged = Collect().merge({"a": _Out("one"), "b": _Out("two")})
+    assert "[a] one" in merged
+    assert "[b] two" in merged
+    # order preserved
+    assert merged.index("[a]") < merged.index("[b]")
+
+
+def test_collect_skips_failures() -> None:
+    merged = Collect().merge({"a": _Out("ok"), "b": RuntimeError("boom")})
+    assert "[a] ok" in merged
+    assert "boom" not in merged
+
+
+def test_first_returns_first_successful_in_order() -> None:
+    out = First().merge({"a": RuntimeError("x"), "b": _Out("second"), "c": _Out("third")})
+    assert out == "second"
+
+
+def test_first_empty_when_all_failed() -> None:
+    assert First().merge({"a": RuntimeError("x")}) == ""
+
+
+def test_merge_strategy_is_the_base() -> None:
+    assert issubclass(Collect, MergeStrategy)
+    assert issubclass(First, MergeStrategy)
+    assert issubclass(Custom, MergeStrategy)
+
+
+# ── Public exports ────────────────────────────────────────────────────────────
+
+
+def test_public_exports() -> None:
+    import jamjet
+
+    assert jamjet.Team is Team
+    assert jamjet.Sequential is Sequential
+    assert jamjet.Parallel is Parallel
+    assert jamjet.Loop is Loop
+    assert jamjet.TeamResult is TeamResult

--- a/sdk/python/tests/test_team_api.py
+++ b/sdk/python/tests/test_team_api.py
@@ -106,6 +106,26 @@ def test_loop_constructs() -> None:
     assert loop.max_iters == 3
 
 
+# ── Duplicate member names rejected ───────────────────────────────────────────
+
+
+def test_duplicate_member_names_are_rejected() -> None:
+    """``per_agent`` keys by name and the coordinator routes by name, so two members
+    sharing a name would silently overwrite / mis-route. Construction must reject it."""
+    import pytest
+
+    for ctor in (Sequential, Parallel, Team):
+        with pytest.raises(ValueError, match="unique names"):
+            ctor([_agent("dup"), _agent("dup")])
+
+
+def test_unique_member_names_still_construct() -> None:
+    a, b = _agent("a"), _agent("b")
+    assert Sequential([a, b]).agents == [a, b]
+    assert Parallel([a, b]).agents == [a, b]
+    assert Team([a, b]).agents == [a, b]
+
+
 # ── TeamResult ────────────────────────────────────────────────────────────────
 
 

--- a/sdk/python/tests/test_team_consolidated.py
+++ b/sdk/python/tests/test_team_consolidated.py
@@ -1,0 +1,161 @@
+"""T6-6 — consolidated patterns coverage + the multi-agent example smoke.
+
+Exercises all four patterns together (a regression guard), the Loop pattern's
+behaviour (until-predicate, max-iters, output threading, isolation), and the
+``examples/team-multi-agent`` example: it imports + constructs cleanly (engine-free
+smoke), governance inheritance reaches the compiled IR, and ``main.py`` compiles.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import py_compile
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from jamjet.compiler.team_ir import compile_team_to_ir
+from jamjet.team import Collect, First, Loop, Parallel, Sequential, Team
+from tests.team_fakes import scripted_agent
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "team-multi-agent"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register under its name BEFORE exec so the in-process strategy can resolve a
+    # tool's handler_ref ("<name>:<fn>") via importlib.import_module(name) — exactly
+    # how the example resolves "specialists:web_search" when run for real.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Consolidated: all four patterns compose ───────────────────────────────────
+
+
+async def test_all_four_patterns_compose() -> None:
+    # sequential threads a -> b
+    seq = await Sequential(
+        [scripted_agent("a", transform=lambda p: f"A({p})"), scripted_agent("b", transform=lambda p: f"B({p})")]
+    ).run("x")
+    assert seq.output == "B(A(x))"
+
+    # parallel fans out + collects
+    par = await Parallel([scripted_agent("a", output="ra"), scripted_agent("b", output="rb")], merge=Collect()).run(
+        "in"
+    )
+    assert par.output == "[a] ra\n[b] rb"
+
+    # coordinator routes to the named specialist
+    coord = await Team(
+        [scripted_agent("researcher", output="R"), scripted_agent("writer", output="W")],
+        coordinator=scripted_agent("router", output="writer"),
+    ).run("task")
+    assert coord.output == "W"
+
+    # loop refines until the predicate holds
+    loop = await Loop(
+        scripted_agent("refiner", transform=lambda p: p + "!"),
+        until=lambda r: r.output.endswith("!!!"),
+        max_iters=10,
+    ).run("x")
+    assert loop.output == "x!!!"
+
+
+# ── Loop behaviour ─────────────────────────────────────────────────────────────
+
+
+async def test_loop_threads_output_and_keys_each_iteration() -> None:
+    result = await Loop(scripted_agent("r", transform=lambda p: p + "!"), max_iters=3).run("x")
+    assert result.output == "x!!!"
+    assert list(result.per_agent) == ["r#0", "r#1", "r#2"]
+    assert result.pattern == "loop"
+
+
+async def test_loop_stops_early_on_predicate() -> None:
+    result = await Loop(
+        scripted_agent("r", transform=lambda p: p + "!"),
+        until=lambda res: res.output == "x!!",
+        max_iters=10,
+    ).run("x")
+    assert result.output == "x!!"
+    assert list(result.per_agent) == ["r#0", "r#1"]  # stopped at the 2nd iteration
+
+
+async def test_loop_respects_max_iters_when_predicate_never_holds() -> None:
+    result = await Loop(
+        scripted_agent("r", transform=lambda p: p + "!"),
+        until=lambda res: False,
+        max_iters=2,
+    ).run("x")
+    assert list(result.per_agent) == ["r#0", "r#1"]
+    assert result.output == "x!!"
+
+
+async def test_loop_isolates_a_failing_iteration() -> None:
+    result = await Loop(scripted_agent("r", fail=RuntimeError("boom")), max_iters=3).run("x")
+    assert isinstance(result.per_agent["r#0"], RuntimeError)
+    assert list(result.per_agent) == ["r#0"]  # the loop stopped on the failure
+    assert result.output == ""
+
+
+# ── Example smoke: import + construct + compile (engine-free) ─────────────────
+
+
+def test_example_specialists_construct_the_teams() -> None:
+    specialists = _load("team_example_specialists", EXAMPLE_DIR / "specialists.py")
+
+    desk = specialists.build_desk()
+    assert isinstance(desk, Team)
+    assert desk.pattern == "coordinator"
+    assert [a.name for a in desk.agents] == ["researcher", "writer"]
+    assert desk.coordinator.name == "router"
+    assert desk.name == "content-desk"
+
+    pipeline = specialists.build_pipeline()
+    assert isinstance(pipeline, Sequential)
+    assert [a.name for a in pipeline.agents] == ["researcher", "writer"]
+
+
+def test_example_governance_default_is_inherited_into_compiled_ir() -> None:
+    specialists = _load("team_example_specialists_gov", EXAMPLE_DIR / "specialists.py")
+    desk = specialists.build_desk()
+    # the un-governed specialists inherited the team's budget cap...
+    assert desk.agents[0].governance.budget.cost_usd == 0.50
+    # ...and it reaches each sub-agent's compiled IR (enforcement-ready).
+    plan = compile_team_to_ir(desk)
+    assert plan.coordinator is not None  # the router compiled too
+    assert all(c.ir["cost_budget_usd"] == 0.50 for c in plan.sub_agents)
+
+
+async def test_example_pipeline_runs_end_to_end_under_the_mock_model() -> None:
+    """The example's specialists actually EXECUTE through the team (researcher ->
+    writer) under the conftest mock model — proves the example orchestrates, not
+    just constructs. No engine, no network."""
+    specialists = _load("team_example_run", EXAMPLE_DIR / "specialists.py")
+    result = await specialists.build_pipeline().run("agent runtimes")
+    assert result.pattern == "sequential"
+    assert set(result.per_agent) == {"researcher", "writer"}
+    assert result.ok
+    assert result.output  # the writer produced a non-empty final answer
+
+
+def test_example_main_compiles() -> None:
+    main_py = EXAMPLE_DIR / "main.py"
+    assert main_py.exists()
+    py_compile.compile(str(main_py), doraise=True)
+
+
+def test_example_readme_exists() -> None:
+    assert (EXAMPLE_DIR / "README.md").exists()
+
+
+async def test_parallel_first_merge_consolidated() -> None:
+    result = await Parallel(
+        [scripted_agent("a", output="winner"), scripted_agent("b", output="loser")], merge=First()
+    ).run("in")
+    assert result.output == "winner"

--- a/sdk/python/tests/test_team_durable.py
+++ b/sdk/python/tests/test_team_durable.py
@@ -1,0 +1,146 @@
+"""T6-4 — ``Team.run_durable`` over N per-sub-agent durable executions.
+
+Each sub-agent runs as its OWN durable execution (the shipped 2j path:
+create_workflow -> start_execution -> poll -> extract). The team composes them per
+the pattern. Two levels of test: (1) orchestration over a scripted ``run_durable``
+(confirms the durable method is used + ``TeamResult.durable``), and (2) the REAL
+``Agent.run_durable`` driven by a fake ``JamjetClient`` (confirms each sub-agent's
+execution actually starts and that a failed/limit_exceeded terminal is isolated —
+never a team crash or hang).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.team import Collect, Parallel, Sequential, Team
+from tests.team_fakes import (
+    MultiAgentFakeClient,
+    completed_terminal,
+    failed_terminal,
+    scripted_agent,
+)
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: MultiAgentFakeClient, urls: list | None = None) -> None:
+    """Patch JamjetClient (constructed inside Agent.run_durable) to the *fake*.
+
+    Optionally capture the runtime_url each construction received into *urls*.
+    """
+
+    def factory(*args: object, **kwargs: object) -> MultiAgentFakeClient:
+        if urls is not None and args:
+            urls.append(args[0])
+        return fake
+
+    monkeypatch.setattr("jamjet.client.JamjetClient", factory)
+
+
+# ── Orchestration level: scripted run_durable ─────────────────────────────────
+
+
+async def test_run_durable_uses_the_durable_path_and_marks_result() -> None:
+    a = scripted_agent("a", transform=lambda p: f"A({p})")
+    b = scripted_agent("b", transform=lambda p: f"B({p})")
+    result = await Sequential([a, b]).run_durable("x", runtime_url="http://engine:9000")
+
+    assert result.durable is True
+    # the DURABLE method was used (not the in-process run), with the threaded url.
+    assert a.calls[0][0] == "run_durable"
+    assert b.calls[0][0] == "run_durable"
+    assert a.durable_runtime_urls == ["http://engine:9000"]
+    # sequential threading still holds on the durable path.
+    assert b.calls[0][1] == "A(x)"
+    assert result.output == "B(A(x))"
+
+
+async def test_run_marks_result_not_durable() -> None:
+    a = scripted_agent("a", output="o")
+    result = await Sequential([a]).run("x")
+    assert result.durable is False
+    assert a.calls[0][0] == "run"
+
+
+# ── Client level: REAL Agent.run_durable through a fake JamjetClient ───────────
+
+
+async def test_run_durable_sequential_starts_each_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MultiAgentFakeClient(
+        {"alpha": completed_terminal("alpha-answer"), "beta": completed_terminal("beta-answer")}
+    )
+    _patch_client(monkeypatch, fake)
+    from jamjet.agents.agent import Agent
+
+    # REAL agents -> the real Agent.run_durable runs through the fake client.
+    a = Agent("alpha", model="anthropic/claude-sonnet-4-6", tools=[])
+    b = Agent("beta", model="anthropic/claude-sonnet-4-6", tools=[])
+
+    result = await Sequential([a, b]).run_durable("start")
+
+    # both sub-agents started their OWN durable execution.
+    assert set(fake.created) == {"alpha", "beta"}
+    assert [w for w, _ in fake.started] == ["alpha", "beta"]
+    # sequential threaded alpha's answer into beta's prompt (durable seed messages).
+    _, beta_input = next((w, i) for w, i in fake.started if w == "beta")
+    assert beta_input["messages"][-1]["content"] == "alpha-answer"
+    assert result.output == "beta-answer"
+    assert result.durable is True
+
+
+async def test_run_durable_parallel_composes_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MultiAgentFakeClient({"x": completed_terminal("x-ans"), "y": completed_terminal("y-ans")})
+    _patch_client(monkeypatch, fake)
+    from jamjet.agents.agent import Agent
+
+    x = Agent("x", model="anthropic/claude-sonnet-4-6", tools=[])
+    y = Agent("y", model="anthropic/claude-sonnet-4-6", tools=[])
+
+    result = await Parallel([x, y], merge=Collect()).run_durable("go")
+
+    assert set(fake.created) == {"x", "y"}
+    assert result.output == "[x] x-ans\n[y] y-ans"
+
+
+async def test_run_durable_isolates_a_failed_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MultiAgentFakeClient({"good": completed_terminal("good-ans"), "bad": failed_terminal("failed")})
+    _patch_client(monkeypatch, fake)
+    from jamjet.agents.agent import Agent
+
+    good = Agent("good", model="anthropic/claude-sonnet-4-6", tools=[])
+    bad = Agent("bad", model="anthropic/claude-sonnet-4-6", tools=[])
+
+    result = await Parallel([good, bad], merge=Collect()).run_durable("go")
+
+    # bad's failed terminal -> RuntimeError isolated into per_agent (not a team crash).
+    assert isinstance(result.per_agent["bad"], RuntimeError)
+    assert result.per_agent["good"].output == "good-ans"
+    assert result.output == "[good] good-ans"
+    assert list(result.errors) == ["bad"]
+
+
+async def test_run_durable_isolates_a_limit_exceeded_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MultiAgentFakeClient({"capped": failed_terminal("limit_exceeded")})
+    _patch_client(monkeypatch, fake)
+    from jamjet.agents.agent import Agent
+
+    capped = Agent("capped", model="anthropic/claude-sonnet-4-6", tools=[])
+
+    result = await Team([capped], coordinator=lambda inp, agents: agents[0]).run_durable("go")
+
+    assert isinstance(result.per_agent["capped"], RuntimeError)
+    assert result.output == ""
+
+
+async def test_run_durable_threads_runtime_url_to_each_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MultiAgentFakeClient({"a": completed_terminal("a"), "b": completed_terminal("b")})
+    urls: list = []
+    _patch_client(monkeypatch, fake, urls=urls)
+    from jamjet.agents.agent import Agent
+
+    a = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[])
+    b = Agent("b", model="anthropic/claude-sonnet-4-6", tools=[])
+
+    await Parallel([a, b]).run_durable("go", runtime_url="http://engine:7777")
+
+    # every sub-agent's durable client was constructed against the team's runtime_url.
+    assert urls and all(u == "http://engine:7777" for u in urls)

--- a/sdk/python/tests/test_team_durable.py
+++ b/sdk/python/tests/test_team_durable.py
@@ -29,8 +29,16 @@ def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: MultiAgentFakeClient, u
     """
 
     def factory(*args: object, **kwargs: object) -> MultiAgentFakeClient:
-        if urls is not None and args:
-            urls.append(args[0])
+        # Record the runtime_url from a positional OR keyword construction so the
+        # capture survives whether JamjetClient(url) or JamjetClient(base_url=url)
+        # is used. One append per construction == one per sub-agent (the count).
+        if urls is not None:
+            if args:
+                urls.append(args[0])
+            elif "base_url" in kwargs:
+                urls.append(kwargs["base_url"])
+            elif "runtime_url" in kwargs:
+                urls.append(kwargs["runtime_url"])
         return fake
 
     monkeypatch.setattr("jamjet.client.JamjetClient", factory)
@@ -142,5 +150,7 @@ async def test_run_durable_threads_runtime_url_to_each_subagent(monkeypatch: pyt
 
     await Parallel([a, b]).run_durable("go", runtime_url="http://engine:7777")
 
-    # every sub-agent's durable client was constructed against the team's runtime_url.
-    assert urls and all(u == "http://engine:7777" for u in urls)
+    # one durable client constructed per sub-agent (count), each against the team's
+    # runtime_url — robust to positional OR keyword JamjetClient construction.
+    assert len(urls) == 2
+    assert all(u == "http://engine:7777" for u in urls)

--- a/sdk/python/tests/test_team_governance.py
+++ b/sdk/python/tests/test_team_governance.py
@@ -1,0 +1,174 @@
+"""T6-5 — governance + session inheritance for team sub-agents.
+
+Two guarantees:
+
+1. **No governance bypass.** A sub-agent compiles and enforces its OWN governance
+   (budget / PII / allowlist). A team adds no enforcement layer and removes none —
+   a budgeted sub-agent in a team STILL denies an over-budget call (the denial is
+   isolated into ``TeamResult``, proving it fired). A team ``governance=`` default
+   is inherited only by un-governed sub-agents; an explicitly-governed sub-agent is
+   never overridden (and so never weakened).
+
+2. **Session model.** A team ``session=`` namespaces a per-sub-agent CHILD session
+   (distinct id per sub-agent) so concurrent siblings never race on one SQLite row.
+   No team session -> sub-agents run stateless.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from jamjet import tool
+from jamjet.agents.agent import Agent
+from jamjet.agents.governance import Budget, GovernanceConfig
+from jamjet.agents.session import Session, SessionStore
+from jamjet.compiler.team_ir import compile_team_to_ir
+from jamjet.model.middleware import BudgetExceededError
+from jamjet.team import Parallel, Sequential
+from jamjet.team.team import derive_child_session
+from tests.team_fakes import scripted_agent
+
+
+def _agent(name: str, **kw: object) -> Agent:
+    return Agent(name, model="anthropic/claude-sonnet-4-6", tools=[], **kw)
+
+
+# ── Governance inheritance (config + compiled IR) ─────────────────────────────
+
+
+def test_explicit_budget_subagent_keeps_its_budget_in_a_team() -> None:
+    governed = _agent("g", budget=0.5)
+    Sequential([governed])  # team construction must NOT strip the sub-agent's budget
+    assert governed.governance.budget == Budget(cost_usd=0.5)
+
+
+def test_team_default_inherited_by_an_ungoverned_subagent() -> None:
+    plain = _agent("p")  # all-default governance
+    assert plain.governance == GovernanceConfig()  # precondition
+    Sequential([plain], governance={"budget": 0.5})
+    assert plain.governance.budget == Budget(cost_usd=0.5)
+    # and the inheritance reaches the compiled IR (enforcement-ready).
+    plan = compile_team_to_ir(Sequential([plain]))  # plain now carries the inherited budget
+    assert plan.sub_agents[0].ir["cost_budget_usd"] == 0.5
+
+
+def test_team_default_does_not_override_an_explicit_subagent() -> None:
+    explicit = _agent("e", budget=2.0)
+    Sequential([explicit], governance={"budget": 0.5})
+    # explicit beats inherited, wholesale — the team never weakens it.
+    assert explicit.governance.budget == Budget(cost_usd=2.0)
+
+
+def test_no_team_governance_means_no_mutation() -> None:
+    plain = _agent("p")
+    Sequential([plain])  # no governance= default
+    assert plain.governance == GovernanceConfig()
+
+
+def test_team_governance_accepts_a_governanceconfig() -> None:
+    plain = _agent("p")
+    Sequential([plain], governance=GovernanceConfig(pii=False))
+    assert plain.governance.pii is False
+
+
+def test_team_governance_bad_type_raises() -> None:
+    with pytest.raises(TypeError, match="governance must be"):
+        Sequential([_agent("p")], governance="not-a-config")  # type: ignore[arg-type]
+
+
+def test_compiled_subagent_ir_carries_budget_pii_and_allowlist() -> None:
+    """The plan's 'budget/PII/allowlist' all survive into the per-sub-agent IR."""
+    governed = _agent("g", budget=0.5, policy="strict")  # strict => anthropic allowlist + pii on
+    plan = compile_team_to_ir(Sequential([governed]))
+    ir = plan.sub_agents[0].ir
+    assert ir["cost_budget_usd"] == 0.5
+    assert ir["policy"]["model_allowlist"] == ["anthropic"]
+    assert "data_policy" in ir  # PII metadata present
+
+
+# ── No governance bypass — a real over-budget denial through the team ──────────
+
+
+@tool
+async def _search(query: str) -> str:
+    """A trivial tool that forces the in-process react loop to make 2 model calls."""
+    return f"Results for: {query}"
+
+
+def _install_backend(monkeypatch: pytest.MonkeyPatch, *, cost: float) -> dict:
+    """Wrap the conftest litellm mock with a fixed per-call cost + a call counter,
+    so the run-scoped budget accumulator trips deterministically."""
+    lm = sys.modules["litellm"]
+    rec = {"calls": 0}
+    original = lm.acompletion
+
+    async def _acompletion(model: str, messages: list, tools: list | None = None, **kw: object) -> object:
+        rec["calls"] += 1
+        return await original(model=model, messages=messages, tools=tools, **kw)
+
+    monkeypatch.setattr(lm, "acompletion", _acompletion)
+    monkeypatch.setattr(lm, "completion_cost", lambda completion_response=None, **kw: cost)
+    return rec
+
+
+async def test_team_does_not_bypass_budget_enforcement(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A budgeted sub-agent in a team STILL denies the over-budget call.
+
+    cost=0.5/call, budget=0.4: call 1 proceeds (spends $0.50), call 2's pre-provider
+    check sees $0.50 >= $0.40 and denies. The team ISOLATES that denial into
+    per_agent (proving the budget fired, and the team did not swallow or bypass it).
+    """
+    rec = _install_backend(monkeypatch, cost=0.5)
+    budgeted = Agent("b", model="gpt-5.2", tools=[_search], strategy="react", budget=0.4)
+    result = await Sequential([budgeted]).run("q")
+
+    assert isinstance(result.per_agent["b"], BudgetExceededError)
+    assert rec["calls"] == 1  # the over-budget 2nd call never reached the provider
+    assert "b" in result.errors
+
+
+# ── Session inheritance — distinct race-safe child sessions ───────────────────
+
+
+def test_derive_child_session_gives_distinct_stable_ids(tmp_path) -> None:
+    store = SessionStore(str(tmp_path / "s.db"))
+    base = store.create("team1")
+    a0 = derive_child_session(base, 0, "a")
+    b1 = derive_child_session(base, 1, "b")
+    a0_again = derive_child_session(base, 0, "a")
+    assert a0 is not None and b1 is not None
+    assert a0.id == "team1::0-a"
+    assert b1.id == "team1::1-b"
+    assert a0.id != b1.id  # distinct per sub-agent (race-safe under parallel)
+    assert a0_again.id == a0.id  # stable across runs (thread persists)
+
+
+def test_no_team_session_is_stateless() -> None:
+    assert derive_child_session(None, 0, "a") is None
+
+
+async def test_team_session_threads_distinct_child_sessions_to_subagents(tmp_path) -> None:
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    team_session = store.create("desk")
+    a = scripted_agent("a", output="ra")
+    b = scripted_agent("b", output="rb")
+
+    await Parallel([a, b], session=team_session).run("go")
+
+    # each sub-agent received its OWN derived child Session (distinct ids, namespaced
+    # by the team session id + agent) — never the same row, so parallel can't race.
+    a_session = a.calls[0][2]
+    b_session = b.calls[0][2]
+    assert isinstance(a_session, Session)
+    assert isinstance(b_session, Session)
+    assert a_session.id == "desk::0-a"
+    assert b_session.id == "desk::1-b"
+    assert a_session.id != b_session.id
+
+
+async def test_no_team_session_runs_subagents_stateless(tmp_path) -> None:
+    a = scripted_agent("a", output="ra")
+    await Sequential([a]).run("go")
+    assert a.calls[0][2] is None

--- a/sdk/python/tests/test_team_ir.py
+++ b/sdk/python/tests/test_team_ir.py
@@ -1,0 +1,95 @@
+"""T6-2 — compile a Team to per-sub-agent IRs + a composition plan.
+
+A Team is N agent IRs orchestrated in Python (Path A), NOT one giant multi-agent
+IR. Each sub-agent compiles via the existing single-agent ``compile_agent_to_ir``
+(so each carries its OWN governance). These tests assert the plan shape: order,
+fan-out, merge, the router IR, and per-sub-agent governance isolation.
+"""
+
+from __future__ import annotations
+
+from jamjet.agents.agent import Agent
+from jamjet.compiler.team_ir import CompiledSubAgent, TeamPlan, compile_team_to_ir
+from jamjet.team import Loop, Parallel, Sequential, Team
+
+
+def _agent(name: str, **kw: object) -> Agent:
+    return Agent(name, model="anthropic/claude-sonnet-4-6", tools=[], **kw)
+
+
+def test_sequential_yields_per_agent_irs_in_order() -> None:
+    a, b = _agent("alpha"), _agent("beta")
+    plan = compile_team_to_ir(Sequential([a, b]))
+    assert isinstance(plan, TeamPlan)
+    assert plan.pattern == "sequential"
+    assert [c.agent for c in plan.sub_agents] == [a, b]
+    # each sub-agent compiled to its OWN agent-loop IR
+    assert plan.sub_agents[0].ir["workflow_id"] == "alpha"
+    assert plan.sub_agents[1].ir["workflow_id"] == "beta"
+    assert plan.sub_agents[0].ir["labels"]["jamjet.agent.loop"] == "true"
+    assert plan.coordinator is None
+    assert plan.merge is None
+
+
+def test_not_one_mega_ir() -> None:
+    """N distinct agent IRs, never a single fused multi-agent IR (Path A)."""
+    plan = compile_team_to_ir(Sequential([_agent("one"), _agent("two")]))
+    irs = [c.ir for c in plan.sub_agents]
+    assert len(irs) == 2
+    assert irs[0]["workflow_id"] != irs[1]["workflow_id"]
+    # there is no parent / fused IR object — only the per-sub-agent list
+    assert all(ir["labels"]["jamjet.agent.loop"] == "true" for ir in irs)
+
+
+def test_parallel_yields_all_irs_and_merge_name() -> None:
+    plan = compile_team_to_ir(Parallel([_agent("a"), _agent("b")], merge="first"))
+    assert plan.pattern == "parallel"
+    assert len(plan.sub_agents) == 2
+    assert plan.merge == "first"
+
+
+def test_parallel_default_merge_is_collect() -> None:
+    plan = compile_team_to_ir(Parallel([_agent("a")]))
+    assert plan.merge == "collect"
+
+
+def test_coordinator_compiles_the_router_agent_too() -> None:
+    router, x, y = _agent("router"), _agent("x"), _agent("y")
+    plan = compile_team_to_ir(Team([x, y], coordinator=router))
+    assert plan.pattern == "coordinator"
+    assert [c.agent for c in plan.sub_agents] == [x, y]
+    assert isinstance(plan.coordinator, CompiledSubAgent)
+    assert plan.coordinator.agent is router
+    assert plan.coordinator.ir["workflow_id"] == "router"
+
+
+def test_callable_coordinator_has_no_router_ir() -> None:
+    plan = compile_team_to_ir(Team([_agent("x")], coordinator=lambda inp, agents: agents[0]))
+    assert plan.coordinator is None
+
+
+def test_loop_yields_single_sub_agent_ir() -> None:
+    plan = compile_team_to_ir(Loop(_agent("refiner")))
+    assert plan.pattern == "loop"
+    assert len(plan.sub_agents) == 1
+    assert plan.sub_agents[0].ir["workflow_id"] == "refiner"
+
+
+def test_each_sub_agent_ir_carries_its_own_governance() -> None:
+    """A budgeted sub-agent's IR carries cost_budget_usd; a default one does not.
+
+    Proves the governance is compiled PER sub-agent (each its own IR), not merged
+    or stripped — the no-bypass guarantee at the compile layer.
+    """
+    governed = _agent("governed", budget=0.5)
+    plain = _agent("plain")
+    plan = compile_team_to_ir(Sequential([governed, plain]))
+    governed_ir = plan.sub_agents[0].ir
+    plain_ir = plan.sub_agents[1].ir
+    assert governed_ir["cost_budget_usd"] == 0.5
+    assert "cost_budget_usd" not in plain_ir
+
+
+def test_irs_convenience_lists_every_sub_agent_ir() -> None:
+    plan = compile_team_to_ir(Parallel([_agent("a"), _agent("b")]))
+    assert [ir["workflow_id"] for ir in plan.irs] == ["a", "b"]

--- a/sdk/python/tests/test_team_patterns.py
+++ b/sdk/python/tests/test_team_patterns.py
@@ -8,6 +8,8 @@ sub-agents are scripted real Agents (see ``tests/team_fakes.py``).
 
 from __future__ import annotations
 
+import asyncio
+
 from jamjet.team import Collect, First, Parallel, Sequential, Team
 from tests.team_fakes import scripted_agent
 
@@ -124,6 +126,44 @@ async def test_coordinator_callable_can_return_a_name() -> None:
     y = scripted_agent("y", output="y-out")
     result = await Team([x, y], coordinator=lambda inp, agents: "x").run("task")
     assert result.output == "x-out"
+
+
+async def test_coordinator_callable_returns_a_noncoroutine_awaitable() -> None:
+    """A routing callable may return ANY awaitable, not only a coroutine: a custom
+    ``__await__`` object resolves to the chosen name and routes correctly (the route
+    path awaits via ``inspect.isawaitable``, not the narrower ``asyncio.iscoroutine``)."""
+    x = scripted_agent("x", output="x-out")
+    y = scripted_agent("y", output="y-out")
+
+    class _Awaitable:
+        def __init__(self, value: object) -> None:
+            self._value = value
+
+        def __await__(self):  # type: ignore[no-untyped-def]
+            async def _inner() -> object:
+                return self._value
+
+            return _inner().__await__()
+
+    result = await Team([x, y], coordinator=lambda inp, agents: _Awaitable("y")).run("task")
+    assert result.output == "y-out"
+    assert "y" in result.per_agent
+    assert "x" not in result.per_agent
+
+
+async def test_coordinator_callable_returns_a_future() -> None:
+    """A routing callable returning an ``asyncio.Future`` (awaitable but not a
+    coroutine) is awaited and routed correctly."""
+    x = scripted_agent("x", output="x-out")
+    y = scripted_agent("y", output="y-out")
+
+    def route(inp: str, agents: list) -> object:
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        fut.set_result("y")
+        return fut
+
+    result = await Team([x, y], coordinator=route).run("task")
+    assert result.output == "y-out"
 
 
 async def test_coordinator_none_runs_first_agent() -> None:

--- a/sdk/python/tests/test_team_patterns.py
+++ b/sdk/python/tests/test_team_patterns.py
@@ -1,0 +1,160 @@
+"""T6-3 — the in-process coordination patterns (over ``Agent.run``).
+
+Sequential threads output a->b; Parallel fans out + merges (Collect / First);
+the coordinator routes to the right specialist; a failing sub-agent is isolated
+(the team never crashes — the error lands in ``TeamResult``). No engine: the
+sub-agents are scripted real Agents (see ``tests/team_fakes.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.team import Collect, First, Parallel, Sequential, Team
+from tests.team_fakes import scripted_agent
+
+# ── Sequential: threads output forward ────────────────────────────────────────
+
+
+async def test_sequential_threads_output_a_to_b() -> None:
+    a = scripted_agent("a", transform=lambda p: f"A({p})")
+    b = scripted_agent("b", transform=lambda p: f"B({p})")
+    result = await Sequential([a, b]).run("x")
+
+    # b's input was a's output, and the final output is b(a(x)).
+    assert b.calls[0][1] == "A(x)"
+    assert result.output == "B(A(x))"
+    assert result.pattern == "sequential"
+    assert set(result.per_agent) == {"a", "b"}
+
+
+async def test_sequential_halts_on_error_and_isolates_it() -> None:
+    a = scripted_agent("a", output="a-out")
+    boom = scripted_agent("boom", fail=RuntimeError("kaboom"))
+    c = scripted_agent("c", output="c-out")
+    result = await Sequential([a, boom, c]).run("go")
+
+    # a ran, boom failed (isolated), c never ran (halt-on-error).
+    assert result.per_agent["a"].output == "a-out"
+    assert isinstance(result.per_agent["boom"], RuntimeError)
+    assert "c" not in result.per_agent
+    assert c.calls == []
+    # the team did not crash; output is the last successful output.
+    assert result.output == "a-out"
+    assert result.ok is False
+    assert "boom" in result.errors
+
+
+# ── Parallel: fan out + merge ─────────────────────────────────────────────────
+
+
+async def test_parallel_runs_all_and_collects() -> None:
+    a = scripted_agent("a", output="ra")
+    b = scripted_agent("b", output="rb")
+    c = scripted_agent("c", output="rc")
+    result = await Parallel([a, b, c], merge=Collect()).run("same-input")
+
+    # every sub-agent saw the SAME input (fan-out, not a pipeline).
+    assert a.calls[0][1] == "same-input"
+    assert b.calls[0][1] == "same-input"
+    assert c.calls[0][1] == "same-input"
+    assert result.output == "[a] ra\n[b] rb\n[c] rc"
+    assert set(result.per_agent) == {"a", "b", "c"}
+
+
+async def test_parallel_first_merge_returns_first_successful() -> None:
+    a = scripted_agent("a", output="first-out")
+    b = scripted_agent("b", output="second-out")
+    result = await Parallel([a, b], merge=First()).run("in")
+    assert result.output == "first-out"
+
+
+async def test_parallel_isolates_a_failing_subagent() -> None:
+    good = scripted_agent("good", output="ok")
+    bad = scripted_agent("bad", fail=ValueError("nope"))
+    result = await Parallel([good, bad], merge=Collect()).run("in")
+
+    # the team did not crash; the failure is captured, the sibling succeeded.
+    assert result.per_agent["good"].output == "ok"
+    assert isinstance(result.per_agent["bad"], ValueError)
+    assert result.output == "[good] ok"  # Collect skips the failure
+    assert list(result.errors) == ["bad"]
+
+
+# ── Coordinator: route to a specialist ────────────────────────────────────────
+
+
+async def test_coordinator_router_agent_routes_to_named_specialist() -> None:
+    researcher = scripted_agent("researcher", output="researched")
+    writer = scripted_agent("writer", output="written")
+    # the router's output NAMES the specialist to run.
+    router = scripted_agent("router", output="writer")
+    result = await Team([researcher, writer], coordinator=router).run("task")
+
+    assert result.output == "written"
+    assert "writer" in result.per_agent
+    assert "router" in result.per_agent
+    # the unchosen specialist never ran.
+    assert "researcher" not in result.per_agent
+    assert researcher.calls == []
+    assert result.pattern == "coordinator"
+
+
+async def test_coordinator_router_matches_name_in_freetext() -> None:
+    researcher = scripted_agent("researcher", output="researched")
+    writer = scripted_agent("writer", output="written")
+    router = scripted_agent("router", output="I think the writer should handle this.")
+    result = await Team([researcher, writer], coordinator=router).run("task")
+    assert result.output == "written"
+
+
+async def test_coordinator_callable_picks_by_return() -> None:
+    x = scripted_agent("x", output="x-out")
+    y = scripted_agent("y", output="y-out")
+
+    def route(inp: str, agents: list) -> object:
+        return agents[1]  # always pick y
+
+    result = await Team([x, y], coordinator=route).run("task")
+    assert result.output == "y-out"
+    assert "y" in result.per_agent
+    assert "x" not in result.per_agent
+
+
+async def test_coordinator_callable_can_return_a_name() -> None:
+    x = scripted_agent("x", output="x-out")
+    y = scripted_agent("y", output="y-out")
+    result = await Team([x, y], coordinator=lambda inp, agents: "x").run("task")
+    assert result.output == "x-out"
+
+
+async def test_coordinator_none_runs_first_agent() -> None:
+    only = scripted_agent("only", output="only-out")
+    result = await Team([only]).run("task")
+    assert result.output == "only-out"
+
+
+async def test_coordinator_isolates_a_failing_specialist() -> None:
+    bad = scripted_agent("bad", fail=RuntimeError("specialist down"))
+    result = await Team([bad], coordinator=lambda inp, agents: agents[0]).run("task")
+    # routing succeeded but the specialist crashed: isolated, not a team crash.
+    assert isinstance(result.per_agent["bad"], RuntimeError)
+    assert result.output == ""
+
+
+async def test_coordinator_isolates_a_failing_router() -> None:
+    specialist = scripted_agent("s", output="s-out")
+    router = scripted_agent("router", fail=RuntimeError("router down"))
+    result = await Team([specialist], coordinator=router).run("task")
+    # the router crashed: recorded, no specialist ran, no team crash.
+    assert isinstance(result.per_agent["router"], RuntimeError)
+    assert specialist.calls == []
+    assert result.output == ""
+
+
+async def test_callable_coordinator_unknown_name_raises_clear_error() -> None:
+    """A routing CALLABLE that returns an invalid name is a code bug -> fail loud
+    (unlike a router AGENT's fuzzy free-text, which falls back to the first agent)."""
+    x = scripted_agent("x", output="x")
+    with pytest.raises(ValueError, match="unknown agent name"):
+        await Team([x], coordinator=lambda inp, agents: "does-not-exist").run("t")

--- a/sdk/python/tests/test_team_patterns.py
+++ b/sdk/python/tests/test_team_patterns.py
@@ -8,8 +8,6 @@ sub-agents are scripted real Agents (see ``tests/team_fakes.py``).
 
 from __future__ import annotations
 
-import pytest
-
 from jamjet.team import Collect, First, Parallel, Sequential, Team
 from tests.team_fakes import scripted_agent
 
@@ -152,9 +150,68 @@ async def test_coordinator_isolates_a_failing_router() -> None:
     assert result.output == ""
 
 
-async def test_callable_coordinator_unknown_name_raises_clear_error() -> None:
-    """A routing CALLABLE that returns an invalid name is a code bug -> fail loud
-    (unlike a router AGENT's fuzzy free-text, which falls back to the first agent)."""
+async def test_callable_coordinator_unknown_name_is_isolated() -> None:
+    """A routing CALLABLE that returns an invalid name is misuse -> a clear,
+    ISOLATED error recorded in per_agent (the team does not crash), consistent
+    with a bad index / foreign agent below. A router AGENT's fuzzy free-text still
+    falls back to the first agent (that path is unchanged)."""
     x = scripted_agent("x", output="x")
-    with pytest.raises(ValueError, match="unknown agent name"):
-        await Team([x], coordinator=lambda inp, agents: "does-not-exist").run("t")
+    result = await Team([x], coordinator=lambda inp, agents: "does-not-exist").run("t")
+    err = result.per_agent["team:coordinator"]
+    assert isinstance(err, ValueError)
+    assert "unknown agent name" in str(err)
+    assert result.output == ""  # clean empty TeamResult, not a crash
+    assert x.calls == []  # no specialist ran
+
+
+async def test_callable_coordinator_out_of_range_index_is_isolated() -> None:
+    """An out-of-range index is recorded as a clear, isolated error, not an opaque
+    IndexError that crashes the team."""
+    x = scripted_agent("x", output="x-out")
+    result = await Team([x], coordinator=lambda inp, agents: 99).run("t")
+    err = result.per_agent["team:coordinator"]
+    assert isinstance(err, ValueError)
+    assert str(err) == "coordinator returned out-of-range agent index 99; team has 1 agents"
+    assert result.output == ""
+    assert x.calls == []
+
+
+async def test_callable_coordinator_foreign_agent_is_isolated() -> None:
+    """An Agent that is not a team member is recorded as a clear, isolated error,
+    not an opaque 'is not in list' ValueError from _orchestrate's .index()."""
+    member = scripted_agent("member", output="member-out")
+    foreign = scripted_agent("foreign", output="foreign-out")
+    result = await Team([member], coordinator=lambda inp, agents: foreign).run("t")
+    err = result.per_agent["team:coordinator"]
+    assert isinstance(err, ValueError)
+    assert str(err) == "coordinator returned an Agent that is not a member of this team"
+    assert result.output == ""
+    assert member.calls == []
+    assert foreign.calls == []
+
+
+# ── Coordinator: word-boundary specialist match (no substring mis-route) ───────
+
+
+async def test_coordinator_router_word_boundary_does_not_misroute_overlap() -> None:
+    """Router free-text naming 'rewriter' runs rewriter, NOT the overlapping
+    substring 'writer' (a whole-word match, not a naive substring match)."""
+    writer = scripted_agent("writer", output="written")
+    rewriter = scripted_agent("rewriter", output="rewritten")
+    router = scripted_agent("router", output="use the rewriter")
+    result = await Team([writer, rewriter], coordinator=router).run("task")
+    assert result.output == "rewritten"  # rewriter ran
+    assert "rewriter" in result.per_agent
+    assert "writer" not in result.per_agent  # the overlapping name did NOT run
+    assert writer.calls == []
+
+
+async def test_coordinator_router_exact_name_still_matches_overlap() -> None:
+    """The exact-name pass still wins: output 'writer' runs writer even though the
+    overlapping 'rewriter' is also a member."""
+    writer = scripted_agent("writer", output="written")
+    rewriter = scripted_agent("rewriter", output="rewritten")
+    router = scripted_agent("router", output="writer")
+    result = await Team([writer, rewriter], coordinator=router).run("task")
+    assert result.output == "written"  # exact match -> writer
+    assert "writer" in result.per_agent


### PR DESCRIPTION
## What

Track 6 of the 9-track ADK plan (the last track in M2) - `Team` multi-agent sugar. All Python, zero Rust.

A `Team` composes several `Agent`s into a coordinated workflow without writing orchestration. Four patterns, each a thin Python orchestrator over the already-shipped single-agent durable path:

- **`Sequential([a, b, c])`** - a pipeline; each agent's output feeds the next. Halts on the first failing step (a broken upstream output should not feed downstream).
- **`Parallel([a, b], merge=...)`** - fan the same input to every agent concurrently and aggregate via a `MergeStrategy` (`Collect` / `First` / `Custom`).
- **`Team([...], coordinator=...)`** - a coordinator routes the input to one specialist. The coordinator is a router `Agent` (its output names the specialist) or a Python routing callable.
- **`Loop(agent, until=..., max_iters=...)`** - re-run one agent until a predicate holds or a bound is hit (a refinement loop).

Every pattern returns a `TeamResult { output, per_agent, pattern, durable }`. `Team.run()` runs each sub-agent in-process; `Team.run_durable()` runs each sub-agent as its own durable execution on the engine.

## The design decision

The master plan assumed Track 6 would reuse the existing Rust `Coordinator`/`AgentTool`/fleet nodes with no Rust change. Grounding the plan against the code showed that premise does not hold: those node kinds and their executors exist and are unit-tested, but they are not wired into the running runtime - only `model`/`eval`/`condition` executors are registered in the worker pool, the scheduler does not enrich their payloads, `AgentTool` is remote-HTTP-A2A only (it rejects a local `jamjet://` target), and the `agent`/`subgraph`/`join` nodes have no executor at all. An unwired node silently returns `{}` via the worker stub - the worst failure mode.

So this ships **Path A**: each sub-agent is its own independent run via the working `Agent.run` / `Agent.run_durable`, composed in Python. It reuses everything already shipped (the single-agent compiler, the durable client, governance, sessions, receipts) and touches no Rust. Wiring the native in-IR multi-agent nodes is left as a follow-up (F-t6-native-nodes).

## Safety

- **Child-crash isolation is natural under Path A** - each sub-agent is a separate execution. A failing sub-agent's exception is captured into `TeamResult.per_agent` and never crashes the team or corrupts a sibling. Parallel uses `gather(return_exceptions=True)`; the others catch `Exception` (so `CancelledError`/`KeyboardInterrupt` still propagate, never swallowed).
- **Governance is not bypassed** - each sub-agent compiles and enforces its own governance IR. A team-level `governance=` default is applied only to a sub-agent that set no explicit governance, and it never overrides a sub-agent's own knob. A real over-budget denial fires through the team and is isolated, proven by a test.
- **Sessions** - a team `session=` derives a distinct per-sub-agent child thread (`{team_id}::{index}-{name}`) so concurrent siblings never race on one SQLite row.

A whole-branch adversarial review passed with no Critical or Important findings; three Minor findings were fixed before this PR (clear isolated errors for bad routing returns, a word-boundary specialist match so `rewriter` does not match `writer`, and precise governance docstrings).

## Tests

1386 Python passed (69 new team tests): the four patterns, the merge strategies, child-crash isolation (a sibling still completes when one child crashes), the durable path driving each sub-agent through `run_durable`, governance not bypassed, and the session child-thread derivation. Plus an `examples/team-multi-agent/` (a coordinator routing to two specialists and a sequential pipeline).

## Follow-ups

F-t6-native-nodes (wire the in-IR multi-agent nodes - Path B), F-t6-dupe-names (per_agent name collision when two sub-agents share a name), F-t6-debate-team, F-t6-dynamic-team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-agent composition support with sequential, parallel, coordinator-based, and looping workflows.
  * Exposed new team-building primitives for routing, merging, and durable execution.
  * Added a runnable multi-agent example showing how to build and execute coordinated specialist workflows.

* **Documentation**
  * Added documentation for the new multi-agent example, including setup, execution modes, and session/budget behavior.

* **Tests**
  * Added broad coverage for team workflows, governance handling, durable runs, IR compilation, and the example flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->