### PR TITLE
feat(track-7a): agent.deploy(runtime=local/self-host/cloud) + honest consistency contract

### DIFF
--- a/docs/adk/consistency.md
+++ b/docs/adk/consistency.md
@@ -1,0 +1,149 @@
+# Consistency contract
+
+What the JamJet durable engine actually guarantees, and what it does not. Every
+claim below is grounded in the engine source so you can verify it yourself. This
+is a description of observed engine invariants, not a distributed-systems wish
+list. Paths are relative to the repository root.
+
+The short version: **a single run is strongly consistent, views across runs are
+eventually consistent, and stored artifacts are immutable.** There is no managed
+multi-tenant execution service and no cross-region replication.
+
+## Within a run: strongly consistent
+
+A single execution's event log is the source of truth. State transitions for one
+run are linear and durable, because the engine commits each turn in one
+transaction.
+
+- **The settle, the event, and the snapshot commit atomically.**
+  `SqliteBackend::commit_turn` opens a single `BEGIN IMMEDIATE` transaction
+  (`runtime/state/src/sqlite.rs:1219`), takes the write lock up front, performs a
+  fenced settle that fails closed on a stale fence and emits nothing
+  (`runtime/state/src/sqlite.rs:1223`), assigns the next sequence and appends the
+  event in the same transaction (`runtime/state/src/sqlite.rs:1254-1265`), records
+  tool effects idempotently (`runtime/state/src/sqlite.rs:1306`), and writes the
+  state snapshot in the same transaction (`runtime/state/src/sqlite.rs:1426`)
+  before a single `tx.commit()` (`runtime/state/src/sqlite.rs:1444`). A crash
+  between steps cannot half-apply a turn: either the whole turn commits or none of
+  it does.
+
+- **Writers are serialized.** `BEGIN IMMEDIATE` takes the write lock at the start
+  of the transaction rather than upgrading mid-way, so a concurrent writer gets an
+  immediate, handled busy signal instead of a silent lost update
+  (`runtime/state/src/sqlite.rs:515-522`). SQLite is single-writer; the engine
+  leans on that rather than fighting it.
+
+- **Replay is deterministic.** The state for a run is a fold over its event log.
+  `apply_events_seeded` is the core replay primitive: it iterates events in
+  sequence order and applies each one to evolve state
+  (`runtime/state/src/materializer.rs:90-159`), and `apply_events` is the
+  from-origin form built on it (`runtime/state/src/materializer.rs:160-173`).
+  Replaying the same log reconstructs the same state, which is what makes
+  time-travel debugging and crash recovery correct.
+
+The practical contract: once `commit_turn` returns for a turn, that turn is
+durable and visible to every later read of that execution, and a restart replays
+the log to exactly the committed state.
+
+## Across runs: eventually consistent
+
+Read and aggregate views that span more than one execution are built by an
+asynchronous projector that tails the event log. They converge; they are not
+instantaneously consistent with the latest write.
+
+- **The projector is a background loop.** `Projector::run` loops forever, calling
+  `tick()` and then sleeping 500ms between passes
+  (`runtime/scheduler/src/projector.rs:250-256`). It is spawned as a detached
+  background task at startup
+  (`runtime/api/src/main.rs:166-167`: `tokio::spawn(async move { projector.run().await })`).
+
+- **It folds events into durable read rows behind a checkpoint.** Each pass reads
+  the event delta since a per-execution checkpoint, folds the relevant events
+  (for example approval events), and advances the checkpoint only if every changed
+  row in the batch committed (`runtime/scheduler/src/projector.rs:113`
+  `project_execution`, reading the delta with `get_events_since` at
+  `runtime/scheduler/src/projector.rs:119` and committing the batch plus the
+  checkpoint atomically via `apply_approval_projection_batch` at
+  `runtime/scheduler/src/projector.rs:227`). The checkpoint makes the projection
+  catch-up safe and idempotent, but it runs after the fact.
+
+The practical contract: a write to one run is immediately consistent for that run,
+but a cross-run projection (for example an approvals view) reflects it on the next
+projector pass, within a bounded lag rather than instantly. Build cross-run UIs
+and queries to tolerate that lag.
+
+## Artifacts: content-addressed and immutable
+
+Large values are stored in a content-addressed store keyed by the SHA-256 of the
+bytes.
+
+- **The key is the hash of the content.** `put_artifact` computes
+  `sha256_hex(bytes)` and stores the blob under that hash
+  (`runtime/state/src/sqlite.rs:868-884`); the hash function is a plain SHA-256
+  hex of the raw bytes (`runtime/state/src/hashing.rs:65-72`). Identical bytes
+  always produce the same reference.
+
+- **Stored artifacts are immutable.** The insert is `INSERT OR IGNORE`, which
+  keeps the first row for a given `(tenant, hash)`
+  (`runtime/state/src/sqlite.rs:872-889`). A second write of the same bytes does
+  not overwrite or mutate what is stored.
+
+The practical contract: an `ArtifactRef` is a stable, verifiable handle. The same
+content hashes to the same ref, and a ref never changes underneath you.
+
+## Storage backends
+
+The engine has exactly two storage backends, selected by the `STORAGE_BACKEND`
+environment variable: an in-memory backend and a SQLite backend
+(`runtime/api/src/main.rs:48-155`). There is no Postgres backend and no other
+durable store in the engine. The in-memory backend is ephemeral and per-process;
+SQLite is the durable, single-writer store used for self-host and hosted
+deployments.
+
+Cron scheduling requires the SQLite backend. The cron handlers return
+"cron scheduling requires the sqlite backend" when no cron store is configured,
+which is the case for the in-memory backend (`runtime/api/src/cron.rs:25-30`).
+
+## What is not guaranteed
+
+State this plainly so nobody designs against a guarantee that does not exist.
+
+- **No managed multi-tenant execution cell.** `runtime="cloud"` deploys the same
+  IR to *your* hosted `jamjet-server` engine (a URL you configure) and layers on
+  JamJet Cloud governance. JamJet Cloud (`api.jamjet.dev`) is a governance and
+  observability span API, not a workflow execution engine. There is no managed
+  "cell" that runs your workflows for you; the string "cell" does not appear in
+  the engine source. The deploy surface that honors this model is
+  `sdk/python/jamjet/deploy/__init__.py`.
+
+- **No cross-region or replicated consistency.** The engine is a single
+  SQLite-or-memory store per process. There is no multi-region replication, no
+  sharding, and no cross-region coordination in the engine (a repository-wide
+  search for region / shard / replica / replication implementation finds none).
+  Run-level guarantees hold within one engine instance, not across a fleet of
+  instances.
+
+- **Cross-run views are not instantaneous.** As above, the projector is
+  asynchronous. Do not assume an aggregate or cross-execution query reflects a
+  write the moment it commits.
+
+## Claim-to-code map
+
+| Claim | Backing code |
+| --- | --- |
+| Atomic settle + event + snapshot per turn | `runtime/state/src/sqlite.rs:1219-1444` (`commit_turn`) |
+| Serialized single writer | `runtime/state/src/sqlite.rs:515-522` (`BEGIN IMMEDIATE`) |
+| Deterministic replay (fold over the log) | `runtime/state/src/materializer.rs:90-173` (`apply_events_seeded`) |
+| Async cross-run projector | `runtime/scheduler/src/projector.rs:250-256`; spawned `runtime/api/src/main.rs:166-167` |
+| Content-addressed artifacts | `runtime/state/src/sqlite.rs:868-884`; `runtime/state/src/hashing.rs:65-72` |
+| Immutable artifacts (`INSERT OR IGNORE`) | `runtime/state/src/sqlite.rs:872-889` |
+| SQLite-or-memory only, no Postgres | `runtime/api/src/main.rs:48-155` |
+| Cron requires SQLite | `runtime/api/src/cron.rs:25-30` |
+
+## See also
+
+- `docs/adr/ADR-003-event-sourcing-snapshots.md` for the event-sourcing and
+  snapshot design decision behind the run-level guarantee.
+- `sdk/python/jamjet/deploy/__init__.py` for the deploy surface (`local` /
+  `self-host` / `cloud`), which honors the same honest model: three engine URLs,
+  with Cloud governance optionally layered on the `cloud` leg.

--- a/docs/adk/consistency.md
+++ b/docs/adk/consistency.md
@@ -47,9 +47,10 @@ the log to exactly the committed state.
 
 ## Across runs: eventually consistent
 
-Read and aggregate views that span more than one execution are built by an
-asynchronous projector that tails the event log. They converge; they are not
-instantaneously consistent with the latest write.
+Read-side projections are asynchronous: they lag the authoritative event log
+rather than updating in lockstep with it. Any view you assemble across more than
+one execution is therefore eventually consistent. It converges on the latest
+write; it is not instantaneously consistent with it.
 
 - **The projector is a background loop.** `Projector::run` loops forever, calling
   `tick()` and then sleeping 500ms between passes

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,15 @@ environment setup script and runs without a model API key.
   idempotency, and park-on-429. The model call still goes through the governed
   seam, and the `@tool` functions run on a separate `jamjet worker`. See
   `react-agent-durable/README.md` for the engine, sidecar, and worker commands.
+- `deploy-an-agent/` - ship a finished agent to a runtime with
+  `agent.deploy(runtime=...)`. The same compiled IR `run_durable` builds is
+  registered on a `jamjet-server` engine, so one agent deploys unchanged to
+  `local` (the dev default on 7700), `self-host` (`$JAMJET_RUNTIME_URL`), or
+  `cloud` (your hosted engine at `$JAMJET_CLOUD_RUNTIME_URL` plus JamJet Cloud
+  governance). A bare `deploy()` always targets local, and the cloud leg is a
+  hosted engine URL plus governance, not a managed execution cell. Governance
+  travels with the deploy. See `deploy-an-agent/README.md` and
+  `docs/adk/consistency.md` for the engine's guarantees.
 
 ## Java
 

--- a/examples/deploy-an-agent/README.md
+++ b/examples/deploy-an-agent/README.md
@@ -53,7 +53,7 @@ python deploy.py
 
 Expected output:
 
-```
+```text
 deployed 'status-reporter' to local (http://127.0.0.1:7700)
   scheduled=False  cloud_governance=False
 ```

--- a/examples/deploy-an-agent/README.md
+++ b/examples/deploy-an-agent/README.md
@@ -1,0 +1,64 @@
+# deploy-an-agent
+
+Ship a finished agent to a runtime with `agent.deploy(runtime=...)`. The same
+compiled IR that `run_durable` builds is registered on a `jamjet-server` engine
+over the existing `create_workflow` path, so one agent deploys unchanged to local,
+self-host, or a hosted cloud engine.
+
+## Files
+
+- `status_agent.py` - the `@tool` function (`service_health`) and the
+  `build_agent()` factory. Imported by both `deploy.py` and the `jamjet worker`.
+- `deploy.py` - calls `await agent.deploy(runtime="local")` and prints the
+  `DeployResult`, with commented self-host / cloud / schedule variants.
+
+## The three legs (one IR, three URLs)
+
+| `runtime=` | Engine URL | Auth | Notes |
+| --- | --- | --- | --- |
+| `None` / `"local"` | `http://127.0.0.1:7700` | none | the `jamjet dev` engine; the default |
+| `"self-host"` | `$JAMJET_RUNTIME_URL` | `$JAMJET_RUNTIME_TOKEN` (optional) | your own `jamjet-server` |
+| `"cloud"` | `$JAMJET_CLOUD_RUNTIME_URL` | `$JAMJET_CLOUD_TOKEN` or `$JAMJET_API_KEY` | your hosted engine + Cloud governance |
+| a URL string | used directly | none | any engine endpoint |
+
+A bare `agent.deploy()` with no `runtime` always targets **local**, so you never
+hit a remote engine by accident. A remote URL is reached only when you pass one.
+
+## The honest cloud model
+
+`runtime="cloud"` deploys the same IR to **your** hosted `jamjet-server` engine (a
+URL you run, for example on Fly) and **also** turns on JamJet Cloud governance
+span-push. JamJet Cloud (`api.jamjet.dev`) is the governance and observability
+plane, not a workflow execution engine. There is no managed multi-tenant "cell"
+that runs your workflows for you. Cloud governance is never load-bearing: the
+deploy succeeds even if Cloud is unreachable. Cloud is the governance plane,
+independent of the runtime. See `docs/adk/consistency.md` for the engine's exact
+guarantees.
+
+## Governance travels with the deploy
+
+The agent's governance (PII redaction, signed audit, receipts, plus any budget or
+policy you set) is compiled into the IR and ships unchanged. Deploy never strips
+those knobs.
+
+## Run it
+
+`deploy.py` registers the workflow; it does not start an execution (use
+`run_durable` for that). With the local dev engine running:
+
+```bash
+jamjet dev            # brings up the local engine on 7700
+python deploy.py
+```
+
+Expected output:
+
+```
+deployed 'status-reporter' to local (http://127.0.0.1:7700)
+  scheduled=False  cloud_governance=False
+```
+
+To deploy to self-host or cloud, set the env vars shown in `deploy.py` and switch
+the `runtime=` argument. To install a recurring schedule, pass a cron expression:
+`agent.deploy(runtime="self-host", schedule="0 9 * * *")` (the target engine needs
+the SQLite backend and an embedded cron worker).

