### PR TITLE
release: jamjet Python SDK 0.11.0 (governance, sessions/memory, Team, deploy, devtools)

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.11.0 — 2026-06-29
+
+The full ADK feature set. A plain `Agent` is now durable and governed by default, with first-class sessions, memory, multi-agent teams, deploy, and a five-minute dev loop.
+
+### Added
+
+- Governance on by default. `Agent(policy=, approval_required=, budget=, pii=, audit=, receipts=)`: a model allowlist, fail-closed budget caps, PII redaction at the model seam, a signed hash-chained audit record per action, and an AgentBoundary receipt per turn. Enforced on both `run()` and `run_durable()`.
+- Sessions and memory. `Session` + a persistent `SessionStore` continue a conversation thread across runs and restarts; `memory=` wires the Engram bridge with an automatic, governed retrieve/record loop keyed by the session.
+- Team multi-agent API: `Sequential`, `Parallel` (with `MergeStrategy`), `Team` (coordinator), and `Loop`. Each sub-agent runs as its own governed durable execution; `run()` / `run_durable()` return a `TeamResult` with per-agent isolation.
+- `agent.deploy(runtime="local" | "self-host" | "cloud" | "<url>")` and `Team.deploy(...)`: ship the same compiled IR to any runtime over the durable engine. Artifacts API (`POST/GET /artifacts`).
+- Devtools: `jamjet create` scaffolds a runnable project, `jamjet dev` runs the whole local stack (model sidecar + engine + worker) with one command, and `jamjet eval` adds deterministic trajectory evaluation (`jamjet eval trajectory-diff`).
+
 ## 0.10.1 — 2026-06-12
 
 ### Added

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -132,4 +132,4 @@ def __dir__() -> list[str]:  # noqa: ANN201
     return list(set(globals()) | set(__all__))
 
 
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jamjet"
-version = "0.10.2"
+version = "0.11.0"
 description = "JamJet — open-source safety layer for AI agents. Block unsafe tool calls, require approval, enforce budgets, audit, replay."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Bumps the Python SDK to 0.11.0 so the ADK feature set merged across Tracks 3-7 ships to PyPI. The published 0.10.2 predates all of it. Tagging `python-sdk-v0.11.0` after merge triggers the Release workflow, which publishes the wheel to PyPI and the jamjet-server binaries (with java_tool) to a GitHub Release the CLI fetches.