### PR TITLE
fix(engine): fence the external-worker HTTP complete path (close duplicate-completion gap)

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1032,6 +1032,9 @@ async fn claim_work_item(
                 "queue_type": wi.queue_type,
                 "payload": wi.payload,
                 "attempt": wi.attempt,
+                // The lease fence the external worker echoes on complete so the
+                // engine can prove the lease is still held (exactly-once-COMMIT).
+                "lease_fence": wi.lease_fence,
             }
         }))),
         None => Ok(Json(json!({ "claimed": false }))),
@@ -1048,6 +1051,12 @@ struct CompleteWorkItemRequest {
     state_patch: Value,
     #[serde(default)]
     duration_ms: u64,
+    /// Lease fence echoed from the claim response. When present, the completion is
+    /// gated on it: a stale/forged fence is rejected (409) and NO `NodeCompleted`
+    /// is emitted. When absent, the legacy unfenced settle-by-id path is used
+    /// (backward-compat for callers not yet echoing the fence).
+    #[serde(default)]
+    lease_fence: Option<i64>,
     // ── GenAI telemetry (forwarded from the python_tool worker or other callers) ──
     /// AI provider system (e.g. "anthropic", "openai").
     #[serde(default)]
@@ -1072,13 +1081,33 @@ async fn complete_work_item(
     Extension(tenant_id): Extension<TenantId>,
     Path(id): Path<String>,
     Json(body): Json<CompleteWorkItemRequest>,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<(StatusCode, Json<Value>), ApiError> {
     let item_id = Uuid::parse_str(&id)
         .map_err(|_| ApiError::BadRequest(format!("invalid work item id: {id}")))?;
     let backend = state.backend_for(&tenant_id);
 
-    // Mark the work item as completed.
-    backend.complete_work_item(item_id).await?;
+    // Settle the work item. When the worker echoes its lease fence, the settle is
+    // fence-gated: a stale / forged fence (reclaimed or replayed worker) is
+    // rejected with 409 and we emit NO terminal event, so a lost lease can never
+    // duplicate a NodeCompleted. When the fence is absent, fall back to the legacy
+    // unfenced settle-by-id (backward-compat for callers not yet echoing it).
+    match body.lease_fence {
+        Some(fence) => {
+            let settled = backend.complete_work_item_fenced(item_id, fence).await?;
+            if !settled {
+                return Ok((
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "completed": false,
+                        "reason": "stale or invalid lease fence",
+                    })),
+                ));
+            }
+        }
+        None => {
+            backend.complete_work_item(item_id).await?;
+        }
+    }
 
     // Emit NodeCompleted event if execution_id and node_id are provided.
     if let (Some(exec_id_str), Some(node_id)) = (&body.execution_id, &body.node_id) {
@@ -1119,7 +1148,10 @@ async fn complete_work_item(
         }
     }
 
