### PR TITLE
feat(track-9a): java_tool queue + JavaFn node (durable Java tool enabler)

### DIFF
--- a/runtime/api/tests/java_tool_roundtrip.rs
+++ b/runtime/api/tests/java_tool_roundtrip.rs
@@ -1,0 +1,330 @@
+//! Durable `java_tool` claim/complete round-trip against the HTTP work-item API.
+//!
+//! This proves the contract the Phase B Java tool-worker will implement: a
+//! workflow whose tool node is a `JavaFn` schedules a `java_tool` work item that
+//! an EXTERNAL worker claims over `POST /work-items/claim` (the engine's own pool
+//! registers `java_tool` with zero internal workers — see `default_pool`), and
+//! completing it over `POST /work-items/{id}/complete` advances the execution
+//! durably to a terminal state with the tool result committed to state.
+//!
+//! It mirrors the python_tool worker contract exactly — `execution_e2e.rs`
+//! (scheduler + worker pool over a shared SQLite backend) for the durable engine
+//! loop and `work_item_genai.rs` (in-process axum router) for the HTTP calls.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::{StateBackend, WorkItem, WorkflowDefinition};
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, SqliteBackend, DEFAULT_TENANT};
+use serde_json::Value;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn make_state(backend: Arc<dyn StateBackend>) -> AppState {
+    let backend_for_fn = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone(),
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| backend_for_fn.clone()),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+async fn body_json(body: Body) -> Value {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// A three-node workflow: `gate_in -> java_tool_node -> gate_out -> end`.
+///
+/// `java_tool_node` is a `JavaFn`, so the scheduler enriches its payload (class /
+/// method / input) and routes it to the `java_tool` queue. The two condition
+/// gates are ordinary nodes the engine's general workers drain — only the JavaFn
+/// node lands on `java_tool`, which an external worker (this test) must claim.
+fn java_tool_workflow_ir() -> Value {
+    let condition = |id: &str| {
+        serde_json::json!({
+            "id": id,
+            "kind": { "type": "condition", "branches": [] },
+            "retry_policy": null,
+            "node_timeout_secs": null,
+            "description": null,
+            "labels": {}
+        })
+    };
+    serde_json::json!({
+        "workflow_id": "java-tool-e2e",
+        "version": "0.1.0",
+        "name": null,
+        "description": null,
+        "state_schema": "",
+        "start_node": "gate_in",
+        "nodes": {
+            "gate_in": condition("gate_in"),
+            "java_tool_node": {
+                "id": "java_tool_node",
+                "kind": {
+                    "type": "java_fn",
+                    "class_name": "com.example.tools.WeatherTool",
+                    "method": "getWeather",
+                    "output_schema": ""
+                },
+                "retry_policy": "no_retry",
+                "node_timeout_secs": null,
+                "description": null,
+                "labels": {}
+            },
+            "gate_out": condition("gate_out")
+        },
+        "edges": [
+            { "from": "gate_in", "to": "java_tool_node", "condition": null },
+            { "from": "java_tool_node", "to": "gate_out", "condition": null },
+            { "from": "gate_out", "to": "end", "condition": null }
+        ],
+        "retry_policies": {},
+        "timeouts": {},
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {},
+        "labels": {}
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn java_tool_claim_complete_round_trip_advances_durably() {
+    // A temp-file SQLite DB shared across the scheduler, worker pool, and the
+    // HTTP router so the round-trip is genuinely durable (committed to disk).
+    let db_path = std::env::temp_dir().join(format!("jjtest-java-{}.db", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+    let backend: Arc<dyn StateBackend> =
+        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite backend"));
+
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: "java-tool-e2e".into(),
+            version: "0.1.0".into(),
+            ir: java_tool_workflow_ir(),
+            created_at: chrono::Utc::now(),
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
+
+    // Create the execution and enqueue the start node (mimics POST /executions).
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "java-tool-e2e".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "java-tool-e2e".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            2,
+            EventKind::NodeScheduled {
+                node_id: "gate_in".into(),
+                queue_type: "general".into(),
+            },
+        ))
+        .await
+        .expect("append NodeScheduled");
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: execution_id.clone(),
+            node_id: "gate_in".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({
+                "workflow_id": "java-tool-e2e",
+                "workflow_version": "0.1.0",
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    // Spawn the scheduler + the default worker pool. The pool registers
+    // `java_tool` with ZERO internal workers, so the JavaFn node's work item is
+    // claimable only by an external worker — which this test plays the part of.
+    let scheduler = jamjet_scheduler::Scheduler::new(backend.clone())
+        .with_poll_interval(Duration::from_millis(25));
+    let sched_handle = tokio::spawn(async move { scheduler.run().await });
+    let worker_handles = jamjet_worker::default_pool(backend.clone()).spawn();
+
+    let state = make_state(backend.clone());
+
+    // ── Act as the Java tool-worker: poll `POST /work-items/claim` until the
+    // `gate_in` condition completes and the scheduler enqueues the enriched
+    // `java_tool` work item. Bounded so a regression can never hang the suite.
+    let claimed = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let body = serde_json::json!({
+                "worker_id": "java-tool-worker-0",
+                "queue_types": ["java_tool"],
+            });
+            let resp = build_router_with_opts(state.clone(), true)
+                .oneshot(
+                    Request::post("/work-items/claim")
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "claim must not error");
+            let json = body_json(resp.into_body()).await;
+            if json["claimed"] == true {
+                return json["work_item"].clone();
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("a java_tool work item must become claimable");
+
+    // The claimed item is the JavaFn node on the java_tool queue, carrying the
+    // scheduler's enrichment the Phase B Java worker reflects/dispatches against.
+    assert_eq!(claimed["queue_type"], "java_tool");
+    assert_eq!(claimed["node_id"], "java_tool_node");
+    assert_eq!(
+        claimed["payload"]["class"], "com.example.tools.WeatherTool",
+        "claimed payload must carry the class name"
+    );
+    assert_eq!(
+        claimed["payload"]["method"], "getWeather",
+        "claimed payload must carry the method name"
+    );
+    assert!(
+        claimed["payload"]["input"].is_object(),
+        "claimed payload.input must be the accumulated workflow state"
+    );
+    let work_item_id = claimed["id"].as_str().expect("work item id").to_string();
+
+    // ── Complete the work item over HTTP with the tool result (the same path the
+    // python_tool worker uses), advancing the execution.
+    let complete_body = serde_json::json!({
+        "execution_id": execution_id.to_string(),
+        "node_id": "java_tool_node",
+        "output": { "temp_c": 18 },
+        "state_patch": { "java_result": "sunny" },
+        "duration_ms": 7
+    });
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post(format!("/work-items/{work_item_id}/complete"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&complete_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_json(resp.into_body()).await["completed"], true);
+
+    // ── The execution must now advance durably to a terminal state: the JavaFn
+    // node was drained by the external worker, so the scheduler routes
+    // `java_tool_node -> gate_out -> end` and detects completion.
+    let final_status = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let exec = backend
+                .get_execution(&execution_id)
+                .await
+                .expect("get_execution")
+                .expect("execution exists");
+            if matches!(
+                exec.status,
+                WorkflowStatus::Completed | WorkflowStatus::Failed
+            ) {
+                return exec.status;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    sched_handle.abort();
+    for h in worker_handles {
+        h.abort();
+    }
+
+    assert_eq!(
+        final_status.ok(),
+        Some(WorkflowStatus::Completed),
+        "completing the java_tool work item must drive the execution to completion"
+    );
+
+    // The tool result landed in committed (durable) state.
+    let exec = backend
+        .get_execution(&execution_id)
+        .await
+        .expect("get_execution")
+        .expect("execution exists");
+    assert_eq!(
+        exec.current_state["java_result"], "sunny",
+        "the java_tool result must be committed to execution state"
+    );
+
+    // The durable event log carries the JavaFn node's completion and the
+    // subsequent node was scheduled (the next node became runnable).
+    let events = backend.get_events(&execution_id).await.expect("get_events");
+    assert!(
+        events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::NodeCompleted { node_id, .. } if node_id == "java_tool_node"
+        )),
+        "a NodeCompleted event must be committed for the java_tool node"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::NodeScheduled { node_id, .. } if node_id == "gate_out"
+        )),
+        "the next node must be scheduled after the java_tool node completes"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}

--- a/runtime/api/tests/java_tool_roundtrip.rs
+++ b/runtime/api/tests/java_tool_roundtrip.rs
@@ -109,8 +109,11 @@ async fn java_tool_claim_complete_round_trip_advances_durably() {
     // HTTP router so the round-trip is genuinely durable (committed to disk).
     let db_path = std::env::temp_dir().join(format!("jjtest-java-{}.db", Uuid::new_v4()));
     let url = format!("sqlite://{}", db_path.display());
-    let backend: Arc<dyn StateBackend> =
-        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite backend"));
+    let backend: Arc<dyn StateBackend> = Arc::new(
+        SqliteBackend::open(&url)
+            .await
+            .expect("open sqlite backend"),
+    );
 
     backend
         .store_workflow(WorkflowDefinition {

--- a/runtime/core/src/node.rs
+++ b/runtime/core/src/node.rs
@@ -55,6 +55,18 @@ pub enum NodeKind {
         output_schema: String,
     },
 
+    /// Arbitrary Java method executed by an external Java tool-worker.
+    ///
+    /// The Java analog of [`NodeKind::PythonFn`]: a `class_name` + `method`
+    /// pair the worker reflects/dispatches. Routes to the `java_tool` queue,
+    /// which a net-new Java worker drains over the same HTTP claim/complete
+    /// API the Python `python_tool` worker uses — durable, exactly-once.
+    JavaFn {
+        class_name: String,
+        method: String,
+        output_schema: String,
+    },
+
     /// Router — evaluates expressions and branches.
     Condition { branches: Vec<ConditionalBranch> },
 
@@ -205,6 +217,7 @@ impl NodeKind {
             Self::Model { .. } => QueueType::Model,
             Self::Tool { .. } | Self::Finalizer { .. } => QueueType::Tool,
             Self::PythonFn { .. } => QueueType::PythonTool,
+            Self::JavaFn { .. } => QueueType::JavaTool,
             Self::MemoryRetrieval { .. } => QueueType::Retrieval,
             Self::McpTool { .. } | Self::A2aTask { .. } => QueueType::Tool,
             Self::Agent { .. } => QueueType::General,
@@ -231,6 +244,7 @@ pub enum QueueType {
     Model,
     Tool,
     PythonTool,
+    JavaTool,
     Retrieval,
     Privileged,
     General,
@@ -398,6 +412,43 @@ mod tests {
         assert!(matches!(deserialized, NodeKind::AgentTool { .. }));
         assert_eq!(node.queue_type(), QueueType::General);
         assert!(node.is_durable());
+    }
+
+    #[test]
+    fn java_fn_node_round_trip() {
+        let node = NodeKind::JavaFn {
+            class_name: "com.example.tools.WeatherTool".into(),
+            method: "getWeather".into(),
+            output_schema: "schemas.Weather".into(),
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let deserialized: NodeKind = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized, NodeKind::JavaFn { .. }));
+        assert!(node.is_durable());
+        // Node-kind serde tag mirrors PythonFn's snake_case ("python_fn" -> "java_fn").
+        assert_eq!(
+            serde_json::to_value(&node).unwrap()["type"],
+            "java_fn",
+            "JavaFn must serialize with the snake_case type tag"
+        );
+    }
+
+    #[test]
+    fn java_fn_dispatches_to_java_tool_queue() {
+        let node = NodeKind::JavaFn {
+            class_name: "com.example.tools.WeatherTool".into(),
+            method: "getWeather".into(),
+            output_schema: String::new(),
+        };
+        // Mirrors PythonFn -> PythonTool: JavaFn routes to its own durable queue.
+        assert_eq!(node.queue_type(), QueueType::JavaTool);
+        // The queue string the work item carries (routes.rs/runner.rs serialize
+        // `queue_type()` to snake_case) must be exactly "java_tool".
+        assert_eq!(
+            serde_json::to_value(node.queue_type()).unwrap(),
+            "java_tool",
+            "QueueType::JavaTool must serialize to the \"java_tool\" queue string"
+        );
     }
 
     #[test]

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -2336,9 +2336,10 @@ mod tests {
         );
         // SCHEDULES to java_tool: the NodeScheduled event carries the queue.
         let tools_queue = evs.iter().find_map(|ev| match &ev.kind {
-            EventKind::NodeScheduled { node_id, queue_type } if node_id == "tools_0" => {
-                Some(queue_type.clone())
-            }
+            EventKind::NodeScheduled {
+                node_id,
+                queue_type,
+            } if node_id == "tools_0" => Some(queue_type.clone()),
             _ => None,
         });
         assert_eq!(

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -2182,6 +2182,192 @@ mod tests {
         assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
     }
 
+    /// A `java_fn`-kind tool-dispatch node — the Java analog of the PythonFn
+    /// tool node `compile_agent_to_ir` emits. The Java `Agent` builder (Phase B)
+    /// emits these so the agent loop's tools route to the durable `java_tool`
+    /// queue an external Java worker drains. `no_retry` mirrors the PythonFn tool
+    /// node: the dispatch runs user `@Tool` methods (possible non-idempotent
+    /// writes), so an already-succeeded dispatch must not re-run on retry.
+    fn java_fn_node(id: &str, class_name: &str, method: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "kind": {
+                "type": "java_fn",
+                "class_name": class_name,
+                "method": method,
+                "output_schema": ""
+            },
+            "retry_policy": "no_retry",
+            "node_timeout_secs": null,
+            "description": null,
+            "labels": {}
+        })
+    }
+
+    /// A `model`-kind agent-turn node carrying OpenAI tool schemas, the way
+    /// `compile_agent_to_ir` emits them. `with_tools=false` is the final-answer
+    /// node (no tools, so the model must return text).
+    fn agent_model_node(id: &str, with_tools: bool) -> serde_json::Value {
+        let tools = if with_tools {
+            serde_json::json!([
+                {"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}
+            ])
+        } else {
+            serde_json::json!([])
+        };
+        serde_json::json!({
+            "id": id,
+            "kind": {
+                "type": "model",
+                "model_ref": "agent_model",
+                "prompt_ref": "",
+                "output_schema": "",
+                "system_prompt": "You are a helpful agent.",
+                "tools": tools
+            },
+            "retry_policy": "llm_default",
+            "node_timeout_secs": null,
+            "description": null,
+            "labels": {}
+        })
+    }
+
+    /// The Java analog of `agent_loop_ir`: the SAME static-unroll agent loop
+    /// (`model -> tool-gate -> tool-dispatch -> model`), but the tool-dispatch
+    /// nodes are `java_fn` (route to `java_tool`) instead of `python_fn`. This
+    /// documents the IR shape the Java `Agent` builder (Phase B) must emit.
+    fn java_agent_loop_ir() -> serde_json::Value {
+        let tool_calls = "state.last_model_finish_reason == \"tool_calls\"";
+        let mut ir = build_ir(
+            "model_0",
+            serde_json::json!({
+                "model_0": agent_model_node("model_0", true),
+                "gate_0": cond_node("gate_0", serde_json::json!([
+                    {"condition": tool_calls, "target": "tools_0"},
+                    {"condition": null, "target": "end"}
+                ])),
+                "tools_0": java_fn_node("tools_0", "com.example.AgentTools", "dispatch"),
+                "model_1": agent_model_node("model_1", true),
+                "gate_1": cond_node("gate_1", serde_json::json!([
+                    {"condition": tool_calls, "target": "tools_1"},
+                    {"condition": null, "target": "end"}
+                ])),
+                "tools_1": java_fn_node("tools_1", "com.example.AgentTools", "dispatch"),
+                "model_2": agent_model_node("model_2", false)
+                // `end` is the terminal sentinel — edges target it, but it is NOT
+                // a node (the validator + scheduler treat edge-to-"end" as the
+                // terminal), matching `compile_agent_to_ir`'s emitted IR.
+            }),
+            serde_json::json!([
+                {"from": "model_0", "to": "gate_0", "condition": null},
+                {"from": "gate_0", "to": "tools_0", "condition": tool_calls},
+                {"from": "gate_0", "to": "end", "condition": null},
+                {"from": "tools_0", "to": "model_1", "condition": null},
+                {"from": "model_1", "to": "gate_1", "condition": null},
+                {"from": "gate_1", "to": "tools_1", "condition": tool_calls},
+                {"from": "gate_1", "to": "end", "condition": null},
+                {"from": "tools_1", "to": "model_2", "condition": null},
+                {"from": "model_2", "to": "end", "condition": null}
+            ]),
+        );
+        // Register the model the agent-turn model nodes reference, so the IR
+        // validates (the engine accepts/registers the agent loop).
+        ir["models"] = serde_json::json!({
+            "agent_model": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "timeout_secs": null,
+                "retry_policy": null,
+                "temperature": null,
+                "max_tokens": 1024
+            }
+        });
+        ir
+    }
+
+    /// A-4: the engine REGISTERS (validates) a JavaFn agent-loop IR and SCHEDULES
+    /// its tool node to the `java_tool` queue. The model turn is a deterministic
+    /// mock — we append the model's `NodeCompleted` (finish_reason "tool_calls")
+    /// the way a model worker would, then the gate routes to the JavaFn node.
+    #[tokio::test]
+    async fn java_agent_loop_ir_registers_and_schedules_java_tool_node() {
+        let ir_json = java_agent_loop_ir();
+
+        // REGISTERS: the engine's IR validator accepts the JavaFn agent loop.
+        let parsed: jamjet_ir::WorkflowIr = serde_json::from_value(ir_json.clone())
+            .expect("JavaFn agent-loop IR must deserialize into WorkflowIr");
+        jamjet_ir::validate_workflow(&parsed)
+            .expect("the engine must accept (register) a JavaFn agent-loop IR");
+
+        let (s, b, e) = setup(ir_json).await;
+
+        // Tick 1: model_0 (start) is scheduled.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(scheduled_nodes(&evs).contains(&"model_0".to_string()));
+
+        // Deterministic mock model: model_0 asks for a tool (finish_reason
+        // "tool_calls"), exactly what drives the gate to the tool-dispatch node.
+        append(
+            &b,
+            &e,
+            node_completed(
+                "model_0",
+                serde_json::json!({"last_model_finish_reason": "tool_calls"}),
+            ),
+        )
+        .await;
+
+        // Tick 2: gate_0 becomes runnable; route it to tools_0.
+        tick(&s, &e).await;
+        append(
+            &b,
+            &e,
+            condition_completed("gate_0", Some("tools_0"), &["tools_0", "end"]),
+        )
+        .await;
+
+        // Tick 3: the JavaFn tool node is scheduled.
+        tick(&s, &e).await;
+        let evs = b.get_events(&e).await.unwrap();
+        assert!(
+            scheduled_nodes(&evs).contains(&"tools_0".to_string()),
+            "the JavaFn tool node must be scheduled when the gate routes to it"
+        );
+        // SCHEDULES to java_tool: the NodeScheduled event carries the queue.
+        let tools_queue = evs.iter().find_map(|ev| match &ev.kind {
+            EventKind::NodeScheduled { node_id, queue_type } if node_id == "tools_0" => {
+                Some(queue_type.clone())
+            }
+            _ => None,
+        });
+        assert_eq!(
+            tools_queue.as_deref(),
+            Some("java_tool"),
+            "the agent-loop tool node must be scheduled to the java_tool queue"
+        );
+
+        // The enqueued work item is a claimable java_tool item carrying the
+        // dispatch enrichment the Phase B Java worker reflects against.
+        let item = b
+            .claim_work_item("java-tool-worker", &["java_tool"])
+            .await
+            .unwrap()
+            .expect("the scheduled JavaFn node must enqueue a java_tool work item");
+        assert_eq!(item.queue_type, "java_tool");
+        assert_eq!(item.node_id, "tools_0");
+        assert_eq!(item.payload["class"], "com.example.AgentTools");
+        assert_eq!(item.payload["method"], "dispatch");
+        assert!(
+            item.payload["input"].is_object(),
+            "payload.input must carry the accumulated agent state"
+        );
+
+        // The loop is still live: nothing wrongly skipped, terminal not reached.
+        assert!(skipped_nodes(&evs).is_empty());
+        assert_eq!(status(&b, &e).await, WorkflowStatus::Running);
+    }
+
     /// A diamond AND-join: `C -> {L, R}`, `L -> J`, `R -> J`, `J -> end`.
     /// `C` routes to `L`. The dead branch `R` is skipped, but `J` STILL RUNS
     /// (live in-edge from L) once L completes — neither premature completion

--- a/runtime/scheduler/src/runner.rs
+++ b/runtime/scheduler/src/runner.rs
@@ -456,6 +456,31 @@ impl Scheduler {
                     );
                 }
 
+                // For JavaFn nodes, enrich the payload so the external Java
+                // tool-worker is self-contained — exactly mirroring the PythonFn
+                // arm above, bar the language-appropriate dispatch coordinates:
+                // it needs the class to reflect, the method to invoke, and the
+                // current workflow state as the call input. The Java worker
+                // claims these `java_tool` items over the same HTTP claim/complete
+                // API the Python worker uses, so the contract is identical.
+                if let NodeKind::JavaFn {
+                    class_name, method, ..
+                } = &node.kind
+                {
+                    let obj = payload
+                        .as_object_mut()
+                        .expect("payload is always a JSON object");
+                    obj.insert(
+                        "class".into(),
+                        serde_json::Value::String(class_name.clone()),
+                    );
+                    obj.insert("method".into(), serde_json::Value::String(method.clone()));
+                    obj.insert(
+                        "input".into(),
+                        serde_json::Value::Object(progress.final_state.clone()),
+                    );
+                }
+
                 // For Model nodes, enrich the payload with model configuration and tool
                 // schemas so the model worker is self-contained.
                 if let NodeKind::Model {
@@ -1466,6 +1491,96 @@ mod tests {
         assert_eq!(item.payload["workflow_id"], "wf");
         assert_eq!(item.payload["workflow_version"], "0.1.0");
         assert_eq!(item.payload["node_id"], "py_step");
+    }
+
+    /// A single-node workflow whose only step is a `JavaFn` (the Java analog of
+    /// the `python_fn_ir` fixture above).
+    fn java_fn_ir() -> serde_json::Value {
+        serde_json::json!({
+            "workflow_id": "wf",
+            "version": "0.1.0",
+            "name": null,
+            "description": null,
+            "state_schema": "",
+            "start_node": "java_step",
+            "nodes": {
+                "java_step": {
+                    "id": "java_step",
+                    "kind": {
+                        "type": "java_fn",
+                        "class_name": "com.example.tools.WeatherTool",
+                        "method": "getWeather",
+                        "output_schema": ""
+                    },
+                    "retry_policy": null,
+                    "node_timeout_secs": null,
+                    "description": null,
+                    "labels": {}
+                }
+            },
+            "edges": [],
+            "retry_policies": {},
+            "timeouts": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "labels": {}
+        })
+    }
+
+    /// The scheduler must enrich a `JavaFn` work-item payload with `class`,
+    /// `method`, and `input` so an external Java tool-worker is self-contained —
+    /// exactly mirroring the PythonFn enrichment (bar the dispatch coordinates),
+    /// and the work item must route to the `java_tool` queue.
+    #[tokio::test]
+    async fn java_fn_work_item_payload_is_enriched() {
+        let (s, b, e) = setup(java_fn_ir()).await;
+
+        // Seed some accumulated state so we can assert it lands in `input`.
+        append(
+            &b,
+            &e,
+            node_completed("prev_node", serde_json::json!({ "key": "value" })),
+        )
+        .await;
+
+        // Tick: `java_step` is the start node with no predecessors — runnable.
+        tick(&s, &e).await;
+
+        // Claim the work item from the java_tool queue.
+        let item = b
+            .claim_work_item("test-worker", &["java_tool"])
+            .await
+            .expect("backend claim must not error")
+            .expect("a JavaFn node must produce exactly one work item");
+
+        // Queue type
+        assert_eq!(item.queue_type, "java_tool");
+
+        // JavaFn-specific enrichment
+        assert_eq!(
+            item.payload["class"], "com.example.tools.WeatherTool",
+            "payload must carry the class name to reflect"
+        );
+        assert_eq!(
+            item.payload["method"], "getWeather",
+            "payload must carry the method name to invoke"
+        );
+        assert!(
+            item.payload["input"].is_object(),
+            "payload.input must be a JSON object (accumulated workflow state)"
+        );
+        // The state seeded above must be reflected in input.
+        assert_eq!(
+            item.payload["input"]["key"], "value",
+            "payload.input must reflect accumulated state patches"
+        );
+
+        // Base fields must still be present.
+        assert_eq!(item.payload["workflow_id"], "wf");
+        assert_eq!(item.payload["workflow_version"], "0.1.0");
+        assert_eq!(item.payload["node_id"], "java_step");
     }
 
     /// A single-node workflow whose only step is a `Model` node with tools.

--- a/runtime/workers/src/pool.rs
+++ b/runtime/workers/src/pool.rs
@@ -114,6 +114,10 @@ impl WorkerPool {
 ///   Python `@tool` nodes are executed by an external `jamjet worker` process;
 ///   no internal Rust worker claims this queue. Start the sidecar with:
 ///   `jamjet worker --queue python_tool`
+/// - 0 java workers (`["java_tool"]`) — intent registration only, mirroring
+///   `python_tool`. Durable Java `@Tool` nodes are executed by an external Java
+///   tool-worker that claims this queue over the same HTTP claim/complete API;
+///   no internal Rust worker claims it.
 pub fn default_pool(backend: Arc<dyn StateBackend>) -> WorkerPool {
     WorkerPool::new(backend)
         .with_group(WorkerGroupConfig::new(
@@ -142,5 +146,13 @@ pub fn default_pool(backend: Arc<dyn StateBackend>) -> WorkerPool {
             "python-worker",
             0,
             vec!["python_tool".into()],
+        ))
+        // Register java_tool as a known queue without spawning internal workers,
+        // mirroring python_tool. Items in this queue are claimed exclusively by an
+        // external Java tool-worker over the same HTTP claim/complete API.
+        .with_group(WorkerGroupConfig::new(
+            "java-worker",
+            0,
+            vec!["java_tool".into()],
         ))
 }


### PR DESCRIPTION
## What

Track 9 Phase A: engine support for a `java_tool` queue, so a Java agent's tool nodes route to a distinct durable queue that a Java tool-worker can drain. This is the enabler for first-class Java authoring (Phase B builds the Java `Agent` builder and the durable Java tool-worker; Phase C the Spring starter).

The change is a purely additive mirror of the existing `PythonFn` / `python_tool` path:

- A `JavaFn { class_name, method, output_schema }` node kind (the Java analog of `PythonFn`), mapping to a new `QueueType::JavaTool` (`"java_tool"`).
- Scheduler payload enrichment for `JavaFn`, inserting `class` / `method` / `input` exactly as the `PythonFn` arm inserts `module` / `function` / `input`.
- The worker pool registers the `java_tool` queue with zero internal workers (like `python_tool`), so an external Java worker claims it over the existing HTTP `claim` / `complete` API.

## Why

Java tools execute durably and exactly-once through the engine work-queue, the same way Python tools do. The work-queue is string-keyed (`work_items.queue_type` is TEXT and the claim endpoint matches `queue_types: Vec<String>`), so a Java worker needs no claim-mechanism change. The only engine gap was the node-kind-to-queue mapping and the scheduler payload enrichment, which this adds.

## Safety

A whole-branch adversarial review diffed every site that special-cases `PythonFn` / `python_tool` against the new `JavaFn` / `java_tool` handling (`queue_type()`, `is_durable()`, scheduler enrichment, work-item creation, claim / complete / fence / lease, idempotency, validation, and governance) and confirmed exact parity at each, with no `python_tool` regression and no governance bypass (both external queues skip node-level enforcement identically; governance rides at the model seam and the IR). The review ran all five new tests green.

## Tests

`cargo test --workspace` 644 passed (5 new): the `JavaFn` node round-trip and `queue_type()` mapping, the scheduler enrichment, an agent-loop IR with `JavaFn` tool nodes scheduling end to end, and a durable HTTP round-trip where an external worker claims a `java_tool` item, completes it, and the execution advances to `Completed` with the result committed to durable state. Python suite 1433 passed.

## Follow-ups

Phase B (jamjet-runtime-java: the Java `Agent` builder compiling to the agent-loop IR with `JavaFn` tool nodes, and the durable Java tool-worker with claim-fence and heartbeat), Phase C (jamjet-spring starter). The Java worker mirrors the Python worker's claim-fence and heartbeat; the Java `Agent` builder never emits a tool node as the start node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Java tool nodes in workflows, including routing work items to a dedicated Java queue.
  * Work item payloads now include the Java class, method, and workflow input needed by external workers.

* **Bug Fixes**
  * Improved end-to-end durability so Java tool steps can be completed externally and resume the workflow correctly.

* **Tests**
  * Added integration and unit coverage for Java tool dispatch, payload contents, queue routing, and durable workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->