--- a/examples/deploy-an-agent/deploy.py
+++ b/examples/deploy-an-agent/deploy.py
@@ -1,0 +1,64 @@
+"""Deploy a finished agent to a runtime with ``agent.deploy(runtime=...)``.
+
+``deploy`` compiles the SAME agent-loop IR that ``run_durable`` builds and
+registers it on a ``jamjet-server`` engine over the existing
+``create_workflow`` path. The three legs differ only by URL and token, so one IR
+ships unchanged to all of them:
+
+    local      -> http://127.0.0.1:7700        (the `jamjet dev` engine; the default)
+    self-host  -> $JAMJET_RUNTIME_URL          (+ $JAMJET_RUNTIME_TOKEN if secured)
+    cloud      -> $JAMJET_CLOUD_RUNTIME_URL     (+ $JAMJET_CLOUD_TOKEN / $JAMJET_API_KEY)
+
+The honest cloud model: ``runtime="cloud"`` deploys to YOUR hosted jamjet-server
+engine (a URL you run, for example on Fly) AND enables JamJet Cloud governance
+span-push. JamJet Cloud (api.jamjet.dev) is the governance and observability
+plane, not a managed execution service; there is no multi-tenant "cell" that runs
+your workflows for you. Cloud governance is never load-bearing: a deploy succeeds
+even if Cloud is unreachable.
+
+A bare ``agent.deploy()`` with no runtime always targets LOCAL, so you never hit
+a remote engine by accident; a remote URL is reached only when you pass one.
+
+Run it (with `jamjet dev` already running so the local engine is up)::
+
+    python deploy.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from status_agent import build_agent
+
+
+async def main() -> None:
+    agent = build_agent()
+
+    # The dev default. Registers the workflow on the local engine and returns a
+    # DeployResult; it does NOT start an execution (use run_durable for that).
+    result = await agent.deploy(runtime="local")
+    print(f"deployed '{result.workflow_id}' to {result.runtime} ({result.url})")
+    print(f"  scheduled={result.scheduled}  cloud_governance={result.cloud_governance}")
+
+    # ── Other legs (uncomment after setting the env vars) ────────────────────
+    #
+    # Self-host: your own jamjet-server, addressed by URL (+ token if secured).
+    #   export JAMJET_RUNTIME_URL=https://engine.internal:8080
+    #   export JAMJET_RUNTIME_TOKEN=...        # optional
+    #   result = await agent.deploy(runtime="self-host")
+    #
+    # Cloud: your hosted engine URL + JamJet Cloud governance.
+    #   export JAMJET_CLOUD_RUNTIME_URL=https://my-engine.fly.dev
+    #   export JAMJET_CLOUD_TOKEN=...          # or JAMJET_API_KEY=jj_...
+    #   result = await agent.deploy(runtime="cloud")
+    #
+    # Any explicit engine URL also works directly:
+    #   result = await agent.deploy(runtime="https://my-engine.example.com")
+    #
+    # Install a cron schedule so the engine fires the workflow (needs the SQLite
+    # backend + an embedded cron worker on the target engine):
+    #   result = await agent.deploy(runtime="self-host", schedule="0 9 * * *")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/deploy-an-agent/status_agent.py
+++ b/examples/deploy-an-agent/status_agent.py
@@ -1,0 +1,35 @@
+"""The agent to deploy: a tiny status-reporter (model + one @tool + instructions).
+
+The tools live in this importable module (not in ``__main__``) because the
+compiled IR records each tool as ``{name: "status_agent:<fn>"}`` (module +
+qualname) and the ``jamjet worker`` resolves it by importing this module. Both
+``deploy.py`` and the worker import ``build_agent`` from here.
+"""
+
+from __future__ import annotations
+
+from jamjet import Agent, tool
+
+
+@tool
+async def service_health(service: str) -> str:
+    """Return a one-line health summary for a named service (demo stub)."""
+    return f"{service}: ok (p99 142ms, 0 errors in last 5m)"
+
+
+def build_agent() -> Agent:
+    """Construct the status-reporter agent.
+
+    Governance is on by default (PII redaction, signed audit, receipts). Those
+    knobs are compiled into the IR and travel with the deploy unchanged; deploy
+    never strips them.
+    """
+    return Agent(
+        "status-reporter",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[service_health],
+        instructions=(
+            "You report service health. Call service_health for each service the "
+            "user names and summarize the results in one short paragraph."
+        ),
+    )

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -42,7 +42,13 @@ from jamjet.durable import (
     reset_execution_context,
     set_execution_context,
 )
-from jamjet.entry import deploy, resume, run
+
+# NB: ``deploy`` is intentionally NOT re-exported here. The deploy surface is the
+# ``jamjet.deploy`` SUBMODULE (resolve_runtime_target / RuntimeTarget /
+# DeployResult) plus the ``Agent.deploy`` / ``Team.deploy`` methods (Track 7a);
+# re-binding a top-level ``deploy`` function would shadow that submodule. The
+# deprecated top-level function still lives at ``jamjet.entry.deploy``.
+from jamjet.entry import resume, run
 from jamjet.eval.registry import scorer
 from jamjet.protocols.adapter import ProtocolAdapter
 from jamjet.protocols.registry import ProtocolRegistry
@@ -99,7 +105,6 @@ __all__ = [
     "Workflow",
     "WorkflowSpec",
     "PolicyDeniedError",
-    "deploy",
     "durable",
     "durable_run",
     "gate",

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -805,13 +805,26 @@ class Agent:
         async with JamjetClient(base_url=target.url, api_token=target.token) as client:
             await client.create_workflow(ir)
             if schedule is not None:
-                await client.create_cron_job(
-                    name=workflow_id,
-                    cron_expression=schedule,
-                    workflow_id=workflow_id,
-                    workflow_version=workflow_version,
-                    input=build_initial_state(self, ""),
-                )
+                try:
+                    await client.create_cron_job(
+                        name=workflow_id,
+                        cron_expression=schedule,
+                        workflow_id=workflow_id,
+                        workflow_version=workflow_version,
+                        input=build_initial_state(self, ""),
+                    )
+                except Exception as exc:
+                    # The workflow IS registered (create_workflow already returned);
+                    # only the scheduling step failed, leaving it registered-but-
+                    # unscheduled. Raise a clear, chained error that says so, so this
+                    # state is distinguishable from a create_workflow failure (never
+                    # registered) — Team.deploy captures THIS exception, so the
+                    # distinction must live in the exception itself. Registration is
+                    # idempotent by (workflow_id, version), so re-running deploy after
+                    # this safely re-registers and retries the schedule.
+                    raise RuntimeError(
+                        f"workflow {workflow_id!r} registered on {target.url} but scheduling failed: {exc}"
+                    ) from exc
                 scheduled = True
 
         return DeployResult(

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -43,6 +43,7 @@ from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
 
 if TYPE_CHECKING:
+    from jamjet.deploy import DeployResult
     from jamjet.memory.engram_bridge import AgentMemory
     from jamjet.spec import AgentSpec
 
@@ -722,6 +723,95 @@ class Agent:
             await self._record_turn(memory, resolved_session.id, prompt, result.output)
 
         return result
+
+    async def deploy(
+        self,
+        *,
+        runtime: str | None = None,
+        schedule: str | None = None,
+        runtime_url: str | None = None,
+    ) -> DeployResult:
+        """Ship this agent's compiled IR to a JamJet runtime (Track 7a).
+
+        Compiles the SAME agent-loop IR that :meth:`run_durable` builds and
+        registers it (``POST /workflows``) onto a ``jamjet-server`` engine, so a
+        finished ADK agent ships unchanged to any of three runtimes that differ
+        only by URL + token:
+
+        - ``runtime=None`` / ``"local"`` — the dev default
+          (``http://127.0.0.1:7700``); a bare ``deploy()`` NEVER targets a remote
+          URL.
+        - ``runtime="self-host"`` — your own engine at ``JAMJET_RUNTIME_URL``.
+        - ``runtime="cloud"`` — YOUR hosted engine at ``JAMJET_CLOUD_RUNTIME_URL``
+          with JamJet Cloud governance layered on. The honest model: ``cloud`` is
+          a hosted engine URL + Cloud span-push governance, NOT a managed
+          execution cell; the deploy client is never pointed at ``api.jamjet.dev``.
+        - ``runtime="https://..."`` or ``runtime_url="https://..."`` — an explicit
+          engine URL, used directly.
+
+        Unlike :meth:`run_durable`, deploy registers the workflow (and, when
+        *schedule* is a cron expression, installs a cron job) WITHOUT starting or
+        polling an execution. The agent's governance knobs (budget / policy / PII)
+        stay in the registered IR — deploy never strips them. ``cloud_governance``
+        in the result only RECORDS that Cloud governance is wired (the
+        ``jamjet.cloud.*`` span pusher is configured separately); deploy does not
+        call into Cloud and so succeeds even when Cloud is unreachable.
+
+        Parameters
+        ----------
+        runtime:
+            A leg name (``local`` / ``self-host`` / ``cloud``) or a base URL.
+        schedule:
+            A cron expression. When set, a cron job is installed so the engine
+            fires the workflow on that schedule (the recurring intent belongs in
+            the agent's ``instructions``; the scheduled seed is an empty user turn).
+        runtime_url:
+            An explicit engine URL. Mutually exclusive with *runtime*.
+
+        Returns
+        -------
+        DeployResult
+            ``workflow_id`` + the resolved ``runtime`` / ``url`` + whether it was
+            ``scheduled`` and whether ``cloud_governance`` is on.
+        """
+        from jamjet.client import JamjetClient  # noqa: PLC0415 - patch point / avoid import cycle
+        from jamjet.compiler.agent_ir import build_initial_state, compile_agent_to_ir  # noqa: PLC0415
+        from jamjet.deploy import DeployResult, resolve_runtime_target  # noqa: PLC0415
+
+        if runtime is not None and runtime_url is not None:
+            raise ValueError(
+                "pass either runtime= (a leg name or URL) or runtime_url= (an explicit engine URL), not both."
+            )
+        target = resolve_runtime_target(runtime_url if runtime_url is not None else runtime)
+
+        # The SAME agent-loop IR run_durable builds. The prompt is per-run and is
+        # NOT embedded in the workflow definition, so deploy compiles with an empty
+        # prompt; governance fields (cost_budget_usd / policy / data_policy) are
+        # merged into the IR by compile_agent_to_ir and are not stripped here.
+        ir = compile_agent_to_ir(self, "")
+        workflow_id: str = ir["workflow_id"]
+        workflow_version: str | None = ir.get("version")
+
+        scheduled = False
+        async with JamjetClient(base_url=target.url, api_token=target.token) as client:
+            await client.create_workflow(ir)
+            if schedule is not None:
+                await client.create_cron_job(
+                    name=workflow_id,
+                    cron_expression=schedule,
+                    workflow_id=workflow_id,
+                    workflow_version=workflow_version,
+                    input=build_initial_state(self, ""),
+                )
+                scheduled = True
+
+        return DeployResult(
+            workflow_id=workflow_id,
+            runtime=target.name,
+            url=target.url,
+            scheduled=scheduled,
+            cloud_governance=target.cloud_governance,
+        )
 
     async def _poll_to_terminal(self, client: Any, exec_id: str) -> dict[str, Any]:
         """Poll ``get_execution`` until the execution reaches a terminal state."""

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -730,13 +730,17 @@ class Agent:
         runtime: str | None = None,
         schedule: str | None = None,
         runtime_url: str | None = None,
+        max_turns: int = 8,
     ) -> DeployResult:
         """Ship this agent's compiled IR to a JamJet runtime (Track 7a).
 
-        Compiles the SAME agent-loop IR that :meth:`run_durable` builds and
-        registers it (``POST /workflows``) onto a ``jamjet-server`` engine, so a
-        finished ADK agent ships unchanged to any of three runtimes that differ
-        only by URL + token:
+        Compiles the SAME agent-loop IR that :meth:`run_durable` builds at the
+        SAME *max_turns*, then registers it (``POST /workflows``) onto a
+        ``jamjet-server`` engine, so a finished ADK agent ships unchanged to any
+        of three runtimes that differ only by URL + token. Because the agent loop
+        is statically unrolled by *max_turns*, deploy at the same *max_turns* you
+        tested with :meth:`run_durable` so the registered graph matches the one
+        you ran:
 
         - ``runtime=None`` / ``"local"`` — the dev default
           (``http://127.0.0.1:7700``); a bare ``deploy()`` NEVER targets a remote
@@ -767,6 +771,10 @@ class Agent:
             the agent's ``instructions``; the scheduled seed is an empty user turn).
         runtime_url:
             An explicit engine URL. Mutually exclusive with *runtime*.
+        max_turns:
+            Static unroll bound for the agent loop (``model -> tools`` turns),
+            matching :meth:`run_durable`. Deploy at the same *max_turns* you ran
+            with so the registered IR is the one you tested. Defaults to ``8``.
 
         Returns
         -------
@@ -784,11 +792,12 @@ class Agent:
             )
         target = resolve_runtime_target(runtime_url if runtime_url is not None else runtime)
 
-        # The SAME agent-loop IR run_durable builds. The prompt is per-run and is
-        # NOT embedded in the workflow definition, so deploy compiles with an empty
-        # prompt; governance fields (cost_budget_usd / policy / data_policy) are
-        # merged into the IR by compile_agent_to_ir and are not stripped here.
-        ir = compile_agent_to_ir(self, "")
+        # The SAME agent-loop IR run_durable builds, at the SAME max_turns. The
+        # prompt is per-run and is NOT embedded in the workflow definition, so
+        # deploy compiles with an empty prompt; governance fields (cost_budget_usd
+        # / policy / data_policy) are merged into the IR by compile_agent_to_ir and
+        # are not stripped here.
+        ir = compile_agent_to_ir(self, "", max_turns=max_turns)
         workflow_id: str = ir["workflow_id"]
         workflow_version: str | None = ir.get("version")
 

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -142,8 +142,8 @@ app.add_typer(demo_app, name="demo")
 console = Console()
 
 
-def _client(runtime: str = "http://localhost:7700") -> JamjetClient:
-    return JamjetClient(base_url=runtime)
+def _client(runtime: str = "http://localhost:7700", token: str | None = None) -> JamjetClient:
+    return JamjetClient(base_url=runtime, api_token=token)
 
 
 # ── Protocol trace helpers ───────────────────────────────────────────────────
@@ -649,16 +649,35 @@ def validate(
 @app.command()
 def deploy(
     file: str = typer.Argument(..., help="Path to a fleet YAML (agents:/workflows:)"),
-    runtime: str = typer.Option("http://localhost:7700", "--runtime", "-r"),
+    runtime: str = typer.Option(
+        "http://localhost:7700",
+        "--runtime",
+        "-r",
+        help="Target engine: local | self-host | cloud | a base URL.",
+    ),
 ) -> None:
-    """Register every unit in a fleet file and install its cron schedules."""
+    """Register every unit in a fleet file and install its cron schedules.
+
+    ``--runtime`` is resolved with the SAME resolver as ``Agent.deploy``:
+    ``local`` (the dev engine on 7700), ``self-host`` (``$JAMJET_RUNTIME_URL``),
+    ``cloud`` (your hosted engine at ``$JAMJET_CLOUD_RUNTIME_URL`` plus JamJet
+    Cloud governance), or a base URL used directly. The default keeps the existing
+    ``http://localhost:7700`` behavior.
+    """
+    from jamjet.deploy import resolve_runtime_target
     from jamjet.workflow.bundle import compile_bundle
+
+    try:
+        target = resolve_runtime_target(runtime)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
 
     data = yaml.safe_load(Path(file).read_text())
     bundle = compile_bundle(data)
 
     async def _deploy() -> None:
-        async with _client(runtime) as c:
+        async with _client(target.url, target.token) as c:
             for ir in bundle.workflows:
                 ir["workflow_id"] = str(ir["workflow_id"])
                 ir["version"] = str(ir["version"])

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -48,6 +48,7 @@ from rich.table import Table
 
 from jamjet.cli.demo import demo_app
 from jamjet.client import JamjetClient
+from jamjet.deploy import LOCAL_RUNTIME_URL
 
 # ── Logo — block letter J  (0=bg  1=yellow#f5c518  2=orange#ea580c) ──────────
 # 6×7 grid: clean J — top bar + vertical stem + orange hook at base.
@@ -142,7 +143,7 @@ app.add_typer(demo_app, name="demo")
 console = Console()
 
 
-def _client(runtime: str = "http://localhost:7700", token: str | None = None) -> JamjetClient:
+def _client(runtime: str = LOCAL_RUNTIME_URL, token: str | None = None) -> JamjetClient:
     return JamjetClient(base_url=runtime, api_token=token)
 
 
@@ -650,7 +651,7 @@ def validate(
 def deploy(
     file: str = typer.Argument(..., help="Path to a fleet YAML (agents:/workflows:)"),
     runtime: str = typer.Option(
-        "http://localhost:7700",
+        LOCAL_RUNTIME_URL,
         "--runtime",
         "-r",
         help="Target engine: local | self-host | cloud | a base URL.",
@@ -661,8 +662,9 @@ def deploy(
     ``--runtime`` is resolved with the SAME resolver as ``Agent.deploy``:
     ``local`` (the dev engine on 7700), ``self-host`` (``$JAMJET_RUNTIME_URL``),
     ``cloud`` (your hosted engine at ``$JAMJET_CLOUD_RUNTIME_URL`` plus JamJet
-    Cloud governance), or a base URL used directly. The default keeps the existing
-    ``http://localhost:7700`` behavior.
+    Cloud governance), or a base URL used directly. The default is the shared
+    local engine URL (``LOCAL_RUNTIME_URL``, ``http://127.0.0.1:7700``) — the SAME
+    source ``Agent.deploy`` uses, so the CLI and the SDK agree on the local target.
     """
     from jamjet.deploy import resolve_runtime_target
     from jamjet.workflow.bundle import compile_bundle

--- a/sdk/python/jamjet/deploy/__init__.py
+++ b/sdk/python/jamjet/deploy/__init__.py
@@ -52,6 +52,29 @@ class RuntimeTarget:
     name: str
 
 
+@dataclass(frozen=True)
+class DeployResult:
+    """The outcome of an :meth:`~jamjet.agents.agent.Agent.deploy` call.
+
+    Attributes:
+        workflow_id: The registered workflow id (the agent's name) — the handle
+            you ``start_execution`` against, or that a cron schedule fires.
+        runtime: The leg the IR was shipped to (``local`` / ``self-host`` /
+            ``cloud``) or the bare URL when one was passed directly.
+        url: The engine base URL the IR was registered against.
+        scheduled: ``True`` when a cron schedule was installed for the workflow.
+        cloud_governance: ``True`` when JamJet Cloud span-push governance is
+            wired alongside this deploy (the ``cloud`` leg). Recording only — the
+            deploy does not call into Cloud, so it succeeds even if Cloud is down.
+    """
+
+    workflow_id: str
+    runtime: str
+    url: str
+    scheduled: bool
+    cloud_governance: bool
+
+
 def _is_url(runtime: str) -> bool:
     return runtime.lower().startswith(("http://", "https://"))
 
@@ -114,4 +137,4 @@ def resolve_runtime_target(runtime: str | None = None) -> RuntimeTarget:
     raise ValueError(f"unknown runtime {runtime!r}; use 'local', 'self-host', 'cloud', or a base URL.")
 
 
-__all__ = ["LOCAL_RUNTIME_URL", "RuntimeTarget", "resolve_runtime_target"]
+__all__ = ["LOCAL_RUNTIME_URL", "DeployResult", "RuntimeTarget", "resolve_runtime_target"]

--- a/sdk/python/jamjet/deploy/__init__.py
+++ b/sdk/python/jamjet/deploy/__init__.py
@@ -43,7 +43,7 @@ class RuntimeTarget:
             never load-bearing: deploy succeeds even if Cloud is unreachable.
         name: A stable label for the leg (``local`` / ``self-host`` / ``cloud``)
             or the bare URL when one was passed directly. Surfaced on
-            :class:`~jamjet.agents.agent.DeployResult.runtime`.
+            :class:`~jamjet.deploy.DeployResult.runtime`.
     """
 
     url: str

--- a/sdk/python/jamjet/deploy/__init__.py
+++ b/sdk/python/jamjet/deploy/__init__.py
@@ -1,0 +1,117 @@
+"""Deploy — ship a compiled agent IR to a runtime (Track 7a).
+
+``agent.deploy(runtime=...)`` registers the SAME compiled IR that
+``agent.run_durable`` builds onto a ``jamjet-server`` engine over the existing
+``JamjetClient.create_workflow`` / ``create_cron_job`` path. The only thing that
+distinguishes the three legs is the engine URL (+ an optional bearer token):
+
+- ``local`` / ``None`` — the dev default, ``http://127.0.0.1:7700`` (``jamjet dev``).
+- ``self-host`` — your own ``jamjet-server`` at ``JAMJET_RUNTIME_URL``.
+- ``cloud`` — YOUR hosted ``jamjet-server`` at ``JAMJET_CLOUD_RUNTIME_URL``, with
+  JamJet Cloud span-push governance layered on (``cloud_governance=True``).
+
+The honest model (2026-06-28 decision): ``runtime="cloud"`` is **a hosted engine
+URL + Cloud governance**, NOT a managed multi-tenant execution "cell". JamJet
+Cloud (``api.jamjet.dev``) is a ``/v1/*`` governance/observability span API, not a
+workflow execution engine — the deploy client is NEVER pointed at it. "Cloud is
+the governance plane, independent of the runtime."
+
+A bare URL string (``resolve_runtime_target("https://my-engine...")``) is used
+directly, so any engine endpoint is reachable without a named leg.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# The dev default — matches Agent.run_durable's runtime_url and the Team default.
+LOCAL_RUNTIME_URL = "http://127.0.0.1:7700"
+
+
+@dataclass(frozen=True)
+class RuntimeTarget:
+    """A resolved deploy destination: an engine URL + how to reach/govern it.
+
+    Attributes:
+        url: The ``jamjet-server`` base URL the IR is registered against
+            (``POST /workflows``). All three legs are the same engine API.
+        token: Optional bearer token for a secured engine. ``None`` lets
+            :class:`~jamjet.client.JamjetClient` fall back to ``JAMJET_TOKEN``.
+        cloud_governance: ``True`` only for the ``cloud`` leg — records that
+            JamJet Cloud span-push governance is wired alongside the run. It is
+            never load-bearing: deploy succeeds even if Cloud is unreachable.
+        name: A stable label for the leg (``local`` / ``self-host`` / ``cloud``)
+            or the bare URL when one was passed directly. Surfaced on
+            :class:`~jamjet.agents.agent.DeployResult.runtime`.
+    """
+
+    url: str
+    token: str | None
+    cloud_governance: bool
+    name: str
+
+
+def _is_url(runtime: str) -> bool:
+    return runtime.lower().startswith(("http://", "https://"))
+
+
+def resolve_runtime_target(runtime: str | None = None) -> RuntimeTarget:
+    """Resolve a friendly runtime name (or a bare URL) to a :class:`RuntimeTarget`.
+
+    Mapping:
+
+    - ``None`` / ``"local"`` -> ``http://127.0.0.1:7700``, no token, no governance.
+    - ``"self-host"`` -> ``JAMJET_RUNTIME_URL`` (+ optional ``JAMJET_RUNTIME_TOKEN``);
+      raises a clear error if the URL is unset.
+    - ``"cloud"`` -> ``JAMJET_CLOUD_RUNTIME_URL`` (+ ``JAMJET_CLOUD_TOKEN`` or
+      ``JAMJET_API_KEY``), ``cloud_governance=True``; raises a clear error naming
+      the honest model if the URL is unset.
+    - a bare ``http(s)://`` URL -> used directly, no token, no governance.
+
+    Raises:
+        ValueError: if a named remote leg has no configured URL, or the runtime
+            name is neither a known leg nor a URL.
+    """
+    if runtime is None:
+        runtime = "local"
+
+    # A bare URL is taken at face value (any engine endpoint, no named leg).
+    if _is_url(runtime):
+        return RuntimeTarget(url=runtime, token=None, cloud_governance=False, name=runtime)
+
+    leg = runtime.strip().lower()
+
+    if leg == "local":
+        return RuntimeTarget(url=LOCAL_RUNTIME_URL, token=None, cloud_governance=False, name="local")
+
+    if leg == "self-host":
+        url = os.environ.get("JAMJET_RUNTIME_URL")
+        if not url:
+            raise ValueError(
+                "runtime='self-host' needs a self-hosted engine URL: set "
+                "JAMJET_RUNTIME_URL to your jamjet-server (e.g. "
+                "https://engine.internal:8080). Add JAMJET_RUNTIME_TOKEN if it is secured."
+            )
+        token = os.environ.get("JAMJET_RUNTIME_TOKEN")
+        return RuntimeTarget(url=url, token=token, cloud_governance=False, name="self-host")
+
+    if leg == "cloud":
+        url = os.environ.get("JAMJET_CLOUD_RUNTIME_URL")
+        if not url:
+            # The honest model: cloud == your hosted engine + Cloud governance.
+            # NEVER name api.jamjet.dev here — that is the span/governance API,
+            # not a workflow execution engine.
+            raise ValueError(
+                "runtime='cloud' deploys to YOUR hosted jamjet-server engine AND "
+                "enables JamJet Cloud governance — it is not a managed execution cell. "
+                "Set JAMJET_CLOUD_RUNTIME_URL to your hosted engine endpoint (e.g. on "
+                "Fly), plus JAMJET_CLOUD_TOKEN or JAMJET_API_KEY for governance."
+            )
+        token = os.environ.get("JAMJET_CLOUD_TOKEN") or os.environ.get("JAMJET_API_KEY")
+        return RuntimeTarget(url=url, token=token, cloud_governance=True, name="cloud")
+
+    raise ValueError(f"unknown runtime {runtime!r}; use 'local', 'self-host', 'cloud', or a base URL.")
+
+
+__all__ = ["LOCAL_RUNTIME_URL", "RuntimeTarget", "resolve_runtime_target"]

--- a/sdk/python/jamjet/entry.py
+++ b/sdk/python/jamjet/entry.py
@@ -73,6 +73,35 @@ async def resume(
     return await rt.resume(spec, execution_id, governance=governance)
 
 
-async def deploy(target: Any, *, runtime: str = "cloud") -> None:
-    """Phase 5 — dispatch to remote runtime. Stub for now."""
-    raise NotImplementedError("deploy() lands in Phase 5.")
+async def deploy(target: Any, *, runtime: str | None = None, **kwargs: Any) -> Any:
+    """Deprecated — use :meth:`jamjet.Agent.deploy` / :meth:`jamjet.Team.deploy`.
+
+    The old top-level ``deploy()`` was a Phase-5 ``NotImplementedError`` stub. The
+    real deploy surface now lives on the ADK objects: ``Agent.deploy(runtime=...)``
+    and ``Team.deploy(...)`` ship the compiled IR to a ``jamjet-server`` engine
+    (local / self-host / cloud) over the working ``JamjetClient`` path (Track 7a).
+
+    For backward compatibility this delegates to ``target.deploy(...)`` when
+    *target* is an :class:`~jamjet.agents.agent.Agent` or a team (anything with a
+    ``deploy`` method), emitting a :class:`DeprecationWarning`. For any other
+    target (a ``@DurableAgent`` class / ``@workflow`` function / spec, which never
+    had a working deploy) it raises a clear error pointing at the new API — it
+    never silently no-ops and never raises the old "lands in Phase 5" stub.
+    """
+    import warnings
+
+    deploy_method = getattr(target, "deploy", None)
+    if callable(deploy_method):
+        warnings.warn(
+            "jamjet.deploy(target) is deprecated; call target.deploy(runtime=...) "
+            "directly (Agent.deploy / Team.deploy).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await deploy_method(runtime=runtime, **kwargs)
+    raise TypeError(
+        f"Cannot deploy {target!r}: the top-level deploy() stub is removed. Use "
+        "Agent.deploy(runtime=...) on a jamjet.Agent (or Team.deploy(...)). 'cloud' "
+        "ships the IR to YOUR hosted jamjet-server engine plus JamJet Cloud "
+        "governance; it is not a managed execution cell."
+    )

--- a/sdk/python/jamjet/runtime/stub/__init__.py
+++ b/sdk/python/jamjet/runtime/stub/__init__.py
@@ -37,7 +37,28 @@ class _StubBase:
 
 
 class CloudRuntime(_StubBase):
+    """There is no in-process "cloud" runtime: JamJet Cloud is the GOVERNANCE
+    plane (a span/observability API), independent of the execution engine. To run
+    on a hosted engine, ship the IR with :meth:`jamjet.Agent.deploy` instead. Both
+    methods raise an honest, actionable error rather than a "coming soon" stub.
+    """
+
     name = "Cloud"
+
+    _GUIDANCE = (
+        "There is no in-process 'cloud' runtime: JamJet Cloud is the governance "
+        "plane, not an execution engine. To run on a hosted engine, use "
+        "Agent.deploy(runtime='cloud') (ships the compiled IR to your hosted "
+        "jamjet-server at JAMJET_CLOUD_RUNTIME_URL, with JamJet Cloud governance "
+        "layered on) or Agent.run_durable(runtime_url=...). For in-process runs "
+        "use LocalRuntime."
+    )
+
+    async def execute(self, *args: Any, **kwargs: Any) -> RuntimeResult:
+        raise NotImplementedError(self._GUIDANCE)
+
+    async def resume(self, *args: Any, **kwargs: Any) -> RuntimeResult:
+        raise NotImplementedError(self._GUIDANCE)
 
 
 class JavaRuntime(_StubBase):

--- a/sdk/python/jamjet/team/team.py
+++ b/sdk/python/jamjet/team/team.py
@@ -57,6 +57,7 @@ from jamjet.agents.session import Session, SessionStore
 
 if TYPE_CHECKING:
     from jamjet.agents.agent import Agent, AgentResult
+    from jamjet.deploy import DeployResult
 
 # A sub-agent run can succeed (AgentResult) or fail (the exception is captured so
 # one failing sub-agent never crashes the team — child-crash isolation).
@@ -303,6 +304,30 @@ class _TeamBase:
         """Run the team durably (each sub-agent its own :meth:`Agent.run_durable`
         execution, polled to a terminal state)."""
         return await self._orchestrate(input, durable=True, runtime_url=runtime_url)
+
+    async def deploy(
+        self,
+        *,
+        runtime: str | None = None,
+        schedule: str | None = None,
+    ) -> list[DeployResult]:
+        """Register each sub-agent's workflow on a runtime (Track 7a-3).
+
+        A team is N agent IRs (Path A): deploy reuses :meth:`Agent.deploy` per
+        member and returns one :class:`~jamjet.deploy.DeployResult` per sub-agent,
+        in declared order. The Python orchestration (sequencing / routing / merge)
+        still runs CLIENT-SIDE when you call :meth:`run_durable`; deploy only
+        pre-registers the building-block workflows. A fully engine-native single
+        team deployment is a follow-up (F-t6-native-nodes).
+
+        *runtime* is resolved the same way as :meth:`Agent.deploy`
+        (``local`` / ``self-host`` / ``cloud`` / a URL). *schedule* installs the
+        SAME cron expression on EACH sub-agent's workflow: for a
+        :class:`Parallel` team that reproduces the fan-out, but for
+        :class:`Sequential` / :class:`Loop` the engine fires each member
+        independently (orchestrated scheduling stays client-side).
+        """
+        return [await agent.deploy(runtime=runtime, schedule=schedule) for agent in self.agents]
 
     # -- the per-sub-agent run primitive --------------------------------------
 

--- a/sdk/python/jamjet/team/team.py
+++ b/sdk/python/jamjet/team/team.py
@@ -310,24 +310,43 @@ class _TeamBase:
         *,
         runtime: str | None = None,
         schedule: str | None = None,
-    ) -> list[DeployResult]:
+        max_turns: int = 8,
+    ) -> dict[str, DeployResult | BaseException]:
         """Register each sub-agent's workflow on a runtime (Track 7a-3).
 
         A team is N agent IRs (Path A): deploy reuses :meth:`Agent.deploy` per
-        member and returns one :class:`~jamjet.deploy.DeployResult` per sub-agent,
+        member and returns a ``{agent.name: DeployResult | BaseException}`` mapping
         in declared order. The Python orchestration (sequencing / routing / merge)
         still runs CLIENT-SIDE when you call :meth:`run_durable`; deploy only
         pre-registers the building-block workflows. A fully engine-native single
         team deployment is a follow-up (F-t6-native-nodes).
+
+        Isolation (mirrors the run path)
+        --------------------------------
+        Each sub-agent deploys INDEPENDENTLY: a sub-agent whose deploy raises has
+        its exception CAPTURED as that name's value in the returned mapping and the
+        remaining members still deploy, so a partial deploy reports exactly what
+        registered and never aborts on the first failure. This mirrors the run
+        path's per-agent child-crash isolation (``TeamResult.per_agent``).
+        Registration is idempotent by ``(workflow_id, version)`` (the runtime
+        caches the IR immutably), so re-running ``deploy`` after a partial failure
+        safely re-registers the survivors and retries the failed member.
 
         *runtime* is resolved the same way as :meth:`Agent.deploy`
         (``local`` / ``self-host`` / ``cloud`` / a URL). *schedule* installs the
         SAME cron expression on EACH sub-agent's workflow: for a
         :class:`Parallel` team that reproduces the fan-out, but for
         :class:`Sequential` / :class:`Loop` the engine fires each member
-        independently (orchestrated scheduling stays client-side).
+        independently (orchestrated scheduling stays client-side). *max_turns* is
+        threaded into each sub-agent's compiled IR, matching :meth:`Agent.deploy`.
         """
-        return [await agent.deploy(runtime=runtime, schedule=schedule) for agent in self.agents]
+        results: dict[str, DeployResult | BaseException] = {}
+        for agent in self.agents:
+            try:
+                results[agent.name] = await agent.deploy(runtime=runtime, schedule=schedule, max_turns=max_turns)
+            except Exception as exc:  # noqa: BLE001 - isolate a sub-agent deploy failure
+                results[agent.name] = exc
+        return results
 
     # -- the per-sub-agent run primitive --------------------------------------
 

--- a/sdk/python/tests/runtime/test_stubs.py
+++ b/sdk/python/tests/runtime/test_stubs.py
@@ -1,10 +1,14 @@
 import pytest
 
-from jamjet.runtime.stub import CloudRuntime, JavaRuntime, RustRuntime
+from jamjet.runtime.stub import JavaRuntime, RustRuntime
 from jamjet.spec import AgentSpec, LLMConfig
 
+# NB: CloudRuntime is intentionally excluded — it no longer carries the generic
+# "lands in Phase 5" stub message. It raises an honest "use Agent.deploy(...)"
+# error instead (Track 7a-4); that behaviour is covered in test_deploy_redirect.py.
 
-@pytest.mark.parametrize("cls", [CloudRuntime, JavaRuntime, RustRuntime])
+
+@pytest.mark.parametrize("cls", [JavaRuntime, RustRuntime])
 async def test_stub_raises_not_implemented(cls):
     rt = cls()
     spec = AgentSpec(name="x", llm=LLMConfig(provider="openai", model="gpt-4o"))
@@ -12,7 +16,7 @@ async def test_stub_raises_not_implemented(cls):
         await rt.execute(spec, input="x")
 
 
-@pytest.mark.parametrize("cls", [CloudRuntime, JavaRuntime, RustRuntime])
+@pytest.mark.parametrize("cls", [JavaRuntime, RustRuntime])
 async def test_stub_resume_raises(cls):
     rt = cls()
     spec = AgentSpec(name="x", llm=LLMConfig(provider="openai", model="gpt-4o"))

--- a/sdk/python/tests/test_agent_deploy.py
+++ b/sdk/python/tests/test_agent_deploy.py
@@ -1,0 +1,235 @@
+"""Tests for ``Agent.deploy`` (Track 7a-2) — ship the compiled IR to a runtime.
+
+No real engine: a fake stands in for ``JamjetClient`` and records the base URL +
+token it was constructed with and every IR / cron job registered. We assert that
+deploy compiles the SAME agent-loop IR as ``run_durable``, registers it over
+``create_workflow`` against the RESOLVED url/token, optionally installs a cron
+schedule, never strips the agent's governance from the IR, records (but does not
+call into) Cloud governance for the cloud leg, and defaults to LOCAL so a bare
+``deploy()`` never targets a remote URL.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jamjet.agents.agent import Agent
+from jamjet.compiler.agent_ir import compile_agent_to_ir
+from jamjet.deploy import LOCAL_RUNTIME_URL, DeployResult
+from jamjet.tools.decorators import tool
+
+
+@tool
+async def get_weather(city: str) -> str:
+    """Return the weather for a city."""
+    return f"sunny in {city}"
+
+
+def _agent(**kw: Any) -> Agent:
+    return Agent(
+        "weatherbot",
+        model="anthropic/claude-sonnet-4-6",
+        tools=[get_weather],
+        instructions="You are a weather assistant.",
+        **kw,
+    )
+
+
+class _FakeDeployClient:
+    """Async-context fake of JamjetClient that records its construction + calls."""
+
+    def __init__(self, base_url: str = "http://localhost:7700", api_token: str | None = None) -> None:
+        self.base_url = base_url
+        self.api_token = api_token
+        self.created: list[dict[str, Any]] = []
+        self.cron: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeDeployClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        self.created.append(ir)
+        return {"workflow_id": ir["workflow_id"], "version": ir.get("version")}
+
+    async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+        self.cron.append(kwargs)
+        return {"name": kwargs.get("name"), "next_run_at": "2026-06-28T09:00:00Z"}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch JamjetClient with the fake; capture the constructed instance."""
+    captured: dict[str, Any] = {}
+
+    def factory(base_url: str = "http://localhost:7700", api_token: str | None = None, **_: Any) -> _FakeDeployClient:
+        client = _FakeDeployClient(base_url=base_url, api_token=api_token)
+        captured["client"] = client
+        return client
+
+    monkeypatch.setattr("jamjet.client.JamjetClient", factory)
+    return captured
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "JAMJET_RUNTIME_URL",
+        "JAMJET_RUNTIME_TOKEN",
+        "JAMJET_CLOUD_RUNTIME_URL",
+        "JAMJET_CLOUD_TOKEN",
+        "JAMJET_API_KEY",
+        "JAMJET_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── local default (no prod-targeting footgun) ─────────────────────────────────
+
+
+async def test_deploy_defaults_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy()
+
+    assert isinstance(result, DeployResult)
+    assert result.runtime == "local"
+    assert result.url == LOCAL_RUNTIME_URL
+    assert result.scheduled is False
+    assert result.cloud_governance is False
+    # Registered against the LOCAL engine — never a remote URL.
+    assert captured["client"].base_url == LOCAL_RUNTIME_URL
+    assert captured["client"].api_token is None
+
+
+async def test_deploy_registers_the_compiled_ir(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+    agent = _agent()
+
+    result = await agent.deploy()
+
+    client = captured["client"]
+    assert len(client.created) == 1
+    deployed_ir = client.created[0]
+    # The SAME IR run_durable builds (prompt is not embedded in the IR).
+    assert deployed_ir == compile_agent_to_ir(agent, "")
+    assert deployed_ir["workflow_id"] == "weatherbot"
+    assert deployed_ir["labels"]["jamjet.agent.loop"] == "true"
+    assert result.workflow_id == "weatherbot"
+
+
+# ── governance is never stripped on deploy ────────────────────────────────────
+
+
+async def test_deploy_does_not_strip_governance(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+    # A governed agent: an explicit cost budget compiles to cost_budget_usd.
+    agent = _agent(max_cost_usd=0.25)
+
+    await agent.deploy()
+
+    deployed_ir = captured["client"].created[0]
+    assert deployed_ir["cost_budget_usd"] == 0.25
+    # PII is on by default -> data_policy metadata survives the deploy.
+    assert "data_policy" in deployed_ir
+
+
+# ── self-host ─────────────────────────────────────────────────────────────────
+
+
+async def test_deploy_self_host_uses_env_url_and_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_RUNTIME_URL", "https://engine.internal:8080")
+    monkeypatch.setenv("JAMJET_RUNTIME_TOKEN", "tok-self")
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy(runtime="self-host")
+
+    assert result.runtime == "self-host"
+    assert result.url == "https://engine.internal:8080"
+    assert captured["client"].base_url == "https://engine.internal:8080"
+    assert captured["client"].api_token == "tok-self"
+    assert result.cloud_governance is False
+
+
+async def test_deploy_self_host_unset_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    with pytest.raises(ValueError, match="JAMJET_RUNTIME_URL"):
+        await _agent().deploy(runtime="self-host")
+
+
+# ── cloud (hosted engine + governance, never load-bearing) ────────────────────
+
+
+async def test_deploy_cloud_targets_hosted_engine_and_records_governance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_CLOUD_RUNTIME_URL", "https://my-engine.fly.dev")
+    monkeypatch.setenv("JAMJET_CLOUD_TOKEN", "tok-cloud")
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy(runtime="cloud")
+
+    # The deploy client hits the hosted ENGINE, never api.jamjet.dev.
+    assert captured["client"].base_url == "https://my-engine.fly.dev"
+    assert captured["client"].api_token == "tok-cloud"
+    assert result.runtime == "cloud"
+    assert result.url == "https://my-engine.fly.dev"
+    # cloud_governance is recorded; deploy does NOT call into Cloud to succeed.
+    assert result.cloud_governance is True
+    assert "api.jamjet.dev" not in captured["client"].base_url
+
+
+# ── scheduling ────────────────────────────────────────────────────────────────
+
+
+async def test_deploy_with_schedule_creates_cron_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy(schedule="0 9 * * *")
+
+    client = captured["client"]
+    assert len(client.cron) == 1
+    job = client.cron[0]
+    assert job["cron_expression"] == "0 9 * * *"
+    assert job["workflow_id"] == "weatherbot"
+    assert result.scheduled is True
+
+
+async def test_deploy_without_schedule_creates_no_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy()
+
+    assert captured["client"].cron == []
+    assert result.scheduled is False
+
+
+# ── explicit url + conflict guard ─────────────────────────────────────────────
+
+
+async def test_deploy_runtime_url_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+
+    result = await _agent().deploy(runtime_url="https://my-box.example.com")
+
+    assert captured["client"].base_url == "https://my-box.example.com"
+    assert result.url == "https://my-box.example.com"
+    assert result.cloud_governance is False
+
+
+async def test_deploy_runtime_and_runtime_url_conflict_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    with pytest.raises(ValueError, match="runtime"):
+        await _agent().deploy(runtime="local", runtime_url="https://box.example.com")

--- a/sdk/python/tests/test_agent_deploy.py
+++ b/sdk/python/tests/test_agent_deploy.py
@@ -122,6 +122,20 @@ async def test_deploy_registers_the_compiled_ir(monkeypatch: pytest.MonkeyPatch)
     assert result.workflow_id == "weatherbot"
 
 
+async def test_deploy_threads_max_turns_into_ir(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client(monkeypatch)
+    agent = _agent()
+
+    await agent.deploy(max_turns=12)
+
+    deployed_ir = captured["client"].created[0]
+    # Registered at the requested max_turns — same IR run_durable(max_turns=12) ships.
+    assert deployed_ir == compile_agent_to_ir(agent, "", max_turns=12)
+    # And NOT the default-8 IR: more turns unroll more nodes -> a different version.
+    assert deployed_ir != compile_agent_to_ir(agent, "", max_turns=8)
+
+
 # ── governance is never stripped on deploy ────────────────────────────────────
 
 

--- a/sdk/python/tests/test_agent_deploy.py
+++ b/sdk/python/tests/test_agent_deploy.py
@@ -216,6 +216,11 @@ async def test_deploy_with_schedule_creates_cron_job(monkeypatch: pytest.MonkeyP
     assert job["cron_expression"] == "0 9 * * *"
     assert job["workflow_id"] == "weatherbot"
     assert result.scheduled is True
+    # The scheduled seed is build_initial_state(agent, "") — an empty user turn
+    # (the recurring intent lives in the agent's instructions, not the seed). The
+    # last message is the empty prompt the engine fires the workflow with.
+    seed = job["input"]
+    assert seed["messages"][-1] == {"role": "user", "content": ""}
 
 
 async def test_deploy_without_schedule_creates_no_cron(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -247,3 +252,68 @@ async def test_deploy_runtime_and_runtime_url_conflict_raises(monkeypatch: pytes
     _patch_client(monkeypatch)
     with pytest.raises(ValueError, match="runtime"):
         await _agent().deploy(runtime="local", runtime_url="https://box.example.com")
+
+
+# ── registered-but-unscheduled is honest and distinguishable ──────────────────
+
+
+async def test_deploy_schedule_failure_after_register_is_distinguishable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_workflow succeeds, create_cron_job fails: the workflow IS registered
+    but unscheduled. The raised error must say so AND chain the cron error, so the
+    registered-but-unscheduled state is distinguishable from a never-registered one
+    (and Team.deploy's captured exception carries that distinction)."""
+    _clear_env(monkeypatch)
+
+    class _CronFailsClient(_FakeDeployClient):
+        async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("cron backend down")
+
+    captured: dict[str, Any] = {}
+
+    def factory(base_url: str = "http://localhost:7700", api_token: str | None = None, **_: Any) -> _CronFailsClient:
+        client = _CronFailsClient(base_url=base_url, api_token=api_token)
+        captured["client"] = client
+        return client
+
+    monkeypatch.setattr("jamjet.client.JamjetClient", factory)
+
+    with pytest.raises(RuntimeError) as exc:
+        await _agent().deploy(schedule="0 9 * * *")
+
+    msg = str(exc.value)
+    assert "weatherbot" in msg  # names the registered workflow id
+    assert "registered" in msg  # states it WAS registered
+    assert "scheduling failed" in msg  # only the schedule step failed
+    # Chained from the underlying cron error (registered-but-unscheduled, not lost).
+    assert isinstance(exc.value.__cause__, RuntimeError)
+    assert "cron backend down" in str(exc.value.__cause__)
+    # The workflow really was registered before the schedule step blew up.
+    assert captured["client"].created and captured["client"].created[0]["workflow_id"] == "weatherbot"
+
+
+async def test_deploy_create_workflow_failure_is_not_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """create_workflow itself fails: the workflow is NOT registered, so the error
+    must NOT claim it was registered (the opposite of the schedule-failure case)."""
+    _clear_env(monkeypatch)
+
+    class _RegisterFailsClient(_FakeDeployClient):
+        async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("engine rejected the IR")
+
+    monkeypatch.setattr(
+        "jamjet.client.JamjetClient",
+        lambda base_url="http://localhost:7700", api_token=None, **_: _RegisterFailsClient(
+            base_url=base_url, api_token=api_token
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        await _agent().deploy(schedule="0 9 * * *")
+
+    msg = str(exc.value)
+    assert "engine rejected the IR" in msg
+    assert "registered" not in msg.lower()  # a create_workflow failure never claims registration

--- a/sdk/python/tests/test_cli_deploy_runtime.py
+++ b/sdk/python/tests/test_cli_deploy_runtime.py
@@ -4,7 +4,8 @@ The CLI deploy command resolves ``--runtime`` with the SAME resolver as
 ``Agent.deploy`` (local / self-host / cloud / a URL), so the CLI and the SDK
 agree on targeting. We patch the JamjetClient class (so the resolver actually
 runs) and assert the resolved base URL + token reach it; a bad runtime errors
-clearly; the default preserves the existing ``http://localhost:7700`` behavior.
+clearly; the default resolves to the shared local engine URL (``LOCAL_RUNTIME_URL``,
+``http://127.0.0.1:7700``) — the SAME source ``Agent.deploy`` uses.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ import pytest
 from typer.testing import CliRunner
 
 from jamjet.cli.main import app
+from jamjet.deploy import LOCAL_RUNTIME_URL
 
 runner = CliRunner()
 
@@ -82,8 +84,9 @@ def test_deploy_default_runtime_preserved(tmp_path, monkeypatch: pytest.MonkeyPa
     result = runner.invoke(app, ["deploy", str(f)])
 
     assert result.exit_code == 0, result.output
-    # Existing behavior: default --runtime is http://localhost:7700, passed through.
-    assert captured["client"].base_url == "http://localhost:7700"
+    # The default --runtime resolves through the SAME resolver as Agent.deploy, so
+    # the CLI and the SDK agree on the local engine URL (127.0.0.1:7700, not localhost).
+    assert captured["client"].base_url == LOCAL_RUNTIME_URL
     assert captured["client"].api_token is None
 
 

--- a/sdk/python/tests/test_cli_deploy_runtime.py
+++ b/sdk/python/tests/test_cli_deploy_runtime.py
@@ -1,0 +1,165 @@
+"""Tests for ``jamjet deploy --runtime`` parity (Track 7a-7).
+
+The CLI deploy command resolves ``--runtime`` with the SAME resolver as
+``Agent.deploy`` (local / self-host / cloud / a URL), so the CLI and the SDK
+agree on targeting. We patch the JamjetClient class (so the resolver actually
+runs) and assert the resolved base URL + token reach it; a bad runtime errors
+clearly; the default preserves the existing ``http://localhost:7700`` behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from jamjet.cli.main import app
+
+runner = CliRunner()
+
+FLEET = """
+version: 1
+defaults:
+  model: claude-sonnet-4-6
+  limits: { max_iterations: 2, max_cost_usd: 0.2, timeout_seconds: 30 }
+agents:
+  researcher:
+    strategy: react
+    goal: brief
+"""
+
+
+class _RecordingClient:
+    def __init__(self, base_url: str = "http://localhost:7700", api_token: str | None = None) -> None:
+        self.base_url = base_url
+        self.api_token = api_token
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        return {"workflow_id": ir["workflow_id"], "version": ir.get("version")}
+
+    async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+        return {"name": kwargs.get("name"), "next_run_at": "x"}
+
+
+def _patch_client_class(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def factory(base_url: str = "http://localhost:7700", api_token: str | None = None, **_: Any) -> _RecordingClient:
+        client = _RecordingClient(base_url=base_url, api_token=api_token)
+        captured["client"] = client
+        return client
+
+    # _client() constructs jamjet.cli.main.JamjetClient; patch it so the resolver runs.
+    monkeypatch.setattr("jamjet.cli.main.JamjetClient", factory)
+    return captured
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "JAMJET_RUNTIME_URL",
+        "JAMJET_RUNTIME_TOKEN",
+        "JAMJET_CLOUD_RUNTIME_URL",
+        "JAMJET_CLOUD_TOKEN",
+        "JAMJET_API_KEY",
+        "JAMJET_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_deploy_default_runtime_preserved(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f)])
+
+    assert result.exit_code == 0, result.output
+    # Existing behavior: default --runtime is http://localhost:7700, passed through.
+    assert captured["client"].base_url == "http://localhost:7700"
+    assert captured["client"].api_token is None
+
+
+def test_deploy_runtime_local(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "local"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["client"].base_url == "http://127.0.0.1:7700"
+
+
+def test_deploy_runtime_self_host(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_RUNTIME_URL", "https://engine.internal:8080")
+    monkeypatch.setenv("JAMJET_RUNTIME_TOKEN", "tok-self")
+    captured = _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "self-host"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["client"].base_url == "https://engine.internal:8080"
+    assert captured["client"].api_token == "tok-self"
+
+
+def test_deploy_runtime_cloud(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_CLOUD_RUNTIME_URL", "https://my-engine.fly.dev")
+    monkeypatch.setenv("JAMJET_CLOUD_TOKEN", "tok-cloud")
+    captured = _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "cloud"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["client"].base_url == "https://my-engine.fly.dev"
+    assert captured["client"].api_token == "tok-cloud"
+
+
+def test_deploy_runtime_url_passthrough(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "https://box.example.com"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["client"].base_url == "https://box.example.com"
+
+
+def test_deploy_bad_runtime_errors_clearly(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "banana"])
+
+    assert result.exit_code != 0
+    assert "banana" in result.output
+
+
+def test_deploy_self_host_unset_errors_clearly(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client_class(monkeypatch)
+    f = tmp_path / "fleet.yaml"
+    f.write_text(FLEET)
+
+    result = runner.invoke(app, ["deploy", str(f), "--runtime", "self-host"])
+
+    assert result.exit_code != 0
+    assert "JAMJET_RUNTIME_URL" in result.output

--- a/sdk/python/tests/test_deploy_redirect.py
+++ b/sdk/python/tests/test_deploy_redirect.py
@@ -82,8 +82,11 @@ async def test_entry_deploy_redirects_team(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.warns(DeprecationWarning):
         results = await entry_deploy(Sequential([_agent("a"), _agent("b")]))
 
-    assert isinstance(results, list)
-    assert [r.workflow_id for r in results] == ["a", "b"]
+    # Team.deploy returns a {name: DeployResult | exception} mapping; entry.deploy
+    # passes it through unchanged.
+    assert isinstance(results, dict)
+    assert list(results.keys()) == ["a", "b"]
+    assert [r.workflow_id for r in results.values()] == ["a", "b"]
 
 
 async def test_entry_deploy_non_agent_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/sdk/python/tests/test_deploy_redirect.py
+++ b/sdk/python/tests/test_deploy_redirect.py
@@ -120,7 +120,9 @@ async def test_cloud_runtime_resume_points_at_agent_deploy() -> None:
 
     with pytest.raises(NotImplementedError) as exc:
         await CloudRuntime().resume(object(), "exec_1")
-    assert "Phase 5" not in str(exc.value)
+    msg = str(exc.value)
+    assert "Agent.deploy" in msg  # same actionable hint as execute()
+    assert "Phase 5" not in msg
 
 
 # ── no name collision: jamjet.deploy is the module ────────────────────────────

--- a/sdk/python/tests/test_deploy_redirect.py
+++ b/sdk/python/tests/test_deploy_redirect.py
@@ -1,0 +1,136 @@
+"""Tests for T7a-4 — the dead ``entry.deploy`` + ``CloudRuntime`` stubs are
+redirected/deprecated, never a ``NotImplementedError`` masquerading as a real API.
+
+- ``jamjet.entry.deploy(target)`` now delegates to ``target.deploy(...)`` when the
+  target is an Agent/Team (with a DeprecationWarning), and raises a clear error
+  pointing at ``Agent.deploy()`` otherwise.
+- ``CloudRuntime.execute`` raises an HONEST message (Cloud is the governance
+  plane, use ``Agent.deploy(runtime='cloud')``), not the old "lands in Phase 5".
+- ``jamjet.deploy`` resolves cleanly to the deploy MODULE (no function/module
+  shadowing collision).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jamjet.agents.agent import Agent
+from jamjet.deploy import DeployResult
+from jamjet.team import Sequential
+from jamjet.tools.decorators import tool
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the text."""
+    return text
+
+
+def _agent(name: str = "redir") -> Agent:
+    return Agent(name, model="anthropic/claude-sonnet-4-6", tools=[echo], instructions="x")
+
+
+class _FakeDeployClient:
+    def __init__(self, base_url: str = "http://localhost:7700", api_token: str | None = None) -> None:
+        self.base_url = base_url
+        self.api_token = api_token
+
+    async def __aenter__(self) -> _FakeDeployClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        return {"workflow_id": ir["workflow_id"]}
+
+    async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+        return {"name": kwargs.get("name")}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("jamjet.client.JamjetClient", lambda **kw: _FakeDeployClient(**kw))
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("JAMJET_RUNTIME_URL", "JAMJET_CLOUD_RUNTIME_URL", "JAMJET_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── entry.deploy redirects ────────────────────────────────────────────────────
+
+
+async def test_entry_deploy_redirects_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    from jamjet.entry import deploy as entry_deploy
+
+    with pytest.warns(DeprecationWarning, match="Agent.deploy"):
+        result = await entry_deploy(_agent())
+
+    assert isinstance(result, DeployResult)
+    assert result.runtime == "local"
+
+
+async def test_entry_deploy_redirects_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    from jamjet.entry import deploy as entry_deploy
+
+    with pytest.warns(DeprecationWarning):
+        results = await entry_deploy(Sequential([_agent("a"), _agent("b")]))
+
+    assert isinstance(results, list)
+    assert [r.workflow_id for r in results] == ["a", "b"]
+
+
+async def test_entry_deploy_non_agent_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    from jamjet.entry import deploy as entry_deploy
+
+    # A legacy spec/function target has no .deploy -> clear redirect error, and it
+    # must NOT be the old "lands in Phase 5" NotImplementedError.
+    with pytest.raises((TypeError, ValueError)) as exc:
+        await entry_deploy(object())
+    msg = str(exc.value)
+    assert "Agent.deploy" in msg
+    assert "Phase 5" not in msg
+
+
+# ── CloudRuntime honest message ───────────────────────────────────────────────
+
+
+async def test_cloud_runtime_execute_points_at_agent_deploy() -> None:
+    from jamjet.runtime.stub import CloudRuntime
+
+    with pytest.raises(NotImplementedError) as exc:
+        await CloudRuntime().execute(object(), {})
+    msg = str(exc.value)
+    assert "Agent.deploy" in msg
+    assert "Phase 5" not in msg  # no masquerading "coming soon" stub message
+
+
+async def test_cloud_runtime_resume_points_at_agent_deploy() -> None:
+    from jamjet.runtime.stub import CloudRuntime
+
+    with pytest.raises(NotImplementedError) as exc:
+        await CloudRuntime().resume(object(), "exec_1")
+    assert "Phase 5" not in str(exc.value)
+
+
+# ── no name collision: jamjet.deploy is the module ────────────────────────────
+
+
+def test_jamjet_deploy_resolves_to_module() -> None:
+    import jamjet
+
+    # The deploy surface lives in the jamjet.deploy MODULE; accessing it after
+    # import must not be shadowed by a top-level deploy() function.
+    assert hasattr(jamjet.deploy, "resolve_runtime_target")
+    assert hasattr(jamjet.deploy, "RuntimeTarget")
+    # The friendly method is the public deploy entry point.
+    assert callable(jamjet.Agent.deploy)
+    # The deprecated top-level deploy() function is no longer exported.
+    assert "deploy" not in jamjet.__all__

--- a/sdk/python/tests/test_deploy_resolver.py
+++ b/sdk/python/tests/test_deploy_resolver.py
@@ -1,0 +1,138 @@
+"""Tests for the runtime-target + auth resolver (Track 7a-1).
+
+``resolve_runtime_target`` maps a friendly runtime name (or a bare URL) to a
+``RuntimeTarget`` carrying the engine URL, an optional bearer token, whether
+JamJet Cloud governance should be layered on, and a stable name. The three
+named legs (local / self-host / cloud) are the SAME ``jamjet-server`` engine,
+distinguished only by URL + token; "cloud" additionally records that Cloud
+span-push governance is wired (it is never load-bearing).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jamjet.deploy import RuntimeTarget, resolve_runtime_target
+
+_LOCAL_URL = "http://127.0.0.1:7700"
+
+
+def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "JAMJET_RUNTIME_URL",
+        "JAMJET_RUNTIME_TOKEN",
+        "JAMJET_CLOUD_RUNTIME_URL",
+        "JAMJET_CLOUD_TOKEN",
+        "JAMJET_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── local (the dev default) ───────────────────────────────────────────────────
+
+
+def test_none_resolves_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    target = resolve_runtime_target(None)
+    assert isinstance(target, RuntimeTarget)
+    assert target.url == _LOCAL_URL
+    assert target.token is None
+    assert target.cloud_governance is False
+    assert target.name == "local"
+
+
+def test_local_string_resolves_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    target = resolve_runtime_target("local")
+    assert target.url == _LOCAL_URL
+    assert target.token is None
+    assert target.cloud_governance is False
+    assert target.name == "local"
+
+
+# ── self-host ─────────────────────────────────────────────────────────────────
+
+
+def test_self_host_reads_env_url_and_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_RUNTIME_URL", "https://engine.internal:8080")
+    monkeypatch.setenv("JAMJET_RUNTIME_TOKEN", "tok-self")
+    target = resolve_runtime_target("self-host")
+    assert target.url == "https://engine.internal:8080"
+    assert target.token == "tok-self"
+    assert target.cloud_governance is False
+    assert target.name == "self-host"
+
+
+def test_self_host_token_optional(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_RUNTIME_URL", "https://engine.internal:8080")
+    target = resolve_runtime_target("self-host")
+    assert target.url == "https://engine.internal:8080"
+    assert target.token is None
+
+
+def test_self_host_unset_url_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    with pytest.raises(ValueError, match="JAMJET_RUNTIME_URL"):
+        resolve_runtime_target("self-host")
+
+
+# ── cloud (hosted engine + Cloud governance) ──────────────────────────────────
+
+
+def test_cloud_reads_env_url_and_enables_governance(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_CLOUD_RUNTIME_URL", "https://my-engine.fly.dev")
+    monkeypatch.setenv("JAMJET_CLOUD_TOKEN", "tok-cloud")
+    target = resolve_runtime_target("cloud")
+    assert target.url == "https://my-engine.fly.dev"
+    assert target.token == "tok-cloud"
+    assert target.cloud_governance is True
+    assert target.name == "cloud"
+
+
+def test_cloud_token_falls_back_to_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_CLOUD_RUNTIME_URL", "https://my-engine.fly.dev")
+    monkeypatch.setenv("JAMJET_API_KEY", "jj_fallback")
+    target = resolve_runtime_target("cloud")
+    assert target.token == "jj_fallback"
+    assert target.cloud_governance is True
+
+
+def test_cloud_unset_url_raises_honest_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    # Even with an API key present, the hosted ENGINE url is required — the
+    # error must name JAMJET_CLOUD_RUNTIME_URL and must NOT point at the span API.
+    monkeypatch.setenv("JAMJET_API_KEY", "jj_key")
+    with pytest.raises(ValueError) as exc:
+        resolve_runtime_target("cloud")
+    msg = str(exc.value)
+    assert "JAMJET_CLOUD_RUNTIME_URL" in msg
+    assert "api.jamjet.dev" not in msg  # the span API is NOT an execution engine
+
+
+# ── a bare URL passthrough ────────────────────────────────────────────────────
+
+
+def test_bare_http_url_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    target = resolve_runtime_target("https://my-engine.example.com")
+    assert target.url == "https://my-engine.example.com"
+    assert target.token is None
+    assert target.cloud_governance is False
+    assert target.name == "https://my-engine.example.com"
+
+
+def test_bare_http_url_lowercase_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    target = resolve_runtime_target("http://localhost:9999")
+    assert target.url == "http://localhost:9999"
+    assert target.cloud_governance is False
+
+
+def test_unknown_runtime_name_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_runtime_env(monkeypatch)
+    with pytest.raises(ValueError, match="unknown runtime"):
+        resolve_runtime_target("banana")

--- a/sdk/python/tests/test_team_deploy.py
+++ b/sdk/python/tests/test_team_deploy.py
@@ -1,11 +1,13 @@
 """Tests for ``Team.deploy`` (Track 7a-3) — register each sub-agent's workflow.
 
 A team is N agent IRs (Track 6, Path A): deploy reuses :meth:`Agent.deploy` per
-sub-agent and returns one :class:`DeployResult` per member. The Python
-orchestration (sequencing / routing / merge) still runs client-side; deploy
-pre-registers the building blocks. We mock ``JamjetClient`` and collect every
-constructed instance so we can assert each sub-agent was registered against the
-resolved runtime.
+sub-agent and returns a ``{agent.name: DeployResult | BaseException}`` mapping
+(insertion order == declared order), mirroring the run path's per-agent
+child-crash isolation: a sub-agent whose deploy raises has its exception captured
+as that key's value and the rest still deploy. The Python orchestration
+(sequencing / routing / merge) still runs client-side; deploy pre-registers the
+building blocks. We mock ``JamjetClient`` and collect every constructed instance
+so we can assert each sub-agent was registered against the resolved runtime.
 """
 
 from __future__ import annotations
@@ -15,6 +17,7 @@ from typing import Any
 import pytest
 
 from jamjet.agents.agent import Agent
+from jamjet.compiler.agent_ir import compile_agent_to_ir
 from jamjet.deploy import LOCAL_RUNTIME_URL, DeployResult
 from jamjet.team import Loop, Parallel, Sequential
 from jamjet.tools.decorators import tool
@@ -77,14 +80,16 @@ async def test_sequential_deploys_each_member(monkeypatch: pytest.MonkeyPatch) -
 
     results = await team.deploy()
 
-    assert isinstance(results, list)
-    assert len(results) == 2
-    assert all(isinstance(r, DeployResult) for r in results)
-    assert [r.workflow_id for r in results] == ["alpha", "beta"]
+    # The mapping is keyed by agent name in declared order.
+    assert isinstance(results, dict)
+    assert list(results.keys()) == ["alpha", "beta"]
+    assert all(isinstance(r, DeployResult) for r in results.values())
+    assert results["alpha"].workflow_id == "alpha"
+    assert results["beta"].workflow_id == "beta"
     # One client per sub-agent, each registered its own IR against LOCAL.
     assert len(instances) == 2
     assert {inst.created[0]["workflow_id"] for inst in instances} == {"alpha", "beta"}
-    assert all(r.url == LOCAL_RUNTIME_URL for r in results)
+    assert all(r.url == LOCAL_RUNTIME_URL for r in results.values())
 
 
 async def test_parallel_deploys_each_member(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,7 +99,8 @@ async def test_parallel_deploys_each_member(monkeypatch: pytest.MonkeyPatch) -> 
 
     results = await team.deploy()
 
-    assert [r.workflow_id for r in results] == ["a", "b", "c"]
+    assert list(results.keys()) == ["a", "b", "c"]
+    assert [r.workflow_id for r in results.values()] == ["a", "b", "c"]
 
 
 async def test_loop_deploys_single_member(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -104,8 +110,8 @@ async def test_loop_deploys_single_member(monkeypatch: pytest.MonkeyPatch) -> No
 
     results = await team.deploy()
 
-    assert len(results) == 1
-    assert results[0].workflow_id == "refiner"
+    assert list(results.keys()) == ["refiner"]
+    assert results["refiner"].workflow_id == "refiner"
 
 
 async def test_team_deploy_threads_runtime_to_each_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,8 +123,8 @@ async def test_team_deploy_threads_runtime_to_each_subagent(monkeypatch: pytest.
 
     results = await team.deploy(runtime="self-host")
 
-    assert all(r.runtime == "self-host" for r in results)
-    assert all(r.url == "https://engine.internal:8080" for r in results)
+    assert all(r.runtime == "self-host" for r in results.values())
+    assert all(r.url == "https://engine.internal:8080" for r in results.values())
     assert all(inst.base_url == "https://engine.internal:8080" for inst in instances)
     assert all(inst.api_token == "tok-self" for inst in instances)
 
@@ -130,7 +136,98 @@ async def test_team_deploy_with_schedule_schedules_each_subagent(monkeypatch: py
 
     results = await team.deploy(schedule="0 9 * * *")
 
-    assert all(r.scheduled for r in results)
+    assert all(r.scheduled for r in results.values())
     # Each sub-agent's workflow got its own cron job.
     assert all(len(inst.cron) == 1 for inst in instances)
     assert {inst.cron[0]["workflow_id"] for inst in instances} == {"a", "b"}
+
+
+# ── child-crash isolation: one failed sub-agent never aborts the team ─────────
+
+
+async def test_team_deploy_isolates_a_failing_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A middle sub-agent whose deploy raises must NOT abort the team.
+
+    The returned mapping carries the two successful :class:`DeployResult`s AND the
+    captured exception for the failed member, keyed by agent name — mirroring the
+    run path's per-agent isolation. The team itself does not raise.
+    """
+    _clear_env(monkeypatch)
+
+    class _BoomError(RuntimeError):
+        pass
+
+    class _FailingMiddleClient:
+        def __init__(self, base_url: str = "http://localhost:7700", api_token: str | None = None) -> None:
+            self.base_url = base_url
+            self.api_token = api_token
+
+        async def __aenter__(self) -> _FailingMiddleClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+            if ir["workflow_id"] == "beta":
+                raise _BoomError("middle sub-agent deploy failed")
+            return {"workflow_id": ir["workflow_id"], "version": ir.get("version")}
+
+        async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+            return {"name": kwargs.get("name")}
+
+    def factory(
+        base_url: str = "http://localhost:7700", api_token: str | None = None, **_: Any
+    ) -> _FailingMiddleClient:
+        return _FailingMiddleClient(base_url=base_url, api_token=api_token)
+
+    monkeypatch.setattr("jamjet.client.JamjetClient", factory)
+
+    team = Sequential([_agent("alpha"), _agent("beta"), _agent("gamma")])
+
+    # Must NOT raise even though the middle sub-agent's deploy fails.
+    results = await team.deploy()
+
+    assert isinstance(results, dict)
+    assert list(results.keys()) == ["alpha", "beta", "gamma"]
+    # The two healthy sub-agents still registered.
+    assert isinstance(results["alpha"], DeployResult)
+    assert isinstance(results["gamma"], DeployResult)
+    assert results["alpha"].workflow_id == "alpha"
+    assert results["gamma"].workflow_id == "gamma"
+    # The failed member's exception is captured as its value, not raised.
+    assert isinstance(results["beta"], _BoomError)
+
+
+async def test_team_deploy_returns_mapping_keyed_by_agent_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: the mapping is keyed by each agent name, in declared order."""
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    team = Sequential([_agent("alpha"), _agent("beta"), _agent("gamma")])
+
+    results = await team.deploy()
+
+    assert isinstance(results, dict)
+    assert list(results.keys()) == ["alpha", "beta", "gamma"]
+    assert all(isinstance(v, DeployResult) for v in results.values())
+    assert {name: r.workflow_id for name, r in results.items()} == {
+        "alpha": "alpha",
+        "beta": "beta",
+        "gamma": "gamma",
+    }
+
+
+async def test_team_deploy_threads_max_turns_to_each_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``max_turns`` flows through to each sub-agent's compiled IR."""
+    _clear_env(monkeypatch)
+    instances = _patch_client(monkeypatch)
+    team = Sequential([_agent("alpha"), _agent("beta")])
+
+    await team.deploy(max_turns=12)
+
+    for inst in instances:
+        ir = inst.created[0]
+        name = ir["workflow_id"]
+        # Registered at the requested max_turns, not the default 8.
+        assert ir == compile_agent_to_ir(_agent(name), "", max_turns=12)
+        assert ir != compile_agent_to_ir(_agent(name), "", max_turns=8)

--- a/sdk/python/tests/test_team_deploy.py
+++ b/sdk/python/tests/test_team_deploy.py
@@ -1,0 +1,136 @@
+"""Tests for ``Team.deploy`` (Track 7a-3) — register each sub-agent's workflow.
+
+A team is N agent IRs (Track 6, Path A): deploy reuses :meth:`Agent.deploy` per
+sub-agent and returns one :class:`DeployResult` per member. The Python
+orchestration (sequencing / routing / merge) still runs client-side; deploy
+pre-registers the building blocks. We mock ``JamjetClient`` and collect every
+constructed instance so we can assert each sub-agent was registered against the
+resolved runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jamjet.agents.agent import Agent
+from jamjet.deploy import LOCAL_RUNTIME_URL, DeployResult
+from jamjet.team import Loop, Parallel, Sequential
+from jamjet.tools.decorators import tool
+
+
+@tool
+async def echo(text: str) -> str:
+    """Echo the text."""
+    return text
+
+
+def _agent(name: str) -> Agent:
+    return Agent(name, model="anthropic/claude-sonnet-4-6", tools=[echo], instructions="x")
+
+
+class _FakeDeployClient:
+    def __init__(self, base_url: str = "http://localhost:7700", api_token: str | None = None) -> None:
+        self.base_url = base_url
+        self.api_token = api_token
+        self.created: list[dict[str, Any]] = []
+        self.cron: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeDeployClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def create_workflow(self, ir: dict[str, Any]) -> dict[str, Any]:
+        self.created.append(ir)
+        return {"workflow_id": ir["workflow_id"], "version": ir.get("version")}
+
+    async def create_cron_job(self, **kwargs: Any) -> dict[str, Any]:
+        self.cron.append(kwargs)
+        return {"name": kwargs.get("name")}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch) -> list[_FakeDeployClient]:
+    """Patch JamjetClient; collect EVERY constructed instance (one per sub-agent)."""
+    instances: list[_FakeDeployClient] = []
+
+    def factory(base_url: str = "http://localhost:7700", api_token: str | None = None, **_: Any) -> _FakeDeployClient:
+        client = _FakeDeployClient(base_url=base_url, api_token=api_token)
+        instances.append(client)
+        return client
+
+    monkeypatch.setattr("jamjet.client.JamjetClient", factory)
+    return instances
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("JAMJET_RUNTIME_URL", "JAMJET_RUNTIME_TOKEN", "JAMJET_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+async def test_sequential_deploys_each_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    instances = _patch_client(monkeypatch)
+    team = Sequential([_agent("alpha"), _agent("beta")])
+
+    results = await team.deploy()
+
+    assert isinstance(results, list)
+    assert len(results) == 2
+    assert all(isinstance(r, DeployResult) for r in results)
+    assert [r.workflow_id for r in results] == ["alpha", "beta"]
+    # One client per sub-agent, each registered its own IR against LOCAL.
+    assert len(instances) == 2
+    assert {inst.created[0]["workflow_id"] for inst in instances} == {"alpha", "beta"}
+    assert all(r.url == LOCAL_RUNTIME_URL for r in results)
+
+
+async def test_parallel_deploys_each_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    team = Parallel([_agent("a"), _agent("b"), _agent("c")])
+
+    results = await team.deploy()
+
+    assert [r.workflow_id for r in results] == ["a", "b", "c"]
+
+
+async def test_loop_deploys_single_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    _patch_client(monkeypatch)
+    team = Loop(_agent("refiner"), max_iters=3)
+
+    results = await team.deploy()
+
+    assert len(results) == 1
+    assert results[0].workflow_id == "refiner"
+
+
+async def test_team_deploy_threads_runtime_to_each_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("JAMJET_RUNTIME_URL", "https://engine.internal:8080")
+    monkeypatch.setenv("JAMJET_RUNTIME_TOKEN", "tok-self")
+    instances = _patch_client(monkeypatch)
+    team = Sequential([_agent("alpha"), _agent("beta")])
+
+    results = await team.deploy(runtime="self-host")
+
+    assert all(r.runtime == "self-host" for r in results)
+    assert all(r.url == "https://engine.internal:8080" for r in results)
+    assert all(inst.base_url == "https://engine.internal:8080" for inst in instances)
+    assert all(inst.api_token == "tok-self" for inst in instances)
+
+
+async def test_team_deploy_with_schedule_schedules_each_subagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    instances = _patch_client(monkeypatch)
+    team = Parallel([_agent("a"), _agent("b")])
+
+    results = await team.deploy(schedule="0 9 * * *")
+
+    assert all(r.scheduled for r in results)
+    # Each sub-agent's workflow got its own cron job.
+    assert all(len(inst.cron) == 1 for inst in instances)
+    assert {inst.cron[0]["workflow_id"] for inst in instances} == {"a", "b"}


### PR DESCRIPTION
## What

Track 7a of the 9-track ADK plan (M3) - the deploy surface. All Python.

A finished agent ships the SAME compiled IR to any runtime over the existing durable path:

- **`agent.deploy(runtime="local" | "self-host" | "cloud" | "<url>", schedule=None, max_turns=8)`** - compiles the agent IR (the same `compile_agent_to_ir` that `run_durable` uses) and registers it via `JamjetClient.create_workflow` (or `create_cron_job` when a schedule is given). Returns a `DeployResult { workflow_id, runtime, url, scheduled, cloud_governance }`.
- **`Team.deploy(...)`** - registers each sub-agent's workflow (a Team is N agent IRs, per Track 6 Path A) and returns a `{name: DeployResult | exception}` mapping with the same per-agent isolation as the run path.
- **`jamjet deploy --runtime ...`** - the CLI uses the same resolver, so the CLI and `agent.deploy()` target identically.
- **A runtime resolver** maps `local` to `127.0.0.1:7700`, `self-host` to `JAMJET_RUNTIME_URL`, `cloud` to `JAMJET_CLOUD_RUNTIME_URL`, or takes a bare URL.

## The cloud leg is honest

Local SQLite and self-host are the same `jamjet-server` engine, differing only by URL and token, so "one IR, three runtimes" already holds for those two. There is no managed multi-tenant execution cell, and this does not pretend otherwise: `runtime="cloud"` ships the IR to **your** hosted engine URL and records that JamJet Cloud governance is wired. Cloud is the governance plane, independent of the runtime - deploy makes zero blocking Cloud calls and never targets `api.jamjet.dev` (which is the governance span API, not an engine). The `entry.deploy()` and `CloudRuntime` stubs that used to raise `NotImplementedError("Phase 5")` now redirect to `Agent.deploy()` with an honest message.

## The consistency contract

`docs/adk/consistency.md` describes the engine's real guarantees, each claim cited to the code: run-level strongly consistent (the fenced `commit_turn` atomic settle+event+snapshot, deterministic replay), cross-run eventually consistent (the read-side projection is asynchronous), content-addressed immutable artifacts. It states plainly what is not guaranteed (no managed cell, no cross-region). Every cited line was verified against `runtime/`.

## Safety

A whole-branch adversarial review passed with no Critical. It found one Important - `Team.deploy` originally used a list comprehension that aborted on the first sub-agent's deploy failure and discarded the already-successful results, silently dropping the team's child-crash-isolation contract. Fixed: it now isolates per-sub-agent failures into the returned mapping (mirroring the run path), proven by a test where a middle sub-agent's deploy raises and the rest still register. Three Minor findings were also fixed (deploy now exposes `max_turns` so it ships the same graph you tested, a docstring xref, and a consistency-doc sentence softened to match the per-execution projector). The review confirmed no prod-targeting footgun (deploy defaults to local; a remote URL is only hit when you pass one), governance is not stripped on deploy, and no test hits a network URL.

## Tests

1431 Python passed (+39 deploy tests): the resolver mapping, `Agent.deploy` registering the governed IR against the resolved URL, the cron path, `Team.deploy` per-agent isolation, the CLI parity, the entry-stub redirects, and the deploy example constructing.

## Follow-ups

F-t7-managed-cell (a real managed Cloud execution endpoint - separate private repo), F-t7-compose (a one-command self-host compose stack), F-t7-deploy-status. Track 7b (the six-page ADK doc set in the jamjet-docs repo) lands next as its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment support for agents and teams, including local, self-hosted, cloud, and direct URL targets.
  * Added a new example showing how to deploy an agent and optionally schedule it on a runtime.
  * Improved CLI deployment so runtime selection is clearer and supports authenticated targets.

* **Bug Fixes**
  * Clarified cloud/runtime error messages and removed outdated stub behavior.
  * Preserved deployment settings and governance details during deploys.

* **Documentation**
  * Expanded examples and deployment guidance with setup, runtime, and scheduling instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->