-    Ok(Json(json!({ "completed": true, "work_item_id": id })))
+    Ok((
+        StatusCode::OK,
+        Json(json!({ "completed": true, "work_item_id": id })),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/tests/java_tool_roundtrip.rs
+++ b/runtime/api/tests/java_tool_roundtrip.rs
@@ -246,15 +246,26 @@ async fn java_tool_claim_complete_round_trip_advances_durably() {
         "claimed payload.input must be the accumulated workflow state"
     );
     let work_item_id = claimed["id"].as_str().expect("work item id").to_string();
+    // The claim response carries the lease fence (F1) the external worker echoes
+    // on complete so the engine can prove the lease is still held.
+    let lease_fence = claimed["lease_fence"]
+        .as_i64()
+        .expect("claim response must carry lease_fence");
+    assert!(
+        lease_fence > 0,
+        "a claimed item must have a non-zero lease fence"
+    );
 
     // ── Complete the work item over HTTP with the tool result (the same path the
-    // python_tool worker uses), advancing the execution.
+    // python_tool worker uses), advancing the execution — echoing the lease fence
+    // so the completion is fence-validated end-to-end.
     let complete_body = serde_json::json!({
         "execution_id": execution_id.to_string(),
         "node_id": "java_tool_node",
         "output": { "temp_c": 18 },
         "state_patch": { "java_result": "sunny" },
-        "duration_ms": 7
+        "duration_ms": 7,
+        "lease_fence": lease_fence
     });
     let resp = build_router_with_opts(state.clone(), true)
         .oneshot(
@@ -327,6 +338,347 @@ async fn java_tool_claim_complete_round_trip_advances_durably() {
             EventKind::NodeScheduled { node_id, .. } if node_id == "gate_out"
         )),
         "the next node must be scheduled after the java_tool node completes"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+// ── Lease-fence validation on the external HTTP complete path ─────────────────
+//
+// The internal worker tier gets exactly-once-COMMIT from the lease fence
+// (`worker.rs` `commit_turn`); these tests prove the EXTERNAL HTTP complete path
+// (`POST /work-items/{id}/complete`) is fenced too, so a reclaimed / replayed
+// worker cannot settle a stale lease and duplicate a `NodeCompleted` event.
+//
+// They drive the complete handler directly (no scheduler / worker pool) so the
+// fence logic is isolated and deterministic.
+
+fn temp_sqlite_url() -> (std::path::PathBuf, String) {
+    let db_path = std::env::temp_dir().join(format!("jjtest-fence-{}.db", Uuid::new_v4()));
+    let url = format!("sqlite://{}", db_path.display());
+    (db_path, url)
+}
+
+/// Create a Running execution and enqueue a single claimable `java_tool` work
+/// item for it, mirroring what the scheduler would enqueue for a JavaFn node.
+async fn seed_claimable_java_item(backend: &Arc<dyn StateBackend>) -> ExecutionId {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "java-tool-fence".into(),
+            workflow_version: "0.1.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: serde_json::json!({}),
+            current_state: serde_json::json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    backend
+        .append_event(Event::new(
+            execution_id.clone(),
+            1,
+            EventKind::WorkflowStarted {
+                workflow_id: "java-tool-fence".into(),
+                workflow_version: "0.1.0".into(),
+                initial_input: serde_json::json!({}),
+            },
+        ))
+        .await
+        .expect("append WorkflowStarted");
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: execution_id.clone(),
+            node_id: "java_tool_node".into(),
+            queue_type: "java_tool".into(),
+            payload: serde_json::json!({
+                "class": "com.example.tools.WeatherTool",
+                "method": "getWeather",
+                "input": {},
+            }),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+    execution_id
+}
+
+/// Claim the single `java_tool` item over HTTP; returns the `work_item` JSON
+/// (which, after F1, carries `lease_fence`).
+async fn http_claim_java(state: &AppState) -> Value {
+    let body = serde_json::json!({
+        "worker_id": "java-fence-worker",
+        "queue_types": ["java_tool"],
+    });
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post("/work-items/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "claim must not error");
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["claimed"], true, "an item must be claimable");
+    json["work_item"].clone()
+}
+
+/// Complete a work item over HTTP; returns the (status, body) pair.
+async fn http_complete(state: &AppState, item_id: &str, body: Value) -> (StatusCode, Value) {
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post(format!("/work-items/{item_id}/complete"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    (status, body_json(resp.into_body()).await)
+}
+
+/// Count `NodeCompleted` events for `node_id` in the durable event log.
+async fn count_node_completed(
+    backend: &Arc<dyn StateBackend>,
+    eid: &ExecutionId,
+    node_id: &str,
+) -> usize {
+    backend
+        .get_events(eid)
+        .await
+        .expect("get_events")
+        .iter()
+        .filter(|e| matches!(&e.kind, EventKind::NodeCompleted { node_id: n, .. } if n == node_id))
+        .count()
+}
+
+/// Happy path: claim returns the fence (F1), and completing WITH the matching
+/// fence settles the item, emits `NodeCompleted`, and lands the result in state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn complete_with_matching_fence_succeeds() {
+    let (db_path, url) = temp_sqlite_url();
+    let backend: Arc<dyn StateBackend> =
+        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite"));
+    let execution_id = seed_claimable_java_item(&backend).await;
+    let state = make_state(backend.clone());
+
+    let claimed = http_claim_java(&state).await;
+    // F1: the claim response must carry the lease fence so the worker can echo it.
+    let fence = claimed["lease_fence"]
+        .as_i64()
+        .expect("claim response must carry lease_fence");
+    assert!(fence > 0, "a claimed item must have a non-zero lease fence");
+    let item_id = claimed["id"].as_str().unwrap().to_string();
+
+    let (status, body) = http_complete(
+        &state,
+        &item_id,
+        serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "java_tool_node",
+            "output": { "temp_c": 18 },
+            "state_patch": { "java_result": "sunny" },
+            "duration_ms": 7,
+            "lease_fence": fence
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "matching fence must be accepted");
+    assert_eq!(body["completed"], true);
+    assert_eq!(
+        count_node_completed(&backend, &execution_id, "java_tool_node").await,
+        1,
+        "exactly one NodeCompleted must be committed"
+    );
+    let exec = backend.get_execution(&execution_id).await.unwrap().unwrap();
+    assert_eq!(
+        exec.current_state["java_result"], "sunny",
+        "the result must land in durable state"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+/// Adversarial dual: an item is claimed (fence F1), then RECLAIMED (a fresh claim
+/// mints F2 > F1). A complete carrying the OLD fence F1 — or a forged fence — is
+/// REJECTED with 409, appends NO `NodeCompleted`, and does NOT double-settle. The
+/// current holder (F2) can still settle exactly once afterward.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn complete_with_stale_or_forged_fence_is_rejected() {
+    let (db_path, url) = temp_sqlite_url();
+    let backend: Arc<dyn StateBackend> =
+        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite"));
+    let execution_id = seed_claimable_java_item(&backend).await;
+    let state = make_state(backend.clone());
+
+    // First claim → fence F1.
+    let first = http_claim_java(&state).await;
+    let item_id = first["id"].as_str().unwrap().to_string();
+    let fence_1 = first["lease_fence"].as_i64().expect("F1 fence");
+    let wi_id = Uuid::parse_str(&item_id).unwrap();
+
+    // Simulate a reclaim: park the leased item back to pending (fence-guarded by
+    // F1, made immediately visible) then claim again → a strictly-greater F2.
+    let past = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+    let parked = backend
+        .park_work_item(wi_id, fence_1, &past, 1)
+        .await
+        .expect("park_work_item");
+    assert!(parked, "parking with the held fence must succeed");
+    let second = http_claim_java(&state).await;
+    assert_eq!(
+        second["id"].as_str().unwrap(),
+        item_id,
+        "the reclaim must be the same item"
+    );
+    let fence_2 = second["lease_fence"].as_i64().expect("F2 fence");
+    assert!(
+        fence_2 > fence_1,
+        "a reclaim must mint a strictly-greater fence (F2={fence_2} > F1={fence_1})"
+    );
+
+    // Zombie worker completes with the STALE fence F1 → must be rejected.
+    let (status, body) = http_complete(
+        &state,
+        &item_id,
+        serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "java_tool_node",
+            "output": { "stale": true },
+            "state_patch": { "java_result": "STALE" },
+            "duration_ms": 1,
+            "lease_fence": fence_1
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a stale fence must be rejected with 409"
+    );
+    assert_eq!(
+        body["completed"], false,
+        "the stale completion must report completed=false"
+    );
+    assert_eq!(
+        count_node_completed(&backend, &execution_id, "java_tool_node").await,
+        0,
+        "a stale completion must NOT append a NodeCompleted event"
+    );
+
+    // Forged / absent-from-the-table fence value → also rejected.
+    let (forged_status, forged_body) = http_complete(
+        &state,
+        &item_id,
+        serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "java_tool_node",
+            "output": { "forged": true },
+            "state_patch": { "java_result": "FORGED" },
+            "duration_ms": 1,
+            "lease_fence": 999_999_999_i64
+        }),
+    )
+    .await;
+    assert_eq!(
+        forged_status,
+        StatusCode::CONFLICT,
+        "a forged fence must be rejected"
+    );
+    assert_eq!(forged_body["completed"], false);
+    assert_eq!(
+        count_node_completed(&backend, &execution_id, "java_tool_node").await,
+        0,
+        "a forged completion must NOT append a NodeCompleted event"
+    );
+
+    // The state was never mutated by the rejected attempts.
+    let exec = backend.get_execution(&execution_id).await.unwrap().unwrap();
+    assert!(
+        exec.current_state.get("java_result").is_none(),
+        "no rejected state_patch may be applied"
+    );
+
+    // The legitimate current holder (F2) settles exactly once.
+    let (ok_status, ok_body) = http_complete(
+        &state,
+        &item_id,
+        serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "java_tool_node",
+            "output": { "ok": true },
+            "state_patch": { "java_result": "fresh" },
+            "duration_ms": 2,
+            "lease_fence": fence_2
+        }),
+    )
+    .await;
+    assert_eq!(
+        ok_status,
+        StatusCode::OK,
+        "the current fence holder must settle"
+    );
+    assert_eq!(ok_body["completed"], true);
+    assert_eq!(
+        count_node_completed(&backend, &execution_id, "java_tool_node").await,
+        1,
+        "the legitimate completion appends exactly one NodeCompleted"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+/// Backward-compat: a complete with NO `lease_fence` keeps the current unfenced
+/// behavior, so existing callers that do not yet echo a fence do not break.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn complete_without_fence_is_backward_compatible() {
+    let (db_path, url) = temp_sqlite_url();
+    let backend: Arc<dyn StateBackend> =
+        Arc::new(SqliteBackend::open(&url).await.expect("open sqlite"));
+    let execution_id = seed_claimable_java_item(&backend).await;
+    let state = make_state(backend.clone());
+
+    let claimed = http_claim_java(&state).await;
+    let item_id = claimed["id"].as_str().unwrap().to_string();
+
+    // No `lease_fence` field at all — the legacy unfenced path.
+    let (status, body) = http_complete(
+        &state,
+        &item_id,
+        serde_json::json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "java_tool_node",
+            "output": { "legacy": true },
+            "state_patch": { "java_result": "legacy" },
+            "duration_ms": 3
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "absent fence must keep working");
+    assert_eq!(body["completed"], true);
+    assert_eq!(
+        count_node_completed(&backend, &execution_id, "java_tool_node").await,
+        1,
+        "the unfenced path still emits NodeCompleted"
     );
 
     let _ = std::fs::remove_file(&db_path);

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -227,6 +227,22 @@ pub trait StateBackend: Send + Sync {
     /// Mark a work item as completed and release the lease.
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()>;
 
+    /// Fence-guarded completion of a work item. Settles the item ONLY if the
+    /// stored `lease_fence` still matches AND the item is still claimable
+    /// (`status = 'claimed'`), returning `true` iff a row was actually updated.
+    ///
+    /// Returns `false` — never an error — on a fence mismatch, an already-settled
+    /// item, or one that was reclaimed under a newer fence. This is the
+    /// exactly-once-COMMIT guard for the EXTERNAL HTTP worker path: a reclaimed /
+    /// replayed worker holding a stale fence is rejected (`false`) so the caller
+    /// can refuse to emit a duplicate terminal event. Mirrors the fence semantics
+    /// (`term * 2^32 + epoch`) the internal worker tier gets from `commit_turn`.
+    async fn complete_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool>;
+
     /// Mark a work item as failed. The scheduler will decide whether to retry.
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()>;
 

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -446,16 +446,19 @@ impl StateBackend for InMemoryBackend {
         //   2. A stale fence after a reclaim — `reclaim_expired_leases` clears
         //      `worker_id` but LEAVES `lease_fence` set, so the old fence lingers.
         // Either case now returns `Ok(false)`. A mismatched fence, an absent
-        // item, or one already settled (removed) also returns `false`. The
-        // get-then-remove is two DashMap ops rather than one atomic step; that is
-        // acceptable for the in-memory dev/test backend (the SQLite backends are
-        // the production path where atomicity is guaranteed by the single UPDATE).
-        match self.work_items.get(&item_id) {
-            Some(entry) if entry.worker_id.is_some() && entry.lease_fence == lease_fence => {}
-            _ => return Ok(false),
-        }
-        self.work_items.remove(&item_id);
-        Ok(true)
+        // item, or one already settled (removed) also returns `false`.
+        //
+        // `remove_if` makes the guard check and the delete a SINGLE atomic step
+        // (it holds the shard lock across the predicate and removal), closing the
+        // get-then-remove TOCTOU where two concurrent settles could both observe a
+        // claimed+matching item and both remove it. It returns `Some` iff the
+        // predicate held and the entry was removed, so exactly one racer settles.
+        Ok(self
+            .work_items
+            .remove_if(&item_id, |_k, entry| {
+                entry.worker_id.is_some() && entry.lease_fence == lease_fence
+            })
+            .is_some())
     }
 
     async fn commit_turn(

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -422,6 +422,25 @@ impl StateBackend for InMemoryBackend {
         Ok(())
     }
 
+    async fn complete_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        // Mirror the `commit_turn` fence guard: only the current holder (matching
+        // fence) of a still-present (claimed) item may settle. A mismatched fence,
+        // an absent item, or one already settled (removed) returns `false`. The
+        // get-then-remove is two DashMap ops rather than one atomic step; that is
+        // acceptable for the in-memory dev/test backend (the SQLite backends are
+        // the production path where atomicity is guaranteed by the single UPDATE).
+        match self.work_items.get(&item_id) {
+            Some(entry) if entry.lease_fence == lease_fence => {}
+            _ => return Ok(false),
+        }
+        self.work_items.remove(&item_id);
+        Ok(true)
+    }
+
     async fn commit_turn(
         &self,
         item_id: WorkItemId,

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -87,6 +87,16 @@ impl InMemoryBackend {
     pub fn seed_tool_effect_for_test(&self, key: String, value: serde_json::Value) {
         self.tool_effects.insert(key, value);
     }
+
+    /// Test helper: backdate a work item's lease so the reclaim sweep
+    /// (`reclaim_expired_leases`) treats it as expired. Mirrors
+    /// `SqliteBackend::force_lease_expired_for_test`. Not part of the
+    /// StateBackend trait; only used in tests / simulators.
+    pub fn force_lease_expired_for_test(&self, item_id: WorkItemId) {
+        if let Some(mut entry) = self.work_items.get_mut(&item_id) {
+            entry.lease_expires_at = Some(Utc::now() - chrono::Duration::hours(1));
+        }
+    }
 }
 
 impl Default for InMemoryBackend {
@@ -427,14 +437,21 @@ impl StateBackend for InMemoryBackend {
         item_id: WorkItemId,
         lease_fence: i64,
     ) -> BackendResult<bool> {
-        // Mirror the `commit_turn` fence guard: only the current holder (matching
-        // fence) of a still-present (claimed) item may settle. A mismatched fence,
-        // an absent item, or one already settled (removed) returns `false`. The
+        // Mirror the SQLite `status = 'claimed'` guard: only the current holder
+        // of a still-CLAIMED item may settle. "Claimed" in memory is
+        // `worker_id.is_some()` (the same predicate `claim_work_item` uses).
+        // Requiring it closes two fail-opens a fence-only check leaves open:
+        //   1. A forged `lease_fence: 0` against a never-claimed pending item —
+        //      pending items carry `lease_fence == 0`, so `0 == 0` would match.
+        //   2. A stale fence after a reclaim — `reclaim_expired_leases` clears
+        //      `worker_id` but LEAVES `lease_fence` set, so the old fence lingers.
+        // Either case now returns `Ok(false)`. A mismatched fence, an absent
+        // item, or one already settled (removed) also returns `false`. The
         // get-then-remove is two DashMap ops rather than one atomic step; that is
         // acceptable for the in-memory dev/test backend (the SQLite backends are
         // the production path where atomicity is guaranteed by the single UPDATE).
         match self.work_items.get(&item_id) {
-            Some(entry) if entry.lease_fence == lease_fence => {}
+            Some(entry) if entry.worker_id.is_some() && entry.lease_fence == lease_fence => {}
             _ => return Ok(false),
         }
         self.work_items.remove(&item_id);

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1083,6 +1083,32 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self), fields(item_id = %item_id, fence = lease_fence))]
+    async fn complete_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        let id_str = item_id.to_string();
+        let completed_at = Utc::now().to_rfc3339();
+
+        // Fence + status guard: only the current holder (matching fence) of a
+        // still-claimed item may settle. A stale/forged fence, an already-completed
+        // item, or one reclaimed under a newer fence matches zero rows -> false.
+        let rows_affected = sqlx::query(
+            "UPDATE work_items SET status = 'completed', completed_at = ?, lease_expires_at = NULL \
+             WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(&completed_at)
+        .bind(&id_str)
+        .bind(lease_fence)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        Ok(rows_affected > 0)
+    }
+
     #[instrument(skip(self, error), fields(item_id = %item_id))]
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()> {
         let id_str = item_id.to_string();
@@ -2068,6 +2094,56 @@ mod tests {
         // No more items
         let none = db.claim_work_item("worker-1", &["default"]).await.unwrap();
         assert!(none.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_complete_work_item_fenced_match_and_mismatch() {
+        let db = open_test_db().await;
+        let exec = sample_execution();
+        let exec_id = exec.execution_id.clone();
+        db.create_execution(exec).await.unwrap();
+
+        let item = WorkItem {
+            id: Uuid::new_v4(),
+            execution_id: exec_id,
+            node_id: "node-1".to_string(),
+            queue_type: "default".to_string(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: crate::tenant::DEFAULT_TENANT.to_string(),
+        };
+        let item_id = item.id;
+        db.enqueue_work_item(item).await.unwrap();
+
+        let claimed = db
+            .claim_work_item("worker-1", &["default"])
+            .await
+            .unwrap()
+            .unwrap();
+        let fence = claimed.lease_fence;
+        assert!(fence > 0, "a claimed item must have a non-zero fence");
+
+        // A mismatched (stale/forged) fence settles nothing and leaves the item
+        // claimable by the true holder.
+        let mismatched = db
+            .complete_work_item_fenced(item_id, fence + 1)
+            .await
+            .unwrap();
+        assert!(!mismatched, "a mismatched fence must not settle the item");
+
+        // The matching fence settles exactly one row.
+        let matched = db.complete_work_item_fenced(item_id, fence).await.unwrap();
+        assert!(matched, "the matching fence must settle the item");
+
+        // A second settle with the same fence is now a no-op (already completed,
+        // status != 'claimed') — proving exactly-once-COMMIT, not double-settle.
+        let again = db.complete_work_item_fenced(item_id, fence).await.unwrap();
+        assert!(!again, "an already-completed item must not settle again");
     }
 
     #[tokio::test]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1014,6 +1014,32 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(())
     }
 
+    #[instrument(skip(self), fields(tenant = %self.tenant_id, item_id = %item_id, fence = lease_fence))]
+    async fn complete_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+    ) -> BackendResult<bool> {
+        let id_str = item_id.to_string();
+        let completed_at = Utc::now().to_rfc3339();
+
+        // Tenant-scoped mirror of the durable fence guard: settle only the current
+        // holder of a still-claimed item for this tenant; zero rows -> false.
+        let rows_affected = sqlx::query(
+            "UPDATE work_items SET status = 'completed', completed_at = ?, lease_expires_at = NULL \
+             WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(&completed_at)
+        .bind(&id_str)
+        .bind(&self.tenant_id.0)
+        .bind(lease_fence)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        Ok(rows_affected > 0)
+    }
+
     #[instrument(skip(self, error), fields(tenant = %self.tenant_id, item_id = %item_id))]
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()> {
         let id_str = item_id.to_string();

--- a/runtime/state/tests/memory_backend.rs
+++ b/runtime/state/tests/memory_backend.rs
@@ -223,6 +223,128 @@ async fn test_complete_work_item_fenced() {
         .unwrap());
 }
 
+/// Build a never-claimed pending work item (worker_id = None, lease_fence = 0).
+fn pending_item(exec_id: &ExecutionId) -> WorkItem {
+    WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: exec_id.clone(),
+        node_id: "n1".into(),
+        queue_type: "default".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: "default".into(),
+    }
+}
+
+/// Reclaim fail-open: after `reclaim_expired_leases` hands a claimed item back
+/// to the queue it clears `worker_id` but LEAVES `lease_fence` set. A zombie
+/// worker presenting that now-stale fence must NOT settle the item.
+#[tokio::test]
+async fn fenced_complete_rejects_stale_fence_after_reclaim() {
+    let backend = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    let item_id = backend
+        .enqueue_work_item(pending_item(&exec_id))
+        .await
+        .unwrap();
+    let claimed = backend
+        .claim_work_item("w1", &["default"])
+        .await
+        .unwrap()
+        .unwrap();
+    let fence = claimed.lease_fence;
+    assert!(fence > 0, "a claimed item must carry a non-zero fence");
+
+    // Force the lease to expire and run the REAL reclaim sweep (the same path
+    // the scheduler drives). It clears worker_id but leaves lease_fence = F1.
+    backend.force_lease_expired_for_test(item_id);
+    let reclaimed = backend.reclaim_expired_leases().await.unwrap();
+    assert_eq!(
+        reclaimed.retryable.len(),
+        1,
+        "the expired item must be reclaimed as retryable"
+    );
+
+    // The zombie presents its stale fence F1. Pre-fix this settled (fence-only
+    // match: 0 != F1 but worker_id was never checked); post-fix the
+    // worker_id-is-None (reclaimed) item is rejected.
+    assert!(
+        !backend
+            .complete_work_item_fenced(item_id, fence)
+            .await
+            .unwrap(),
+        "a reclaimed item (worker_id cleared) must not settle via the stale fence"
+    );
+
+    // The item must survive the rejected settle and remain re-claimable.
+    assert!(
+        backend
+            .claim_work_item("w2", &["default"])
+            .await
+            .unwrap()
+            .is_some(),
+        "the item must still be claimable after the stale-fence settle was rejected"
+    );
+}
+
+/// Forged-fence-0 fail-open: a never-claimed pending item carries
+/// `lease_fence == 0`. A forged `lease_fence: 0` (the value an attacker can put
+/// on the HTTP complete request) must NOT settle it.
+#[tokio::test]
+async fn fenced_complete_rejects_forged_fence_zero_on_pending_item() {
+    let backend = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    let item_id = backend
+        .enqueue_work_item(pending_item(&exec_id))
+        .await
+        .unwrap();
+
+    // Pre-fix: 0 == 0 matched the pending item's fence and removed it.
+    assert!(
+        !backend.complete_work_item_fenced(item_id, 0).await.unwrap(),
+        "a forged fence 0 must not settle a never-claimed pending item"
+    );
+
+    // The pending item must survive and remain claimable.
+    assert!(
+        backend
+            .claim_work_item("w1", &["default"])
+            .await
+            .unwrap()
+            .is_some(),
+        "the pending item must still be claimable after the forged-fence settle was rejected"
+    );
+}
+
+/// Happy path: a currently-claimed item settled with its matching fence returns
+/// true (the worker_id-is-some guard must not block the legitimate holder).
+#[tokio::test]
+async fn fenced_complete_settles_claimed_item_with_matching_fence() {
+    let backend = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    let item_id = backend
+        .enqueue_work_item(pending_item(&exec_id))
+        .await
+        .unwrap();
+    let claimed = backend
+        .claim_work_item("w1", &["default"])
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        backend
+            .complete_work_item_fenced(item_id, claimed.lease_fence)
+            .await
+            .unwrap(),
+        "the current holder with the matching fence must settle the item"
+    );
+}
+
 #[tokio::test]
 async fn test_patch_append_array() {
     let backend = InMemoryBackend::new();

--- a/runtime/state/tests/memory_backend.rs
+++ b/runtime/state/tests/memory_backend.rs
@@ -345,6 +345,59 @@ async fn fenced_complete_settles_claimed_item_with_matching_fence() {
     );
 }
 
+/// Atomicity: many concurrent fenced completes of the SAME claimed item with the
+/// SAME matching fence must yield EXACTLY ONE `true`. `complete_work_item_fenced`
+/// uses DashMap's `remove_if`, so the claimed+fence-match check and the delete are
+/// one atomic step — the get-then-remove TOCTOU where two racers both observe the
+/// item and both remove it (double-settle) cannot happen.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fenced_complete_is_atomic_under_concurrency() {
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let exec_id = ExecutionId::new();
+    let item_id = backend
+        .enqueue_work_item(pending_item(&exec_id))
+        .await
+        .unwrap();
+    let claimed = backend
+        .claim_work_item("w1", &["default"])
+        .await
+        .unwrap()
+        .unwrap();
+    let fence = claimed.lease_fence;
+    assert!(fence > 0);
+
+    // Release all racers simultaneously (the barrier maximizes the overlap on the
+    // single contended item) and have each present the matching fence.
+    const RACERS: usize = 16;
+    let barrier = Arc::new(Barrier::new(RACERS));
+    let mut handles = Vec::with_capacity(RACERS);
+    for _ in 0..RACERS {
+        let backend = Arc::clone(&backend);
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            backend
+                .complete_work_item_fenced(item_id, fence)
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut settled = 0usize;
+    for h in handles {
+        if h.await.unwrap() {
+            settled += 1;
+        }
+    }
+    assert_eq!(
+        settled, 1,
+        "exactly one concurrent fenced complete may settle the item (atomic check-and-delete)"
+    );
+}
+
 #[tokio::test]
 async fn test_patch_append_array() {
     let backend = InMemoryBackend::new();

--- a/runtime/state/tests/memory_backend.rs
+++ b/runtime/state/tests/memory_backend.rs
@@ -181,6 +181,49 @@ async fn test_work_queue() {
 }
 
 #[tokio::test]
+async fn test_complete_work_item_fenced() {
+    let backend = InMemoryBackend::new();
+    let exec_id = ExecutionId::new();
+    let item = WorkItem {
+        id: Uuid::new_v4(),
+        execution_id: exec_id,
+        node_id: "n1".into(),
+        queue_type: "default".into(),
+        payload: json!({}),
+        attempt: 0,
+        max_attempts: 3,
+        created_at: Utc::now(),
+        lease_expires_at: None,
+        worker_id: None,
+        lease_fence: 0,
+        tenant_id: "default".into(),
+    };
+    let item_id = backend.enqueue_work_item(item).await.unwrap();
+    let claimed = backend
+        .claim_work_item("w1", &["default"])
+        .await
+        .unwrap()
+        .unwrap();
+    let fence = claimed.lease_fence;
+    assert!(fence > 0);
+
+    // Mismatched fence settles nothing; matching fence settles exactly once; a
+    // repeat settle is a no-op (item already removed) — exactly-once-COMMIT.
+    assert!(!backend
+        .complete_work_item_fenced(item_id, fence + 1)
+        .await
+        .unwrap());
+    assert!(backend
+        .complete_work_item_fenced(item_id, fence)
+        .await
+        .unwrap());
+    assert!(!backend
+        .complete_work_item_fenced(item_id, fence)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
 async fn test_patch_append_array() {
     let backend = InMemoryBackend::new();
     let id = ExecutionId::new();

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1859,6 +1859,10 @@ async def _worker_loop(
                     duration_ms,
                     gen_ai_model=gen_ai_model_field,
                     finish_reason=finish_reason_field,
+                    # Echo the lease fence from the claim so the runtime can fence
+                    # the completion (reject a stale/reclaimed lease). Omitted when
+                    # 0/absent, keeping the unfenced fallback backward-compatible.
+                    lease_fence=lease_fence,
                 )
                 console.print(f"[green]Completed[/green] id={item_id} node=[bold]{node_id}[/bold] {duration_ms}ms")
             except Exception as exc:

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1850,20 +1850,36 @@ async def _worker_loop(
                     gen_ai_model_field = output.get("gen_ai_model") or None
                     finish_reason_field = output.get("finish_reason") or None
 
-                await client.complete_work_item(
-                    item_id,
-                    exec_id,
-                    node_id,
-                    output,
-                    state_patch,
-                    duration_ms,
-                    gen_ai_model=gen_ai_model_field,
-                    finish_reason=finish_reason_field,
-                    # Echo the lease fence from the claim so the runtime can fence
-                    # the completion (reject a stale/reclaimed lease). Omitted when
-                    # 0/absent, keeping the unfenced fallback backward-compatible.
-                    lease_fence=lease_fence,
-                )
+                try:
+                    await client.complete_work_item(
+                        item_id,
+                        exec_id,
+                        node_id,
+                        output,
+                        state_patch,
+                        duration_ms,
+                        gen_ai_model=gen_ai_model_field,
+                        finish_reason=finish_reason_field,
+                        # Echo the lease fence from the claim so the runtime can fence
+                        # the completion (reject a stale/reclaimed lease). Omitted when
+                        # 0/absent, keeping the unfenced fallback backward-compatible.
+                        lease_fence=lease_fence,
+                    )
+                except Exception as complete_exc:
+                    # A 409 means our echoed fence no longer matches: the lease was
+                    # reclaimed and a NEW worker owns this item now. This (stale)
+                    # worker must NOT fail_work_item — that would clobber the
+                    # reclaimed work the new claimant is running and defeat the fence.
+                    # Treat the lost lease as a no-op and move on. httpx surfaces the
+                    # rejection as HTTPStatusError carrying .response.status_code.
+                    status = getattr(getattr(complete_exc, "response", None), "status_code", None)
+                    if status == 409:
+                        console.print(f"[yellow]Completion rejected; lease lost[/yellow] id={item_id}")
+                        if once:
+                            return
+                        continue
+                    # Any other completion error keeps the existing fail behavior.
+                    raise
                 console.print(f"[green]Completed[/green] id={item_id} node=[bold]{node_id}[/bold] {duration_ms}ms")
             except Exception as exc:
                 console.print(f"[red]Failed[/red] node={node_id}: {exc}")

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -287,8 +287,15 @@ class JamjetClient:
         duration_ms: int = 0,
         gen_ai_model: str | None = None,
         finish_reason: str | None = None,
+        lease_fence: int | None = None,
     ) -> None:
-        """Mark a work item as completed and emit a NodeCompleted event."""
+        """Mark a work item as completed and emit a NodeCompleted event.
+
+        When ``lease_fence`` is provided (and non-zero), it is echoed back so the
+        runtime can prove this worker still holds the lease: a stale fence (the
+        item was reclaimed/replayed) is rejected with 409 and no NodeCompleted is
+        emitted. A falsy/absent fence keeps the legacy unfenced behavior.
+        """
         body: dict[str, Any] = {
             "output": output,
             "state_patch": state_patch,
@@ -302,6 +309,8 @@ class JamjetClient:
             body["gen_ai_model"] = gen_ai_model
         if finish_reason is not None:
             body["finish_reason"] = finish_reason
+        if lease_fence:
+            body["lease_fence"] = lease_fence
         r = await self._client.post(
             f"/work-items/{item_id}/complete",
             json=body,

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -75,6 +75,7 @@ class _StubClient:
         duration_ms: int = 0,
         gen_ai_model: str | None = None,
         finish_reason: str | None = None,
+        lease_fence: int | None = None,
     ) -> None:
         self.complete_calls.append(
             {
@@ -85,6 +86,7 @@ class _StubClient:
                 "state_patch": state_patch,
                 "gen_ai_model": gen_ai_model,
                 "finish_reason": finish_reason,
+                "lease_fence": lease_fence,
             }
         )
 
@@ -243,6 +245,45 @@ _DISPATCH_ITEM: dict = {
     },
     "lease_fence": 0,
 }
+
+
+_FENCED_ITEM: dict = {
+    "id": "wi-006",
+    "execution_id": "exec_fenced",
+    "node_id": "fenced_step",
+    "queue_type": "python_tool",
+    "payload": {
+        "module": "tests.test_worker",
+        "function": "_add",
+        "input": {"a": 1, "b": 1},
+    },
+    # A real claim carries a non-zero lease fence (term * 2^32 + epoch).
+    "lease_fence": 4_294_967_297,
+}
+
+
+async def test_worker_echoes_lease_fence_on_complete() -> None:
+    """The fence from the claim response is echoed on complete so the runtime can
+    fence the settle (exactly-once-COMMIT for the external python_tool path)."""
+    stub = _StubClient(claimed_item=_FENCED_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    assert stub.complete_calls[0]["lease_fence"] == 4_294_967_297, (
+        "the worker must echo the claim's lease_fence on complete"
+    )
+
+
+async def test_worker_absent_fence_forwarded_as_zero() -> None:
+    """An item with no real fence (lease_fence=0) forwards 0; the client omits it,
+    keeping the unfenced fallback backward-compatible."""
+    stub = _StubClient(claimed_item=_ADD_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    assert stub.complete_calls[0]["lease_fence"] == 0, (
+        "absent fence is forwarded as 0 and dropped by the client (unfenced path)"
+    )
 
 
 async def test_worker_dispatch_tool_calls_return_reaches_state() -> None:

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -13,6 +13,8 @@ No live runtime is required; a _StubClient records all outbound calls.
 
 from __future__ import annotations
 
+import httpx
+
 from jamjet.cli.main import _worker_loop  # noqa: E402
 
 # ── Test handler functions ────────────────────────────────────────────────────
@@ -95,6 +97,30 @@ class _StubClient:
 
     async def heartbeat_work_item(self, item_id: str, worker_id: str, lease_fence: int = 0) -> None:
         self.heartbeat_calls.append({"item_id": item_id, "lease_fence": lease_fence})
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    """Build the exact exception JamjetClient.complete_work_item raises on a non-2xx
+    response: httpx's HTTPStatusError carrying `.response.status_code` (the engine
+    returns 409 when the echoed lease fence no longer matches)."""
+    req = httpx.Request("POST", "http://runtime/work-items/wi/complete")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=req, response=resp)
+
+
+class _Conflict409Client(_StubClient):
+    """Stub whose complete_work_item raises a 409 — i.e. the lease was reclaimed and
+    a NEW worker now owns the item; this (stale) worker's settle is rejected."""
+
+    async def complete_work_item(self, *args: object, **kwargs: object) -> None:
+        raise _http_status_error(409)
+
+
+class _ServerError500Client(_StubClient):
+    """Stub whose complete_work_item raises a NON-409 error (transient server fault)."""
+
+    async def complete_work_item(self, *args: object, **kwargs: object) -> None:
+        raise _http_status_error(500)
 
 
 # ── Fixtures / constants ──────────────────────────────────────────────────────
@@ -275,15 +301,44 @@ async def test_worker_echoes_lease_fence_on_complete() -> None:
 
 
 async def test_worker_absent_fence_forwarded_as_zero() -> None:
-    """An item with no real fence (lease_fence=0) forwards 0; the client omits it,
-    keeping the unfenced fallback backward-compatible."""
-    stub = _StubClient(claimed_item=_ADD_ITEM)
+    """When the claim response OMITS the lease_fence key ENTIRELY (not even an
+    explicit 0), the worker must still forward 0 — the client then drops it, keeping
+    the unfenced fallback backward-compatible.
+
+    Regression: this previously claimed an item built from _ADD_ITEM, which already
+    carries an explicit lease_fence=0, so it only exercised the explicit-0 path and
+    never the missing-key path it is named for. Build an item without the key."""
+    no_fence_item = {k: v for k, v in _ADD_ITEM.items() if k != "lease_fence"}
+    assert "lease_fence" not in no_fence_item, "the key must be truly absent from the claim"
+    stub = _StubClient(claimed_item=no_fence_item)
     await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
 
     assert len(stub.complete_calls) == 1
     assert stub.complete_calls[0]["lease_fence"] == 0, (
-        "absent fence is forwarded as 0 and dropped by the client (unfenced path)"
+        "an absent fence is forwarded as 0 and dropped by the client (unfenced path)"
     )
+
+
+async def test_worker_409_complete_is_lost_lease_noop() -> None:
+    """A 409 from complete_work_item means our lease fence no longer matches: the
+    item was reclaimed and a NEW worker owns it now. The stale worker must treat the
+    rejection as a lost-lease no-op — it must NOT call fail_work_item, because that
+    would clobber the reclaimed work the new claimant is running. With --once it
+    returns cleanly."""
+    stub = _Conflict409Client(claimed_item=_FENCED_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.fail_calls) == 0, "a 409 lost-lease must NOT call fail_work_item"
+
+
+async def test_worker_non_409_complete_error_still_fails() -> None:
+    """A NON-409 completion error keeps the existing behavior: it falls through to
+    fail_work_item (the lease is still ours; the settle just did not land)."""
+    stub = _ServerError500Client(claimed_item=_FENCED_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.fail_calls) == 1, "a non-409 completion error must still call fail_work_item"
+    assert stub.fail_calls[0]["item_id"] == "wi-006"
 
 
 async def test_worker_dispatch_tool_calls_return_reaches_state() -> None:


### PR DESCRIPTION
## What

Fence the external-worker HTTP `/work-items/:id/complete` path so a reclaimed or replayed worker can no longer settle a stale lease and duplicate a `NodeCompleted` event. This hardens both external worker tiers (`python_tool` and the new `java_tool`) and is the safety prerequisite for the durable Java tool-worker (Track 9 Phase B).

- The claim response now returns the work item's `lease_fence`, so a worker can echo it on completion.
- A new `StateBackend::complete_work_item_fenced(item_id, lease_fence)` settles only if the stored fence still matches and the item is still claimed (`status = 'claimed'` on SQLite / tenant-scoped; `worker_id.is_some()` in memory). It returns whether the settle actually happened.
- The complete handler, when given a `lease_fence`, uses the fenced path and rejects a mismatch with a 409 before any `NodeCompleted` is appended or any `state_patch` applied. With no `lease_fence` it keeps the prior unfenced behavior, so existing callers are unaffected.
- The Python worker now reads the fence from the claim and echoes it on complete.

## Why

The internal worker tier already gets exactly-once-commit from the lease fence; only the external HTTP completion path was unfenced, which a code review flagged as a way to duplicate a node completion after a lease reclaim. This closes that gap without breaking the unfenced fallback.

## Safety

This is enforcement code, so it got a second independent adversarial review. The review traced the marquee scenario (worker A claims fence F1, the lease is reclaimed as F2, worker A completes with the stale F1) and confirmed the durable SQLite and tenant-scoped paths reject it. It also caught a real fail-open in the in-memory backend (it checked the fence but not whether the item was still claimed, so a forged `lease_fence: 0` could complete a never-claimed item and a stale fence could survive a reclaim, because the in-memory reclaim clears `worker_id` but leaves the fence). That is fixed: the in-memory fenced settle now also requires the item to be currently claimed, and three in-memory adversarial tests pin it. The fix is scoped to the one path reachable from the HTTP surface; the internal-only fenced mutators stay byte-for-byte parallel to their SQLite versions.

## Tests

`cargo test --workspace` passes (the adversarial dual on SQLite and in memory: a matching fence settles exactly once, a stale or forged fence returns 409 with zero `NodeCompleted` and no state mutation, and the absent-fence fallback still works). Python suite 1435 passed, including the worker echoing the fence.

## Follow-ups

F-fence-metrics (a counter on rejected fences and on unfenced completes, to detect zombie workers and to gate making the fence mandatory later); the fence stays advisory/opt-in for this version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer work-item completion with optional lease-fence validation.
  * Workers now return and can forward a lease fence when claiming and completing work items.

* **Bug Fixes**
  * Prevents stale or forged completions from settling items when a newer lease exists.
  * Returns a clear conflict response when fenced completion is rejected.
  * Preserves backward-compatible completion without a fence for older clients.

* **Tests**
  * Expanded end-to-end and backend coverage for matching, stale, forged, and unfenced completion flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->