### PR TITLE
fix(policy): enforce tool policy and approval on ADK agent dispatch (C1), refuse to fire on a spent budget (C2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,19 @@ jobs:
           # --deny unsound: fail on CVEs/unsound advisories (not on unmaintained warnings)
           # --ignore RUSTSEC-2023-0071: rsa Marvin Attack — no upstream fix available yet;
           #   we use rsa only as a transitive dep of tonic, not for key operations.
+          # --ignore RUSTSEC-2026-0258: h2 unbounded empty DATA frames (h2 0.3.27).
+          #   The fix is h2 >=0.4.16, which means moving off hyper 0.14 entirely.
+          #   The vulnerable copy reaches us ONLY as
+          #   jamjet-telemetry -> opentelemetry-otlp 0.15 -> tonic 0.11 -> hyper 0.14,
+          #   i.e. the OTLP exporter, which is an outbound client: reaching it needs a
+          #   hostile collector we already trust with our telemetry, not an inbound
+          #   request. Every server that accepts untrusted traffic — jamjet-api and the
+          #   a2a server — is on axum 0.7 -> hyper 1.x -> h2 0.4.15, which this advisory
+          #   does not flag. Tracked for the opentelemetry/tonic upgrade in #115;
+          #   re-evaluate when that lands.
           cargo audit --deny unsound \
-            --ignore RUSTSEC-2023-0071
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2026-0258
 
   python-audit:
     name: Python dependency audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege for the whole workflow. Every job here reads the repo, builds,
+# and reports — none of them writes to it, so none needs the default write-capable
+# token. Declared once at the top rather than per job, so a job added later
+# inherits the floor instead of silently getting write.
+#
+# Publishing is unaffected: the release workflows are separate files and keep
+# their own `id-token: write` for OIDC.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,31 @@ jobs:
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0258
 
+      - name: Assert the h2 advisory exception still holds
+        working-directory: runtime
+        run: |
+          # --ignore is project-wide, so it would keep suppressing RUSTSEC-2026-0258
+          # if the vulnerable h2 ever appeared somewhere that actually matters. The
+          # exception above is justified by WHERE h2 0.3.x sits, so assert that,
+          # rather than trusting a comment to stay true.
+          TREE="$(cargo tree --workspace --invert h2@0.3.27 2>/dev/null || true)"
+          if [ -z "$TREE" ]; then
+            echo "h2 0.3.x is gone — drop --ignore RUSTSEC-2026-0258 (see #115)."
+            exit 1
+          fi
+          if ! grep -q 'opentelemetry-otlp' <<<"$TREE"; then
+            echo "The RUSTSEC-2026-0258 exception is stale: h2 0.3.x no longer"
+            echo "reaches us via the OTLP exporter. Re-assess before ignoring it."
+            echo "$TREE"
+            exit 1
+          fi
+          if grep -qE 'jamjet-a2a|axum v0\.7' <<<"$TREE"; then
+            echo "The RUSTSEC-2026-0258 exception is UNSAFE: the vulnerable h2 is"
+            echo "now reachable from a server that accepts inbound traffic."
+            echo "$TREE"
+            exit 1
+          fi
+
   python-audit:
     name: Python dependency audit
     runs-on: ubuntu-latest

--- a/runtime/api/Cargo.toml
+++ b/runtime/api/Cargo.toml
@@ -49,3 +49,7 @@ async-trait = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
 tracing-subscriber = { workspace = true }
+# Route tests that assert a work item's DURABLE settle state read `work_items.status`
+# directly; `StateBackend` exposes no work-item read, and an indirect probe cannot
+# tell `fail_work_item` from `complete_work_item`.
+sqlx = { workspace = true }

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1109,18 +1109,66 @@ async fn claim_work_item(
 /// same `{"claimed": false}` — so acting on it would create exactly the signal
 /// the uniform response exists to deny the caller.
 async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkItem) -> ClaimGate {
-    // The same coordinates `Worker::execute_item` reads (`parse_payload`), so
-    // both transports resolve the same IR for the same item.
-    let workflow_id = wi
-        .payload
-        .get("workflow_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
-    let workflow_version = wi
-        .payload
-        .get("workflow_version")
-        .and_then(|v| v.as_str())
-        .unwrap_or("1.0.0");
+    // AUTHORITY. The coordinates that select the policy chain come from the
+    // EXECUTION record, never from the payload.
+    //
+    // `POST /work-items` copies a caller-supplied `payload` and `node_id`
+    // verbatim into the queue behind the same write role as this route. If the
+    // payload chose the workflow, that caller could point a `python_tool` item
+    // at an unpoliced workflow and drop the workflow layer out of the chain, or
+    // omit the version and have v1.0.0's rules evaluated against a v2.0.0
+    // execution. The execution record is engine-written, so it is the only
+    // trustworthy answer to "which policy governs this item".
+    let execution = match backend.get_execution(&wi.execution_id).await {
+        // Infrastructure — see the `get_workflow` Err arm below.
+        Err(e) => {
+            warn!(
+                execution_id = %wi.execution_id,
+                node_id = %wi.node_id,
+                error = %e,
+                "claim: execution lookup failed; withholding the payload"
+            );
+            return ClaimGate::Withhold;
+        }
+        Ok(None) => {
+            return fail_closed(backend, wi, "execution not found".to_string()).await;
+        }
+        Ok(Some(e)) => e,
+    };
+    let workflow_id = execution.workflow_id.as_str();
+    let workflow_version = execution.workflow_version.as_str();
+
+    // Tripwire. `Worker::execute_item` still resolves its IR from the payload
+    // (`parse_payload`), so a payload that disagrees with its own execution
+    // would make the two enforcement seams evaluate different policy for the
+    // same item. There is no legitimate producer of that shape — the scheduler
+    // builds every payload from these very coordinates
+    // (`runtime/scheduler/src/runner.rs`) — so a disagreement means one of the
+    // two is lying and we cannot tell which. Refuse rather than pick.
+    //
+    // Absent coordinates are NOT a mismatch: nothing is claimed, so nothing can
+    // conflict, and the execution's values are used regardless. There is no
+    // default here to exploit — the old `unwrap_or("unknown")` /
+    // `unwrap_or("1.0.0")` fallbacks are gone.
+    let payload_disagrees = |key: &str, authoritative: &str| {
+        wi.payload
+            .get(key)
+            .and_then(|v| v.as_str())
+            .is_some_and(|claimed| claimed != authoritative)
+    };
+    if payload_disagrees("workflow_id", workflow_id)
+        || payload_disagrees("workflow_version", workflow_version)
+    {
+        return fail_closed(
+            backend,
+            wi,
+            format!(
+                "work item payload coordinates disagree with execution {workflow_id} \
+                 v{workflow_version}"
+            ),
+        )
+        .await;
+    }
 
     let ir = match backend.get_workflow(workflow_id, workflow_version).await {
         // Infrastructure, not a decision: the engine could not read its own
@@ -1188,6 +1236,24 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
         // The guard already recorded the `PolicyViolation`. Failing the item is
         // what stops a blocked dispatch from being re-claimed forever: on a
         // durable backend `fail_work_item` is terminal.
+        //
+        // KNOWN ASYMMETRY — this seam and the worker seam disagree on
+        // terminality, and this is the outcome of EVERY successful enforcement
+        // here, not an edge case.
+        //
+        // `SqliteBackend::fail_work_item` sets `status = 'failed'`
+        // unconditionally, so the reclaimer never returns the item and NOTHING
+        // emits `NodeFailed`. The execution therefore stays `Running` with the
+        // node still in the scheduler fold's `scheduled` set — it stalls rather
+        // than going terminal. `Worker::execute_item` does emit the terminal
+        // event, via the fenced `commit_turn`, so the same policy denial ends
+        // the execution on the in-process path and hangs it here.
+        //
+        // Safety is unaffected: the tool does not run and the denial is on the
+        // Prove surface either way. Closing the gap means emitting a
+        // fence-committed terminal event from the claim route, which is a
+        // scheduler-interaction change and is deliberately NOT done inside this
+        // security fix. It needs its own task.
         DispatchGuardOutcome::Blocked { reason } => {
             warn!(
                 execution_id = %wi.execution_id,
@@ -1206,7 +1272,13 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
         // An outstanding `ToolApprovalRequired` exists for the node. Settle the
         // item cleanly so its lease never expires into the retry path; the node
         // stays parked in the scheduler fold's `scheduled` set until a human
-        // decides. Same settle the in-process worker performs.
+        // decides.
+        //
+        // Fenced, unlike the worker's plain `complete_work_item`: we hold a
+        // fence minted by the claim we just made, so we can prove the lease is
+        // still ours. A lost fence means something else already settled or
+        // reclaimed the item, which is not ours to overwrite — and the payload
+        // is withheld either way.
         DispatchGuardOutcome::Held { gated } => {
             info!(
                 execution_id = %wi.execution_id,
@@ -1214,7 +1286,21 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
                 gated = ?gated,
                 "claim: agent tool dispatch awaiting approval"
             );
-            settle(backend.complete_work_item(wi.id).await, wi)
+            match backend
+                .complete_work_item_fenced(wi.id, wi.lease_fence)
+                .await
+            {
+                Ok(true) => ClaimGate::Withhold,
+                Ok(false) => {
+                    warn!(
+                        execution_id = %wi.execution_id,
+                        node_id = %wi.node_id,
+                        "claim: lease fence lost while settling a held work item"
+                    );
+                    ClaimGate::Withhold
+                }
+                Err(e) => settle(Err(e), wi),
+            }
         }
 
         // NOT a denial — no policy was ever consulted, so nothing is audited and

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -174,7 +174,19 @@ async fn create_workflow(
     // (Reference resolution is deliberately left to the runtime: models/tools are
     // resolved against the worker registry, not the IR maps, so we validate the
     // shape here, not `validate_workflow`'s ref rules.)
-    serde_json::from_value::<jamjet_ir::WorkflowIr>(body.ir.clone())
+    let parsed = serde_json::from_value::<jamjet_ir::WorkflowIr>(body.ir.clone())
+        .map_err(|e| ApiError::BadRequest(format!("invalid workflow IR: {e}")))?;
+
+    // ONE rule from `validate_workflow` runs here, deliberately, while the ref
+    // rules above do not. An unmarked ADK tool-dispatch node is not a reference
+    // problem the runtime can resolve later — it is a policy-enforcement hole,
+    // and registration is the only place it is detectable. An IR compiled by a
+    // pre-marker SDK deserializes with `agent_tool_dispatch: false`, so the
+    // claim route treats it as an ordinary `python_fn` and hands out a whole
+    // turn's model-chosen tool calls with no tool policy evaluated at all.
+    // Storing it would bake that hole in permanently; rejecting it makes the
+    // version skew loud at the one moment the operator can act on it.
+    jamjet_ir::validate_agent_tool_dispatch(&parsed)
         .map_err(|e| ApiError::BadRequest(format!("invalid workflow IR: {e}")))?;
 
     let backend = state.backend_for(&tenant_id);

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1223,10 +1223,21 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
         return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
     };
 
-    // NARROWNESS. This route serves every queue. Everything that is not a
-    // marked agent tool dispatch — every model node, tool node, condition,
-    // ordinary python_fn — leaves here having had zero policy evaluation and
-    // zero extra backend calls, and is returned exactly as before.
+    // NARROWNESS. This route serves every queue. Everything that is not an agent
+    // tool dispatch — every model node, tool node, condition, ordinary python_fn
+    // — leaves here having had zero POLICY evaluation, and is returned exactly
+    // as before.
+    //
+    // Not free, though: reaching this line already cost `get_execution`,
+    // `get_workflow` and a full `WorkflowIr` parse, and this is the hot path
+    // every external worker polls. Those lookups are what make the decision
+    // trustworthy — the execution record is the only engine-written answer to
+    // "which policy governs this item" — so they cannot simply move below this
+    // check. A `wi.queue_type` gate above them would skip the whole function for
+    // queues that can never hold a dispatch node, but it would also skip the
+    // coordinate tripwire and the execution-not-found fail-closed for those
+    // queues, which is a behaviour change and not one to make inside a security
+    // fix. Tracked in #116.
     if !jamjet_worker::dispatch_guard::is_agent_tool_dispatch(&node_def.kind) {
         return ClaimGate::Release;
     }

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -23,8 +23,10 @@ use jamjet_agents::{AgentCard, AgentFilter, AgentStatus};
 use jamjet_audit::backend::AuditQuery;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::{Tenant, TenantId, TenantStatus, WorkItem, WorkflowDefinition};
+use jamjet_worker::DispatchGuardOutcome;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use tracing::{info, warn};
 use uuid::Uuid;
 
 /// Build the Axum router with all API routes.
@@ -1011,6 +1013,24 @@ struct ClaimWorkItemRequest {
     queue_types: Vec<String>,
 }
 
+/// The claim response for "you get nothing".
+///
+/// A refusal MUST be byte-identical to an empty queue. The external worker is
+/// untrusted for the enforcement decision, so it must not be able to tell
+/// "policy blocked this" from "nothing to do" — otherwise the claim endpoint
+/// becomes an oracle for which tools a tenant's policy forbids.
+fn nothing_to_claim() -> Json<Value> {
+    Json(json!({ "claimed": false }))
+}
+
+/// Whether a claimed item may be handed to the caller.
+enum ClaimGate {
+    /// Hand back the payload.
+    Release,
+    /// Refuse. The item has already been settled as its outcome requires.
+    Withhold,
+}
+
 /// `POST /work-items/claim` — claim the next available work item.
 async fn claim_work_item(
     State(state): State<AppState>,
@@ -1022,23 +1042,231 @@ async fn claim_work_item(
     let item = backend
         .claim_work_item(&body.worker_id, &queue_refs)
         .await?;
-    match item {
-        Some(wi) => Ok(Json(json!({
-            "claimed": true,
-            "work_item": {
-                "id": wi.id.to_string(),
-                "execution_id": wi.execution_id.to_string(),
-                "node_id": wi.node_id,
-                "queue_type": wi.queue_type,
-                "payload": wi.payload,
-                "attempt": wi.attempt,
-                // The lease fence the external worker echoes on complete so the
-                // engine can prove the lease is still held (exactly-once-COMMIT).
-                "lease_fence": wi.lease_fence,
-            }
-        }))),
-        None => Ok(Json(json!({ "claimed": false }))),
+    let Some(wi) = item else {
+        return Ok(nothing_to_claim());
+    };
+
+    // Enforcement lives HERE, not only in the in-process worker: `python_tool`
+    // and `java_tool` are registered with zero in-process workers, so an ADK
+    // agent's tool-dispatch node reaches production down this route and never
+    // through `Worker::execute_item`. See `gate_claimed_item`.
+    if matches!(
+        gate_claimed_item(backend.as_ref(), &wi).await,
+        ClaimGate::Withhold
+    ) {
+        return Ok(nothing_to_claim());
     }
+
+    Ok(Json(json!({
+        "claimed": true,
+        "work_item": {
+            "id": wi.id.to_string(),
+            "execution_id": wi.execution_id.to_string(),
+            "node_id": wi.node_id,
+            "queue_type": wi.queue_type,
+            "payload": wi.payload,
+            "attempt": wi.attempt,
+            // The lease fence the external worker echoes on complete so the
+            // engine can prove the lease is still held (exactly-once-COMMIT).
+            "lease_fence": wi.lease_fence,
+        }
+    })))
+}
+
+/// Run the shared agent-dispatch guard over a freshly claimed item.
+///
+/// An ADK agent compiles a whole turn's model-chosen tool calls into ONE
+/// `python_fn` / `java_fn` node, so the tool names are invisible to the ordinary
+/// node-kind policy path (review finding C1). The decision itself lives in
+/// `jamjet_worker::dispatch_guard` so this route and the in-process worker
+/// enforce the IDENTICAL policy; this function owns only the settle, which is
+/// transport-specific. Nothing here re-implements a policy rule — a second copy
+/// would drift, and a drifted copy of an enforcement rule is a hole.
+///
+/// Enforcement is server-side on purpose: the external worker is untrusted, so
+/// a stale or hostile `jamjet worker` build cannot opt out of it.
+///
+/// KNOWN LIMIT — duplicate approval requests. `guard_dispatch`'s `NotRequested`
+/// arm reads "is there an open request?" and then appends one, with no
+/// compare-and-set between. Two claims that reach it concurrently for the SAME
+/// node can each append, and because `node_approval_status` resets to `Pending`
+/// on every new request, a human's settled decision would refer to a superseded
+/// request and could never stick.
+///
+/// This is NOT serialised here, deliberately. `claim_work_item` is atomic, so
+/// one work item goes to exactly one caller; reaching the race needs two
+/// distinct work items for the same node, which is the same exposure the
+/// in-process worker already has (a lease serialises one ITEM, not one NODE).
+/// A process-local mutex would not serialise the multiple `jamjet-server`
+/// processes a real deployment runs, so it would buy nothing but false
+/// confidence. Closing it properly needs an "append iff no open request for this
+/// node" primitive on `StateBackend`, which is a backend change, not a route
+/// change. Fail-closed holds either way: both racers return `Held`, so nothing
+/// runs unapproved.
+///
+/// `Held` also conflates "awaiting a decision" with "a human rejected this".
+/// That distinction is deliberately unobservable here — every refusal is the
+/// same `{"claimed": false}` — so acting on it would create exactly the signal
+/// the uniform response exists to deny the caller.
+async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkItem) -> ClaimGate {
+    // The same coordinates `Worker::execute_item` reads (`parse_payload`), so
+    // both transports resolve the same IR for the same item.
+    let workflow_id = wi
+        .payload
+        .get("workflow_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let workflow_version = wi
+        .payload
+        .get("workflow_version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("1.0.0");
+
+    let ir = match backend.get_workflow(workflow_id, workflow_version).await {
+        // Infrastructure, not a decision: the engine could not read its own
+        // catalogue. Settle NOTHING — failing the item would kill work that was
+        // never evaluated, and completing it would silently drop it. The lease
+        // expires, the reclaimer requeues, and the next claim decides properly.
+        Err(e) => {
+            warn!(
+                execution_id = %wi.execution_id,
+                node_id = %wi.node_id,
+                error = %e,
+                "claim: workflow lookup failed; withholding the payload"
+            );
+            return ClaimGate::Withhold;
+        }
+        // Permanent, and identical to the worker's `ExecutorError::Fatal` for
+        // the same condition. Fail closed: without the IR the
+        // `agent_tool_dispatch` marker cannot be read, so whether this item
+        // needs policy evaluation is UNKNOWN. Handing it out would make "point
+        // the payload at a workflow that does not exist" a complete bypass.
+        Ok(None) => {
+            return fail_closed(
+                backend,
+                wi,
+                format!("workflow {workflow_id} v{workflow_version} not found"),
+            )
+            .await;
+        }
+        Ok(Some(def)) => match serde_json::from_value::<jamjet_ir::WorkflowIr>(def.ir) {
+            Ok(ir) => ir,
+            Err(e) => {
+                return fail_closed(backend, wi, format!("failed to load IR: {e}")).await;
+            }
+        },
+    };
+
+    // The node id selects both the policy set and the dispatch marker, so a
+    // node that is not in the IR has neither and cannot be evaluated.
+    let Some(node_def) = ir.node(&wi.node_id) else {
+        return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
+    };
+
+    // NARROWNESS. This route serves every queue. Everything that is not a
+    // marked agent tool dispatch — every model node, tool node, condition,
+    // ordinary python_fn — leaves here having had zero policy evaluation and
+    // zero extra backend calls, and is returned exactly as before.
+    if !jamjet_worker::dispatch_guard::is_agent_tool_dispatch(&node_def.kind) {
+        return ClaimGate::Release;
+    }
+
+    let input = jamjet_worker::dispatch_guard::payload_input(&wi.payload);
+    match jamjet_worker::dispatch_guard::guard_dispatch(
+        backend,
+        &wi.execution_id,
+        &wi.node_id,
+        &wi.tenant_id,
+        &ir,
+        node_def,
+        &input,
+    )
+    .await
+    {
+        DispatchGuardOutcome::Allow => ClaimGate::Release,
+
+        // The guard already recorded the `PolicyViolation`. Failing the item is
+        // what stops a blocked dispatch from being re-claimed forever: on a
+        // durable backend `fail_work_item` is terminal.
+        DispatchGuardOutcome::Blocked { reason } => {
+            warn!(
+                execution_id = %wi.execution_id,
+                node_id = %wi.node_id,
+                %reason,
+                "claim: policy blocked an agent tool dispatch"
+            );
+            settle(
+                backend
+                    .fail_work_item(wi.id, &format!("policy blocked: {reason}"))
+                    .await,
+                wi,
+            )
+        }
+
+        // An outstanding `ToolApprovalRequired` exists for the node. Settle the
+        // item cleanly so its lease never expires into the retry path; the node
+        // stays parked in the scheduler fold's `scheduled` set until a human
+        // decides. Same settle the in-process worker performs.
+        DispatchGuardOutcome::Held { gated } => {
+            info!(
+                execution_id = %wi.execution_id,
+                node_id = %wi.node_id,
+                gated = ?gated,
+                "claim: agent tool dispatch awaiting approval"
+            );
+            settle(backend.complete_work_item(wi.id).await, wi)
+        }
+
+        // NOT a denial — no policy was ever consulted, so nothing is audited and
+        // nothing is settled. See the `Err` arm above for why leaving the lease
+        // alone is the right infrastructure-failure behaviour.
+        DispatchGuardOutcome::Unavailable { reason } => {
+            warn!(
+                execution_id = %wi.execution_id,
+                node_id = %wi.node_id,
+                %reason,
+                "claim: could not decide an agent tool dispatch; withholding the payload"
+            );
+            ClaimGate::Withhold
+        }
+    }
+}
+
+/// Terminally fail an item the engine cannot evaluate, and withhold it.
+///
+/// No `PolicyViolation` is recorded: these are structural failures (missing
+/// workflow, unparseable IR, unknown node), not policy denials, and auditing
+/// them as denials would put a refusal on the Prove surface that no policy made.
+/// The worker treats the identical conditions as `ExecutorError::Fatal`.
+async fn fail_closed(
+    backend: &dyn jamjet_state::StateBackend,
+    wi: &WorkItem,
+    reason: String,
+) -> ClaimGate {
+    warn!(
+        execution_id = %wi.execution_id,
+        node_id = %wi.node_id,
+        %reason,
+        "claim: cannot evaluate policy for this item; withholding the payload"
+    );
+    settle(backend.fail_work_item(wi.id, &reason).await, wi)
+}
+
+/// Withhold regardless of whether the settle landed.
+///
+/// A settle that fails leaves the item leased until the lease expires, which is
+/// a liveness cost, never a safety one: the payload is withheld either way.
+/// Fail closed, never open.
+fn settle(result: jamjet_state::backend::BackendResult<()>, wi: &WorkItem) -> ClaimGate {
+    if let Err(e) = result {
+        warn!(
+            execution_id = %wi.execution_id,
+            node_id = %wi.node_id,
+            error = %e,
+            "claim: failed to settle a withheld work item"
+        );
+    }
+    ClaimGate::Withhold
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -133,8 +133,17 @@ fn dispatch_ir(marked: bool, blocked: &[&str], approval: &[&str]) -> Value {
 
 /// A node kind that can never be an agent dispatch — the "every other queue"
 /// case the route must not perturb.
-fn condition_ir() -> Value {
+///
+/// It carries a REAL `blocked_tools` policy on purpose. An unpoliced fixture
+/// would prove nothing: `guard_dispatch` short-circuits an empty policy chain
+/// and returns `Allow` before it reads anything, so such a node sails through
+/// whether or not the marker gate exists. With a policy in force and a payload
+/// that has no `input` key, removing the gate makes the guard read the calls,
+/// get `NotAnObject`, and terminally fail the item — which is precisely the
+/// "breaks all durable tool execution" regression this fixture must catch.
+fn policed_condition_ir() -> Value {
     ir_with_node(json!({ "id": "n1", "kind": { "type": "condition", "branches": [] } }))
+        .tap_policy(&["send_wire"], &[])
 }
 
 fn ir_with_node(node: Value) -> Value {
@@ -211,18 +220,22 @@ async fn seed(
     queue_type: &str,
     payload: Value,
 ) -> (ExecutionId, Uuid) {
-    let now = chrono::Utc::now();
+    store(backend, WF, VERSION, ir).await;
+    seed_item(backend, queue_type, payload).await
+}
+
+/// Store one workflow definition under explicit coordinates.
+async fn store(backend: &Arc<dyn StateBackend>, workflow_id: &str, version: &str, ir: Value) {
     backend
         .store_workflow(WorkflowDefinition {
-            workflow_id: WF.into(),
-            version: VERSION.into(),
+            workflow_id: workflow_id.into(),
+            version: version.into(),
             ir,
-            created_at: now,
+            created_at: chrono::Utc::now(),
             tenant_id: DEFAULT_TENANT.into(),
         })
         .await
         .expect("store_workflow");
-    seed_item(backend, queue_type, payload).await
 }
 
 /// Enqueue a claimable item for a fresh execution WITHOUT storing a workflow —
@@ -318,6 +331,47 @@ fn memory() -> Arc<dyn StateBackend> {
     Arc::new(InMemoryBackend::new())
 }
 
+/// A durable backend plus the raw pool used to read `work_items.status`.
+///
+/// `StateBackend` exposes no work-item read, so the SETTLE a claim performed can
+/// only be observed in the table. Indirect probes (re-claim, `renew_lease`)
+/// cannot separate `fail_work_item` from `complete_work_item` — both leave the
+/// item unclaimable — which is exactly how an unbound settle assertion hides.
+struct Durable {
+    backend: Arc<dyn StateBackend>,
+    pool: sqlx::SqlitePool,
+    db_path: std::path::PathBuf,
+}
+
+impl Durable {
+    async fn new() -> Self {
+        let db_path = std::env::temp_dir().join(format!("jjtest-claim-{}.db", Uuid::new_v4()));
+        let url = format!("sqlite://{}", db_path.display());
+        let backend: Arc<dyn StateBackend> =
+            Arc::new(SqliteBackend::open(&url).await.expect("open sqlite"));
+        let pool = sqlx::SqlitePool::connect(&url).await.expect("open pool");
+        Self {
+            backend,
+            pool,
+            db_path,
+        }
+    }
+
+    /// The item's durable `status`: `claimed`, `completed`, `failed`, `pending`.
+    async fn status(&self, item_id: Uuid) -> String {
+        sqlx::query_scalar::<_, String>("SELECT status FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&self.pool)
+            .await
+            .expect("the work item row must exist")
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        let _ = std::fs::remove_file(&self.db_path);
+    }
+}
+
 // ══ 1. Enforcement ════════════════════════════════════════════════════════════
 
 /// **The C1 reproduction.** Before this route ran the guard, `send_wire` came
@@ -410,35 +464,76 @@ async fn a_blocked_item_never_leaks_its_payload_however_often_it_is_reclaimed() 
     );
 }
 
-/// On a durable backend `fail_work_item` is terminal (`status = 'failed'`), so a
-/// blocked item is never re-claimed at all: the violation count stays at one.
+/// On a durable backend a blocked item is TERMINALLY failed.
+///
+/// The status assertion is the load-bearing one: `failed` and `completed` are
+/// both unclaimable, so any probe that only re-claims would pass for either, and
+/// the settle would be untested.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_blocked_dispatch_is_terminally_failed_on_a_durable_backend() {
-    let db_path = std::env::temp_dir().join(format!("jjtest-claim-{}.db", Uuid::new_v4()));
-    let backend: Arc<dyn StateBackend> = Arc::new(
-        SqliteBackend::open(&format!("sqlite://{}", db_path.display()))
-            .await
-            .expect("open sqlite"),
-    );
-    let (execution_id, _) = seed(
-        &backend,
+    let d = Durable::new().await;
+    let (execution_id, item_id) = seed(
+        &d.backend,
         dispatch_ir(true, &["send_wire"], &[]),
         "python_tool",
         dispatch_payload(calls_input(&["send_wire"])),
     )
     .await;
-    let state = make_state(backend.clone());
+    let state = make_state(d.backend.clone());
 
-    assert_withheld(&claim(&state, "python_tool").await);
     assert_withheld(&claim(&state, "python_tool").await);
 
     assert_eq!(
-        violations(&backend, &execution_id).await.len(),
+        d.status(item_id).await,
+        "failed",
+        "a blocked dispatch must be failed, not completed and not left claimed"
+    );
+
+    // And terminal: never re-claimed, so never re-evaluated.
+    assert_withheld(&claim(&state, "python_tool").await);
+    assert_eq!(
+        violations(&d.backend, &execution_id).await.len(),
         1,
         "a terminally failed item is not re-claimed, so it is not re-evaluated"
     );
 
-    let _ = std::fs::remove_file(&db_path);
+    d.cleanup().await;
+}
+
+/// A held item is SETTLED, and settled as `completed` — not failed, and above
+/// all not left `claimed` with a lease ticking down into the retry path.
+///
+/// This assertion is what binds the `Held` arm's settle. Removing the settle
+/// leaves the item `claimed`, which no re-claim probe can detect: an item still
+/// leased is skipped by `claim_work_item` exactly as a completed one is, so the
+/// re-claim returns nothing and the request count stays at one either way.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_held_dispatch_is_settled_as_completed_on_a_durable_backend() {
+    let d = Durable::new().await;
+    let (execution_id, item_id) = seed(
+        &d.backend,
+        dispatch_ir(true, &[], &["send_wire"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let state = make_state(d.backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    assert_eq!(
+        d.status(item_id).await,
+        "completed",
+        "a held item must be settled so its lease never expires into the retry \
+         path; still 'claimed' means the settle is missing"
+    );
+    assert_eq!(
+        approval_requests(&d.backend, &execution_id).await.len(),
+        1,
+        "exactly one approval request"
+    );
+
+    d.cleanup().await;
 }
 
 /// An approval-gated batch is held, not handed out, and the request carries the
@@ -640,6 +735,162 @@ async fn an_item_whose_node_is_absent_from_the_ir_is_not_handed_out() {
     assert_withheld(&claim(&make_state(backend), "python_tool").await);
 }
 
+// ══ 2b. Policy authority — the execution, not the payload ════════════════════
+//
+// `POST /work-items` copies a caller-supplied `payload` and `node_id` verbatim
+// into the queue behind the same write role as the claim route. If the payload
+// chose which workflow's policy applied, that caller could simply name a
+// workflow with no `blocked_tools` and walk the batch straight through a
+// legitimate external worker. The execution record is engine-written, so it is
+// the only trustworthy answer to "which policy governs this item".
+
+/// The attack: the execution belongs to a policed workflow, but the payload
+/// names an unpoliced one. Trusting the payload drops the workflow layer out of
+/// the chain and allows `send_wire`.
+#[tokio::test]
+async fn a_payload_naming_a_different_workflow_than_the_execution_is_not_handed_out() {
+    let backend = memory();
+    // The workflow the EXECUTION belongs to: blocks send_wire.
+    store(
+        &backend,
+        WF,
+        VERSION,
+        dispatch_ir(true, &["send_wire"], &[]),
+    )
+    .await;
+    // A real, stored, but UNPOLICED workflow the attacker would rather be judged by.
+    store(
+        &backend,
+        "unpoliced-wf",
+        VERSION,
+        dispatch_ir(true, &[], &[]),
+    )
+    .await;
+
+    let mut payload = dispatch_payload(calls_input(&["send_wire"]));
+    payload["workflow_id"] = json!("unpoliced-wf");
+    seed_item(&backend, "python_tool", payload).await;
+
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
+/// The version variant: v1.0.0 is unpoliced, the execution is on v2.0.0 which
+/// blocks `send_wire`. Trusting the payload evaluates the wrong version's rules.
+#[tokio::test]
+async fn a_payload_naming_a_different_workflow_version_is_not_handed_out() {
+    let backend = memory();
+    store(
+        &backend,
+        WF,
+        "2.0.0",
+        dispatch_ir(true, &["send_wire"], &[]),
+    )
+    .await;
+    store(&backend, WF, VERSION, dispatch_ir(true, &[], &[])).await;
+
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: WF.into(),
+            workflow_version: "2.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            execution_id,
+            node_id: "n1".into(),
+            queue_type: "python_tool".into(),
+            // Claims v1.0.0, which is unpoliced.
+            payload: dispatch_payload(calls_input(&["send_wire"])),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
+/// With the coordinates gone from the payload entirely, the execution still
+/// selects the policy. This is what proves the `unwrap_or("unknown")` /
+/// `unwrap_or("1.0.0")` defaults are gone: under those, this item resolved no
+/// IR at all and could never have been policed by the workflow that owns it.
+#[tokio::test]
+async fn an_item_with_no_payload_coordinates_is_still_policed_by_its_execution() {
+    let backend = memory();
+    let mut payload = dispatch_payload(calls_input(&["send_wire"]));
+    let obj = payload.as_object_mut().unwrap();
+    obj.remove("workflow_id");
+    obj.remove("workflow_version");
+
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        payload,
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    assert_eq!(
+        violations(&backend, &execution_id).await.len(),
+        1,
+        "the execution's workflow policy must have been the one that decided"
+    );
+}
+
+/// No execution record means no authoritative coordinates, so nothing can be
+/// evaluated.
+#[tokio::test]
+async fn an_item_whose_execution_is_missing_is_not_handed_out() {
+    let backend = memory();
+    store(
+        &backend,
+        WF,
+        VERSION,
+        dispatch_ir(true, &["send_wire"], &[]),
+    )
+    .await;
+    backend
+        .enqueue_work_item(WorkItem {
+            id: Uuid::new_v4(),
+            // An execution that was never created.
+            execution_id: ExecutionId::new(),
+            node_id: "n1".into(),
+            queue_type: "python_tool".into(),
+            payload: dispatch_payload(calls_input(&["send_wire"])),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: chrono::Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
 // ══ 3. Approval binding ═══════════════════════════════════════════════════════
 
 /// The availability dual. Without this, an implementation that withheld
@@ -774,12 +1025,17 @@ async fn an_unmarked_python_fn_item_is_handed_out_untouched() {
 
 /// Every other queue — the regression that would break all durable tool
 /// execution if the guard were not gated on the dispatch marker.
+///
+/// The workflow is POLICED and the payload has no `input` key, which is the
+/// ordinary shape for a non-dispatch node. Without the marker gate the guard
+/// would read the calls out of a `Null` input, fail closed on `NotAnObject`,
+/// and terminally fail this item at claim time.
 #[tokio::test]
 async fn an_ordinary_item_on_another_queue_is_handed_out_untouched() {
     let backend = memory();
     let (execution_id, _) = seed(
         &backend,
-        condition_ir(),
+        policed_condition_ir(),
         "tool",
         json!({ "workflow_id": WF, "workflow_version": VERSION, "node_id": "n1" }),
     )

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -999,12 +999,30 @@ async fn an_approval_for_a_different_call_set_does_not_release_the_payload() {
 /// An ordinary `python_fn` (not an ADK dispatch) carries no model-chosen calls,
 /// so the guard must not touch it — even though it is on the same queue and its
 /// payload holds a name a `blocked_tools` rule would match.
+///
+/// The coordinates matter: this fixture must NOT be the ADK dispatch coroutine.
+/// A node at `jamjet.agents.tool_runtime::dispatch_tool_calls` IS an agent
+/// dispatch whether or not it carries the marker, and is guarded on its
+/// coordinates — see `an_unmarked_adk_dispatch_is_still_enforced` directly
+/// below. Narrowness is about ordinary python functions, not about unmarked
+/// dispatch nodes.
 #[tokio::test]
 async fn an_unmarked_python_fn_item_is_handed_out_untouched() {
     let backend = memory();
+    let ordinary = ir_with_node(json!({
+        "id": "n1",
+        "kind": {
+            "type": "python_fn",
+            "module": "my_app.tasks",
+            "function": "resize_image",
+            "output_schema": "",
+            "agent_tool_dispatch": false
+        }
+    }))
+    .tap_policy(&["send_wire"], &[]);
     let (execution_id, _) = seed(
         &backend,
-        dispatch_ir(false, &["send_wire"], &[]),
+        ordinary,
         "python_tool",
         dispatch_payload(calls_input(&["send_wire"])),
     )
@@ -1020,6 +1038,40 @@ async fn an_unmarked_python_fn_item_is_handed_out_untouched() {
     assert!(
         backend.get_events(&execution_id).await.unwrap().is_empty(),
         "an untouched item writes nothing"
+    );
+}
+
+/// A workflow registered before the marker existed deserializes to
+/// `agent_tool_dispatch: false`, and nothing re-validates an IR already in the
+/// backend — `validate_agent_tool_dispatch` guards the REGISTRATION route only.
+/// Keying enforcement on the marker alone would therefore hand this payload
+/// straight out, with a `blocked_tools` rule in force and a blocked call inside
+/// it: C1 still open, for exactly the workflows that predate the fix.
+///
+/// The dispatch coordinates identify the node without the marker, so the route
+/// blocks it on those instead.
+#[tokio::test]
+async fn an_unmarked_adk_dispatch_is_still_enforced() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(false, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    let recorded = violations(&backend, &execution_id).await;
+    assert_eq!(
+        recorded.len(),
+        1,
+        "the denial must reach the Prove surface like any other"
+    );
+    assert!(
+        recorded[0].contains("send_wire"),
+        "the audit rule must name the blocked tool, got {:?}",
+        recorded[0]
     );
 }
 

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1,0 +1,1246 @@
+//! Tool-policy enforcement on `POST /work-items/claim`.
+//!
+//! An ADK agent compiles a whole turn's model-chosen tool calls into ONE
+//! `python_fn` node, which the scheduler routes to the `python_tool` queue. The
+//! engine's own worker pool registers that queue with ZERO in-process workers
+//! (`runtime/workers/src/pool.rs`) — it is claimed exclusively by the external
+//! `jamjet worker` CLI over HTTP. So the in-process worker's policy check never
+//! saw an ADK dispatch node in production, and `blocked_tools` /
+//! `require_approval_for` were silently unenforced on exactly the nodes that
+//! execute model-chosen tools (review finding C1).
+//!
+//! These tests drive the real route. The load-bearing assertion in every
+//! enforcement case is that the response carries NO `work_item` — because the
+//! payload IS the capability: once it is handed back, the external worker
+//! dispatches the tool and no later check can un-send a wire transfer.
+//!
+//! Harness follows `work_item_genai.rs` (in-process axum router over an
+//! `InMemoryBackend`, dev-mode so no auth) and `java_tool_roundtrip.rs` (a
+//! SQLite backend where durable work-item status is the thing under test).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkflowDefinition};
+use jamjet_state::event::{ApprovalDecision, EventKind};
+use jamjet_state::{content_hash, Event, InMemoryBackend, SqliteBackend, DEFAULT_TENANT};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+fn make_state(backend: Arc<dyn StateBackend>) -> AppState {
+    let backend_for_fn = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone(),
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| backend_for_fn.clone()),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+/// The raw response bytes of one claim, so a refusal can be compared to an
+/// empty-queue response byte for byte rather than field by field.
+async fn claim_raw(state: &AppState, queue: &str) -> Vec<u8> {
+    let body = json!({ "worker_id": "external-python-worker-0", "queue_types": [queue] });
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post("/work-items/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "claim must stay a 200 — a distinct status is itself a signal the \
+         untrusted worker could act on"
+    );
+    resp.into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec()
+}
+
+async fn claim(state: &AppState, queue: &str) -> Value {
+    serde_json::from_slice(&claim_raw(state, queue).await).unwrap()
+}
+
+/// The whole enforcement contract in one assertion: the caller learns nothing
+/// and, above all, does NOT get the payload.
+fn assert_withheld(resp: &Value) {
+    // The payload assertion comes FIRST because it is the load-bearing one: the
+    // payload is the capability, and a failure here must name what leaked.
+    assert_eq!(
+        resp.get("work_item"),
+        None,
+        "the payload is the capability — a refusal that still returns it has \
+         enforced nothing; got {resp}"
+    );
+    assert_eq!(
+        resp["claimed"],
+        json!(false),
+        "the item must not be claimed"
+    );
+}
+
+fn assert_handed_out(resp: &Value, node_id: &str) {
+    assert_eq!(resp["claimed"], json!(true), "the item must be claimed");
+    assert_eq!(resp["work_item"]["node_id"], json!(node_id));
+    assert!(
+        resp["work_item"]["payload"].is_object(),
+        "the payload must be intact; got {resp}"
+    );
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const WF: &str = "adk-wf";
+const VERSION: &str = "1.0.0";
+
+/// A one-node workflow whose node is the ADK tool-dispatch `python_fn`.
+///
+/// `marked` toggles `agent_tool_dispatch`, which is the ONLY thing separating a
+/// node the guard evaluates from one it must pass through untouched.
+fn dispatch_ir(marked: bool, blocked: &[&str], approval: &[&str]) -> Value {
+    ir_with_node(json!({
+        "id": "n1",
+        "kind": {
+            "type": "python_fn",
+            "module": "jamjet.agents.tool_runtime",
+            "function": "dispatch_tool_calls",
+            "output_schema": "",
+            "agent_tool_dispatch": marked
+        }
+    }))
+    .tap_policy(blocked, approval)
+}
+
+/// A node kind that can never be an agent dispatch — the "every other queue"
+/// case the route must not perturb.
+fn condition_ir() -> Value {
+    ir_with_node(json!({ "id": "n1", "kind": { "type": "condition", "branches": [] } }))
+}
+
+fn ir_with_node(node: Value) -> Value {
+    json!({
+        "workflow_id": WF,
+        "version": VERSION,
+        "state_schema": "{}",
+        "start_node": "n1",
+        "nodes": { "n1": node },
+        "edges": [],
+        "retry_policies": {},
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {}
+    })
+}
+
+/// Attach a workflow-level policy set. Absent entirely when both lists are
+/// empty, so the empty-policy-chain case is genuinely policy-free.
+trait TapPolicy {
+    fn tap_policy(self, blocked: &[&str], approval: &[&str]) -> Value;
+}
+
+impl TapPolicy for Value {
+    fn tap_policy(mut self, blocked: &[&str], approval: &[&str]) -> Value {
+        if blocked.is_empty() && approval.is_empty() {
+            return self;
+        }
+        self["policy"] = json!({
+            "blocked_tools": blocked,
+            "require_approval_for": approval,
+            "model_allowlist": []
+        });
+        self
+    }
+}
+
+fn call(name: &str) -> Value {
+    json!({ "id": format!("call-{name}"), "name": name, "arguments": {} })
+}
+
+/// The scheduler's enriched `python_fn` payload (`runtime/scheduler/src/runner.rs`):
+/// workflow coordinates, dispatch coordinates, and the frozen accumulated state
+/// as `input`. The pending tool calls live at `payload["input"]["tool_calls"]`.
+fn dispatch_payload(input: Value) -> Value {
+    json!({
+        "workflow_id": WF,
+        "workflow_version": VERSION,
+        "node_id": "n1",
+        "module": "jamjet.agents.tool_runtime",
+        "function": "dispatch_tool_calls",
+        "input": input
+    })
+}
+
+fn calls_input(names: &[&str]) -> Value {
+    json!({ "tool_calls": names.iter().map(|n| call(n)).collect::<Vec<_>>() })
+}
+
+/// The exact shape `guard_dispatch` hashes when it binds an approval to the
+/// calls that approval authorises.
+fn calls_hash_for(names: &[&str]) -> String {
+    content_hash(&json!(names
+        .iter()
+        .map(|n| json!({ "name": n, "arguments": {} }))
+        .collect::<Vec<_>>()))
+}
+
+/// Store `ir`, create a Running execution, and enqueue one claimable work item.
+async fn seed(
+    backend: &Arc<dyn StateBackend>,
+    ir: Value,
+    queue_type: &str,
+    payload: Value,
+) -> (ExecutionId, Uuid) {
+    let now = chrono::Utc::now();
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: WF.into(),
+            version: VERSION.into(),
+            ir,
+            created_at: now,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
+    seed_item(backend, queue_type, payload).await
+}
+
+/// Enqueue a claimable item for a fresh execution WITHOUT storing a workflow —
+/// the unresolvable-coordinates case.
+async fn seed_item(
+    backend: &Arc<dyn StateBackend>,
+    queue_type: &str,
+    payload: Value,
+) -> (ExecutionId, Uuid) {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: WF.into(),
+            workflow_version: VERSION.into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    let node_id = payload
+        .get("node_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("n1")
+        .to_string();
+    let id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id,
+            execution_id: execution_id.clone(),
+            node_id,
+            queue_type: queue_type.into(),
+            payload,
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+    (execution_id, id)
+}
+
+async fn append(backend: &Arc<dyn StateBackend>, execution_id: &ExecutionId, kind: EventKind) {
+    // Sequence 0 is a placeholder; both backends assign the real sequence.
+    backend
+        .append_event(Event::new(execution_id.clone(), 0, kind))
+        .await
+        .expect("append_event");
+}
+
+async fn violations(backend: &Arc<dyn StateBackend>, execution_id: &ExecutionId) -> Vec<String> {
+    backend
+        .get_events(execution_id)
+        .await
+        .expect("get_events")
+        .iter()
+        .filter_map(|e| match &e.kind {
+            EventKind::PolicyViolation { rule, .. } => Some(rule.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn approval_requests(
+    backend: &Arc<dyn StateBackend>,
+    execution_id: &ExecutionId,
+) -> Vec<Value> {
+    backend
+        .get_events(execution_id)
+        .await
+        .expect("get_events")
+        .iter()
+        .filter_map(|e| match &e.kind {
+            EventKind::ToolApprovalRequired { context, .. } => Some(context.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn memory() -> Arc<dyn StateBackend> {
+    Arc::new(InMemoryBackend::new())
+}
+
+// ══ 1. Enforcement ════════════════════════════════════════════════════════════
+
+/// **The C1 reproduction.** Before this route ran the guard, `send_wire` came
+/// straight back to the external worker with `claimed: true` and a payload
+/// carrying the call — while the SDK told the operator the engine enforced
+/// `blocked_tools` fail-closed.
+#[tokio::test]
+async fn a_blocked_tool_is_never_handed_to_the_worker() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["read_file", "send_wire"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    let recorded = violations(&backend, &execution_id).await;
+    assert_eq!(
+        recorded.len(),
+        1,
+        "a refusal must reach the Prove surface exactly once; got {recorded:?}"
+    );
+    assert!(
+        recorded[0].contains("send_wire"),
+        "the audit rule must name the rule that matched; got {recorded:?}"
+    );
+}
+
+/// A refusal must be indistinguishable from an empty queue. The external worker
+/// is untrusted for this decision: if it could tell "blocked" from "nothing to
+/// do" it would gain a probe for which tools a tenant's policy forbids.
+#[tokio::test]
+async fn a_refusal_is_byte_identical_to_an_empty_queue() {
+    let empty = make_state(memory());
+    let empty_bytes = claim_raw(&empty, "python_tool").await;
+
+    let backend = memory();
+    seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let blocked_bytes = claim_raw(&make_state(backend), "python_tool").await;
+
+    assert_eq!(
+        blocked_bytes, empty_bytes,
+        "a blocked claim must be byte-identical to an empty-queue claim"
+    );
+}
+
+/// Anti-livelock. `InMemoryBackend::fail_work_item` clears the lease rather than
+/// marking the item terminal, so the blocked item becomes claimable again — the
+/// most hostile version of this test. However many times it comes back, the
+/// payload must never escape.
+#[tokio::test]
+async fn a_blocked_item_never_leaks_its_payload_however_often_it_is_reclaimed() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    for attempt in 1..=3 {
+        let resp = claim(&state, "python_tool").await;
+        assert_eq!(
+            resp["claimed"],
+            json!(false),
+            "claim {attempt} handed out a blocked item"
+        );
+        assert_eq!(
+            resp.get("work_item"),
+            None,
+            "claim {attempt} leaked the payload"
+        );
+    }
+
+    assert!(
+        !violations(&backend, &execution_id).await.is_empty(),
+        "every refusal is audited"
+    );
+}
+
+/// On a durable backend `fail_work_item` is terminal (`status = 'failed'`), so a
+/// blocked item is never re-claimed at all: the violation count stays at one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_blocked_dispatch_is_terminally_failed_on_a_durable_backend() {
+    let db_path = std::env::temp_dir().join(format!("jjtest-claim-{}.db", Uuid::new_v4()));
+    let backend: Arc<dyn StateBackend> = Arc::new(
+        SqliteBackend::open(&format!("sqlite://{}", db_path.display()))
+            .await
+            .expect("open sqlite"),
+    );
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    assert_eq!(
+        violations(&backend, &execution_id).await.len(),
+        1,
+        "a terminally failed item is not re-claimed, so it is not re-evaluated"
+    );
+
+    let _ = std::fs::remove_file(&db_path);
+}
+
+/// An approval-gated batch is held, not handed out, and the request carries the
+/// material a human needs to decide plus the hash that binds the decision to
+/// these exact calls.
+#[tokio::test]
+async fn an_approval_gated_tool_is_held_and_requests_approval() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &[], &["send_wire"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    let requests = approval_requests(&backend, &execution_id).await;
+    assert_eq!(requests.len(), 1, "exactly one request; got {requests:?}");
+    assert_eq!(requests[0]["gated_tools"], json!(["send_wire"]));
+    assert_eq!(
+        requests[0]["calls"],
+        json!([{"name": "send_wire", "arguments": {}}])
+    );
+    assert_eq!(
+        requests[0]["calls_hash"],
+        json!(calls_hash_for(&["send_wire"])),
+        "the request must bind the calls it authorises"
+    );
+    assert!(
+        violations(&backend, &execution_id).await.is_empty(),
+        "a hold is not a denial"
+    );
+
+    // Held settles the item, so it is not re-claimed into a duplicate request.
+    assert_withheld(&claim(&state, "python_tool").await);
+    assert_eq!(
+        approval_requests(&backend, &execution_id).await.len(),
+        1,
+        "a held item must not stack up approval requests"
+    );
+}
+
+/// One gated call holds the WHOLE batch. Running the two permitted calls and
+/// holding the third would execute a partial turn the approver never saw.
+#[tokio::test]
+async fn one_gated_call_holds_the_whole_batch() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &[], &["send_wire"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["read_file", "send_wire", "log_event"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    let requests = approval_requests(&backend, &execution_id).await;
+    assert_eq!(
+        requests[0]["gated_tools"],
+        json!(["send_wire"]),
+        "only the gated call is named to the approver"
+    );
+    assert_eq!(
+        requests[0]["calls"],
+        json!([
+            {"name": "read_file", "arguments": {}},
+            {"name": "send_wire", "arguments": {}},
+            {"name": "log_event", "arguments": {}}
+        ]),
+        "the whole batch is bound, so approving cannot silently widen it"
+    );
+}
+
+// ══ 2. Fail closed ════════════════════════════════════════════════════════════
+
+/// The live shape of a malformed dispatch: no `input` key at all. Reading the
+/// whole payload instead of `payload["input"]` would make this read as "no calls
+/// pending" and allow every tool.
+#[tokio::test]
+async fn a_payload_with_no_input_key_is_not_handed_out() {
+    let backend = memory();
+    let mut payload = dispatch_payload(calls_input(&["send_wire"]));
+    payload.as_object_mut().unwrap().remove("input");
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        payload,
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    assert_eq!(violations(&backend, &execution_id).await.len(), 1);
+}
+
+#[tokio::test]
+async fn a_non_object_input_is_not_handed_out() {
+    for input in [json!("send_wire"), json!([{"name": "send_wire"}]), json!(7)] {
+        let backend = memory();
+        let (execution_id, _) = seed(
+            &backend,
+            dispatch_ir(true, &["send_wire"], &[]),
+            "python_tool",
+            dispatch_payload(input.clone()),
+        )
+        .await;
+
+        let resp = claim(&make_state(backend.clone()), "python_tool").await;
+        assert_eq!(
+            resp.get("work_item"),
+            None,
+            "input {input} is unreadable and must not be handed out"
+        );
+        assert_eq!(violations(&backend, &execution_id).await.len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn a_non_array_tool_calls_is_not_handed_out() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(json!({ "tool_calls": "send_wire" })),
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    assert_eq!(violations(&backend, &execution_id).await.len(), 1);
+}
+
+/// A call whose name cannot be read cannot be matched against `blocked_tools`,
+/// so it must not run — otherwise omitting `name` is a policy bypass.
+#[tokio::test]
+async fn a_call_with_no_name_is_not_handed_out() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(json!({ "tool_calls": [{ "id": "c1", "arguments": {} }] })),
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    assert_eq!(violations(&backend, &execution_id).await.len(), 1);
+}
+
+/// If the IR cannot be resolved, the `agent_tool_dispatch` marker cannot be
+/// read — so whether this item needs policy evaluation is UNKNOWN. Handing it
+/// out would make "point the payload at a workflow that does not exist" a
+/// complete bypass of the guard.
+#[tokio::test]
+async fn an_item_whose_workflow_cannot_be_resolved_is_not_handed_out() {
+    let backend = memory();
+    seed_item(
+        &backend,
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
+/// Same reasoning for an IR that is stored but unparseable.
+#[tokio::test]
+async fn an_item_whose_workflow_ir_is_corrupt_is_not_handed_out() {
+    let backend = memory();
+    seed(
+        &backend,
+        json!("this is not a workflow ir"),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
+/// The node id is what selects the policy set and the dispatch marker. A node
+/// that is not in the IR has neither, so it cannot be evaluated.
+#[tokio::test]
+async fn an_item_whose_node_is_absent_from_the_ir_is_not_handed_out() {
+    let backend = memory();
+    let mut payload = dispatch_payload(calls_input(&["send_wire"]));
+    payload["node_id"] = json!("ghost");
+    seed(
+        &backend,
+        dispatch_ir(true, &["send_wire"], &[]),
+        "python_tool",
+        payload,
+    )
+    .await;
+    assert_withheld(&claim(&make_state(backend), "python_tool").await);
+}
+
+// ══ 3. Approval binding ═══════════════════════════════════════════════════════
+
+/// The availability dual. Without this, an implementation that withheld
+/// everything would pass every other enforcement test here.
+#[tokio::test]
+async fn a_matching_approval_releases_the_payload() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &[], &["send_wire"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    append(
+        &backend,
+        &execution_id,
+        EventKind::ToolApprovalRequired {
+            node_id: "n1".into(),
+            tool_name: "send_wire".into(),
+            approver: "human".into(),
+            context: json!({
+                "node_id": "n1",
+                "gated_tools": ["send_wire"],
+                "calls": [{"name": "send_wire", "arguments": {}}],
+                "calls_hash": calls_hash_for(&["send_wire"]),
+            }),
+        },
+    )
+    .await;
+    append(
+        &backend,
+        &execution_id,
+        EventKind::ApprovalReceived {
+            node_id: "n1".into(),
+            user_id: "risk-officer".into(),
+            decision: ApprovalDecision::Approved,
+            comment: None,
+            state_patch: None,
+        },
+    )
+    .await;
+
+    let resp = claim(&make_state(backend.clone()), "python_tool").await;
+    assert_handed_out(&resp, "n1");
+    assert_eq!(
+        resp["work_item"]["payload"]["input"]["tool_calls"][0]["name"],
+        json!("send_wire"),
+        "the approved batch must reach the worker intact"
+    );
+    assert!(violations(&backend, &execution_id).await.is_empty());
+}
+
+/// A settled approval authorises one call set, not the node forever. Otherwise
+/// a human approving `read_file` would silently authorise a later `send_wire`.
+#[tokio::test]
+async fn an_approval_for_a_different_call_set_does_not_release_the_payload() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &[], &["send_wire", "read_file"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    append(
+        &backend,
+        &execution_id,
+        EventKind::ToolApprovalRequired {
+            node_id: "n1".into(),
+            tool_name: "read_file".into(),
+            approver: "human".into(),
+            context: json!({
+                "node_id": "n1",
+                "gated_tools": ["read_file"],
+                "calls": [{"name": "read_file", "arguments": {}}],
+                "calls_hash": calls_hash_for(&["read_file"]),
+            }),
+        },
+    )
+    .await;
+    append(
+        &backend,
+        &execution_id,
+        EventKind::ApprovalReceived {
+            node_id: "n1".into(),
+            user_id: "risk-officer".into(),
+            decision: ApprovalDecision::Approved,
+            comment: None,
+            state_patch: None,
+        },
+    )
+    .await;
+
+    assert_withheld(&claim(&make_state(backend.clone()), "python_tool").await);
+    let recorded = violations(&backend, &execution_id).await;
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(
+        recorded[0],
+        "approved tool calls do not match pending calls"
+    );
+}
+
+// ══ 4. Narrowness — the route serves every queue ══════════════════════════════
+
+/// An ordinary `python_fn` (not an ADK dispatch) carries no model-chosen calls,
+/// so the guard must not touch it — even though it is on the same queue and its
+/// payload holds a name a `blocked_tools` rule would match.
+#[tokio::test]
+async fn an_unmarked_python_fn_item_is_handed_out_untouched() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(false, &["send_wire"], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+
+    let resp = claim(&make_state(backend.clone()), "python_tool").await;
+    assert_handed_out(&resp, "n1");
+    assert_eq!(
+        resp["work_item"]["payload"],
+        dispatch_payload(calls_input(&["send_wire"])),
+        "the payload must come back byte-for-byte"
+    );
+    assert!(
+        backend.get_events(&execution_id).await.unwrap().is_empty(),
+        "an untouched item writes nothing"
+    );
+}
+
+/// Every other queue — the regression that would break all durable tool
+/// execution if the guard were not gated on the dispatch marker.
+#[tokio::test]
+async fn an_ordinary_item_on_another_queue_is_handed_out_untouched() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        condition_ir(),
+        "tool",
+        json!({ "workflow_id": WF, "workflow_version": VERSION, "node_id": "n1" }),
+    )
+    .await;
+
+    let resp = claim(&make_state(backend.clone()), "tool").await;
+    assert_handed_out(&resp, "n1");
+    assert_eq!(resp["work_item"]["queue_type"], json!("tool"));
+    assert!(resp["work_item"]["lease_fence"].as_i64().unwrap() > 0);
+    assert!(backend.get_events(&execution_id).await.unwrap().is_empty());
+}
+
+/// A marked dispatch with nothing to enforce runs. The guard short-circuits an
+/// empty policy chain before it reads the payload, so an unpoliced workflow
+/// never starts failing on payload shape.
+#[tokio::test]
+async fn a_marked_dispatch_under_an_empty_policy_chain_is_handed_out() {
+    let backend = memory();
+    let (execution_id, _) = seed(
+        &backend,
+        dispatch_ir(true, &[], &[]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+
+    assert_handed_out(
+        &claim(&make_state(backend.clone()), "python_tool").await,
+        "n1",
+    );
+    assert!(backend.get_events(&execution_id).await.unwrap().is_empty());
+}
+
+// ══ 5. Unavailable — infrastructure failure is not a policy denial ════════════
+
+/// An `InMemoryBackend` whose `get_events` fails ONCE, and only `get_events`.
+///
+/// This drives `DispatchGuardOutcome::Unavailable`: the engine could not read
+/// its own approval state. That is infrastructure, not a decision — so the
+/// route must withhold the payload WITHOUT auditing a denial no policy made and
+/// WITHOUT settling an item it never evaluated. Every other method delegates to
+/// a real backend, so "nothing was written" is an observation rather than an
+/// artefact of a stub that cannot write.
+struct FailFirstGetEvents {
+    inner: InMemoryBackend,
+    failed: std::sync::atomic::AtomicBool,
+}
+
+impl FailFirstGetEvents {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            failed: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl StateBackend for FailFirstGetEvents {
+    // ── The one injected failure ──────────────────────────────────────────────
+
+    async fn get_events(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<Vec<Event>> {
+        if !self.failed.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return Err(StateBackendError::Database(
+                "injected: event log unreadable".into(),
+            ));
+        }
+        self.inner.get_events(execution_id).await
+    }
+
+    // ── Everything else is the real backend ───────────────────────────────────
+
+    async fn store_workflow(
+        &self,
+        def: WorkflowDefinition,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.store_workflow(def).await
+    }
+
+    async fn get_workflow(
+        &self,
+        workflow_id: &str,
+        version: &str,
+    ) -> jamjet_state::backend::BackendResult<Option<WorkflowDefinition>> {
+        self.inner.get_workflow(workflow_id, version).await
+    }
+
+    async fn create_execution(
+        &self,
+        execution: WorkflowExecution,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.create_execution(execution).await
+    }
+
+    async fn get_execution(
+        &self,
+        id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<Option<WorkflowExecution>> {
+        self.inner.get_execution(id).await
+    }
+
+    async fn update_execution_status(
+        &self,
+        id: &ExecutionId,
+        status: WorkflowStatus,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.update_execution_status(id, status).await
+    }
+
+    async fn update_execution_current_state(
+        &self,
+        id: &ExecutionId,
+        current_state: &Value,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .update_execution_current_state(id, current_state)
+            .await
+    }
+
+    async fn patch_append_array(
+        &self,
+        execution_id: &ExecutionId,
+        key: &str,
+        value: Value,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .patch_append_array(execution_id, key, value)
+            .await
+    }
+
+    async fn list_executions(
+        &self,
+        status: Option<WorkflowStatus>,
+        limit: u32,
+        offset: u32,
+    ) -> jamjet_state::backend::BackendResult<Vec<WorkflowExecution>> {
+        self.inner.list_executions(status, limit, offset).await
+    }
+
+    async fn append_event(
+        &self,
+        event: Event,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+        self.inner.append_event(event).await
+    }
+
+    async fn get_events_since(
+        &self,
+        execution_id: &ExecutionId,
+        since_sequence: jamjet_state::EventSequence,
+    ) -> jamjet_state::backend::BackendResult<Vec<Event>> {
+        self.inner
+            .get_events_since(execution_id, since_sequence)
+            .await
+    }
+
+    async fn latest_sequence(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+        self.inner.latest_sequence(execution_id).await
+    }
+
+    async fn write_snapshot(
+        &self,
+        snapshot: jamjet_state::Snapshot,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.write_snapshot(snapshot).await
+    }
+
+    async fn latest_snapshot(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::Snapshot>> {
+        self.inner.latest_snapshot(execution_id).await
+    }
+
+    async fn create_segment_atomic(
+        &self,
+        execution: WorkflowExecution,
+        seed_snapshot: jamjet_state::Snapshot,
+        started_event: EventKind,
+        scheduled_event: EventKind,
+        work_item: WorkItem,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .create_segment_atomic(
+                execution,
+                seed_snapshot,
+                started_event,
+                scheduled_event,
+                work_item,
+            )
+            .await
+    }
+
+    async fn get_tool_effect(
+        &self,
+        key: &str,
+    ) -> jamjet_state::backend::BackendResult<Option<Value>> {
+        self.inner.get_tool_effect(key).await
+    }
+
+    async fn put_artifact(
+        &self,
+        bytes: &[u8],
+        media_type: Option<&str>,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::ArtifactRef> {
+        self.inner.put_artifact(bytes, media_type).await
+    }
+
+    async fn get_artifact(
+        &self,
+        hash: &str,
+    ) -> jamjet_state::backend::BackendResult<Option<Vec<u8>>> {
+        self.inner.get_artifact(hash).await
+    }
+
+    async fn enqueue_work_item(
+        &self,
+        item: WorkItem,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::WorkItemId> {
+        self.inner.enqueue_work_item(item).await
+    }
+
+    async fn claim_work_item(
+        &self,
+        worker_id: &str,
+        queue_types: &[&str],
+    ) -> jamjet_state::backend::BackendResult<Option<WorkItem>> {
+        self.inner.claim_work_item(worker_id, queue_types).await
+    }
+
+    async fn renew_lease(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        worker_id: &str,
+        lease_fence: i64,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .renew_lease(item_id, worker_id, lease_fence)
+            .await
+    }
+
+    async fn complete_work_item(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.complete_work_item(item_id).await
+    }
+
+    async fn complete_work_item_fenced(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        lease_fence: i64,
+    ) -> jamjet_state::backend::BackendResult<bool> {
+        self.inner
+            .complete_work_item_fenced(item_id, lease_fence)
+            .await
+    }
+
+    async fn fail_work_item(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        error: &str,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.fail_work_item(item_id, error).await
+    }
+
+    async fn commit_turn(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        lease_fence: i64,
+        terminal_event: Event,
+        write_snapshot: bool,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+        self.inner
+            .commit_turn(item_id, lease_fence, terminal_event, write_snapshot)
+            .await
+    }
+
+    async fn park_work_item(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        lease_fence: i64,
+        retry_after: &str,
+        next_attempt: u32,
+    ) -> jamjet_state::backend::BackendResult<bool> {
+        self.inner
+            .park_work_item(item_id, lease_fence, retry_after, next_attempt)
+            .await
+    }
+
+    async fn finalize_rollover_fenced(
+        &self,
+        execution_id: &ExecutionId,
+        work_item_id: jamjet_state::backend::WorkItemId,
+        lease_fence: i64,
+    ) -> jamjet_state::backend::BackendResult<bool> {
+        self.inner
+            .finalize_rollover_fenced(execution_id, work_item_id, lease_fence)
+            .await
+    }
+
+    async fn reclaim_expired_leases(
+        &self,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::ReclaimResult> {
+        self.inner.reclaim_expired_leases().await
+    }
+
+    async fn move_to_dead_letter(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        last_error: &str,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.move_to_dead_letter(item_id, last_error).await
+    }
+
+    async fn create_token(
+        &self,
+        name: &str,
+        role: &str,
+    ) -> jamjet_state::backend::BackendResult<(String, jamjet_state::backend::ApiToken)> {
+        self.inner.create_token(name, role).await
+    }
+
+    async fn validate_token(
+        &self,
+        token: &str,
+    ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::ApiToken>> {
+        self.inner.validate_token(token).await
+    }
+
+    async fn apply_approval_projection(
+        &self,
+        row: jamjet_state::ApprovalProjectionRow,
+        projection_name: &str,
+        new_checkpoint: i64,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .apply_approval_projection(row, projection_name, new_checkpoint)
+            .await
+    }
+
+    async fn apply_approval_projection_batch(
+        &self,
+        rows: Vec<jamjet_state::ApprovalProjectionRow>,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .apply_approval_projection_batch(rows, projection_name, execution_id, new_checkpoint)
+            .await
+    }
+
+    async fn get_approval_projection(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<Vec<jamjet_state::ApprovalProjectionRow>> {
+        self.inner.get_approval_projection(execution_id).await
+    }
+
+    async fn get_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+    ) -> jamjet_state::backend::BackendResult<i64> {
+        self.inner
+            .get_projector_checkpoint(projection_name, execution_id)
+            .await
+    }
+
+    async fn set_projector_checkpoint(
+        &self,
+        projection_name: &str,
+        execution_id: &ExecutionId,
+        new_checkpoint: i64,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner
+            .set_projector_checkpoint(projection_name, execution_id, new_checkpoint)
+            .await
+    }
+
+    async fn create_tenant(
+        &self,
+        tenant: jamjet_state::Tenant,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.create_tenant(tenant).await
+    }
+
+    async fn get_tenant(
+        &self,
+        id: &jamjet_state::TenantId,
+    ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::Tenant>> {
+        self.inner.get_tenant(id).await
+    }
+
+    async fn list_tenants(
+        &self,
+    ) -> jamjet_state::backend::BackendResult<Vec<jamjet_state::Tenant>> {
+        self.inner.list_tenants().await
+    }
+
+    async fn update_tenant(
+        &self,
+        tenant: jamjet_state::Tenant,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.update_tenant(tenant).await
+    }
+}
+
+/// A backend failure must withhold the payload, audit NOTHING, and settle
+/// NOTHING.
+///
+/// Auditing here would put a denial on the Prove surface that no policy made,
+/// and failing the item would make a transient outage permanently kill work the
+/// engine never evaluated. Leaving the item leased is the fail-closed choice:
+/// the lease expires, the reclaimer returns it to the queue, and the next claim
+/// decides properly.
+#[tokio::test]
+async fn a_backend_failure_withholds_without_auditing_or_settling() {
+    let backend: Arc<dyn StateBackend> = Arc::new(FailFirstGetEvents::new());
+    let (execution_id, item_id) = seed(
+        &backend,
+        dispatch_ir(true, &[], &["send_wire"]),
+        "python_tool",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+    let state = make_state(backend.clone());
+
+    assert_withheld(&claim(&state, "python_tool").await);
+
+    assert!(
+        violations(&backend, &execution_id).await.is_empty(),
+        "no policy denied — a PolicyViolation here is a false denial"
+    );
+    assert!(
+        approval_requests(&backend, &execution_id).await.is_empty(),
+        "an undecided dispatch requests nothing"
+    );
+
+    // The item must still exist (not completed). `renew_lease` reports
+    // `NotFound` only for an item that is gone; a live item held by another
+    // worker reports `FenceLost`, so this distinguishes the two.
+    if let Err(StateBackendError::NotFound(_)) =
+        backend.renew_lease(item_id, "someone-else", 0).await
+    {
+        panic!("the item was settled as complete despite never being evaluated");
+    }
+
+    // … and must still be leased, not returned to the queue as failed. The
+    // injected failure has healed, so a re-claimable item would now produce an
+    // approval request; silence proves the lease was left intact.
+    assert_withheld(&claim(&state, "python_tool").await);
+    assert!(
+        approval_requests(&backend, &execution_id).await.is_empty(),
+        "the item was failed back onto the queue instead of being left leased"
+    );
+}

--- a/runtime/api/tests/java_tool_roundtrip.rs
+++ b/runtime/api/tests/java_tool_roundtrip.rs
@@ -361,9 +361,29 @@ fn temp_sqlite_url() -> (std::path::PathBuf, String) {
 
 /// Create a Running execution and enqueue a single claimable `java_tool` work
 /// item for it, mirroring what the scheduler would enqueue for a JavaFn node.
+///
+/// The workflow definition is stored and the payload carries the workflow
+/// coordinates because that is what the scheduler always produces
+/// (`runtime/scheduler/src/runner.rs` builds every payload with `workflow_id` /
+/// `workflow_version`, and it could not have scheduled the node at all without
+/// the definition on file). The claim route resolves those coordinates to
+/// decide whether the node is an ADK agent tool dispatch that needs policy
+/// evaluation, so a fixture without them is not a shape production can reach.
 async fn seed_claimable_java_item(backend: &Arc<dyn StateBackend>) -> ExecutionId {
     let execution_id = ExecutionId::new();
     let now = chrono::Utc::now();
+    let mut ir = java_tool_workflow_ir();
+    ir["workflow_id"] = serde_json::json!("java-tool-fence");
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: "java-tool-fence".into(),
+            version: "0.1.0".into(),
+            ir,
+            created_at: now,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
     backend
         .create_execution(WorkflowExecution {
             execution_id: execution_id.clone(),
@@ -400,6 +420,9 @@ async fn seed_claimable_java_item(backend: &Arc<dyn StateBackend>) -> ExecutionI
             node_id: "java_tool_node".into(),
             queue_type: "java_tool".into(),
             payload: serde_json::json!({
+                "workflow_id": "java-tool-fence",
+                "workflow_version": "0.1.0",
+                "node_id": "java_tool_node",
                 "class": "com.example.tools.WeatherTool",
                 "method": "getWeather",
                 "input": {},

--- a/runtime/api/tests/workflow_validation.rs
+++ b/runtime/api/tests/workflow_validation.rs
@@ -5,8 +5,23 @@
 //! and only fails later when the scheduler tries to deserialize it, leaving the
 //! execution stuck in `running` forever. These tests pin both directions: the
 //! canonical compiled workflow must pass, and incomplete IR must be rejected.
+//!
+//! The route also runs ONE rule from `validate_workflow` — the ADK
+//! tool-dispatch marker check — because an unmarked dispatch node is a
+//! policy-enforcement hole rather than a reference the runtime resolves later.
+//! The route-level tests at the bottom drive that through the real router.
 
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
 use jamjet_ir::WorkflowIr;
+use jamjet_state::backend::StateBackend;
+use jamjet_state::InMemoryBackend;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
 
 #[test]
 fn canonical_compiled_ir_deserializes() {
@@ -50,5 +65,144 @@ fn fleet_agent_ir_registers() {
         parsed.is_ok(),
         "fleet researcher IR must deserialize into WorkflowIr, got: {:?}",
         parsed.err()
+    );
+}
+
+// ── Route-level: the ADK tool-dispatch marker ────────────────────────────────
+//
+// Harness follows `claim_route_policy.rs` (in-process axum router over an
+// `InMemoryBackend`, dev-mode so no auth).
+
+const WF: &str = "adk-wf";
+const VERSION: &str = "1.0.0";
+
+fn make_state(backend: Arc<dyn StateBackend>) -> AppState {
+    let backend_for_fn = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone(),
+        backend_for_fn: Arc::new(move |_tenant_id: &jamjet_state::TenantId| backend_for_fn.clone()),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+/// A one-node IR whose node is the ADK tool-dispatch `python_fn`.
+///
+/// Built from raw JSON so the marker can be omitted ENTIRELY, which is how an
+/// IR compiled by a pre-marker SDK arrives. Everything else about the IR is
+/// valid and deserializes cleanly, so the marker rule is the only thing that
+/// can reject it.
+fn dispatch_ir(marker: Option<bool>) -> Value {
+    let mut kind = json!({
+        "type": "python_fn",
+        "module": "jamjet.agents.tool_runtime",
+        "function": "dispatch_tool_calls",
+        "output_schema": ""
+    });
+    if let Some(m) = marker {
+        kind["agent_tool_dispatch"] = json!(m);
+    }
+    json!({
+        "workflow_id": WF,
+        "version": VERSION,
+        "state_schema": "{}",
+        "start_node": "n1",
+        "nodes": { "n1": { "id": "n1", "kind": kind } },
+        "edges": [],
+        "retry_policies": {},
+        "models": {},
+        "tools": {},
+        "mcp_servers": {},
+        "remote_agents": {}
+    })
+}
+
+async fn post_workflow(state: &AppState, ir: Value) -> StatusCode {
+    let body = json!({ "ir": ir });
+    build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post("/workflows")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+}
+
+/// The version-skew case, driven through the real route: a pre-marker ADK IR
+/// must be refused AND must not reach storage.
+///
+/// Storing it is the whole harm. Once the definition is persisted, every
+/// execution of it hands a whole turn's model-chosen tool calls to the external
+/// worker with no tool policy evaluated, and nothing downstream can recover the
+/// marker that was never compiled in.
+#[tokio::test]
+async fn unmarked_adk_dispatch_ir_is_rejected_by_the_route() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+
+    let status = post_workflow(&state, dispatch_ir(None)).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unmarked ADK dispatch node must be refused at registration"
+    );
+
+    // The load-bearing assertion: refused AND not persisted.
+    assert!(
+        backend
+            .get_workflow(WF, VERSION)
+            .await
+            .expect("backend lookup must succeed")
+            .is_none(),
+        "a refused IR must not be stored — a persisted definition runs its tool \
+         calls unpoliced on every later execution"
+    );
+}
+
+/// An explicit `false` is the same hole as an absent marker, and must be
+/// refused identically. This is the case a pre-marker SDK cannot emit but a
+/// hand-edited or replayed IR can.
+#[tokio::test]
+async fn explicitly_unmarked_adk_dispatch_ir_is_rejected_by_the_route() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+
+    let status = post_workflow(&state, dispatch_ir(Some(false))).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(backend
+        .get_workflow(WF, VERSION)
+        .await
+        .expect("backend lookup must succeed")
+        .is_none());
+}
+
+/// Narrowness: the IR Task 2's compiler actually emits still registers. Without
+/// this, the rule above could be "reject every ADK workflow" and still pass.
+#[tokio::test]
+async fn marked_adk_dispatch_ir_registers() {
+    let backend = Arc::new(InMemoryBackend::new());
+    let state = make_state(backend.clone());
+
+    let status = post_workflow(&state, dispatch_ir(Some(true))).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a correctly marked ADK dispatch IR must still register"
+    );
+    assert!(
+        backend
+            .get_workflow(WF, VERSION)
+            .await
+            .expect("backend lookup must succeed")
+            .is_some(),
+        "the accepted definition must be stored"
     );
 }

--- a/runtime/core/src/node.rs
+++ b/runtime/core/src/node.rs
@@ -53,6 +53,16 @@ pub enum NodeKind {
         module: String,
         function: String,
         output_schema: String,
+        /// True when this node is an ADK agent tool-dispatch node, i.e. it runs a
+        /// whole turn's model-chosen tool calls in one shot.
+        ///
+        /// Policy for these nodes cannot be derived from the static node kind:
+        /// the tool names only exist in runtime state. The worker instead
+        /// evaluates the frozen pending calls carried in the work-item payload.
+        /// `#[serde(default)]` so IRs compiled before this field existed
+        /// deserialize to `false` and behave exactly as they did before.
+        #[serde(default)]
+        agent_tool_dispatch: bool,
     },
 
     /// Arbitrary Java method executed by an external Java tool-worker.
@@ -65,6 +75,11 @@ pub enum NodeKind {
         class_name: String,
         method: String,
         output_schema: String,
+        /// See [`NodeKind::PythonFn::agent_tool_dispatch`]. The Java tool-worker
+        /// receives identical payload enrichment, so it has the identical
+        /// enforcement gap and needs the identical marker.
+        #[serde(default)]
+        agent_tool_dispatch: bool,
     },
 
     /// Router — evaluates expressions and branches.
@@ -420,6 +435,7 @@ mod tests {
             class_name: "com.example.tools.WeatherTool".into(),
             method: "getWeather".into(),
             output_schema: "schemas.Weather".into(),
+            agent_tool_dispatch: false,
         };
         let json = serde_json::to_string(&node).unwrap();
         let deserialized: NodeKind = serde_json::from_str(&json).unwrap();
@@ -439,6 +455,7 @@ mod tests {
             class_name: "com.example.tools.WeatherTool".into(),
             method: "getWeather".into(),
             output_schema: String::new(),
+            agent_tool_dispatch: false,
         };
         // Mirrors PythonFn -> PythonTool: JavaFn routes to its own durable queue.
         assert_eq!(node.queue_type(), QueueType::JavaTool);
@@ -449,6 +466,82 @@ mod tests {
             "java_tool",
             "QueueType::JavaTool must serialize to the \"java_tool\" queue string"
         );
+    }
+
+    #[test]
+    fn python_fn_without_dispatch_flag_defaults_to_false() {
+        // An IR persisted before this field existed must deserialize unchanged.
+        let json = serde_json::json!({
+            "type": "python_fn",
+            "module": "m",
+            "function": "f",
+            "output_schema": ""
+        });
+        let kind: NodeKind =
+            serde_json::from_value(json).expect("legacy python_fn must deserialize");
+        match kind {
+            NodeKind::PythonFn {
+                agent_tool_dispatch,
+                ..
+            } => assert!(!agent_tool_dispatch),
+            other => panic!("expected PythonFn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn python_fn_dispatch_flag_round_trips() {
+        let json = serde_json::json!({
+            "type": "python_fn",
+            "module": "m",
+            "function": "f",
+            "output_schema": "",
+            "agent_tool_dispatch": true
+        });
+        let kind: NodeKind = serde_json::from_value(json).expect("python_fn must deserialize");
+        match kind {
+            NodeKind::PythonFn {
+                agent_tool_dispatch,
+                ..
+            } => assert!(agent_tool_dispatch),
+            other => panic!("expected PythonFn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn java_fn_without_dispatch_flag_defaults_to_false() {
+        let json = serde_json::json!({
+            "type": "java_fn",
+            "class_name": "C",
+            "method": "m",
+            "output_schema": ""
+        });
+        let kind: NodeKind = serde_json::from_value(json).expect("legacy java_fn must deserialize");
+        match kind {
+            NodeKind::JavaFn {
+                agent_tool_dispatch,
+                ..
+            } => assert!(!agent_tool_dispatch),
+            other => panic!("expected JavaFn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn java_fn_dispatch_flag_round_trips() {
+        let json = serde_json::json!({
+            "type": "java_fn",
+            "class_name": "C",
+            "method": "m",
+            "output_schema": "",
+            "agent_tool_dispatch": true
+        });
+        let kind: NodeKind = serde_json::from_value(json).expect("java_fn must deserialize");
+        match kind {
+            NodeKind::JavaFn {
+                agent_tool_dispatch,
+                ..
+            } => assert!(agent_tool_dispatch),
+            other => panic!("expected JavaFn, got {other:?}"),
+        }
     }
 
     #[test]

--- a/runtime/ir/src/error.rs
+++ b/runtime/ir/src/error.rs
@@ -26,6 +26,9 @@ pub enum IrError {
     #[error("condition node '{node}' branch target '{target}' has no matching out-edge")]
     BranchTargetMissingOutEdge { node: String, target: String },
 
+    #[error("node '{0}' dispatches ADK agent tool calls but is not marked agent_tool_dispatch, so tool policy would not be enforced for it")]
+    UnmarkedAgentToolDispatch(String),
+
     #[error("node '{0}' is unreachable from the start node")]
     UnreachableNode(String),
 

--- a/runtime/ir/src/lib.rs
+++ b/runtime/ir/src/lib.rs
@@ -3,5 +3,8 @@ pub mod validate;
 pub mod workflow;
 
 pub use error::IrError;
-pub use validate::{validate_agent_tool_dispatch, validate_workflow};
+pub use validate::{
+    is_adk_dispatch_coordinates, validate_agent_tool_dispatch, validate_workflow,
+    ADK_DISPATCH_FUNCTION, ADK_DISPATCH_MODULE,
+};
 pub use workflow::{EdgeDef, NodeDef, WorkflowIr};

--- a/runtime/ir/src/lib.rs
+++ b/runtime/ir/src/lib.rs
@@ -3,5 +3,5 @@ pub mod validate;
 pub mod workflow;
 
 pub use error::IrError;
-pub use validate::validate_workflow;
+pub use validate::{validate_agent_tool_dispatch, validate_workflow};
 pub use workflow::{EdgeDef, NodeDef, WorkflowIr};

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -16,6 +16,7 @@ use std::collections::{HashSet, VecDeque};
 /// 8. All tool_ref, model_ref, agent_ref resolve to known definitions
 /// 9. All MCP servers referenced by mcp_tool nodes are configured
 /// 10. All remote agents referenced by a2a_task nodes are configured
+/// 11. Every ADK tool-dispatch node carries its `agent_tool_dispatch` marker
 pub fn validate_workflow(ir: &WorkflowIr) -> IrResult<()> {
     validate_metadata(ir)?;
     validate_no_duplicate_nodes(ir)?;
@@ -24,6 +25,46 @@ pub fn validate_workflow(ir: &WorkflowIr) -> IrResult<()> {
     validate_branch_targets(ir)?;
     validate_reachability(ir)?;
     validate_refs(ir)?;
+    validate_agent_tool_dispatch(ir)?;
+    Ok(())
+}
+
+/// The ADK tool-dispatch coroutine. Kept in sync with `_DISPATCH_MODULE` and
+/// `_DISPATCH_FUNCTION` in `sdk/python/jamjet/compiler/agent_ir.py:51-52`.
+const ADK_DISPATCH_MODULE: &str = "jamjet.agents.tool_runtime";
+const ADK_DISPATCH_FUNCTION: &str = "dispatch_tool_calls";
+
+/// Reject an ADK tool-dispatch node that is missing its policy marker.
+///
+/// Without the marker the worker treats the node as an opaque python_fn and
+/// enforces no tool policy on it. An IR compiled before the marker existed
+/// deserializes to `false`, so this makes the drift loud instead of silent.
+///
+/// The dispatch coordinates are the only signal that survives to Rust: the
+/// compiler nests its `tools` resolver map inside the *kind* dict, `PythonFn`
+/// has no such field, and serde drops unknown keys.
+///
+/// Python coordinates only — no Java ADK compiler emits `java_fn` dispatch
+/// nodes yet. Add the Java pair here when that compiler lands.
+fn validate_agent_tool_dispatch(ir: &WorkflowIr) -> IrResult<()> {
+    use jamjet_core::node::NodeKind;
+
+    for (id, node) in &ir.nodes {
+        if let NodeKind::PythonFn {
+            module,
+            function,
+            agent_tool_dispatch,
+            ..
+        } = &node.kind
+        {
+            if module == ADK_DISPATCH_MODULE
+                && function == ADK_DISPATCH_FUNCTION
+                && !agent_tool_dispatch
+            {
+                return Err(IrError::UnmarkedAgentToolDispatch(id.clone()));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -353,6 +394,68 @@ mod tests {
             matches!(&err, Err(IrError::BranchTargetMissingOutEdge { node, target }) if node == "a" && target == "b"),
             "a branch target with no matching out-edge must fail with BranchTargetMissingOutEdge, got {err:?}"
         );
+    }
+
+    /// A one-node IR built from raw JSON, so a node kind can omit
+    /// `agent_tool_dispatch` entirely — exactly how a pre-marker IR
+    /// deserializes. The struct fixture above cannot express that: the field is
+    /// not optional in Rust, so it can only ever be written as `false`.
+    ///
+    /// The maps are spelled out because `WorkflowIr` has no serde defaults for
+    /// them; this mirrors the dispatch fixtures in `runtime/workers` and
+    /// `runtime/api`.
+    fn ir_with_kind(kind: serde_json::Value) -> WorkflowIr {
+        serde_json::from_value(serde_json::json!({
+            "workflow_id": "wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": { "n1": { "id": "n1", "kind": kind } },
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {}
+        }))
+        .expect("fixture IR must parse")
+    }
+
+    #[test]
+    fn unmarked_adk_dispatch_node_is_rejected() {
+        // An ADK IR compiled before the flag existed would otherwise run with
+        // no tool policy at all (C1 regression guard).
+        let ir = ir_with_kind(serde_json::json!({
+            "type": "python_fn",
+            "module": "jamjet.agents.tool_runtime",
+            "function": "dispatch_tool_calls",
+            "output_schema": ""
+        }));
+        let err = validate_workflow(&ir).expect_err("must reject an unmarked dispatch node");
+        assert!(format!("{err}").contains("agent_tool_dispatch"));
+    }
+
+    #[test]
+    fn marked_adk_dispatch_node_validates() {
+        let ir = ir_with_kind(serde_json::json!({
+            "type": "python_fn",
+            "module": "jamjet.agents.tool_runtime",
+            "function": "dispatch_tool_calls",
+            "output_schema": "",
+            "agent_tool_dispatch": true
+        }));
+        assert!(validate_workflow(&ir).is_ok());
+    }
+
+    #[test]
+    fn ordinary_python_fn_validates() {
+        let ir = ir_with_kind(serde_json::json!({
+            "type": "python_fn",
+            "module": "my.module",
+            "function": "my_fn",
+            "output_schema": ""
+        }));
+        assert!(validate_workflow(&ir).is_ok());
     }
 
     #[test]

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -31,8 +31,20 @@ pub fn validate_workflow(ir: &WorkflowIr) -> IrResult<()> {
 
 /// The ADK tool-dispatch coroutine. Kept in sync with `_DISPATCH_MODULE` and
 /// `_DISPATCH_FUNCTION` in `sdk/python/jamjet/compiler/agent_ir.py:51-52`.
-const ADK_DISPATCH_MODULE: &str = "jamjet.agents.tool_runtime";
-const ADK_DISPATCH_FUNCTION: &str = "dispatch_tool_calls";
+pub const ADK_DISPATCH_MODULE: &str = "jamjet.agents.tool_runtime";
+pub const ADK_DISPATCH_FUNCTION: &str = "dispatch_tool_calls";
+
+/// True when a `python_fn`'s coordinates are the ADK tool-dispatch coroutine.
+///
+/// The marker is the declarative signal, but it is `#[serde(default)]`, so an IR
+/// stored before the marker existed reads as unmarked — and nothing re-validates
+/// a workflow already in the backend. Enforcement therefore keys on these
+/// coordinates too, which is why this is public rather than inlined into
+/// [`validate_agent_tool_dispatch`]: the validator and the worker must agree on
+/// what an ADK dispatch node IS, from one definition.
+pub fn is_adk_dispatch_coordinates(module: &str, function: &str) -> bool {
+    module == ADK_DISPATCH_MODULE && function == ADK_DISPATCH_FUNCTION
+}
 
 /// Reject an ADK tool-dispatch node that is missing its policy marker.
 ///
@@ -61,10 +73,7 @@ pub fn validate_agent_tool_dispatch(ir: &WorkflowIr) -> IrResult<()> {
             ..
         } = &node.kind
         {
-            if module == ADK_DISPATCH_MODULE
-                && function == ADK_DISPATCH_FUNCTION
-                && !agent_tool_dispatch
-            {
+            if is_adk_dispatch_coordinates(module, function) && !agent_tool_dispatch {
                 return Err(IrError::UnmarkedAgentToolDispatch(id.clone()));
             }
         }

--- a/runtime/ir/src/validate.rs
+++ b/runtime/ir/src/validate.rs
@@ -46,7 +46,11 @@ const ADK_DISPATCH_FUNCTION: &str = "dispatch_tool_calls";
 ///
 /// Python coordinates only — no Java ADK compiler emits `java_fn` dispatch
 /// nodes yet. Add the Java pair here when that compiler lands.
-fn validate_agent_tool_dispatch(ir: &WorkflowIr) -> IrResult<()> {
+///
+/// Public, and callable independently of [`validate_workflow`], because the
+/// `POST /workflows` route needs exactly this rule without the ref rules it
+/// deliberately skips (see `runtime/api/src/routes.rs`).
+pub fn validate_agent_tool_dispatch(ir: &WorkflowIr) -> IrResult<()> {
     use jamjet_core::node::NodeKind;
 
     for (id, node) in &ir.nodes {

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -19,6 +19,26 @@ pub struct PendingToolCall {
     pub arguments: Value,
 }
 
+/// The longest tool name that may reach the matcher.
+///
+/// These names are model output, so a prompt injection can choose them. They are
+/// matched by [`crate::glob_match`], which recurses once per character and never
+/// memoizes: recursion depth is linear in the name length, and a Rust stack
+/// overflow aborts the process rather than unwinding. A multi-star pattern also
+/// backtracks superlinearly over the same input.
+///
+/// 512 is far above any real tool name — the OpenAI and Anthropic function-name
+/// limits are 64 — and far below anything that threatens a worker stack, so it
+/// rejects only implausible input.
+pub const MAX_TOOL_NAME_LEN: usize = 512;
+
+/// The most pending calls one dispatch batch may carry.
+///
+/// Bounds the total matching work for a batch, so a single payload cannot force
+/// an unbounded number of glob evaluations. A model turn emits a handful of tool
+/// calls; 256 is generous for a legitimate batch.
+pub const MAX_PENDING_CALLS: usize = 256;
+
 /// Why a dispatch payload's pending calls could not be read.
 ///
 /// Every variant means the same thing to the enforcement decision — the caller
@@ -37,6 +57,11 @@ pub enum UnreadableCalls {
     /// A call in the list has no readable string `name`, so it cannot be matched
     /// against `blocked_tools` / `require_approval_for`.
     UnnamedCall,
+    /// A call's `name` exceeds [`MAX_TOOL_NAME_LEN`]. Refused before it reaches
+    /// the matcher, because the matcher's recursion depth is linear in the name.
+    NameTooLong,
+    /// The call list holds more than [`MAX_PENDING_CALLS`] entries.
+    TooManyCalls,
 }
 
 /// Read the tool calls a marked agent-dispatch node will execute from its
@@ -70,6 +95,13 @@ pub fn read_pending_tool_calls(input: &Value) -> Result<Vec<PendingToolCall>, Un
     };
 
     let arr = raw.as_array().ok_or(UnreadableCalls::NotAList)?;
+    // Bound the batch before reading it, so an oversized list cannot force an
+    // unbounded number of glob evaluations downstream.
+    if arr.len() > MAX_PENDING_CALLS {
+        return Err(UnreadableCalls::TooManyCalls);
+    }
+    // `with_capacity(arr.len())` is safe only because the length is bounded
+    // above; without that check a payload could dictate a huge allocation.
     let mut out = Vec::with_capacity(arr.len());
     for call in arr {
         // A call whose name cannot be read cannot be matched against
@@ -78,8 +110,13 @@ pub fn read_pending_tool_calls(input: &Value) -> Result<Vec<PendingToolCall>, Un
         let name = call
             .get("name")
             .and_then(|n| n.as_str())
-            .ok_or(UnreadableCalls::UnnamedCall)?
-            .to_string();
+            .ok_or(UnreadableCalls::UnnamedCall)?;
+        // Counted in chars, not bytes: `glob_match` collects both sides into
+        // `Vec<char>` and recurses per char, so chars are what bound the depth.
+        if name.chars().count() > MAX_TOOL_NAME_LEN {
+            return Err(UnreadableCalls::NameTooLong);
+        }
+        let name = name.to_string();
         let arguments = call.get("arguments").cloned().unwrap_or(Value::Null);
         out.push(PendingToolCall { name, arguments });
     }
@@ -421,5 +458,55 @@ mod tests {
         let node = policy(&[], &["send_wire"]);
         let d = evaluate_dispatch("__tools_0__", &pending(&["send_wire"]), &[&tenant, &node]);
         assert!(matches!(d, DispatchDecision::RequireApproval { .. }));
+    }
+
+    // ── Bounds on model-controlled input ──────────────────────────────────────
+    //
+    // These names come from model output, so they are attacker-influenceable via
+    // prompt injection. They are matched with `glob_match`, which recurses once
+    // per character and never memoizes: depth is linear in the name, so a long
+    // enough name overflows the stack (an abort in Rust, not a catchable error),
+    // and a multi-star pattern backtracks superlinearly on top of that. Bounding
+    // the input here is what keeps an unbounded string from reaching it.
+
+    #[test]
+    fn an_overlong_tool_name_is_unreadable() {
+        let long = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        let input = json!({"tool_calls": [{"name": long, "arguments": {}}]});
+        assert_eq!(
+            read_pending_tool_calls(&input),
+            Err(UnreadableCalls::NameTooLong)
+        );
+    }
+
+    #[test]
+    fn a_tool_name_at_the_limit_still_reads() {
+        // The bound must reject only what is implausible, never a legitimate
+        // name sitting exactly at the edge.
+        let name = "a".repeat(MAX_TOOL_NAME_LEN);
+        let input = json!({"tool_calls": [{"name": name, "arguments": {}}]});
+        let calls = read_pending_tool_calls(&input).expect("a name at the limit is readable");
+        assert_eq!(calls.len(), 1);
+    }
+
+    #[test]
+    fn an_oversized_call_list_is_unreadable() {
+        let calls: Vec<_> = (0..MAX_PENDING_CALLS + 1)
+            .map(|i| json!({"name": format!("t{i}"), "arguments": {}}))
+            .collect();
+        let input = json!({ "tool_calls": calls });
+        assert_eq!(
+            read_pending_tool_calls(&input),
+            Err(UnreadableCalls::TooManyCalls)
+        );
+    }
+
+    #[test]
+    fn bounds_are_enforced_before_any_matching() {
+        // Fail closed: an over-long name must be refused as unreadable rather
+        // than reaching the evaluator, even when no rule would have matched it.
+        let long = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        let input = json!({"tool_calls": [{"name": long, "arguments": {}}]});
+        assert!(pending_tool_calls(&input).is_none());
     }
 }

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -1,0 +1,129 @@
+//! Policy evaluation for ADK agent tool-dispatch nodes.
+//!
+//! An ADK agent compiles a whole turn's tool calls into one `python_fn` /
+//! `java_fn` node, so the tool names are absent from the static node kind and
+//! the ordinary [`crate::EvaluationContext::from_node_kind`] path sees nothing
+//! to police (review finding C1). The scheduler freezes the accumulated state
+//! into the work-item payload before the worker runs, so the pending calls are
+//! readable here — the same bytes the dispatch will consume, which is what
+//! makes this free of a time-of-check-to-time-of-use window.
+
+use serde_json::Value;
+
+/// One tool call an agent dispatch node is about to execute.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingToolCall {
+    pub name: String,
+    pub arguments: Value,
+}
+
+/// Read the tool calls a marked agent-dispatch node will execute from its
+/// frozen work-item input.
+///
+/// The key order MUST stay identical to `dispatch_tool_calls` in
+/// `sdk/python/jamjet/agents/tool_runtime.py:48-50`: `tool_calls` first (unless
+/// null/absent), then `last_model_tool_calls`. If the two sides ever disagree,
+/// policy evaluates a different list than the one that executes.
+///
+/// Returns `None` when the calls are present but not well-formed. Callers MUST
+/// treat `None` as a block. `Some(vec![])` means there is genuinely nothing to
+/// run and is safe to allow.
+pub fn pending_tool_calls(input: &Value) -> Option<Vec<PendingToolCall>> {
+    let raw = match input.get("tool_calls") {
+        Some(v) if !v.is_null() => v,
+        _ => match input.get("last_model_tool_calls") {
+            Some(v) if !v.is_null() => v,
+            // Neither key present: the dispatch has nothing to execute.
+            _ => return Some(Vec::new()),
+        },
+    };
+
+    let arr = raw.as_array()?;
+    let mut out = Vec::with_capacity(arr.len());
+    for call in arr {
+        // A call whose name cannot be read cannot be matched against
+        // blocked_tools or require_approval_for, so it must not run.
+        let name = call.get("name")?.as_str()?.to_string();
+        let arguments = call.get("arguments").cloned().unwrap_or(Value::Null);
+        out.push(PendingToolCall { name, arguments });
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn call(name: &str) -> serde_json::Value {
+        json!({"id": "c1", "name": name, "arguments": {"x": 1}})
+    }
+
+    #[test]
+    fn reads_tool_calls_key_first() {
+        // Mirrors tool_runtime.py:48-50 — `tool_calls` wins when present.
+        let input = json!({
+            "tool_calls": [call("send_wire")],
+            "last_model_tool_calls": [call("read_only")],
+        });
+        let calls = pending_tool_calls(&input).expect("readable");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "send_wire");
+    }
+
+    #[test]
+    fn falls_back_to_last_model_tool_calls() {
+        let input = json!({"last_model_tool_calls": [call("send_wire")]});
+        let calls = pending_tool_calls(&input).expect("readable");
+        assert_eq!(calls[0].name, "send_wire");
+    }
+
+    #[test]
+    fn null_tool_calls_falls_back() {
+        // Python: `input.get("tool_calls")` returning None triggers the fallback.
+        let input = json!({
+            "tool_calls": null,
+            "last_model_tool_calls": [call("send_wire")],
+        });
+        let calls = pending_tool_calls(&input).expect("readable");
+        assert_eq!(calls[0].name, "send_wire");
+    }
+
+    #[test]
+    fn empty_tool_calls_list_is_not_a_fallback() {
+        // Python uses an explicit `is None` check, so an empty list stays empty
+        // rather than falling through to last_model_tool_calls.
+        let input = json!({
+            "tool_calls": [],
+            "last_model_tool_calls": [call("send_wire")],
+        });
+        let calls = pending_tool_calls(&input).expect("readable");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn both_absent_means_no_calls() {
+        let calls = pending_tool_calls(&json!({})).expect("readable");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn non_array_is_unreadable() {
+        let input = json!({"tool_calls": "send_wire"});
+        assert!(pending_tool_calls(&input).is_none());
+    }
+
+    #[test]
+    fn call_without_a_name_is_unreadable() {
+        // Fail closed: a call we cannot name is a call we cannot police.
+        let input = json!({"tool_calls": [{"id": "c1", "arguments": {}}]});
+        assert!(pending_tool_calls(&input).is_none());
+    }
+
+    #[test]
+    fn missing_arguments_defaults_to_null() {
+        let input = json!({"tool_calls": [{"id": "c1", "name": "t"}]});
+        let calls = pending_tool_calls(&input).expect("readable");
+        assert_eq!(calls[0].arguments, serde_json::Value::Null);
+    }
+}

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -287,6 +287,26 @@ mod tests {
     }
 
     #[test]
+    fn every_gated_call_is_reported_to_the_approver() {
+        // `gated` is what a human approver is shown as the tools they are
+        // authorising. A truncated list means approving `send_wire` silently
+        // releases `wire_batch` too, so membership AND order are load-bearing.
+        // The ungated call in the middle also re-proves the filter.
+        let p = policy(&[], &["send_wire", "wire_batch"]);
+        let d = evaluate_dispatch(
+            "__tools_0__",
+            &pending(&["send_wire", "read_file", "wire_batch"]),
+            &[&p],
+        );
+        match d {
+            DispatchDecision::RequireApproval { gated, .. } => {
+                assert_eq!(gated, vec!["send_wire", "wire_batch"])
+            }
+            other => panic!("expected RequireApproval, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn block_wins_over_approval() {
         // Fail closed: a batch containing both must never merely hold.
         let p = policy(&["drop_table"], &["send_wire"]);

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -19,45 +19,79 @@ pub struct PendingToolCall {
     pub arguments: Value,
 }
 
+/// Why a dispatch payload's pending calls could not be read.
+///
+/// Every variant means the same thing to the enforcement decision — the caller
+/// MUST block — but they are different production failures, and an operator
+/// reading the Prove surface should be able to tell a malformed producer from a
+/// call the model named badly. The audit vocabulary that renders these lives at
+/// the enforcement layer (`jamjet_worker::dispatch_guard`); this enum only
+/// reports which shape failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnreadableCalls {
+    /// `input` itself is not a JSON object. The live case is `Value::Null`,
+    /// which is what `payload["input"]` yields when the key is absent.
+    NotAnObject,
+    /// A call-list key is present but does not hold a JSON array.
+    NotAList,
+    /// A call in the list has no readable string `name`, so it cannot be matched
+    /// against `blocked_tools` / `require_approval_for`.
+    UnnamedCall,
+}
+
 /// Read the tool calls a marked agent-dispatch node will execute from its
-/// frozen work-item input.
+/// frozen work-item input, reporting WHY when they cannot be read.
 ///
 /// The key order MUST stay identical to `dispatch_tool_calls` in
 /// `sdk/python/jamjet/agents/tool_runtime.py:48-50`: `tool_calls` first (unless
 /// null/absent), then `last_model_tool_calls`. If the two sides ever disagree,
 /// policy evaluates a different list than the one that executes.
 ///
-/// Returns `None` when the input is not an object, or when the calls are present
-/// but not well-formed. Callers MUST treat `None` as a block. `Some(vec![])`
-/// means there is genuinely nothing to run and is safe to allow.
-pub fn pending_tool_calls(input: &Value) -> Option<Vec<PendingToolCall>> {
+/// `Ok(vec![])` means there is genuinely nothing to run and is safe to allow;
+/// every `Err` is a block. This is the single implementation —
+/// [`pending_tool_calls`] discards the cause and is kept for callers that only
+/// need the decision.
+pub fn read_pending_tool_calls(input: &Value) -> Result<Vec<PendingToolCall>, UnreadableCalls> {
     // A non-object input is unreadable, not empty. `Value::get` returns `None`
     // for every non-object variant rather than only for a missing key, so
     // without this check a non-object would fall through both arms below and
     // read as "nothing to run" — allowing the whole dispatch unpoliced. The
     // live case: `payload["input"]` yields `Value::Null` when the key is absent
     // or misspelled, because `Index for Value` returns null instead of panicking.
-    let obj = input.as_object()?;
+    let obj = input.as_object().ok_or(UnreadableCalls::NotAnObject)?;
 
     let raw = match obj.get("tool_calls") {
         Some(v) if !v.is_null() => v,
         _ => match obj.get("last_model_tool_calls") {
             Some(v) if !v.is_null() => v,
             // Neither key present: the dispatch has nothing to execute.
-            _ => return Some(Vec::new()),
+            _ => return Ok(Vec::new()),
         },
     };
 
-    let arr = raw.as_array()?;
+    let arr = raw.as_array().ok_or(UnreadableCalls::NotAList)?;
     let mut out = Vec::with_capacity(arr.len());
     for call in arr {
         // A call whose name cannot be read cannot be matched against
-        // blocked_tools or require_approval_for, so it must not run.
-        let name = call.get("name")?.as_str()?.to_string();
+        // blocked_tools or require_approval_for, so it must not run. `get`
+        // returns None for a non-object element too, so a null entry lands here.
+        let name = call
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or(UnreadableCalls::UnnamedCall)?
+            .to_string();
         let arguments = call.get("arguments").cloned().unwrap_or(Value::Null);
         out.push(PendingToolCall { name, arguments });
     }
-    Some(out)
+    Ok(out)
+}
+
+/// [`read_pending_tool_calls`] with the cause discarded.
+///
+/// Callers MUST treat `None` as a block. `Some(vec![])` means there is
+/// genuinely nothing to run and is safe to allow.
+pub fn pending_tool_calls(input: &Value) -> Option<Vec<PendingToolCall>> {
+    read_pending_tool_calls(input).ok()
 }
 
 /// The aggregate policy outcome for one dispatch batch.
@@ -234,6 +268,55 @@ mod tests {
     #[test]
     fn null_call_element_is_unreadable() {
         assert!(pending_tool_calls(&json!({"tool_calls": [null]})).is_none());
+    }
+
+    #[test]
+    fn unreadable_causes_are_reported_distinctly() {
+        // The decision is identical for all three — block — but a production
+        // denial must be attributable on the Prove surface, so the cause has to
+        // survive the read. Collapsing these back into one value would make a
+        // malformed producer indistinguishable from a badly named call.
+        assert_eq!(
+            read_pending_tool_calls(&serde_json::Value::Null),
+            Err(UnreadableCalls::NotAnObject)
+        );
+        assert_eq!(
+            read_pending_tool_calls(&json!({"tool_calls": "send_wire"})),
+            Err(UnreadableCalls::NotAList)
+        );
+        assert_eq!(
+            read_pending_tool_calls(&json!({"tool_calls": [{"id": "c1"}]})),
+            Err(UnreadableCalls::UnnamedCall)
+        );
+        assert_eq!(
+            read_pending_tool_calls(&json!({"tool_calls": [null]})),
+            Err(UnreadableCalls::UnnamedCall)
+        );
+        assert_eq!(
+            read_pending_tool_calls(&json!({"tool_calls": [{"name": 123}]})),
+            Err(UnreadableCalls::UnnamedCall)
+        );
+    }
+
+    #[test]
+    fn the_option_form_agrees_with_the_result_form() {
+        // `pending_tool_calls` must stay a pure projection of
+        // `read_pending_tool_calls`; a second parse would be a second place for
+        // the fail-closed shape checks to drift.
+        for input in [
+            serde_json::Value::Null,
+            json!({}),
+            json!({"tool_calls": []}),
+            json!({"tool_calls": "x"}),
+            json!({"tool_calls": [call("send_wire")]}),
+            json!({"last_model_tool_calls": [call("send_wire")]}),
+        ] {
+            assert_eq!(
+                pending_tool_calls(&input),
+                read_pending_tool_calls(&input).ok(),
+                "disagreement on {input}"
+            );
+        }
     }
 
     #[test]

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -25,13 +25,21 @@ pub struct PendingToolCall {
 /// null/absent), then `last_model_tool_calls`. If the two sides ever disagree,
 /// policy evaluates a different list than the one that executes.
 ///
-/// Returns `None` when the calls are present but not well-formed. Callers MUST
-/// treat `None` as a block. `Some(vec![])` means there is genuinely nothing to
-/// run and is safe to allow.
+/// Returns `None` when the input is not an object, or when the calls are present
+/// but not well-formed. Callers MUST treat `None` as a block. `Some(vec![])`
+/// means there is genuinely nothing to run and is safe to allow.
 pub fn pending_tool_calls(input: &Value) -> Option<Vec<PendingToolCall>> {
-    let raw = match input.get("tool_calls") {
+    // A non-object input is unreadable, not empty. `Value::get` returns `None`
+    // for every non-object variant rather than only for a missing key, so
+    // without this check a non-object would fall through both arms below and
+    // read as "nothing to run" — allowing the whole dispatch unpoliced. The
+    // live case: `payload["input"]` yields `Value::Null` when the key is absent
+    // or misspelled, because `Index for Value` returns null instead of panicking.
+    let obj = input.as_object()?;
+
+    let raw = match obj.get("tool_calls") {
         Some(v) if !v.is_null() => v,
-        _ => match input.get("last_model_tool_calls") {
+        _ => match obj.get("last_model_tool_calls") {
             Some(v) if !v.is_null() => v,
             // Neither key present: the dispatch has nothing to execute.
             _ => return Some(Vec::new()),
@@ -118,6 +126,30 @@ mod tests {
         // Fail closed: a call we cannot name is a call we cannot police.
         let input = json!({"tool_calls": [{"id": "c1", "arguments": {}}]});
         assert!(pending_tool_calls(&input).is_none());
+    }
+
+    #[test]
+    fn non_object_input_is_unreadable() {
+        // `Value::get` returns None for EVERY non-object variant, not just for a
+        // missing key, so without an explicit object check these would read as
+        // "nothing to run" and allow the dispatch through unpoliced. The null
+        // case is the live one: `payload["input"]` yields Value::Null when the
+        // key is absent or misspelled.
+        assert!(pending_tool_calls(&serde_json::Value::Null).is_none());
+        assert!(pending_tool_calls(&json!("send_wire")).is_none());
+        assert!(pending_tool_calls(&json!([call("send_wire")])).is_none());
+    }
+
+    #[test]
+    fn call_with_a_non_string_name_is_unreadable() {
+        // Stringifying instead of rejecting would yield the tool name "123",
+        // which quietly fails to match blocked_tools — a fail-open.
+        assert!(pending_tool_calls(&json!({"tool_calls": [{"name": 123}]})).is_none());
+    }
+
+    #[test]
+    fn null_call_element_is_unreadable() {
+        assert!(pending_tool_calls(&json!({"tool_calls": [null]})).is_none());
     }
 
     #[test]

--- a/runtime/policy/src/dispatch.rs
+++ b/runtime/policy/src/dispatch.rs
@@ -8,6 +8,8 @@
 //! readable here — the same bytes the dispatch will consume, which is what
 //! makes this free of a time-of-check-to-time-of-use window.
 
+use crate::{EvaluationContext, PolicyDecision, PolicyEvaluator};
+use jamjet_ir::workflow::PolicySetIr;
 use serde_json::Value;
 
 /// One tool call an agent dispatch node is about to execute.
@@ -58,13 +60,95 @@ pub fn pending_tool_calls(input: &Value) -> Option<Vec<PendingToolCall>> {
     Some(out)
 }
 
+/// The aggregate policy outcome for one dispatch batch.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DispatchDecision {
+    Allow,
+    Block {
+        tool_name: String,
+        reason: String,
+    },
+    RequireApproval {
+        approver: String,
+        gated: Vec<String>,
+    },
+}
+
+/// Evaluate every pending call and collapse the results to one decision.
+///
+/// Precedence is fail-closed: any Block blocks the batch, otherwise any
+/// RequireApproval holds the batch, otherwise Allow. The first block wins and
+/// short-circuits, since the outcome for the batch cannot get any stricter.
+///
+/// Approval is per-batch rather than per-call because `hold_for_approval` keys
+/// approval state on `node_id` (`runtime/workers/src/worker.rs:667`). `gated`
+/// carries every call that asked for approval so the approver sees all of them.
+pub fn evaluate_dispatch(
+    node_id: &str,
+    calls: &[PendingToolCall],
+    policy_sets: &[&PolicySetIr],
+) -> DispatchDecision {
+    let ev = PolicyEvaluator;
+    let mut gated: Vec<String> = Vec::new();
+    let mut approver: Option<String> = None;
+
+    for call in calls {
+        let ctx = EvaluationContext {
+            node_id: node_id.to_string(),
+            // "tool", not "python_fn": only the model-allowlist branch keys on
+            // the tag (runtime/policy/src/lib.rs:62), and "tool" is what makes
+            // blocked_tools / require_approval_for read naturally here.
+            node_kind_tag: "tool".to_string(),
+            tool_name: Some(call.name.clone()),
+            model_ref: None,
+        };
+        match ev.evaluate(&ctx, policy_sets) {
+            PolicyDecision::Block { reason } => {
+                return DispatchDecision::Block {
+                    tool_name: call.name.clone(),
+                    reason,
+                }
+            }
+            PolicyDecision::RequireApproval { approver: a } => {
+                gated.push(call.name.clone());
+                approver.get_or_insert(a);
+            }
+            PolicyDecision::Allow => {}
+        }
+    }
+
+    match approver {
+        Some(a) => DispatchDecision::RequireApproval { approver: a, gated },
+        None => DispatchDecision::Allow,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jamjet_ir::workflow::PolicySetIr;
     use serde_json::json;
 
     fn call(name: &str) -> serde_json::Value {
         json!({"id": "c1", "name": name, "arguments": {"x": 1}})
+    }
+
+    fn policy(blocked: &[&str], approval: &[&str]) -> PolicySetIr {
+        PolicySetIr {
+            blocked_tools: blocked.iter().map(|s| s.to_string()).collect(),
+            require_approval_for: approval.iter().map(|s| s.to_string()).collect(),
+            model_allowlist: vec![],
+        }
+    }
+
+    fn pending(names: &[&str]) -> Vec<PendingToolCall> {
+        names
+            .iter()
+            .map(|n| PendingToolCall {
+                name: n.to_string(),
+                arguments: json!({}),
+            })
+            .collect()
     }
 
     #[test]
@@ -157,5 +241,82 @@ mod tests {
         let input = json!({"tool_calls": [{"id": "c1", "name": "t"}]});
         let calls = pending_tool_calls(&input).expect("readable");
         assert_eq!(calls[0].arguments, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn ungated_batch_is_allowed() {
+        let p = policy(&[], &[]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["read_file"]), &[&p]);
+        assert_eq!(d, DispatchDecision::Allow);
+    }
+
+    #[test]
+    fn blocked_tool_blocks_the_batch() {
+        let p = policy(&["send_wire"], &[]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["read_file", "send_wire"]), &[&p]);
+        match d {
+            DispatchDecision::Block { tool_name, .. } => assert_eq!(tool_name, "send_wire"),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_tool_holds_the_batch() {
+        let p = policy(&[], &["send_wire"]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["send_wire"]), &[&p]);
+        match d {
+            DispatchDecision::RequireApproval { gated, .. } => assert_eq!(gated, vec!["send_wire"]),
+            other => panic!("expected RequireApproval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn one_gated_call_holds_the_whole_batch() {
+        // Documented limitation: approval is per-batch, because hold_for_approval
+        // keys approval state on node_id.
+        let p = policy(&[], &["send_wire"]);
+        let d = evaluate_dispatch(
+            "__tools_0__",
+            &pending(&["read_file", "send_wire", "log"]),
+            &[&p],
+        );
+        match d {
+            DispatchDecision::RequireApproval { gated, .. } => assert_eq!(gated, vec!["send_wire"]),
+            other => panic!("expected RequireApproval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_wins_over_approval() {
+        // Fail closed: a batch containing both must never merely hold.
+        let p = policy(&["drop_table"], &["send_wire"]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["send_wire", "drop_table"]), &[&p]);
+        assert!(matches!(d, DispatchDecision::Block { .. }));
+    }
+
+    #[test]
+    fn glob_patterns_match_per_call() {
+        let p = policy(&["admin_*"], &[]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["admin_delete"]), &[&p]);
+        assert!(matches!(d, DispatchDecision::Block { .. }));
+    }
+
+    #[test]
+    fn empty_batch_is_allowed() {
+        let p = policy(&["send_wire"], &[]);
+        assert_eq!(
+            evaluate_dispatch("__tools_0__", &[], &[&p]),
+            DispatchDecision::Allow
+        );
+    }
+
+    #[test]
+    fn node_policy_overrides_tenant_policy() {
+        // Sets are ordered least-specific to most-specific; the evaluator
+        // iterates in reverse, so the node layer wins.
+        let tenant = policy(&["send_wire"], &[]);
+        let node = policy(&[], &["send_wire"]);
+        let d = evaluate_dispatch("__tools_0__", &pending(&["send_wire"]), &[&tenant, &node]);
+        assert!(matches!(d, DispatchDecision::RequireApproval { .. }));
     }
 }

--- a/runtime/policy/src/lib.rs
+++ b/runtime/policy/src/lib.rs
@@ -10,6 +10,7 @@
 //! - Circuit breaker for agents in error loops
 
 pub mod autonomy;
+pub mod dispatch;
 pub mod engine;
 pub mod redaction;
 

--- a/runtime/state/src/budget.rs
+++ b/runtime/state/src/budget.rs
@@ -214,7 +214,9 @@ mod tests {
     }
 
     #[test]
-    fn input_and_output_sub_ceilings_trip_independently() {
+    fn input_sub_ceiling_trips_without_reporting_output() {
+        // Only an input ceiling is set, and output counters are non-zero: the trip
+        // must name and report the input dimension, never the output one.
         let b = BudgetState {
             total_input_tokens: 900,
             total_output_tokens: 10,
@@ -226,8 +228,39 @@ mod tests {
             output_tokens: None,
         };
         assert_eq!(
-            b.exhausted(Some(&tb), None).expect("exhausted").kind,
-            "input_tokens"
+            b.exhausted(Some(&tb), None),
+            Some(BudgetTrip {
+                kind: "input_tokens".into(),
+                limit: 900.0,
+                current: 900.0,
+            })
+        );
+    }
+
+    #[test]
+    fn output_sub_ceiling_trips_at_its_own_ceiling() {
+        // The mirror of the input case, and the one that catches a copy-pasted
+        // output branch: input is well under its own count, so an implementation
+        // that compares (or reports) `total_input_tokens` while labelling
+        // "output_tokens" fails here. Sitting exactly on the ceiling also pins
+        // `>=` on this branch specifically.
+        let b = BudgetState {
+            total_input_tokens: 10,
+            total_output_tokens: 500,
+            ..Default::default()
+        };
+        let tb = TokenBudgetIr {
+            total_tokens: None,
+            input_tokens: None,
+            output_tokens: Some(500),
+        };
+        assert_eq!(
+            b.exhausted(Some(&tb), None),
+            Some(BudgetTrip {
+                kind: "output_tokens".into(),
+                limit: 500.0,
+                current: 500.0,
+            })
         );
     }
 

--- a/runtime/state/src/budget.rs
+++ b/runtime/state/src/budget.rs
@@ -4,6 +4,7 @@
 //! in the execution's workflow state (inside `Snapshot.state`). This avoids
 //! a separate table or schema migration.
 
+use jamjet_ir::workflow::TokenBudgetIr;
 use serde::{Deserialize, Serialize};
 
 /// Accumulated runtime budget for a single workflow execution.
@@ -72,6 +73,71 @@ impl BudgetState {
     }
 }
 
+/// A budget ceiling that has already been reached or passed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BudgetTrip {
+    /// Which ceiling: "total_tokens", "input_tokens", "output_tokens", "cost_usd".
+    pub kind: String,
+    pub limit: f64,
+    pub current: f64,
+}
+
+impl BudgetState {
+    /// True when the accumulated counters have already reached a ceiling, i.e.
+    /// firing another billable node would overspend.
+    ///
+    /// Deliberately `>=`, unlike the post-execution check's `>`: a run can settle
+    /// exactly at the limit, and the point of this predicate is to refuse the
+    /// *next* call from that state. This is what stops a rollover child, which
+    /// inherits the parent's pinned counters, from making one paid call per
+    /// segment forever.
+    pub fn exhausted(
+        &self,
+        token_budget: Option<&TokenBudgetIr>,
+        cost_budget_usd: Option<f64>,
+    ) -> Option<BudgetTrip> {
+        if let Some(tb) = token_budget {
+            if let Some(limit) = tb.total_tokens {
+                if self.total_tokens() >= limit as u64 {
+                    return Some(BudgetTrip {
+                        kind: "total_tokens".into(),
+                        limit: limit as f64,
+                        current: self.total_tokens() as f64,
+                    });
+                }
+            }
+            if let Some(limit) = tb.input_tokens {
+                if self.total_input_tokens >= limit as u64 {
+                    return Some(BudgetTrip {
+                        kind: "input_tokens".into(),
+                        limit: limit as f64,
+                        current: self.total_input_tokens as f64,
+                    });
+                }
+            }
+            if let Some(limit) = tb.output_tokens {
+                if self.total_output_tokens >= limit as u64 {
+                    return Some(BudgetTrip {
+                        kind: "output_tokens".into(),
+                        limit: limit as f64,
+                        current: self.total_output_tokens as f64,
+                    });
+                }
+            }
+        }
+        if let Some(limit) = cost_budget_usd {
+            if self.total_cost_usd >= limit {
+                return Some(BudgetTrip {
+                    kind: "cost_usd".into(),
+                    limit,
+                    current: self.total_cost_usd,
+                });
+            }
+        }
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,5 +167,89 @@ mod tests {
         let mut b = BudgetState::default();
         b.accumulate(Some(300), Some(200), None);
         assert_eq!(b.total_tokens(), 500);
+    }
+
+    #[test]
+    fn fresh_budget_is_not_exhausted() {
+        let b = BudgetState::default();
+        let tb = TokenBudgetIr {
+            total_tokens: Some(1000),
+            input_tokens: None,
+            output_tokens: None,
+        };
+        assert_eq!(b.exhausted(Some(&tb), None), None);
+    }
+
+    #[test]
+    fn budget_at_the_ceiling_is_exhausted() {
+        // The post-execution check uses `>`, so a run can settle exactly at the
+        // limit. Firing again from there would overspend, so `>=` is correct here.
+        let b = BudgetState {
+            total_input_tokens: 600,
+            total_output_tokens: 400,
+            ..Default::default()
+        };
+        let tb = TokenBudgetIr {
+            total_tokens: Some(1000),
+            input_tokens: None,
+            output_tokens: None,
+        };
+        let trip = b.exhausted(Some(&tb), None).expect("must be exhausted");
+        assert_eq!(trip.kind, "total_tokens");
+    }
+
+    #[test]
+    fn budget_over_the_ceiling_is_exhausted() {
+        // This is the carried-over state a rollover child inherits.
+        let b = BudgetState {
+            total_input_tokens: 5000,
+            ..Default::default()
+        };
+        let tb = TokenBudgetIr {
+            total_tokens: Some(1000),
+            input_tokens: None,
+            output_tokens: None,
+        };
+        assert!(b.exhausted(Some(&tb), None).is_some());
+    }
+
+    #[test]
+    fn input_and_output_sub_ceilings_trip_independently() {
+        let b = BudgetState {
+            total_input_tokens: 900,
+            total_output_tokens: 10,
+            ..Default::default()
+        };
+        let tb = TokenBudgetIr {
+            total_tokens: None,
+            input_tokens: Some(900),
+            output_tokens: None,
+        };
+        assert_eq!(
+            b.exhausted(Some(&tb), None).expect("exhausted").kind,
+            "input_tokens"
+        );
+    }
+
+    #[test]
+    fn cost_ceiling_trips() {
+        let b = BudgetState {
+            total_cost_usd: 0.5,
+            ..Default::default()
+        };
+        assert_eq!(
+            b.exhausted(None, Some(0.5)).expect("exhausted").kind,
+            "cost_usd"
+        );
+    }
+
+    #[test]
+    fn no_budget_configured_never_trips() {
+        let b = BudgetState {
+            total_input_tokens: u64::MAX / 2,
+            total_cost_usd: 1e9,
+            ..Default::default()
+        };
+        assert_eq!(b.exhausted(None, None), None);
     }
 }

--- a/runtime/state/src/budget.rs
+++ b/runtime/state/src/budget.rs
@@ -126,7 +126,19 @@ impl BudgetState {
             }
         }
         if let Some(limit) = cost_budget_usd {
-            if self.total_cost_usd >= limit {
+            // NaN loses every comparison, so a plain `>=` would return false and
+            // let the run keep spending — for the REST OF THE RUN, since the
+            // accumulator never recovers once a NaN lands in it. A ceiling that
+            // silently stops existing is the failure this predicate exists to
+            // prevent, so NaN on either side counts as tripped. It reaches us
+            // from arithmetic, not from JSON, which cannot encode it: a provider
+            // adapter computing a price from a zero divisor is enough.
+            //
+            // Infinities are deliberately left to the ordinary comparison. An
+            // infinite ACCUMULATED cost trips against any finite ceiling, which
+            // is right; an infinite CEILING reads as "no limit" and must not be
+            // forced closed, or configuring one would refuse every node.
+            if self.total_cost_usd.is_nan() || limit.is_nan() || self.total_cost_usd >= limit {
                 return Some(BudgetTrip {
                     kind: "cost_usd".into(),
                     limit,
@@ -284,5 +296,54 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(b.exhausted(None, None), None);
+    }
+
+    /// A NaN accumulated cost must trip, not vanish.
+    ///
+    /// `NaN >= limit` is false, so a bare comparison would report "not
+    /// exhausted" — and keep doing so for the rest of the run, because the
+    /// accumulator never recovers. The ceiling would be silently gone at exactly
+    /// the moment it was needed.
+    #[test]
+    fn a_nan_accumulated_cost_counts_as_exhausted() {
+        let b = BudgetState {
+            total_cost_usd: f64::NAN,
+            ..Default::default()
+        };
+        let trip = b
+            .exhausted(None, Some(2.00))
+            .expect("a NaN cost must never read as budget remaining");
+        assert_eq!(trip.kind, "cost_usd");
+    }
+
+    /// A NaN ceiling is broken configuration; refuse rather than spend against it.
+    #[test]
+    fn a_nan_cost_ceiling_counts_as_exhausted() {
+        let b = BudgetState {
+            total_cost_usd: 0.01,
+            ..Default::default()
+        };
+        assert!(b.exhausted(None, Some(f64::NAN)).is_some());
+    }
+
+    /// An infinite ceiling reads as "no limit" and must NOT be forced closed —
+    /// otherwise configuring one would refuse every node in the run.
+    #[test]
+    fn an_infinite_cost_ceiling_does_not_trip() {
+        let b = BudgetState {
+            total_cost_usd: 1e9,
+            ..Default::default()
+        };
+        assert_eq!(b.exhausted(None, Some(f64::INFINITY)), None);
+    }
+
+    /// An infinite accumulated cost is over every finite ceiling.
+    #[test]
+    fn an_infinite_accumulated_cost_trips() {
+        let b = BudgetState {
+            total_cost_usd: f64::INFINITY,
+            ..Default::default()
+        };
+        assert!(b.exhausted(None, Some(2.00)).is_some());
     }
 }

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -27,7 +27,7 @@ pub use backend::{
     ApiToken, ApprovalProjectionRow, BackendResult, ReclaimResult, StateBackend, StateBackendError,
     WorkItem, WorkItemId, WorkflowDefinition,
 };
-pub use budget::BudgetState;
+pub use budget::{BudgetState, BudgetTrip};
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
 pub use hashing::{canonical_json, content_hash, sha256_hex};
 pub use materializer::{

--- a/runtime/workers/src/dispatch_guard.rs
+++ b/runtime/workers/src/dispatch_guard.rs
@@ -273,6 +273,31 @@ pub async fn guard_dispatch(
                 }
 
                 NodeApprovalStatus::NotRequested => {
+                    // KNOWN LIMIT: reading `NotRequested` and then appending the
+                    // request is a read-modify-write with no compare-and-set,
+                    // the same shape as `record_policy_violation` below — but
+                    // NOT the same consequence, so do not carry that note's
+                    // "cosmetic" reading over to here.
+                    //
+                    // Under a lease exactly one worker holds a work item, so the
+                    // worker path is safe. On the HTTP claim route, two
+                    // concurrent claims for the same node can each read
+                    // `NotRequested` from their own snapshot and each append a
+                    // `ToolApprovalRequired`. The damage is a DUPLICATE
+                    // OUTSTANDING APPROVAL REQUEST, not a colliding sequence
+                    // number: `node_approval_status` resets to `Pending` on every
+                    // new request, so a human's settled decision would refer to a
+                    // request that has already been superseded and could never
+                    // stick. That is precisely the invariant
+                    // `an_already_pending_node_is_held_without_a_duplicate_request`
+                    // exists to protect, and today it holds only because a lease
+                    // keeps the writer single.
+                    //
+                    // The backend trait offers no conditional/CAS append, so this
+                    // cannot be closed here — it needs a primitive that makes
+                    // "append iff no open request for this node" atomic, and the
+                    // route path must supply it. Fail-closed is preserved either
+                    // way: both racers return `Held`, so nothing runs unapproved.
                     info!(execution_id = %execution_id, node_id, %approver, "Node requires approval");
                     // `gated` carries tool NAMES only: two calls to the same
                     // gated tool render as ["send_wire", "send_wire"] with no
@@ -388,6 +413,12 @@ fn latest_request_calls_hash(events: &[Event], node_id: &str) -> Option<String> 
 /// offers no CAS append, so this is not fixable here; it is a known limit of the
 /// route path, and it affects only the audit record's sequence — never whether
 /// the denial is enforced.
+///
+/// That last sentence is about THIS append and no other. The `NotRequested` arm
+/// of `guard_dispatch` performs a read-modify-write of the same shape whose
+/// consequence is materially worse — duplicate outstanding approval requests,
+/// which can stop a human decision from ever settling. See the KNOWN LIMIT note
+/// there before concluding the route path is only cosmetically affected.
 async fn record_policy_violation(
     backend: &dyn StateBackend,
     execution_id: &ExecutionId,
@@ -607,6 +638,443 @@ mod tests {
                 })
                 .collect()
         }
+    }
+
+    // ── A backend that cannot read its own event log ──────────────────────────
+
+    /// An `InMemoryBackend` whose `get_events` fails, and only `get_events`.
+    ///
+    /// `InMemoryBackend` never errors, so without this every `Unavailable` arm in
+    /// the guard is unreachable from a test and an implementation that returned
+    /// `Blocked` on a backend failure would pass the whole suite — while writing
+    /// a `PolicyViolation` saying policy denied something the engine merely could
+    /// not read. Delegating every other method to a real backend is what makes
+    /// "nothing was written" an observation rather than an artefact of a stub
+    /// that cannot write at all: the append path here works perfectly.
+    struct FailingGetEvents {
+        inner: InMemoryBackend,
+    }
+
+    impl FailingGetEvents {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryBackend::new(),
+            }
+        }
+
+        /// Read the log the guard could not, bypassing the injected failure.
+        async fn recorded(&self, execution_id: &ExecutionId) -> Vec<Event> {
+            self.inner.get_events(execution_id).await.unwrap()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl StateBackend for FailingGetEvents {
+        // ── The one injected failure ──────────────────────────────────────────
+
+        async fn get_events(
+            &self,
+            _execution_id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<Vec<Event>> {
+            Err(jamjet_state::backend::StateBackendError::Database(
+                "injected: event log unreadable".into(),
+            ))
+        }
+
+        // ── Everything else is the real backend ───────────────────────────────
+
+        async fn store_workflow(
+            &self,
+            def: jamjet_state::backend::WorkflowDefinition,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.store_workflow(def).await
+        }
+
+        async fn get_workflow(
+            &self,
+            workflow_id: &str,
+            version: &str,
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::WorkflowDefinition>>
+        {
+            self.inner.get_workflow(workflow_id, version).await
+        }
+
+        async fn create_execution(
+            &self,
+            execution: jamjet_core::workflow::WorkflowExecution,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.create_execution(execution).await
+        }
+
+        async fn get_execution(
+            &self,
+            id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_core::workflow::WorkflowExecution>>
+        {
+            self.inner.get_execution(id).await
+        }
+
+        async fn update_execution_status(
+            &self,
+            id: &ExecutionId,
+            status: jamjet_core::workflow::WorkflowStatus,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.update_execution_status(id, status).await
+        }
+
+        async fn update_execution_current_state(
+            &self,
+            id: &ExecutionId,
+            current_state: &serde_json::Value,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .update_execution_current_state(id, current_state)
+                .await
+        }
+
+        async fn patch_append_array(
+            &self,
+            execution_id: &ExecutionId,
+            key: &str,
+            value: serde_json::Value,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .patch_append_array(execution_id, key, value)
+                .await
+        }
+
+        async fn list_executions(
+            &self,
+            status: Option<jamjet_core::workflow::WorkflowStatus>,
+            limit: u32,
+            offset: u32,
+        ) -> jamjet_state::backend::BackendResult<Vec<jamjet_core::workflow::WorkflowExecution>>
+        {
+            self.inner.list_executions(status, limit, offset).await
+        }
+
+        async fn append_event(
+            &self,
+            event: Event,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+            self.inner.append_event(event).await
+        }
+
+        async fn get_events_since(
+            &self,
+            execution_id: &ExecutionId,
+            since_sequence: jamjet_state::EventSequence,
+        ) -> jamjet_state::backend::BackendResult<Vec<Event>> {
+            self.inner
+                .get_events_since(execution_id, since_sequence)
+                .await
+        }
+
+        async fn latest_sequence(
+            &self,
+            execution_id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+            self.inner.latest_sequence(execution_id).await
+        }
+
+        async fn write_snapshot(
+            &self,
+            snapshot: jamjet_state::Snapshot,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.write_snapshot(snapshot).await
+        }
+
+        async fn latest_snapshot(
+            &self,
+            execution_id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::Snapshot>> {
+            self.inner.latest_snapshot(execution_id).await
+        }
+
+        async fn create_segment_atomic(
+            &self,
+            execution: jamjet_core::workflow::WorkflowExecution,
+            seed_snapshot: jamjet_state::Snapshot,
+            started_event: EventKind,
+            scheduled_event: EventKind,
+            work_item: jamjet_state::backend::WorkItem,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .create_segment_atomic(
+                    execution,
+                    seed_snapshot,
+                    started_event,
+                    scheduled_event,
+                    work_item,
+                )
+                .await
+        }
+
+        async fn get_tool_effect(
+            &self,
+            key: &str,
+        ) -> jamjet_state::backend::BackendResult<Option<serde_json::Value>> {
+            self.inner.get_tool_effect(key).await
+        }
+
+        async fn put_artifact(
+            &self,
+            bytes: &[u8],
+            media_type: Option<&str>,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::ArtifactRef> {
+            self.inner.put_artifact(bytes, media_type).await
+        }
+
+        async fn get_artifact(
+            &self,
+            hash: &str,
+        ) -> jamjet_state::backend::BackendResult<Option<Vec<u8>>> {
+            self.inner.get_artifact(hash).await
+        }
+
+        async fn enqueue_work_item(
+            &self,
+            item: jamjet_state::backend::WorkItem,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::WorkItemId> {
+            self.inner.enqueue_work_item(item).await
+        }
+
+        async fn claim_work_item(
+            &self,
+            worker_id: &str,
+            queue_types: &[&str],
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::WorkItem>> {
+            self.inner.claim_work_item(worker_id, queue_types).await
+        }
+
+        async fn renew_lease(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            worker_id: &str,
+            lease_fence: i64,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .renew_lease(item_id, worker_id, lease_fence)
+                .await
+        }
+
+        async fn complete_work_item(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.complete_work_item(item_id).await
+        }
+
+        async fn complete_work_item_fenced(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            lease_fence: i64,
+        ) -> jamjet_state::backend::BackendResult<bool> {
+            self.inner
+                .complete_work_item_fenced(item_id, lease_fence)
+                .await
+        }
+
+        async fn fail_work_item(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            error: &str,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.fail_work_item(item_id, error).await
+        }
+
+        async fn commit_turn(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            lease_fence: i64,
+            terminal_event: Event,
+            write_snapshot: bool,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::EventSequence> {
+            self.inner
+                .commit_turn(item_id, lease_fence, terminal_event, write_snapshot)
+                .await
+        }
+
+        async fn park_work_item(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            lease_fence: i64,
+            retry_after: &str,
+            next_attempt: u32,
+        ) -> jamjet_state::backend::BackendResult<bool> {
+            self.inner
+                .park_work_item(item_id, lease_fence, retry_after, next_attempt)
+                .await
+        }
+
+        async fn finalize_rollover_fenced(
+            &self,
+            execution_id: &ExecutionId,
+            work_item_id: jamjet_state::backend::WorkItemId,
+            lease_fence: i64,
+        ) -> jamjet_state::backend::BackendResult<bool> {
+            self.inner
+                .finalize_rollover_fenced(execution_id, work_item_id, lease_fence)
+                .await
+        }
+
+        async fn reclaim_expired_leases(
+            &self,
+        ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::ReclaimResult> {
+            self.inner.reclaim_expired_leases().await
+        }
+
+        async fn move_to_dead_letter(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            last_error: &str,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.move_to_dead_letter(item_id, last_error).await
+        }
+
+        async fn create_token(
+            &self,
+            name: &str,
+            role: &str,
+        ) -> jamjet_state::backend::BackendResult<(String, jamjet_state::backend::ApiToken)>
+        {
+            self.inner.create_token(name, role).await
+        }
+
+        async fn validate_token(
+            &self,
+            token: &str,
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::ApiToken>> {
+            self.inner.validate_token(token).await
+        }
+
+        async fn apply_approval_projection(
+            &self,
+            row: jamjet_state::ApprovalProjectionRow,
+            projection_name: &str,
+            new_checkpoint: i64,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .apply_approval_projection(row, projection_name, new_checkpoint)
+                .await
+        }
+
+        async fn apply_approval_projection_batch(
+            &self,
+            rows: Vec<jamjet_state::ApprovalProjectionRow>,
+            projection_name: &str,
+            execution_id: &ExecutionId,
+            new_checkpoint: i64,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .apply_approval_projection_batch(
+                    rows,
+                    projection_name,
+                    execution_id,
+                    new_checkpoint,
+                )
+                .await
+        }
+
+        async fn get_approval_projection(
+            &self,
+            execution_id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<Vec<jamjet_state::ApprovalProjectionRow>>
+        {
+            self.inner.get_approval_projection(execution_id).await
+        }
+
+        async fn get_projector_checkpoint(
+            &self,
+            projection_name: &str,
+            execution_id: &ExecutionId,
+        ) -> jamjet_state::backend::BackendResult<i64> {
+            self.inner
+                .get_projector_checkpoint(projection_name, execution_id)
+                .await
+        }
+
+        async fn set_projector_checkpoint(
+            &self,
+            projection_name: &str,
+            execution_id: &ExecutionId,
+            new_checkpoint: i64,
+        ) -> jamjet_state::backend::BackendResult<()> {
+            self.inner
+                .set_projector_checkpoint(projection_name, execution_id, new_checkpoint)
+                .await
+        }
+
+        async fn create_tenant(&self, tenant: Tenant) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.create_tenant(tenant).await
+        }
+
+        async fn get_tenant(
+            &self,
+            id: &jamjet_state::TenantId,
+        ) -> jamjet_state::backend::BackendResult<Option<Tenant>> {
+            self.inner.get_tenant(id).await
+        }
+
+        async fn list_tenants(&self) -> jamjet_state::backend::BackendResult<Vec<Tenant>> {
+            self.inner.list_tenants().await
+        }
+
+        async fn update_tenant(&self, tenant: Tenant) -> jamjet_state::backend::BackendResult<()> {
+            self.inner.update_tenant(tenant).await
+        }
+    }
+
+    /// An unreadable event log is infrastructure, not a decision.
+    ///
+    /// The outcome assertion is half the point; the audit assertion is the other
+    /// half and the more important one. Returning `Blocked` here would record a
+    /// `PolicyViolation` claiming a policy denied the batch, when in truth no
+    /// policy was ever consulted — a false denial on the Prove surface, and a
+    /// permanent one, since the caller would stop retrying something that only
+    /// needed a working backend.
+    #[tokio::test]
+    async fn an_unreadable_event_log_is_unavailable_and_records_no_denial() {
+        let backend = FailingGetEvents::new();
+        let execution_id = ExecutionId::new();
+        let ir = ir(&[], &["send_wire"]);
+        let node_def = ir.node("n1").expect("node n1 must exist");
+
+        let outcome = guard_dispatch(
+            &backend,
+            &execution_id,
+            "n1",
+            "default",
+            &ir,
+            node_def,
+            &input_for(&["send_wire"]),
+        )
+        .await;
+
+        match &outcome {
+            DispatchGuardOutcome::Unavailable { reason } => {
+                assert!(
+                    reason.contains("injected: event log unreadable"),
+                    "the underlying failure must survive into the reason; got {reason:?}"
+                );
+            }
+            other => {
+                panic!("a backend failure is infrastructure, not a policy denial; got {other:?}")
+            }
+        }
+
+        let recorded = backend.recorded(&execution_id).await;
+        assert!(
+            !recorded
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::PolicyViolation { .. })),
+            "no policy denied — a PolicyViolation here is a false denial in the \
+             audit log; got {recorded:?}"
+        );
+        assert!(
+            recorded.is_empty(),
+            "an undecidable dispatch writes nothing at all; got {recorded:?}"
+        );
     }
 
     fn approved(node_id: &str) -> EventKind {

--- a/runtime/workers/src/dispatch_guard.rs
+++ b/runtime/workers/src/dispatch_guard.rs
@@ -138,12 +138,31 @@ pub async fn guard_dispatch(
     payload_input: &Value,
 ) -> DispatchGuardOutcome {
     // Load tenant policy (sits between global and workflow in the chain).
-    let tenant_policy_set = backend
+    //
+    // `Ok(None)` — this tenant has no policy — and `Err` — we could not find out
+    // — must NOT collapse together. Swallowing the error makes an unreadable
+    // tenant record look like an absent policy: when the tenant layer is the
+    // whole chain, `sets` empties and the guard returns `Allow` before it even
+    // reads the pending calls, so a tenant-level `blocked_tools` rule goes
+    // unenforced on a transient backend blip. That contradicts this module's own
+    // contract, which is that unreadable state yields `Unavailable` and the
+    // caller retries — never a decision no policy made.
+    let tenant_policy_set = match backend
         .get_tenant(&jamjet_state::TenantId::from(tenant_id))
         .await
-        .ok()
-        .flatten()
-        .and_then(|t| t.policy_set());
+    {
+        Ok(tenant) => tenant.and_then(|t| t.policy_set()),
+        Err(e) => {
+            warn!(
+                execution_id = %execution_id,
+                node_id,
+                "tenant policy unreadable — refusing to decide"
+            );
+            return DispatchGuardOutcome::Unavailable {
+                reason: format!("tenant policy unavailable; refusing to run unpoliced: {e}"),
+            };
+        }
+    };
 
     // Build policy chain: tenant -> workflow -> node (least-specific to
     // most-specific). The evaluator iterates in reverse, so node rules win.
@@ -681,12 +700,26 @@ mod tests {
     /// that cannot write at all: the append path here works perfectly.
     struct FailingGetEvents {
         inner: InMemoryBackend,
+        fail_events: bool,
+        fail_tenant: bool,
     }
 
     impl FailingGetEvents {
         fn new() -> Self {
             Self {
                 inner: InMemoryBackend::new(),
+                fail_events: true,
+                fail_tenant: false,
+            }
+        }
+
+        /// Fail `get_tenant` instead, so the tenant layer is unreadable rather
+        /// than absent — the two must not be confused.
+        fn failing_tenant() -> Self {
+            Self {
+                inner: InMemoryBackend::new(),
+                fail_events: false,
+                fail_tenant: true,
             }
         }
 
@@ -702,8 +735,11 @@ mod tests {
 
         async fn get_events(
             &self,
-            _execution_id: &ExecutionId,
+            execution_id: &ExecutionId,
         ) -> jamjet_state::backend::BackendResult<Vec<Event>> {
+            if !self.fail_events {
+                return self.inner.get_events(execution_id).await;
+            }
             Err(jamjet_state::backend::StateBackendError::Database(
                 "injected: event log unreadable".into(),
             ))
@@ -1041,6 +1077,11 @@ mod tests {
             &self,
             id: &jamjet_state::TenantId,
         ) -> jamjet_state::backend::BackendResult<Option<Tenant>> {
+            if self.fail_tenant {
+                return Err(jamjet_state::backend::StateBackendError::Database(
+                    "injected: tenant record unreadable".into(),
+                ));
+            }
             self.inner.get_tenant(id).await
         }
 
@@ -1051,6 +1092,48 @@ mod tests {
         async fn update_tenant(&self, tenant: Tenant) -> jamjet_state::backend::BackendResult<()> {
             self.inner.update_tenant(tenant).await
         }
+    }
+
+    /// An unreadable TENANT record is infrastructure too, and collapsing it into
+    /// "this tenant has no policy" is a fail-open.
+    ///
+    /// The tenant layer is the only policy here, so treating a backend error as
+    /// an absent policy empties the chain, and the guard returns `Allow` without
+    /// even reading the pending calls — a tenant-level `blocked_tools` rule
+    /// silently not enforced, on the transport ADK nodes actually take. The
+    /// module contract is that state the guard cannot read yields `Unavailable`,
+    /// never a decision.
+    #[tokio::test]
+    async fn an_unreadable_tenant_record_is_unavailable_not_allow() {
+        let backend = FailingGetEvents::failing_tenant();
+        let execution_id = ExecutionId::new();
+        // No workflow and no node policy: the tenant layer is the whole chain,
+        // which is what makes a swallowed error decide the outcome.
+        let ir = ir(&[], &[]);
+        let node_def = ir.node("n1").expect("node n1 must exist");
+
+        let outcome = guard_dispatch(
+            &backend,
+            &execution_id,
+            "n1",
+            "default",
+            &ir,
+            node_def,
+            &input_for(&["send_wire"]),
+        )
+        .await;
+
+        match &outcome {
+            DispatchGuardOutcome::Unavailable { reason } => assert!(
+                reason.contains("injected: tenant record unreadable"),
+                "the underlying failure must survive into the reason; got {reason:?}"
+            ),
+            other => panic!("an unreadable tenant record must be Unavailable, got {other:?}"),
+        }
+        assert!(
+            backend.recorded(&execution_id).await.is_empty(),
+            "no policy denied anything, so nothing may be audited"
+        );
     }
 
     /// An unreadable event log is infrastructure, not a decision.

--- a/runtime/workers/src/dispatch_guard.rs
+++ b/runtime/workers/src/dispatch_guard.rs
@@ -68,17 +68,43 @@ pub enum DispatchGuardOutcome {
 }
 
 /// True for nodes that run a whole agent turn's model-chosen tool calls.
+///
+/// TWO signals, and the second is not redundant. The marker is declarative and
+/// covers both languages, but it is `#[serde(default)]`, so an IR compiled
+/// before the marker existed deserializes to `false`.
+/// `validate_agent_tool_dispatch` makes that drift loud — on the REGISTRATION
+/// route only. Nothing re-validates a workflow already sitting in the backend,
+/// so a workflow registered before this change and started from stored IR (a
+/// cron/scheduled fleet, or any `start_execution` without a fresh
+/// `create_workflow`) would reach the executor unmarked and run every tool
+/// unpoliced. That is C1 exactly, still open, for precisely the population that
+/// cannot be fixed by validating new registrations.
+///
+/// So enforcement falls back to the dispatch coordinates, which identify the
+/// node with no marker at all — the same rule the validator matches on, shared
+/// from one definition. The marker stays the cheap path; it is no longer the
+/// only one.
+///
+/// NARROWNESS is preserved: an ordinary `python_fn` that merely lacks the marker
+/// is still not a dispatch node. Only the ADK dispatch coroutine's own
+/// coordinates qualify. Java keeps the marker as its sole signal because no Java
+/// ADK compiler emits `java_fn` dispatch nodes yet, so there is no pre-marker
+/// population to rescue — add the coordinate pair here when that compiler lands.
 pub fn is_agent_tool_dispatch(kind: &NodeKind) -> bool {
-    matches!(
-        kind,
+    match kind {
         NodeKind::PythonFn {
             agent_tool_dispatch: true,
             ..
-        } | NodeKind::JavaFn {
+        }
+        | NodeKind::JavaFn {
             agent_tool_dispatch: true,
             ..
-        }
-    )
+        } => true,
+        NodeKind::PythonFn {
+            module, function, ..
+        } => jamjet_ir::is_adk_dispatch_coordinates(module, function),
+        _ => false,
+    }
 }
 
 /// The frozen accumulated state the scheduler enriched onto a PythonFn/JavaFn
@@ -368,6 +394,8 @@ fn unreadable_rule(cause: UnreadableCalls) -> String {
         UnreadableCalls::NotAnObject => "input is not an object",
         UnreadableCalls::NotAList => "the call list is not an array",
         UnreadableCalls::UnnamedCall => "a call has no readable name",
+        UnreadableCalls::NameTooLong => "a call name exceeds the length bound",
+        UnreadableCalls::TooManyCalls => "the call list exceeds the batch bound",
     };
     format!("{UNREADABLE}: {detail}")
 }
@@ -1123,7 +1151,10 @@ mod tests {
     async fn a_permitted_tool_is_allowed_and_audits_nothing() {
         let f = Fixture::new();
         let outcome = f
-            .guard(&ir(&["send_wire"], &["wire_batch"]), &input_for(&["read_file"]))
+            .guard(
+                &ir(&["send_wire"], &["wire_batch"]),
+                &input_for(&["read_file"]),
+            )
             .await;
         assert_eq!(outcome, DispatchGuardOutcome::Allow);
         assert!(
@@ -1157,7 +1188,8 @@ mod tests {
         );
         // Even an unreadable payload: with no policy there is no decision to make.
         assert_eq!(
-            f.guard(&unpoliced_ir(), &json!({"tool_calls": "nope"})).await,
+            f.guard(&unpoliced_ir(), &json!({"tool_calls": "nope"}))
+                .await,
             DispatchGuardOutcome::Allow
         );
         assert!(f.events().await.is_empty());
@@ -1169,7 +1201,10 @@ mod tests {
     async fn a_blocked_tool_is_blocked_and_audited_exactly_once() {
         let f = Fixture::new();
         let outcome = f
-            .guard(&ir(&["send_wire"], &[]), &input_for(&["read_file", "send_wire"]))
+            .guard(
+                &ir(&["send_wire"], &[]),
+                &input_for(&["read_file", "send_wire"]),
+            )
             .await;
         match outcome {
             DispatchGuardOutcome::Blocked { reason } => {
@@ -1221,7 +1256,10 @@ mod tests {
     async fn a_non_array_call_list_is_blocked() {
         let f = Fixture::new();
         let outcome = f
-            .guard(&ir(&["send_wire"], &[]), &json!({"tool_calls": "send_wire"}))
+            .guard(
+                &ir(&["send_wire"], &[]),
+                &json!({"tool_calls": "send_wire"}),
+            )
             .await;
         assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
         assert_eq!(f.violations().await.len(), 1);
@@ -1261,7 +1299,9 @@ mod tests {
     async fn an_absent_input_key_is_blocked() {
         let f = Fixture::new();
         let payload = json!({"workflow_id": "adk-wf", "tool_calls": []});
-        let outcome = f.guard(&ir(&["send_wire"], &[]), &payload_input(&payload)).await;
+        let outcome = f
+            .guard(&ir(&["send_wire"], &[]), &payload_input(&payload))
+            .await;
         assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
         assert_eq!(f.violations().await.len(), 1);
     }
@@ -1303,7 +1343,9 @@ mod tests {
     #[tokio::test]
     async fn a_gated_tool_is_held_and_requests_approval_exactly_once() {
         let f = Fixture::new();
-        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        let outcome = f
+            .guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"]))
+            .await;
         assert_eq!(
             outcome,
             DispatchGuardOutcome::Held {
@@ -1369,8 +1411,12 @@ mod tests {
     #[tokio::test]
     async fn an_already_pending_node_is_held_without_a_duplicate_request() {
         let f = Fixture::new();
-        let first = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
-        let second = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        let first = f
+            .guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"]))
+            .await;
+        let second = f
+            .guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"]))
+            .await;
         assert!(matches!(first, DispatchGuardOutcome::Held { .. }));
         assert!(matches!(second, DispatchGuardOutcome::Held { .. }));
         assert_eq!(
@@ -1387,9 +1433,15 @@ mod tests {
         let f = Fixture::new();
         f.seed(vec![request_for(&["send_wire"], None), rejected("n1")])
             .await;
-        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        let outcome = f
+            .guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"]))
+            .await;
         assert!(matches!(outcome, DispatchGuardOutcome::Held { .. }));
-        assert_eq!(f.requests().await.len(), 1, "no new request for a rejection");
+        assert_eq!(
+            f.requests().await.len(),
+            1,
+            "no new request for a rejection"
+        );
     }
 
     /// The dual of the binding check: an approval DOES release the exact call
@@ -1403,7 +1455,9 @@ mod tests {
             approved("n1"),
         ])
         .await;
-        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        let outcome = f
+            .guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"]))
+            .await;
         assert_eq!(outcome, DispatchGuardOutcome::Allow);
         assert_eq!(
             f.requests().await.len(),
@@ -1418,8 +1472,11 @@ mod tests {
     async fn an_approval_does_not_authorise_a_different_call_set() {
         let f = Fixture::new();
         let hash = content_hash(&calls_json_for(&["read_file"]));
-        f.seed(vec![request_for(&["read_file"], Some(hash)), approved("n1")])
-            .await;
+        f.seed(vec![
+            request_for(&["read_file"], Some(hash)),
+            approved("n1"),
+        ])
+        .await;
         let outcome = f
             .guard(
                 &ir(&[], &["send_wire", "read_file"]),
@@ -1491,6 +1548,37 @@ mod tests {
         }))
         .unwrap();
         assert!(!is_agent_tool_dispatch(&unmarked.node("n1").unwrap().kind));
+    }
+
+    /// An IR stored before the marker existed deserializes to
+    /// `agent_tool_dispatch: false`, and nothing re-validates a workflow that is
+    /// already in the backend — `validate_agent_tool_dispatch` runs on the
+    /// REGISTRATION route only. Keying enforcement solely on the marker would
+    /// therefore leave C1 fully open for every ADK workflow registered before
+    /// this change and started from stored IR (a cron/scheduled fleet, or any
+    /// `start_execution` without a fresh `create_workflow`).
+    ///
+    /// The dispatch coordinates identify the node without the marker — that is
+    /// exactly what the registration validator matches on — so enforcement keys
+    /// on them too. The marker stays as the cheap path, not the only signal.
+    #[tokio::test]
+    async fn unmarked_adk_dispatch_coordinates_are_still_guarded() {
+        let unmarked: WorkflowIr = serde_json::from_value(json!({
+            "workflow_id": "wf", "version": "1.0.0", "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": { "n1": { "id": "n1", "kind": {
+                "type": "python_fn",
+                "module": "jamjet.agents.tool_runtime",
+                "function": "dispatch_tool_calls",
+                "output_schema": "", "agent_tool_dispatch": false }}},
+            "edges": [], "retry_policies": {}, "models": {}, "tools": {},
+            "mcp_servers": {}, "remote_agents": {}
+        }))
+        .unwrap();
+        assert!(
+            is_agent_tool_dispatch(&unmarked.node("n1").unwrap().kind),
+            "an unmarked node carrying the ADK dispatch coordinates must still be guarded"
+        );
     }
 
     #[test]

--- a/runtime/workers/src/dispatch_guard.rs
+++ b/runtime/workers/src/dispatch_guard.rs
@@ -1,0 +1,1034 @@
+//! The shared enforcement decision for ADK agent tool-dispatch nodes.
+//!
+//! An ADK agent compiles a whole turn's model-chosen tool calls into one
+//! `python_fn` / `java_fn` node, so the tool names are invisible to the ordinary
+//! node-kind policy path and every `blocked_tools` / `require_approval_for` rule
+//! silently misses (review finding C1). This module owns the decision that
+//! closes that hole, and the audit trail the decision leaves behind.
+//!
+//! It deliberately does NOT settle the work item. Settling differs by transport:
+//! the in-process worker completes a held item so its lease never expires into
+//! the retry path, while the HTTP claim route is handing the item OUT and must
+//! not complete an item its caller is simultaneously claiming. Keeping the
+//! settle at the call site is what lets one decision serve both.
+//!
+//! Nothing here may reference `Worker`, worker-local state, lease fences or
+//! `WorkItemId` — those are worker lifecycle concerns, and depending on them
+//! would re-couple the decision to one transport.
+
+use jamjet_core::node::NodeKind;
+use jamjet_core::workflow::ExecutionId;
+use jamjet_ir::workflow::{NodeDef, PolicySetIr, WorkflowIr};
+use jamjet_policy::dispatch::{DispatchDecision, UnreadableCalls};
+use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
+use jamjet_state::approvals::NodeApprovalStatus;
+use jamjet_state::backend::StateBackend;
+use jamjet_state::content_hash;
+use jamjet_state::event::EventKind;
+use jamjet_state::Event;
+use serde_json::Value;
+use tracing::{info, warn};
+
+/// The rule string recorded when a marked dispatch node's pending calls cannot
+/// be read. Every cause-specific rule starts with this, so the phrase stays a
+/// stable needle for anything matching on the family rather than the cause.
+const UNREADABLE: &str = "agent dispatch tool calls unreadable";
+
+/// The rule string recorded when a settled approval does not authorise the calls
+/// that are actually pending.
+const APPROVAL_MISMATCH: &str = "approved tool calls do not match pending calls";
+
+/// What the guard decided about one agent dispatch batch.
+///
+/// This is deliberately NOT the worker's
+/// `Option<Result<(), Box<dyn Error + Send + Sync>>>`, which encodes worker
+/// lifecycle ("None = proceed, Some(Err) = fail this node, Some(Ok) = held and
+/// already settled"). A caller has to be able to tell a policy denial — audit
+/// it, refuse the payload, do not retry — from state it could not read, which
+/// is a transient infrastructure failure that should be retried and must NOT
+/// pollute the Prove surface with a denial that no policy made.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchGuardOutcome {
+    /// Policy permits the batch. The caller may run it.
+    Allow,
+    /// Policy denied the batch. A `PolicyViolation` has already been recorded
+    /// (best effort — the denial stands either way). `reason` is the audit rule,
+    /// not a user-facing message.
+    Blocked { reason: String },
+    /// The batch needs human approval and must not run. An outstanding
+    /// `ToolApprovalRequired` exists for the node — this call either found one
+    /// or appended it. The caller settles the work item however its transport
+    /// requires.
+    Held { gated: Vec<String> },
+    /// The state needed to decide could not be read or the decision could not be
+    /// recorded. The caller MUST NOT run the batch. No `PolicyViolation` is
+    /// recorded, because no policy denied — this is infrastructure, and the
+    /// caller should retry rather than audit a denial that never happened.
+    Unavailable { reason: String },
+}
+
+/// True for nodes that run a whole agent turn's model-chosen tool calls.
+pub fn is_agent_tool_dispatch(kind: &NodeKind) -> bool {
+    matches!(
+        kind,
+        NodeKind::PythonFn {
+            agent_tool_dispatch: true,
+            ..
+        } | NodeKind::JavaFn {
+            agent_tool_dispatch: true,
+            ..
+        }
+    )
+}
+
+/// The frozen accumulated state the scheduler enriched onto a PythonFn/JavaFn
+/// work item (`runtime/scheduler/src/runner.rs:441-480`). This is the exact
+/// input the dispatch will consume, which is what makes policy evaluation over
+/// it free of a time-of-check-to-time-of-use window.
+///
+/// It MUST be `payload["input"]`, never `payload`. The pending calls live one
+/// level down; reading the whole payload would leave both call keys absent, so
+/// the calls would read as "nothing to run" and every tool would be allowed
+/// while the code read like a correct allow. When the key is missing, this
+/// yields `Value::Null`, which the reader rejects as unreadable.
+pub fn payload_input(payload: &Value) -> Value {
+    payload.get("input").cloned().unwrap_or(Value::Null)
+}
+
+/// Decide whether a marked agent dispatch node may run, and emit the audit
+/// trail. **The CALLER settles the work item.**
+///
+/// The frozen `payload_input` is the same bytes the dispatch will consume, so
+/// there is no time-of-check-to-time-of-use window: this deliberately does NOT
+/// re-read the node's input from the backend or from a snapshot.
+#[allow(clippy::too_many_arguments)]
+pub async fn guard_dispatch(
+    backend: &dyn StateBackend,
+    execution_id: &ExecutionId,
+    node_id: &str,
+    tenant_id: &str,
+    ir: &WorkflowIr,
+    node_def: &NodeDef,
+    payload_input: &Value,
+) -> DispatchGuardOutcome {
+    // Load tenant policy (sits between global and workflow in the chain).
+    let tenant_policy_set = backend
+        .get_tenant(&jamjet_state::TenantId::from(tenant_id))
+        .await
+        .ok()
+        .flatten()
+        .and_then(|t| t.policy_set());
+
+    // Build policy chain: tenant -> workflow -> node (least-specific to
+    // most-specific). The evaluator iterates in reverse, so node rules win.
+    let mut sets: Vec<&PolicySetIr> = Vec::new();
+    if let Some(ref tp) = tenant_policy_set {
+        sets.push(tp);
+    }
+    if let Some(p) = &ir.policy {
+        sets.push(p);
+    }
+    if let Some(p) = &node_def.policy {
+        sets.push(p);
+    }
+    if sets.is_empty() {
+        return DispatchGuardOutcome::Allow;
+    }
+
+    let calls = match jamjet_policy::dispatch::read_pending_tool_calls(payload_input) {
+        Ok(calls) => calls,
+        Err(cause) => {
+            // Fail closed: never run a node whose policy-relevant state we
+            // cannot read. `Ok(vec![])` (genuinely nothing to run) is distinct
+            // and falls through to Allow below — do not collapse the two.
+            let rule = unreadable_rule(cause);
+            warn!(
+                execution_id = %execution_id,
+                node_id,
+                rule,
+                "agent dispatch tool calls unreadable — refusing to run"
+            );
+            // A fail-closed refusal is a policy denial and must reach the audit
+            // surface like any other. Scope is "unknown" because the engine's
+            // fail-closed rule denied here, not a policy layer.
+            record_policy_violation(
+                backend,
+                execution_id,
+                node_id,
+                rule.clone(),
+                "unknown".to_string(),
+            )
+            .await;
+            return DispatchGuardOutcome::Blocked { reason: rule };
+        }
+    };
+
+    match jamjet_policy::dispatch::evaluate_dispatch(node_id, &calls, &sets) {
+        DispatchDecision::Allow => DispatchGuardOutcome::Allow,
+
+        DispatchDecision::Block { tool_name, reason } => {
+            // Attribute the scope using the same per-call context
+            // `evaluate_dispatch` matched on; a node-kind context carries no
+            // tool_name, so reusing one would record every dispatch block as
+            // "unknown".
+            let policy_scope = identify_policy_scope(
+                &tool_ctx(node_id, &tool_name),
+                tenant_policy_set.as_ref(),
+                ir.policy.as_ref(),
+                node_def.policy.as_ref(),
+            );
+            warn!(execution_id = %execution_id, node_id, %tool_name, %reason, %policy_scope, "Policy blocked agent tool call");
+            record_policy_violation(backend, execution_id, node_id, reason.clone(), policy_scope)
+                .await;
+            DispatchGuardOutcome::Blocked { reason }
+        }
+
+        DispatchDecision::RequireApproval { approver, gated } => {
+            // Bind the approval to the exact calls it authorises, so a settled
+            // approval cannot be replayed against a different payload
+            // (approval-loop hardening: decision not bound to resolved params).
+            //
+            // COVERAGE: the bound material is `name` + `arguments` per call, in
+            // order, and nothing else. Every other field a producer may carry on
+            // a raw call — `id` above all, plus any provider-specific extras —
+            // is deliberately UNBOUND, so a re-fire that differs only in call id
+            // still matches the approval. Widening this to the raw call objects
+            // would bind the approval to fields that carry no authority and
+            // would make benign re-issues fail the check.
+            let calls_json = serde_json::json!(calls
+                .iter()
+                .map(|c| serde_json::json!({"name": c.name, "arguments": c.arguments}))
+                .collect::<Vec<_>>());
+            let current_hash = content_hash(&calls_json);
+
+            // ONE read of the event log, for the whole approval decision.
+            //
+            // The binding check and the "is there already a request?" check both
+            // need approval state. Reading twice is safe under a lease, which
+            // serializes one work item to one worker — but this unit also runs
+            // on the HTTP claim route, where two concurrent claims for the same
+            // node could both pass the binding check in the window between two
+            // reads and then diverge on the second. One read cannot straddle a
+            // write, so everything below decides from the same snapshot.
+            let events = match backend.get_events(execution_id).await {
+                Ok(events) => events,
+                Err(e) => {
+                    // Fail closed: never run an approval-gated node blind. This
+                    // is infrastructure, not a denial, so nothing is audited.
+                    return DispatchGuardOutcome::Unavailable {
+                        reason: format!(
+                            "approval state unavailable; refusing to run unapproved: {e}"
+                        ),
+                    };
+                }
+            };
+
+            match jamjet_state::approvals::node_approval_status(&events, node_id) {
+                NodeApprovalStatus::Approved { .. } => {
+                    // An existing approval authorised one specific call set. If
+                    // the pending calls differ, the approval must not carry over
+                    // — otherwise a settled approval authorises whatever happens
+                    // to be pending when the node re-fires.
+                    let approved_hash = latest_request_calls_hash(&events, node_id);
+                    if approved_hash.as_deref() != Some(current_hash.as_str()) {
+                        warn!(
+                            execution_id = %execution_id,
+                            node_id,
+                            "approved call set does not match pending calls — refusing"
+                        );
+                        // The highest-value audit record here: an approval was on
+                        // file but did not authorise these calls. The approval
+                        // requirement came from an identifiable layer, so name it.
+                        let policy_scope = gated
+                            .first()
+                            .map(|tool| {
+                                identify_policy_scope(
+                                    &tool_ctx(node_id, tool),
+                                    tenant_policy_set.as_ref(),
+                                    ir.policy.as_ref(),
+                                    node_def.policy.as_ref(),
+                                )
+                            })
+                            .unwrap_or_else(|| "unknown".to_string());
+                        record_policy_violation(
+                            backend,
+                            execution_id,
+                            node_id,
+                            APPROVAL_MISMATCH.to_string(),
+                            policy_scope,
+                        )
+                        .await;
+                        return DispatchGuardOutcome::Blocked {
+                            reason: APPROVAL_MISMATCH.to_string(),
+                        };
+                    }
+                    info!(execution_id = %execution_id, node_id, "Approval satisfied — proceeding");
+                    DispatchGuardOutcome::Allow
+                }
+
+                // Already requested (or decided rejected — the scheduler owns
+                // the failure). Hold; emit nothing.
+                NodeApprovalStatus::Pending(_) | NodeApprovalStatus::Rejected { .. } => {
+                    DispatchGuardOutcome::Held { gated }
+                }
+
+                NodeApprovalStatus::NotRequested => {
+                    info!(execution_id = %execution_id, node_id, %approver, "Node requires approval");
+                    // `gated` carries tool NAMES only: two calls to the same
+                    // gated tool render as ["send_wire", "send_wire"] with no
+                    // discriminator. `calls` is what identifies them.
+                    let context = serde_json::json!({
+                        "node_id": node_id,
+                        "gated_tools": gated,
+                        "calls": calls_json,
+                        "calls_hash": current_hash,
+                    });
+                    let seq = match backend.latest_sequence(execution_id).await {
+                        Ok(s) => s + 1,
+                        Err(e) => {
+                            return DispatchGuardOutcome::Unavailable {
+                                reason: format!("approval required but could not be recorded: {e}"),
+                            }
+                        }
+                    };
+                    if let Err(e) = backend
+                        .append_event(Event::new(
+                            execution_id.clone(),
+                            seq,
+                            EventKind::ToolApprovalRequired {
+                                node_id: node_id.to_string(),
+                                tool_name: gated.join(", "),
+                                approver,
+                                context,
+                            },
+                        ))
+                        .await
+                    {
+                        // Fail closed: an unrecorded request is an invisible hold.
+                        return DispatchGuardOutcome::Unavailable {
+                            reason: format!("approval required but could not be recorded: {e}"),
+                        };
+                    }
+                    DispatchGuardOutcome::Held { gated }
+                }
+            }
+        }
+    }
+}
+
+/// The per-call evaluation context `evaluate_dispatch` matched on.
+///
+/// `"tool"`, not `"python_fn"`: only the model-allowlist branch keys on the tag
+/// (`runtime/policy/src/lib.rs:62`), and `"tool"` is what makes `blocked_tools` /
+/// `require_approval_for` read naturally here. This MUST stay identical to the
+/// context built in `jamjet_policy::dispatch::evaluate_dispatch`, or scope
+/// attribution names a layer that did not decide.
+fn tool_ctx(node_id: &str, tool_name: &str) -> EvaluationContext {
+    EvaluationContext {
+        node_id: node_id.to_string(),
+        node_kind_tag: "tool".to_string(),
+        tool_name: Some(tool_name.to_string()),
+        model_ref: None,
+    }
+}
+
+/// The audit rule for each way a dispatch payload can be unreadable.
+///
+/// The prefix is applied here rather than written into each arm, so the family
+/// phrase cannot drift on one cause and quietly stop matching: the decision is
+/// identical for all of them, so anything keyed on the family must keep
+/// matching, while the Prove surface gains the cause.
+fn unreadable_rule(cause: UnreadableCalls) -> String {
+    let detail = match cause {
+        UnreadableCalls::NotAnObject => "input is not an object",
+        UnreadableCalls::NotAList => "the call list is not an array",
+        UnreadableCalls::UnnamedCall => "a call has no readable name",
+    };
+    format!("{UNREADABLE}: {detail}")
+}
+
+/// The `calls_hash` bound to the LATEST approval request for a node.
+///
+/// `node_approval_status` resets to Pending on each new request, so an
+/// `Approved` status always refers to the latest request. Find that event FIRST,
+/// then read its hash — a `find_map` over the hash would skip a hash-less latest
+/// request and silently inherit an older, superseded request's hash, which is a
+/// fail-open. Selecting the event first makes an absent hash yield `None`, which
+/// never equals `Some(current)` and blocks.
+fn latest_request_calls_hash(events: &[Event], node_id: &str) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            matches!(
+                &e.kind,
+                EventKind::ToolApprovalRequired { node_id: n, .. } if n == node_id
+            )
+        })
+        .and_then(|e| match &e.kind {
+            EventKind::ToolApprovalRequired { context, .. } => context
+                .get("calls_hash")
+                .and_then(|h| h.as_str())
+                .map(|s| s.to_string()),
+            _ => None,
+        })
+}
+
+/// Record a policy denial in the event log, best effort.
+///
+/// The denial is enforced by the caller regardless of whether this record lands:
+/// fail closed, never open. Used by every deny path in the guard — the
+/// policy-rule block AND the two fail-closed refusals (unreadable calls,
+/// approved-set mismatch) — so that no refusal is invisible to audit.
+///
+/// KNOWN LIMIT: `latest_sequence() + 1` is a read-modify-write with no
+/// compare-and-set. Under a lease exactly one worker holds a work item, so the
+/// sequence cannot be raced. On the HTTP claim route, two concurrent claims for
+/// the same execution can compute the same next sequence. The backend trait
+/// offers no CAS append, so this is not fixable here; it is a known limit of the
+/// route path, and it affects only the audit record's sequence — never whether
+/// the denial is enforced.
+async fn record_policy_violation(
+    backend: &dyn StateBackend,
+    execution_id: &ExecutionId,
+    node_id: &str,
+    rule: String,
+    policy_scope: String,
+) {
+    if let Ok(latest) = backend.latest_sequence(execution_id).await {
+        let _ = backend
+            .append_event(Event::new(
+                execution_id.clone(),
+                latest + 1,
+                EventKind::PolicyViolation {
+                    node_id: node_id.to_string(),
+                    rule,
+                    decision: "blocked".to_string(),
+                    policy_scope,
+                },
+            ))
+            .await;
+    }
+}
+
+/// Determine which policy scope triggered a non-Allow decision.
+///
+/// Checks each scope individually from most-specific (node) to least-specific
+/// (tenant), returning the name of the first scope that produces a non-Allow
+/// decision.
+pub fn identify_policy_scope(
+    ctx: &EvaluationContext,
+    tenant_policy: Option<&PolicySetIr>,
+    workflow_policy: Option<&PolicySetIr>,
+    node_policy: Option<&PolicySetIr>,
+) -> String {
+    // Check most-specific first (same order as evaluator's reverse iteration).
+    if let Some(p) = node_policy {
+        if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
+            return "node".to_string();
+        }
+    }
+    if let Some(p) = workflow_policy {
+        if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
+            return "workflow".to_string();
+        }
+    }
+    if let Some(p) = tenant_policy {
+        if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
+            return "tenant".to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jamjet_state::tenant::{Tenant, TenantStatus};
+    use jamjet_state::InMemoryBackend;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    /// A single marked agent-dispatch node, optionally under a workflow policy.
+    fn ir_with(policy: Option<serde_json::Value>) -> WorkflowIr {
+        let mut doc = json!({
+            "workflow_id": "adk-wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": { "n1": { "id": "n1", "kind": {
+                "type": "python_fn",
+                "module": "jamjet.agents.tool_runtime",
+                "function": "dispatch_tool_calls",
+                "output_schema": "",
+                "agent_tool_dispatch": true
+            }}},
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {}
+        });
+        if let Some(p) = policy {
+            doc["policy"] = p;
+        }
+        serde_json::from_value(doc).expect("dispatch IR must deserialize")
+    }
+
+    fn policy_json(blocked: &[&str], approval: &[&str]) -> serde_json::Value {
+        json!({
+            "blocked_tools": blocked,
+            "require_approval_for": approval,
+            "model_allowlist": []
+        })
+    }
+
+    /// Workflow-level policy — the ordinary shape.
+    fn ir(blocked: &[&str], approval: &[&str]) -> WorkflowIr {
+        ir_with(Some(policy_json(blocked, approval)))
+    }
+
+    /// No policy anywhere: the empty-chain case.
+    fn unpoliced_ir() -> WorkflowIr {
+        ir_with(None)
+    }
+
+    fn one_call(name: &str) -> serde_json::Value {
+        json!({"id": "c1", "name": name, "arguments": {}})
+    }
+
+    fn input_for(names: &[&str]) -> serde_json::Value {
+        json!({"tool_calls": names.iter().map(|n| one_call(n)).collect::<Vec<_>>()})
+    }
+
+    /// The exact `calls_json` shape the guard hashes. Both the recorded approval
+    /// context and the re-fire check must hash this same shape, or the binding
+    /// never matches and an approved node can never proceed.
+    fn calls_json_for(names: &[&str]) -> serde_json::Value {
+        json!(names
+            .iter()
+            .map(|n| json!({"name": n, "arguments": {}}))
+            .collect::<Vec<_>>())
+    }
+
+    struct Fixture {
+        backend: Arc<InMemoryBackend>,
+        execution_id: ExecutionId,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            Self {
+                backend: Arc::new(InMemoryBackend::new()),
+                execution_id: ExecutionId::new(),
+            }
+        }
+
+        async fn seed(&self, kinds: Vec<EventKind>) {
+            for kind in kinds {
+                // InMemoryBackend assigns the sequence itself; 0 is a placeholder.
+                self.backend
+                    .append_event(Event::new(self.execution_id.clone(), 0, kind))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        async fn with_tenant_policy(&self, blocked: &[&str], approval: &[&str]) {
+            let now = chrono::Utc::now();
+            self.backend
+                .create_tenant(Tenant {
+                    id: "default".into(),
+                    name: "default".into(),
+                    status: TenantStatus::Active,
+                    policy: Some(policy_json(blocked, approval)),
+                    limits: None,
+                    created_at: now,
+                    updated_at: now,
+                })
+                .await
+                .unwrap();
+        }
+
+        async fn guard(&self, ir: &WorkflowIr, input: &serde_json::Value) -> DispatchGuardOutcome {
+            let node_def = ir.node("n1").expect("node n1 must exist");
+            guard_dispatch(
+                self.backend.as_ref(),
+                &self.execution_id,
+                "n1",
+                "default",
+                ir,
+                node_def,
+                input,
+            )
+            .await
+        }
+
+        async fn events(&self) -> Vec<Event> {
+            self.backend.get_events(&self.execution_id).await.unwrap()
+        }
+
+        /// Every `PolicyViolation` as `(rule, policy_scope)`.
+        async fn violations(&self) -> Vec<(String, String)> {
+            self.events()
+                .await
+                .iter()
+                .filter_map(|e| match &e.kind {
+                    EventKind::PolicyViolation {
+                        rule,
+                        decision,
+                        policy_scope,
+                        ..
+                    } => {
+                        assert_eq!(decision, "blocked", "a violation is always a block");
+                        Some((rule.clone(), policy_scope.clone()))
+                    }
+                    _ => None,
+                })
+                .collect()
+        }
+
+        /// Every `ToolApprovalRequired` as `(tool_name, approver, context)`.
+        async fn requests(&self) -> Vec<(String, String, serde_json::Value)> {
+            self.events()
+                .await
+                .iter()
+                .filter_map(|e| match &e.kind {
+                    EventKind::ToolApprovalRequired {
+                        tool_name,
+                        approver,
+                        context,
+                        ..
+                    } => Some((tool_name.clone(), approver.clone(), context.clone())),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    fn approved(node_id: &str) -> EventKind {
+        EventKind::ApprovalReceived {
+            node_id: node_id.into(),
+            user_id: "approver".into(),
+            decision: jamjet_state::event::ApprovalDecision::Approved,
+            comment: None,
+            state_patch: None,
+        }
+    }
+
+    fn rejected(node_id: &str) -> EventKind {
+        EventKind::ApprovalReceived {
+            node_id: node_id.into(),
+            user_id: "approver".into(),
+            decision: jamjet_state::event::ApprovalDecision::Rejected,
+            comment: None,
+            state_patch: None,
+        }
+    }
+
+    fn request_for(names: &[&str], hash: Option<String>) -> EventKind {
+        let mut context = json!({
+            "node_id": "n1",
+            "gated_tools": names,
+            "calls": calls_json_for(names),
+        });
+        if let Some(h) = hash {
+            context["calls_hash"] = json!(h);
+        }
+        EventKind::ToolApprovalRequired {
+            node_id: "n1".into(),
+            tool_name: names.join(", "),
+            approver: "human".into(),
+            context,
+        }
+    }
+
+    // ── Allow ─────────────────────────────────────────────────────────────────
+
+    /// The availability dual of the whole guard, and the most common production
+    /// shape: an agent calling a permitted tool while a real policy is in force.
+    /// An implementation that denied on Allow would pass every deny test here.
+    #[tokio::test]
+    async fn a_permitted_tool_is_allowed_and_audits_nothing() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(&ir(&["send_wire"], &["wire_batch"]), &input_for(&["read_file"]))
+            .await;
+        assert_eq!(outcome, DispatchGuardOutcome::Allow);
+        assert!(
+            f.events().await.is_empty(),
+            "an allowed dispatch must write no events"
+        );
+    }
+
+    /// `Ok(vec![])` (genuinely nothing to run) must stay distinct from an
+    /// unreadable payload at THIS seam, not only inside the reader.
+    #[tokio::test]
+    async fn an_empty_call_list_is_allowed_not_unreadable() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(&ir(&["send_wire"], &[]), &json!({"tool_calls": []}))
+            .await;
+        assert_eq!(outcome, DispatchGuardOutcome::Allow);
+        assert!(f.violations().await.is_empty());
+    }
+
+    /// An empty policy chain has nothing to enforce, so the guard steps aside
+    /// before it ever reads the payload. This mirrors the worker's long-standing
+    /// short-circuit; changing it would make an unpoliced workflow start failing
+    /// on payload shape.
+    #[tokio::test]
+    async fn an_empty_policy_chain_allows() {
+        let f = Fixture::new();
+        assert_eq!(
+            f.guard(&unpoliced_ir(), &input_for(&["send_wire"])).await,
+            DispatchGuardOutcome::Allow
+        );
+        // Even an unreadable payload: with no policy there is no decision to make.
+        assert_eq!(
+            f.guard(&unpoliced_ir(), &json!({"tool_calls": "nope"})).await,
+            DispatchGuardOutcome::Allow
+        );
+        assert!(f.events().await.is_empty());
+    }
+
+    // ── Block ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_blocked_tool_is_blocked_and_audited_exactly_once() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(&ir(&["send_wire"], &[]), &input_for(&["read_file", "send_wire"]))
+            .await;
+        match outcome {
+            DispatchGuardOutcome::Blocked { reason } => {
+                assert!(
+                    reason.contains("matches blocked pattern 'send_wire'"),
+                    "the audit rule must name the rule that matched; got {reason:?}"
+                );
+            }
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+        let violations = f.violations().await;
+        assert_eq!(
+            violations.len(),
+            1,
+            "exactly one PolicyViolation, got {violations:?}"
+        );
+        assert_eq!(violations[0].1, "workflow", "the blocking layer is named");
+    }
+
+    /// Fail closed: a batch holding both a blocked and a gated call must block,
+    /// never merely hold.
+    #[tokio::test]
+    async fn a_block_beats_an_approval_gate() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(
+                &ir(&["drop_table"], &["send_wire"]),
+                &input_for(&["send_wire", "drop_table"]),
+            )
+            .await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
+        assert!(f.requests().await.is_empty(), "a blocked batch is not held");
+    }
+
+    /// The tenant layer is part of the chain the guard builds. A guard that
+    /// only read the workflow and node policies would allow this.
+    #[tokio::test]
+    async fn a_tenant_policy_blocks_and_is_named_as_the_scope() {
+        let f = Fixture::new();
+        f.with_tenant_policy(&["send_wire"], &[]).await;
+        let outcome = f.guard(&unpoliced_ir(), &input_for(&["send_wire"])).await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
+        assert_eq!(f.violations().await[0].1, "tenant");
+    }
+
+    // ── Unreadable ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_non_array_call_list_is_blocked() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(&ir(&["send_wire"], &[]), &json!({"tool_calls": "send_wire"}))
+            .await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
+        assert_eq!(f.violations().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_nameless_call_is_blocked() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(
+                &ir(&["send_wire"], &[]),
+                &json!({"tool_calls": [{"id": "c1", "arguments": {}}]}),
+            )
+            .await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
+        assert_eq!(f.violations().await.len(), 1);
+    }
+
+    /// A non-object input is unreadable, not empty — the live shape of a missing
+    /// `input` key, which `payload_input` renders as `Value::Null`.
+    #[tokio::test]
+    async fn a_non_object_input_is_blocked() {
+        let f = Fixture::new();
+        for input in [Value::Null, json!("send_wire"), json!([one_call("x")])] {
+            let outcome = f.guard(&ir(&["send_wire"], &[]), &input).await;
+            assert!(
+                matches!(outcome, DispatchGuardOutcome::Blocked { .. }),
+                "{input} must be unreadable, got {outcome:?}"
+            );
+        }
+    }
+
+    /// The end-to-end shape a route or worker actually hits: a payload with no
+    /// `input` key at all, plus a top-level decoy. Reading the whole payload
+    /// instead of `payload["input"]` would make this readable and allow it.
+    #[tokio::test]
+    async fn an_absent_input_key_is_blocked() {
+        let f = Fixture::new();
+        let payload = json!({"workflow_id": "adk-wf", "tool_calls": []});
+        let outcome = f.guard(&ir(&["send_wire"], &[]), &payload_input(&payload)).await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Blocked { .. }));
+        assert_eq!(f.violations().await.len(), 1);
+    }
+
+    /// Audit fidelity: a production denial has to be attributable. Three
+    /// different malformations previously recorded one indistinguishable rule.
+    /// Each must still carry the family phrase, because that is the needle
+    /// existing consumers match on.
+    #[tokio::test]
+    async fn each_unreadable_cause_records_a_distinct_rule() {
+        let cases = [
+            Value::Null,
+            json!({"tool_calls": "send_wire"}),
+            json!({"tool_calls": [{"id": "c1"}]}),
+        ];
+        let mut rules = Vec::new();
+        for input in cases {
+            let f = Fixture::new();
+            let outcome = f.guard(&ir(&["send_wire"], &[]), &input).await;
+            let DispatchGuardOutcome::Blocked { reason } = outcome else {
+                panic!("{input} must block");
+            };
+            let recorded = f.violations().await;
+            assert_eq!(recorded.len(), 1);
+            assert_eq!(recorded[0].0, reason, "the audit rule is the denial reason");
+            assert!(
+                reason.starts_with(UNREADABLE),
+                "every cause keeps the family phrase; got {reason:?}"
+            );
+            rules.push(reason);
+        }
+        rules.sort();
+        rules.dedup();
+        assert_eq!(rules.len(), 3, "the three causes must be distinguishable");
+    }
+
+    // ── Approval ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_gated_tool_is_held_and_requests_approval_exactly_once() {
+        let f = Fixture::new();
+        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        assert_eq!(
+            outcome,
+            DispatchGuardOutcome::Held {
+                gated: vec!["send_wire".into()]
+            }
+        );
+        let requests = f.requests().await;
+        assert_eq!(requests.len(), 1, "exactly one request, got {requests:?}");
+        assert!(f.violations().await.is_empty(), "a hold is not a violation");
+    }
+
+    /// `gated` is what a human approver is shown as the tools they are
+    /// authorising, so membership is load-bearing: naming the whole batch would
+    /// over-report, naming none would under-report.
+    #[tokio::test]
+    async fn one_gated_call_in_a_batch_of_three_holds_and_names_only_that_call() {
+        let f = Fixture::new();
+        let outcome = f
+            .guard(
+                &ir(&[], &["send_wire"]),
+                &input_for(&["read_file", "send_wire", "log"]),
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            DispatchGuardOutcome::Held {
+                gated: vec!["send_wire".into()]
+            }
+        );
+    }
+
+    /// The approval is bound to the exact calls it authorises, so a settled
+    /// approval cannot be replayed against a different payload.
+    #[tokio::test]
+    async fn the_request_context_carries_the_gated_tools_calls_and_a_hash() {
+        let f = Fixture::new();
+        f.guard(
+            &ir(&[], &["send_wire"]),
+            &input_for(&["read_file", "send_wire"]),
+        )
+        .await;
+        let requests = f.requests().await;
+        let (tool_name, approver, context) = &requests[0];
+        assert_eq!(tool_name, "send_wire", "tool_name lists the gated calls");
+        assert_eq!(approver, "human");
+        assert_eq!(context["node_id"], "n1");
+        assert_eq!(context["gated_tools"], json!(["send_wire"]));
+        assert_eq!(
+            context["calls"],
+            calls_json_for(&["read_file", "send_wire"]),
+            "the WHOLE batch is bound, not just the gated call"
+        );
+        assert_eq!(
+            context["calls_hash"],
+            json!(content_hash(&calls_json_for(&["read_file", "send_wire"]))),
+            "the hash must cover the same shape the re-fire check recomputes"
+        );
+    }
+
+    /// Re-entering an already-pending node must not stack up requests: an
+    /// approver would see duplicates and `node_approval_status` would keep
+    /// resetting to Pending, so a settled decision could never stick.
+    #[tokio::test]
+    async fn an_already_pending_node_is_held_without_a_duplicate_request() {
+        let f = Fixture::new();
+        let first = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        let second = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        assert!(matches!(first, DispatchGuardOutcome::Held { .. }));
+        assert!(matches!(second, DispatchGuardOutcome::Held { .. }));
+        assert_eq!(
+            f.requests().await.len(),
+            1,
+            "the second pass must not append a second request"
+        );
+    }
+
+    /// A rejected node holds too: the scheduler owns turning a rejection into a
+    /// failure. Re-requesting here would reopen a decision a human already made.
+    #[tokio::test]
+    async fn a_rejected_node_is_held_without_a_new_request() {
+        let f = Fixture::new();
+        f.seed(vec![request_for(&["send_wire"], None), rejected("n1")])
+            .await;
+        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        assert!(matches!(outcome, DispatchGuardOutcome::Held { .. }));
+        assert_eq!(f.requests().await.len(), 1, "no new request for a rejection");
+    }
+
+    /// The dual of the binding check: an approval DOES release the exact call
+    /// set it authorised. Without this, blocking always would satisfy the check.
+    #[tokio::test]
+    async fn an_approval_releases_the_call_set_it_authorised() {
+        let f = Fixture::new();
+        let hash = content_hash(&calls_json_for(&["send_wire"]));
+        f.seed(vec![
+            request_for(&["send_wire"], Some(hash)),
+            approved("n1"),
+        ])
+        .await;
+        let outcome = f.guard(&ir(&[], &["send_wire"]), &input_for(&["send_wire"])).await;
+        assert_eq!(outcome, DispatchGuardOutcome::Allow);
+        assert_eq!(
+            f.requests().await.len(),
+            1,
+            "an approved node is not re-requested"
+        );
+        assert!(f.violations().await.is_empty());
+    }
+
+    /// An approval authorises a specific set of calls, not the node forever.
+    #[tokio::test]
+    async fn an_approval_does_not_authorise_a_different_call_set() {
+        let f = Fixture::new();
+        let hash = content_hash(&calls_json_for(&["read_file"]));
+        f.seed(vec![request_for(&["read_file"], Some(hash)), approved("n1")])
+            .await;
+        let outcome = f
+            .guard(
+                &ir(&[], &["send_wire", "read_file"]),
+                &input_for(&["send_wire"]),
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            DispatchGuardOutcome::Blocked {
+                reason: APPROVAL_MISMATCH.into()
+            }
+        );
+        let violations = f.violations().await;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].0, APPROVAL_MISMATCH);
+        assert_eq!(
+            violations[0].1, "workflow",
+            "the approval requirement came from an identifiable layer, so the \
+             mismatch record must name it rather than shrug with \"unknown\""
+        );
+    }
+
+    /// The approved hash must come from the LATEST request for the node, and an
+    /// absent hash on that request must block.
+    ///
+    /// `node_approval_status` resets to Pending on every new request, so an
+    /// `Approved` status always refers to the latest one. A lookup that scans
+    /// backwards for the first event *yielding a hash* walks straight past a
+    /// hash-less latest request and inherits an older, superseded request's
+    /// hash — a fail-open. The pending calls below deliberately MATCH the older
+    /// request, so that lookup would allow and only the correct one blocks.
+    #[tokio::test]
+    async fn a_hashless_latest_request_does_not_inherit_an_older_hash() {
+        let f = Fixture::new();
+        let old = content_hash(&calls_json_for(&["read_file"]));
+        f.seed(vec![
+            request_for(&["read_file"], Some(old)),
+            request_for(&["read_file"], None),
+            approved("n1"),
+        ])
+        .await;
+        let outcome = f
+            .guard(&ir(&[], &["read_file"]), &input_for(&["read_file"]))
+            .await;
+        assert_eq!(
+            outcome,
+            DispatchGuardOutcome::Blocked {
+                reason: APPROVAL_MISMATCH.into()
+            }
+        );
+        assert_eq!(f.violations().await.len(), 1);
+    }
+
+    // ── Narrowness ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn only_marked_nodes_are_agent_tool_dispatch() {
+        let marked = ir(&[], &[]);
+        assert!(is_agent_tool_dispatch(&marked.node("n1").unwrap().kind));
+
+        let unmarked: WorkflowIr = serde_json::from_value(json!({
+            "workflow_id": "wf", "version": "1.0.0", "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": { "n1": { "id": "n1", "kind": {
+                "type": "python_fn", "module": "m", "function": "f",
+                "output_schema": "", "agent_tool_dispatch": false }}},
+            "edges": [], "retry_policies": {}, "models": {}, "tools": {},
+            "mcp_servers": {}, "remote_agents": {}
+        }))
+        .unwrap();
+        assert!(!is_agent_tool_dispatch(&unmarked.node("n1").unwrap().kind));
+    }
+
+    #[test]
+    fn payload_input_reads_one_level_down() {
+        assert_eq!(payload_input(&json!({"input": {"a": 1}})), json!({"a": 1}));
+        assert_eq!(payload_input(&json!({"tool_calls": []})), Value::Null);
+        assert_eq!(payload_input(&Value::Null), Value::Null);
+    }
+}

--- a/runtime/workers/src/lib.rs
+++ b/runtime/workers/src/lib.rs
@@ -7,12 +7,14 @@
 //! - Emit heartbeats to renew leases
 //! - Report results back via the state backend
 
+pub mod dispatch_guard;
 pub mod executor;
 pub mod executors;
 pub mod heartbeat;
 pub mod pool;
 pub mod worker;
 
+pub use dispatch_guard::{guard_dispatch, DispatchGuardOutcome};
 pub use executor::{ExecutionResult, ExecutorError, NodeExecutor};
 pub use executors::{
     A2aTaskExecutor, AgentDiscoveryExecutor, ConditionNodeExecutor, EvalExecutor, McpToolExecutor,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -1,3 +1,4 @@
+use crate::dispatch_guard::{self, DispatchGuardOutcome};
 use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
 use crate::heartbeat::spawn_heartbeat;
 use chrono::Utc;
@@ -731,6 +732,48 @@ impl Worker {
         ir: &WorkflowIr,
         payload: &serde_json::Value,
     ) -> Option<Result<(), Box<dyn std::error::Error + Send + Sync>>> {
+        // ADK agent dispatch nodes hide their tool names behind a single
+        // python_fn / java_fn, so a node-kind context carries no tool_name and
+        // every blocked_tools / require_approval_for rule silently misses (C1).
+        // The decision lives in `dispatch_guard` so the HTTP claim route — the
+        // transport ADK nodes actually take in production — runs the identical
+        // logic. This branch owns only the SETTLE, which is worker-specific.
+        if dispatch_guard::is_agent_tool_dispatch(kind) {
+            let input = dispatch_guard::payload_input(payload);
+            return match dispatch_guard::guard_dispatch(
+                self.backend.as_ref(),
+                execution_id,
+                node_id,
+                tenant_id,
+                ir,
+                node_def,
+                &input,
+            )
+            .await
+            {
+                DispatchGuardOutcome::Allow => None,
+                DispatchGuardOutcome::Blocked { reason } => {
+                    Some(Err(format!("policy blocked: {reason}").into()))
+                }
+                // Not a denial: the decision could not be made or recorded, so
+                // the node fails and is retried rather than being audited as
+                // blocked. Same shape as a block to the scheduler, deliberately
+                // different on the Prove surface.
+                DispatchGuardOutcome::Unavailable { reason } => Some(Err(reason.into())),
+                // Settle the item cleanly so the lease never expires into the
+                // retry/dead-letter path. The node stays parked because it
+                // remains in the scheduler fold's `scheduled` set (so it is
+                // never re-dispatched); the fold's `held` set only gates which
+                // decision events are acted on.
+                DispatchGuardOutcome::Held { .. } => {
+                    match self.backend.complete_work_item(item_id).await {
+                        Ok(()) => Some(Ok(())),
+                        Err(e) => Some(Err(format!("failed to settle held work item: {e}").into())),
+                    }
+                }
+            };
+        }
+
         let ctx = EvaluationContext::from_node_kind(node_id, kind);
 
         // Load tenant policy (sits between global and workflow in the chain).
@@ -758,190 +801,13 @@ impl Worker {
             return None;
         }
 
-        // ADK agent dispatch nodes hide their tool names behind a single
-        // python_fn / java_fn, so `ctx` above carries no tool_name and every
-        // blocked_tools / require_approval_for rule silently misses (C1).
-        // Evaluate the frozen pending calls from the work item instead. Those
-        // are the same bytes the executor will hand the dispatch, so there is
-        // no time-of-check-to-time-of-use window: we deliberately do NOT
-        // re-read state from the backend or from a snapshot here.
-        if is_agent_tool_dispatch(kind) {
-            let input = payload_input(payload);
-            let calls = match jamjet_policy::dispatch::pending_tool_calls(&input) {
-                Some(calls) => calls,
-                None => {
-                    // Fail closed, mirroring hold_for_approval's unavailable-state
-                    // arm: never run a node whose policy-relevant state we cannot
-                    // read. `Some(vec![])` (genuinely nothing to run) is distinct
-                    // and falls through to Allow below — do not collapse the two
-                    // with unwrap_or_default.
-                    warn!(
-                        execution_id = %execution_id,
-                        node_id,
-                        "agent dispatch tool calls unreadable — refusing to run"
-                    );
-                    // A fail-closed refusal is a policy denial and must reach the
-                    // audit surface like any other. Scope is "unknown" because the
-                    // engine's fail-closed rule denied here, not a policy layer.
-                    self.record_policy_violation(
-                        execution_id,
-                        node_id,
-                        "agent dispatch tool calls unreadable".to_string(),
-                        "unknown".to_string(),
-                    )
-                    .await;
-                    return Some(Err(
-                        "policy blocked: agent dispatch tool calls unreadable".into(),
-                    ));
-                }
-            };
-
-            return match jamjet_policy::dispatch::evaluate_dispatch(node_id, &calls, &sets) {
-                jamjet_policy::dispatch::DispatchDecision::Allow => None,
-
-                jamjet_policy::dispatch::DispatchDecision::Block { tool_name, reason } => {
-                    // Attribute the scope using the same per-call context
-                    // `evaluate_dispatch` matched on; `ctx` has no tool_name, so
-                    // reusing it would record every dispatch block as "unknown".
-                    let blocked_ctx = EvaluationContext {
-                        node_id: node_id.to_string(),
-                        node_kind_tag: "tool".to_string(),
-                        tool_name: Some(tool_name.clone()),
-                        model_ref: None,
-                    };
-                    let policy_scope = self.identify_policy_scope(
-                        &blocked_ctx,
-                        tenant_policy_set.as_ref(),
-                        ir.policy.as_ref(),
-                        node_def.policy.as_ref(),
-                    );
-                    warn!(execution_id = %execution_id, node_id, %tool_name, %reason, %policy_scope, "Policy blocked agent tool call");
-                    self.record_policy_violation(
-                        execution_id,
-                        node_id,
-                        reason.clone(),
-                        policy_scope,
-                    )
-                    .await;
-                    Some(Err(format!("policy blocked: {reason}").into()))
-                }
-
-                jamjet_policy::dispatch::DispatchDecision::RequireApproval { approver, gated } => {
-                    // Bind the approval to the exact calls it authorises, so a
-                    // settled approval cannot be replayed against a different
-                    // payload (approval-loop hardening: decision not bound to
-                    // resolved params).
-                    //
-                    // COVERAGE: the bound material is `name` + `arguments` per
-                    // call, in order, and nothing else. Every other field a
-                    // producer may carry on a raw call — `id` above all, plus any
-                    // provider-specific extras — is deliberately UNBOUND, so a
-                    // re-fire that differs only in call id still matches the
-                    // approval. Widening this to the raw call objects would bind
-                    // the approval to fields that carry no authority and would
-                    // make benign re-issues fail the check.
-                    let calls_json = serde_json::json!(calls
-                        .iter()
-                        .map(|c| serde_json::json!({"name": c.name, "arguments": c.arguments}))
-                        .collect::<Vec<_>>());
-                    let current_hash = content_hash(&calls_json);
-
-                    // An existing approval authorised one specific call set. If
-                    // the pending calls differ, the approval must not carry over
-                    // — otherwise a settled approval authorises whatever happens
-                    // to be pending when the node re-fires.
-                    match self.backend.get_events(execution_id).await {
-                        Err(e) => {
-                            return Some(Err(format!(
-                                "approval state unavailable; refusing to run unapproved: {e}"
-                            )
-                            .into()))
-                        }
-                        Ok(events) => {
-                            if matches!(
-                                jamjet_state::approvals::node_approval_status(&events, node_id),
-                                NodeApprovalStatus::Approved { .. }
-                            ) {
-                                // `node_approval_status` resets to Pending on each
-                                // new request, so `Approved` always refers to the
-                                // LATEST request for this node. Find that event
-                                // FIRST, then read its hash — a `find_map` over
-                                // the hash would skip a hash-less latest request
-                                // and silently inherit an older, superseded
-                                // request's hash, which is a fail-open. Selecting
-                                // the event first makes an absent hash yield None,
-                                // which never equals `Some(current)` and blocks.
-                                let approved_hash = events
-                                    .iter()
-                                    .rev()
-                                    .find(|e| {
-                                        matches!(
-                                            &e.kind,
-                                            EventKind::ToolApprovalRequired { node_id: n, .. }
-                                                if n == node_id
-                                        )
-                                    })
-                                    .and_then(|e| match &e.kind {
-                                        EventKind::ToolApprovalRequired { context, .. } => context
-                                            .get("calls_hash")
-                                            .and_then(|h| h.as_str())
-                                            .map(|s| s.to_string()),
-                                        _ => None,
-                                    });
-                                if approved_hash.as_deref() != Some(current_hash.as_str()) {
-                                    warn!(
-                                        execution_id = %execution_id,
-                                        node_id,
-                                        "approved call set does not match pending calls — refusing"
-                                    );
-                                    // The highest-value audit record in this
-                                    // change: an approval was on file but did not
-                                    // authorise these calls. Scope is "unknown" —
-                                    // the binding check denied, not a policy layer.
-                                    self.record_policy_violation(
-                                        execution_id,
-                                        node_id,
-                                        "approved tool calls do not match pending calls".to_string(),
-                                        "unknown".to_string(),
-                                    )
-                                    .await;
-                                    return Some(Err(
-                                        "policy blocked: approved tool calls do not match pending calls".into(),
-                                    ));
-                                }
-                            }
-                        }
-                    }
-
-                    // `gated` carries tool NAMES only: two calls to the same
-                    // gated tool render as ["send_wire", "send_wire"] with no
-                    // discriminator. `calls` below is what identifies them.
-                    let context = serde_json::json!({
-                        "node_id": node_id,
-                        "gated_tools": gated,
-                        "calls": calls_json,
-                        "calls_hash": current_hash,
-                    });
-                    self.hold_for_approval(
-                        execution_id,
-                        node_id,
-                        item_id,
-                        gated.join(", "),
-                        approver,
-                        context,
-                    )
-                    .await
-                }
-            };
-        }
-
         let decision = PolicyEvaluator.evaluate(&ctx, &sets);
 
         match decision {
             PolicyDecision::Allow => None,
 
             PolicyDecision::Block { reason } => {
-                let policy_scope = self.identify_policy_scope(
+                let policy_scope = dispatch_guard::identify_policy_scope(
                     &ctx,
                     tenant_policy_set.as_ref(),
                     ir.policy.as_ref(),
@@ -981,68 +847,6 @@ impl Worker {
                 .await
             }
         }
-    }
-
-    /// Record a policy denial in the event log, best effort.
-    ///
-    /// The denial is enforced by the caller regardless of whether this record
-    /// lands: fail closed, never open. Used by every deny path in the agent
-    /// dispatch branch — the policy-rule block AND the two fail-closed refusals
-    /// (unreadable calls, approved-set mismatch) — so that no refusal is
-    /// invisible to the audit surface.
-    async fn record_policy_violation(
-        &self,
-        execution_id: &ExecutionId,
-        node_id: &str,
-        rule: String,
-        policy_scope: String,
-    ) {
-        if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
-            let _ = self
-                .backend
-                .append_event(jamjet_state::Event::new(
-                    execution_id.clone(),
-                    latest + 1,
-                    EventKind::PolicyViolation {
-                        node_id: node_id.to_string(),
-                        rule,
-                        decision: "blocked".to_string(),
-                        policy_scope,
-                    },
-                ))
-                .await;
-        }
-    }
-
-    /// Determine which policy scope triggered a non-Allow decision.
-    ///
-    /// Checks each scope individually from most-specific (node) to least-specific
-    /// (tenant), returning the name of the first scope that produces a non-Allow
-    /// decision.
-    fn identify_policy_scope(
-        &self,
-        ctx: &EvaluationContext,
-        tenant_policy: Option<&jamjet_ir::workflow::PolicySetIr>,
-        workflow_policy: Option<&jamjet_ir::workflow::PolicySetIr>,
-        node_policy: Option<&jamjet_ir::workflow::PolicySetIr>,
-    ) -> String {
-        // Check most-specific first (same order as evaluator's reverse iteration).
-        if let Some(p) = node_policy {
-            if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
-                return "node".to_string();
-            }
-        }
-        if let Some(p) = workflow_policy {
-            if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
-                return "workflow".to_string();
-            }
-        }
-        if let Some(p) = tenant_policy {
-            if !matches!(PolicyEvaluator.evaluate(ctx, &[p]), PolicyDecision::Allow) {
-                return "tenant".to_string();
-            }
-        }
-        "unknown".to_string()
     }
 
     // ── Autonomy check ────────────────────────────────────────────────────────
@@ -1492,37 +1296,6 @@ fn parse_payload(payload: &serde_json::Value) -> (String, String) {
         .unwrap_or("1.0.0")
         .to_string();
     (workflow_id, workflow_version)
-}
-
-/// The frozen accumulated state the scheduler enriched onto a PythonFn/JavaFn
-/// work item (`runtime/scheduler/src/runner.rs:441-480`). This is the exact
-/// input the dispatch will consume, which is what makes policy evaluation over
-/// it free of a time-of-check-to-time-of-use window.
-///
-/// It MUST be `payload["input"]`, never `payload`. The pending calls live one
-/// level down; reading the whole payload would leave both call keys absent, so
-/// `pending_tool_calls` would return `Some(vec![])` and every tool would be
-/// allowed while the code read like a correct allow. When the key is missing,
-/// this yields `Value::Null`, which `pending_tool_calls` rejects as unreadable.
-fn payload_input(payload: &serde_json::Value) -> serde_json::Value {
-    payload
-        .get("input")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null)
-}
-
-/// True for nodes that run a whole agent turn's model-chosen tool calls.
-fn is_agent_tool_dispatch(kind: &NodeKind) -> bool {
-    matches!(
-        kind,
-        NodeKind::PythonFn {
-            agent_tool_dispatch: true,
-            ..
-        } | NodeKind::JavaFn {
-            agent_tool_dispatch: true,
-            ..
-        }
-    )
 }
 
 #[cfg(test)]

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -780,6 +780,16 @@ impl Worker {
                         node_id,
                         "agent dispatch tool calls unreadable — refusing to run"
                     );
+                    // A fail-closed refusal is a policy denial and must reach the
+                    // audit surface like any other. Scope is "unknown" because the
+                    // engine's fail-closed rule denied here, not a policy layer.
+                    self.record_policy_violation(
+                        execution_id,
+                        node_id,
+                        "agent dispatch tool calls unreadable".to_string(),
+                        "unknown".to_string(),
+                    )
+                    .await;
                     return Some(Err(
                         "policy blocked: agent dispatch tool calls unreadable".into(),
                     ));
@@ -806,23 +816,13 @@ impl Worker {
                         node_def.policy.as_ref(),
                     );
                     warn!(execution_id = %execution_id, node_id, %tool_name, %reason, %policy_scope, "Policy blocked agent tool call");
-                    // Best-effort audit. The block is enforced regardless of
-                    // whether recording the violation succeeds.
-                    if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
-                        let _ = self
-                            .backend
-                            .append_event(jamjet_state::Event::new(
-                                execution_id.clone(),
-                                latest + 1,
-                                EventKind::PolicyViolation {
-                                    node_id: node_id.to_string(),
-                                    rule: reason.clone(),
-                                    decision: "blocked".to_string(),
-                                    policy_scope,
-                                },
-                            ))
-                            .await;
-                    }
+                    self.record_policy_violation(
+                        execution_id,
+                        node_id,
+                        reason.clone(),
+                        policy_scope,
+                    )
+                    .await;
                     Some(Err(format!("policy blocked: {reason}").into()))
                 }
 
@@ -831,6 +831,15 @@ impl Worker {
                     // settled approval cannot be replayed against a different
                     // payload (approval-loop hardening: decision not bound to
                     // resolved params).
+                    //
+                    // COVERAGE: the bound material is `name` + `arguments` per
+                    // call, in order, and nothing else. Every other field a
+                    // producer may carry on a raw call — `id` above all, plus any
+                    // provider-specific extras — is deliberately UNBOUND, so a
+                    // re-fire that differs only in call id still matches the
+                    // approval. Widening this to the raw call objects would bind
+                    // the approval to fields that carry no authority and would
+                    // make benign re-issues fail the check.
                     let calls_json = serde_json::json!(calls
                         .iter()
                         .map(|c| serde_json::json!({"name": c.name, "arguments": c.arguments}))
@@ -853,17 +862,27 @@ impl Worker {
                                 jamjet_state::approvals::node_approval_status(&events, node_id),
                                 NodeApprovalStatus::Approved { .. }
                             ) {
-                                // The latest request for this node is the one the
-                                // approval settled, so its hash is the authorised
-                                // call set. A request with no hash (e.g. from the
-                                // non-dispatch path) yields None and blocks.
-                                let approved_hash =
-                                    events.iter().rev().find_map(|e| match &e.kind {
-                                        EventKind::ToolApprovalRequired {
-                                            node_id: n,
-                                            context,
-                                            ..
-                                        } if n == node_id => context
+                                // `node_approval_status` resets to Pending on each
+                                // new request, so `Approved` always refers to the
+                                // LATEST request for this node. Find that event
+                                // FIRST, then read its hash — a `find_map` over
+                                // the hash would skip a hash-less latest request
+                                // and silently inherit an older, superseded
+                                // request's hash, which is a fail-open. Selecting
+                                // the event first makes an absent hash yield None,
+                                // which never equals `Some(current)` and blocks.
+                                let approved_hash = events
+                                    .iter()
+                                    .rev()
+                                    .find(|e| {
+                                        matches!(
+                                            &e.kind,
+                                            EventKind::ToolApprovalRequired { node_id: n, .. }
+                                                if n == node_id
+                                        )
+                                    })
+                                    .and_then(|e| match &e.kind {
+                                        EventKind::ToolApprovalRequired { context, .. } => context
                                             .get("calls_hash")
                                             .and_then(|h| h.as_str())
                                             .map(|s| s.to_string()),
@@ -875,6 +894,17 @@ impl Worker {
                                         node_id,
                                         "approved call set does not match pending calls — refusing"
                                     );
+                                    // The highest-value audit record in this
+                                    // change: an approval was on file but did not
+                                    // authorise these calls. Scope is "unknown" —
+                                    // the binding check denied, not a policy layer.
+                                    self.record_policy_violation(
+                                        execution_id,
+                                        node_id,
+                                        "approved tool calls do not match pending calls".to_string(),
+                                        "unknown".to_string(),
+                                    )
+                                    .await;
                                     return Some(Err(
                                         "policy blocked: approved tool calls do not match pending calls".into(),
                                     ));
@@ -950,6 +980,37 @@ impl Worker {
                 )
                 .await
             }
+        }
+    }
+
+    /// Record a policy denial in the event log, best effort.
+    ///
+    /// The denial is enforced by the caller regardless of whether this record
+    /// lands: fail closed, never open. Used by every deny path in the agent
+    /// dispatch branch — the policy-rule block AND the two fail-closed refusals
+    /// (unreadable calls, approved-set mismatch) — so that no refusal is
+    /// invisible to the audit surface.
+    async fn record_policy_violation(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        rule: String,
+        policy_scope: String,
+    ) {
+        if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
+            let _ = self
+                .backend
+                .append_event(jamjet_state::Event::new(
+                    execution_id.clone(),
+                    latest + 1,
+                    EventKind::PolicyViolation {
+                        node_id: node_id.to_string(),
+                        rule,
+                        decision: "blocked".to_string(),
+                        policy_scope,
+                    },
+                ))
+                .await;
         }
     }
 
@@ -3219,6 +3280,80 @@ mod tests {
         serde_json::json!({"id": "c1", "name": name, "arguments": {}})
     }
 
+    /// Pin WHICH guard denied. `is_err()` alone is satisfied by any failure,
+    /// including an unrelated IR-load or backend error, so a fail-closed test
+    /// that only asserts `is_err()` can pass without the guard ever running.
+    fn assert_denied_because(
+        result: Result<(), Box<dyn std::error::Error + Send + Sync>>,
+        needle: &str,
+    ) {
+        let err = result
+            .err()
+            .map(|e| e.to_string())
+            .expect("the node must be denied");
+        assert!(
+            err.contains(needle),
+            "expected the denial reason to contain {needle:?}; got {err:?}"
+        );
+    }
+
+    fn has_policy_violation(events: &[jamjet_state::Event], rule_needle: &str) -> bool {
+        events.iter().any(|e| match &e.kind {
+            EventKind::PolicyViolation { rule, decision, .. } => {
+                rule.contains(rule_needle) && decision == "blocked"
+            }
+            _ => false,
+        })
+    }
+
+    /// The availability dual of the whole feature, and the most common
+    /// production shape: an ADK agent calling a permitted tool while a real
+    /// policy is in force. An implementation that denied on `Allow` would pass
+    /// every deny test in this module but fail here.
+    #[tokio::test]
+    async fn allowed_tool_in_marked_dispatch_runs() {
+        let (result, events, count) = run_dispatch_node(
+            // A non-trivial policy that simply does not name `read_file`, so the
+            // Allow arm is reached through real rule evaluation rather than
+            // through the `sets.is_empty()` short-circuit.
+            dispatch_ir_json("python_fn", true, &["send_wire"], &["wire_batch"]),
+            serde_json::json!({"tool_calls": [one_call("read_file")]}),
+        )
+        .await;
+        assert!(result.is_ok(), "a permitted tool must run; got {result:?}");
+        assert_eq!(count, 1, "the permitted dispatch must execute exactly once");
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::PolicyViolation { .. })),
+            "a permitted dispatch must record no PolicyViolation"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            "a permitted dispatch must not be held for approval"
+        );
+    }
+
+    /// `Some(vec![])` (genuinely nothing to run) must stay distinct from `None`
+    /// (unreadable) at THIS seam, not only inside `pending_tool_calls`. A single
+    /// `unwrap_or_default` on that Option would erase the difference in the
+    /// other direction and turn every unreadable payload into an allow.
+    #[tokio::test]
+    async fn empty_tool_call_list_is_allowed_not_unreadable() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": []}),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "an empty call list is nothing to run, not unreadable; got {result:?}"
+        );
+        assert_eq!(count, 1, "the node itself must still run");
+    }
+
     /// C1 core: a blocked tool must never execute.
     #[tokio::test]
     async fn blocked_tool_in_dispatch_never_executes() {
@@ -3228,7 +3363,7 @@ mod tests {
         )
         .await;
         assert_eq!(count, 0, "the blocked tool dispatch must not run");
-        assert!(result.is_err(), "a blocked node must not succeed");
+        assert_denied_because(result, "matches blocked pattern 'send_wire'");
         assert!(
             events
                 .iter()
@@ -3270,28 +3405,37 @@ mod tests {
             .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })));
     }
 
-    /// Fail closed: unreadable pending calls must block, not pass.
+    /// Fail closed: unreadable pending calls must block, not pass — and the
+    /// refusal must be visible to audit like any other policy denial.
     #[tokio::test]
     async fn unreadable_tool_calls_block() {
-        let (result, _, count) = run_dispatch_node(
+        let (result, events, count) = run_dispatch_node(
             dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
             serde_json::json!({"tool_calls": "not-an-array"}),
         )
         .await;
         assert_eq!(count, 0);
-        assert!(result.is_err(), "unreadable calls must block");
+        assert_denied_because(result, "agent dispatch tool calls unreadable");
+        assert!(
+            has_policy_violation(&events, "agent dispatch tool calls unreadable"),
+            "a fail-closed refusal must still record a PolicyViolation"
+        );
     }
 
     /// Fail closed: a call we cannot name is a call we cannot police.
     #[tokio::test]
     async fn nameless_call_blocks() {
-        let (result, _, count) = run_dispatch_node(
+        let (result, events, count) = run_dispatch_node(
             dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
             serde_json::json!({"tool_calls": [{"id": "c1", "arguments": {}}]}),
         )
         .await;
         assert_eq!(count, 0);
-        assert!(result.is_err(), "a nameless call must block");
+        assert_denied_because(result, "agent dispatch tool calls unreadable");
+        assert!(has_policy_violation(
+            &events,
+            "agent dispatch tool calls unreadable"
+        ));
     }
 
     /// Fail closed: the payload's `input` is where the frozen calls live. Reading
@@ -3370,10 +3514,7 @@ mod tests {
             .expect("item must be claimable");
         let result = worker.execute_item(item).await;
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 0);
-        assert!(
-            result.is_err(),
-            "an absent payload input must block, not allow"
-        );
+        assert_denied_because(result, "agent dispatch tool calls unreadable");
     }
 
     /// Narrowness: an ordinary python_fn is unaffected by the new branch.
@@ -3419,7 +3560,7 @@ mod tests {
         )
         .await;
         assert_eq!(count, 0, "the blocked Java tool dispatch must not run");
-        assert!(result.is_err());
+        assert_denied_because(result, "matches blocked pattern 'send_wire'");
     }
 
     /// The exact `calls_json` shape the enforcement hashes. Both the recorded
@@ -3439,7 +3580,7 @@ mod tests {
         // `send_wire` pending — a different call set, so the settled approval
         // must not carry over.
         let approved_hash = content_hash(&calls_json_for(&["read_file"]));
-        let (result, _, count) = run_dispatch_node_seeded(
+        let (result, events, count) = run_dispatch_node_seeded(
             dispatch_ir_json("python_fn", true, &[], &["send_wire", "read_file"]),
             serde_json::json!({"tool_calls": [one_call("send_wire")]}),
             vec![
@@ -3468,10 +3609,76 @@ mod tests {
             count, 0,
             "an approval for one call set must not release a different one"
         );
+        assert_denied_because(result, "approved tool calls do not match pending calls");
         assert!(
-            result.is_err(),
-            "a mismatched approved call set must block, not run"
+            has_policy_violation(&events, "approved tool calls do not match pending calls"),
+            "the approval-binding denial is the highest-value audit record here \
+             and must reach the event log"
         );
+    }
+
+    /// The approved hash must come from the LATEST request for the node, and an
+    /// absent hash on that request must block.
+    ///
+    /// `node_approval_status` resets to Pending on every new
+    /// `ToolApprovalRequired`, so an `Approved` status always refers to the
+    /// latest request. A lookup that scans backwards for the first event
+    /// *yielding a hash* — rather than for the latest matching event — walks
+    /// straight past a hash-less latest request and inherits the hash of an
+    /// older, already-superseded one. That is a fail-open: an approval settled
+    /// against an unbound request would authorise the older request's calls.
+    ///
+    /// Latent while no in-tree producer writes a hash-less request for a marked
+    /// dispatch node; live the moment a second writer (the claim route) exists.
+    #[tokio::test]
+    async fn hashless_latest_request_does_not_inherit_an_older_hash() {
+        // The pending calls deliberately MATCH the OLD request's hash. A lookup
+        // that skipped back to it would find a match and allow, so this test
+        // only passes when the lookup stops at the latest (hash-less) request.
+        let old_hash = content_hash(&calls_json_for(&["read_file"]));
+        let (result, events, count) = run_dispatch_node_seeded(
+            dispatch_ir_json("python_fn", true, &[], &["read_file"]),
+            serde_json::json!({"tool_calls": [one_call("read_file")]}),
+            vec![
+                // Older request: carries a hash for exactly these calls.
+                EventKind::ToolApprovalRequired {
+                    node_id: "n1".into(),
+                    tool_name: "read_file".into(),
+                    approver: "human".into(),
+                    context: serde_json::json!({
+                        "node_id": "n1",
+                        "gated_tools": ["read_file"],
+                        "calls": calls_json_for(&["read_file"]),
+                        "calls_hash": old_hash,
+                    }),
+                },
+                // Newer request: supersedes the one above and carries NO hash.
+                EventKind::ToolApprovalRequired {
+                    node_id: "n1".into(),
+                    tool_name: "read_file".into(),
+                    approver: "human".into(),
+                    context: serde_json::json!({"node_id": "n1"}),
+                },
+                // The approval settles the NEWER, unbound request.
+                EventKind::ApprovalReceived {
+                    node_id: "n1".into(),
+                    user_id: "approver".into(),
+                    decision: jamjet_state::event::ApprovalDecision::Approved,
+                    comment: None,
+                    state_patch: None,
+                },
+            ],
+        )
+        .await;
+        assert_eq!(
+            count, 0,
+            "an approval settled against an unbound request must authorise nothing"
+        );
+        assert_denied_because(result, "approved tool calls do not match pending calls");
+        assert!(has_policy_violation(
+            &events,
+            "approved tool calls do not match pending calls"
+        ));
     }
 
     /// The dual: the approval DOES release the exact call set it authorised.

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -2756,8 +2756,7 @@ mod tests {
             &self,
             _item: &jamjet_state::backend::WorkItem,
         ) -> Result<ExecutionResult, ExecutorError> {
-            self.calls
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(ExecutionResult {
                 output: serde_json::json!({}),
                 state_patch: serde_json::json!({}),
@@ -2857,7 +2856,10 @@ mod tests {
             .iter()
             .find_map(|e| match &e.kind {
                 EventKind::TokenBudgetExceeded {
-                    kind, limit, current, ..
+                    kind,
+                    limit,
+                    current,
+                    ..
                 } => Some((kind.clone(), *limit, *current)),
                 _ => None,
             })
@@ -3270,6 +3272,15 @@ mod tests {
         })
     }
 
+    /// A policed `python_fn` that is a real application function, not the ADK
+    /// dispatch coroutine — the narrowness fixture.
+    fn ordinary_python_fn_ir_json(blocked: &[&str]) -> serde_json::Value {
+        let mut ir = dispatch_ir_json("python_fn", false, blocked, &[]);
+        ir["nodes"]["n1"]["kind"]["module"] = serde_json::json!("my_app.tasks");
+        ir["nodes"]["n1"]["kind"]["function"] = serde_json::json!("resize_image");
+        ir
+    }
+
     /// Drive one marked dispatch node and return (result, events, dispatch count).
     ///
     /// `seed` events are appended before the item is claimed, which is how a test
@@ -3616,15 +3627,37 @@ mod tests {
     }
 
     /// Narrowness: an ordinary python_fn is unaffected by the new branch.
+    ///
+    /// "Ordinary" means the coordinates too. A node at
+    /// `jamjet.agents.tool_runtime::dispatch_tool_calls` is an agent dispatch
+    /// whether or not it carries the marker — see
+    /// `unmarked_adk_dispatch_is_still_enforced` below — so this fixture uses a
+    /// genuine application function. Using the dispatch coordinates here would
+    /// assert the fail-open instead of narrowness.
     #[tokio::test]
     async fn unmarked_python_fn_is_unaffected() {
         let (result, _, count) = run_dispatch_node(
-            dispatch_ir_json("python_fn", false, &["send_wire"], &[]),
+            ordinary_python_fn_ir_json(&["send_wire"]),
             serde_json::json!({"tool_calls": [one_call("send_wire")]}),
         )
         .await;
         assert_eq!(count, 1, "a non-ADK python_fn must still run");
         assert!(result.is_ok());
+    }
+
+    /// An IR stored before the marker existed deserializes to `false`, and only
+    /// the registration route re-validates. Enforcement therefore keys on the
+    /// dispatch coordinates as well, so a pre-marker workflow is still policed
+    /// on the in-process path.
+    #[tokio::test]
+    async fn unmarked_adk_dispatch_is_still_enforced() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", false, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        assert_eq!(count, 0, "the blocked tool must never dispatch");
+        assert_denied_because(result, "send_wire");
     }
 
     /// The approval must be bound to the calls it authorises.

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -210,6 +210,18 @@ impl Worker {
                         return r;
                     }
 
+                    // Budget check BEFORE execution — never fire on a spent budget.
+                    // The post-execution check trips only after the call is paid
+                    // for, so without this a rollover child inherits pinned
+                    // counters and buys one more call per segment (C2).
+                    if let Some(r) = self
+                        .check_budget_before_execution(&execution_id, &node_id, &ir, &budget)
+                        .await
+                    {
+                        heartbeat.abort();
+                        return r;
+                    }
+
                     // Autonomy check.
                     if let Some(r) = self
                         .check_autonomy(&execution_id, item_id, &node_id, kind, &budget)
@@ -1001,6 +1013,89 @@ impl Worker {
             .flatten()
             .map(|s| BudgetState::from_snapshot_state(&s.state))
             .unwrap_or_default()
+    }
+
+    /// Refuse to fire when the budget is already spent.
+    ///
+    /// `check_budget_after_execution` only trips once the call has been made and
+    /// paid for. This pre-check is what makes a spent budget refuse the *next*
+    /// call instead of buying it first.
+    ///
+    /// SCOPE — this is half of C2, and the half it is not closes elsewhere.
+    /// Because the post-execution check is `>` and a tripping turn is DISCARDED
+    /// rather than committed, committed counters normally settle strictly BELOW
+    /// the ceiling. This guard's `>=` therefore catches the case where a turn
+    /// lands exactly ON the ceiling, not the ordinary rollover chain: a
+    /// `continue_as_new` child inherits under-ceiling counters, passes this
+    /// guard, and buys one more discarded call per segment. Stopping that chain
+    /// means not rolling over on a budget trip at all, which is a separate change
+    /// to the rollover branch in `execute_item`.
+    ///
+    /// Deliberately kind-agnostic: budget accounting follows the tokens an
+    /// executor reports, not the node kind, so a kind allowlist would leak — the
+    /// budget fixture in this file trips on a `tool` node.
+    ///
+    /// SEMANTIC CHANGE: under `>=`, a ceiling of literally zero (`total_tokens:
+    /// 0`, `cost_budget_usd: 0.0`) now refuses every node up front, where it
+    /// previously allowed exactly one call before tripping. "Spend nothing" now
+    /// means nothing.
+    ///
+    /// Returns `Some(Err(..))` to refuse, `None` to let the node fire.
+    async fn check_budget_before_execution(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        ir: &WorkflowIr,
+        budget: &BudgetState,
+    ) -> Option<Result<(), Box<dyn std::error::Error + Send + Sync>>> {
+        let trip = budget.exhausted(ir.token_budget.as_ref(), ir.cost_budget_usd)?;
+        warn!(
+            execution_id = %execution_id,
+            node_id,
+            kind = %trip.kind,
+            limit = trip.limit,
+            current = trip.current,
+            "Budget already exhausted; refusing to fire"
+        );
+
+        // The audit record is best-effort; the refusal is not. A backend read
+        // failure here must never downgrade into letting the node fire, so the
+        // sequence lookup is `if let Ok` rather than `?`.
+        if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
+            // A cost trip carries dollars, which do not survive the u64 cast that
+            // TokenBudgetExceeded's limit/current fields require: a $0.50 ceiling
+            // would be recorded as 0. Report it on the cost event instead, exactly
+            // as the post-execution path does. Token ceilings are u32 in the IR,
+            // so their f64 -> u64 roundtrip is lossless.
+            let kind = if trip.kind == "cost_usd" {
+                EventKind::CostBudgetExceeded {
+                    node_id: node_id.to_string(),
+                    limit_usd: trip.limit,
+                    current_usd: trip.current,
+                }
+            } else {
+                EventKind::TokenBudgetExceeded {
+                    node_id: node_id.to_string(),
+                    kind: trip.kind.clone(),
+                    limit: trip.limit as u64,
+                    current: trip.current as u64,
+                }
+            };
+            let _ = self
+                .backend
+                .append_event(jamjet_state::Event::new(
+                    execution_id.clone(),
+                    latest + 1,
+                    kind,
+                ))
+                .await;
+        }
+
+        Some(Err(format!(
+            "budget exhausted before execution: {} {} >= {}",
+            trip.kind, trip.current, trip.limit
+        )
+        .into()))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2175,7 +2270,9 @@ mod tests {
 
     // ── Continue-as-new tests (Task 2g-3) ────────────────────────────────────
 
-    /// Returns 1 input token -- triggers any IR with token_budget.total_tokens: 0.
+    /// Returns 2 input tokens -- exceeds `budget_ceiling_ir_json`'s
+    /// `total_tokens: 1` ceiling on the post-execution `>` check, while leaving a
+    /// fresh execution genuinely under the ceiling for the pre-execution `>=` check.
     struct BudgetTriggerExecutor;
 
     #[async_trait::async_trait]
@@ -2190,7 +2287,7 @@ mod tests {
                 duration_ms: 1,
                 gen_ai_system: None,
                 gen_ai_model: None,
-                input_tokens: Some(1), // triggers total_tokens budget check
+                input_tokens: Some(2), // exceeds the total_tokens: 1 ceiling
                 output_tokens: None,
                 finish_reason: None,
             })
@@ -2204,7 +2301,11 @@ mod tests {
             "state_schema": "{}",
             "start_node": "n1",
             "continue_as_new": continue_as_new,
-            "token_budget": { "total_tokens": 0 }, // any >0 tokens exceeds this
+            // A ceiling of 1, not 0: the executor's 2 tokens exceed it after the
+            // fact, but a FRESH execution (0 tokens) is genuinely under it, so the
+            // pre-execution `>=` guard lets the first turn fire. A zero ceiling
+            // would read as already-exhausted before anything ran.
+            "token_budget": { "total_tokens": 1 },
             "nodes": {
                 "n1": {
                     "id": "n1",
@@ -2639,6 +2740,230 @@ mod tests {
              got {:?} — means crash-before-terminal was not repaired",
             exec_final.status
         );
+    }
+
+    // ── Pre-execution budget guard tests (C2) ─────────────────────────────────
+
+    /// Counts every executor invocation. A refused node must leave it at 0 —
+    /// that count IS the money, so it is the assertion that matters.
+    struct CountingBudgetExecutor {
+        calls: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for CountingBudgetExecutor {
+        async fn execute(
+            &self,
+            _item: &jamjet_state::backend::WorkItem,
+        ) -> Result<ExecutionResult, ExecutorError> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(ExecutionResult {
+                output: serde_json::json!({}),
+                state_patch: serde_json::json!({}),
+                duration_ms: 1,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: Some(2),
+                output_tokens: None,
+                finish_reason: None,
+            })
+        }
+    }
+
+    /// Seed the execution's latest snapshot with an already-spent `__budget`.
+    ///
+    /// This is exactly the state a continue-as-new child inherits: the parent's
+    /// counters, carried forward by `materialize`, sitting at the ceiling with the
+    /// same ceiling still in the same IR.
+    async fn seed_spent_budget(backend: &InMemoryBackend, eid: &ExecutionId, input_tokens: u64) {
+        let budget = BudgetState {
+            total_input_tokens: input_tokens,
+            ..Default::default()
+        };
+        let mut state = serde_json::json!({ "counter": 5 });
+        budget.patch_into_snapshot_state(&mut state);
+        backend
+            .write_snapshot(jamjet_state::Snapshot::new(eid.clone(), 0, state))
+            .await
+            .expect("seed snapshot must write");
+    }
+
+    /// The guard is wired into `execute_item` ahead of every executor dispatch:
+    /// an execution whose counters already sit at the ceiling makes ZERO executor
+    /// calls. That count is the whole point — it is the money.
+    ///
+    /// This does NOT prove the `continue_as_new` chain terminates. It cannot: the
+    /// chain's carried counters land strictly BELOW the ceiling (the post-check is
+    /// `>`, the tripping turn is discarded), so the seeded state here is reached
+    /// by a turn landing exactly on the ceiling, not by the chain. Terminating the
+    /// chain means not rolling over on a trip, which lives in the rollover branch.
+    ///
+    /// Driven with `continue_as_new: true` so a regression that lets the node fire
+    /// shows up as the runaway itself: without the guard this returns `Ok(())`,
+    /// having paid for one call, discarded it, and rolled over.
+    #[tokio::test]
+    async fn exhausted_budget_makes_no_executor_call() {
+        let (backend, eid) = setup_budget_backend(true).await;
+        // The fixture node is a TOOL node, not a model node. That is deliberate:
+        // budget accounting follows the tokens an executor reports, not the node
+        // kind, so a `Model | Agent` allowlist in the guard would silently let
+        // this through and this assertion would still pass while the count did not.
+        let ir: WorkflowIr =
+            serde_json::from_value(budget_ceiling_ir_json(true)).expect("fixture IR must parse");
+        assert_eq!(
+            node_kind_tag(&ir.node("n1").expect("n1 exists").kind),
+            "tool",
+            "fixture node must be a tool node for the kind-agnostic claim to bite"
+        );
+
+        // Ceiling is total_tokens: 1; 1 input token means the counters sit exactly
+        // on it, which is the state a turn landing on the ceiling commits.
+        seed_spent_budget(&backend, &eid, 1).await;
+
+        let calls = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(CountingBudgetExecutor {
+                calls: Arc::clone(&calls),
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+
+        let result = worker.execute_item(item).await;
+        assert!(
+            result.is_err(),
+            "an exhausted budget must refuse the node, not run it: {result:?}"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "C2: an exhausted budget must not pay for one more call"
+        );
+
+        // The refusal is on the record, and it names the ceiling that tripped.
+        let events = backend.get_events(&eid).await.unwrap();
+        let trip = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::TokenBudgetExceeded {
+                    kind, limit, current, ..
+                } => Some((kind.clone(), *limit, *current)),
+                _ => None,
+            })
+            .expect("refusal must emit TokenBudgetExceeded");
+        assert_eq!(trip, ("total_tokens".to_string(), 1, 1));
+
+        // And it must NOT roll over: rolling over on an exhausted budget is the
+        // runaway itself, since the child inherits the same spent counters.
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e.kind, EventKind::SegmentBoundary { .. }))
+                .count(),
+            0,
+            "C2: a refused node must not roll over into another segment"
+        );
+    }
+
+    /// A fresh budget under the ceiling fires normally — the guard must not be a
+    /// blanket stop.
+    #[tokio::test]
+    async fn budget_under_the_ceiling_fires() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        );
+        let ir: WorkflowIr =
+            serde_json::from_value(budget_ceiling_ir_json(false)).expect("fixture IR must parse");
+        let refused = worker
+            .check_budget_before_execution(&ExecutionId::new(), "n1", &ir, &BudgetState::default())
+            .await;
+        assert!(refused.is_none(), "a fresh budget must not be refused");
+    }
+
+    /// No budget configured means the guard never fires, however large the counters.
+    #[tokio::test]
+    async fn no_budget_configured_never_refuses() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        );
+        let mut ir_json = budget_ceiling_ir_json(false);
+        ir_json["token_budget"] = serde_json::Value::Null;
+        let ir: WorkflowIr = serde_json::from_value(ir_json).expect("IR must parse");
+        let huge = BudgetState {
+            total_input_tokens: 10_000_000,
+            ..Default::default()
+        };
+        let refused = worker
+            .check_budget_before_execution(&ExecutionId::new(), "n1", &ir, &huge)
+            .await;
+        assert!(refused.is_none());
+    }
+
+    /// A spent COST budget reports as `CostBudgetExceeded`, matching the
+    /// post-execution path. Routing it through `TokenBudgetExceeded` would cast
+    /// the dollar limit to u64 and record a $0.50 ceiling as `limit: 0`.
+    #[tokio::test]
+    async fn exhausted_cost_budget_reports_dollars_not_truncated_tokens() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        );
+        let mut ir_json = budget_ceiling_ir_json(false);
+        ir_json["token_budget"] = serde_json::Value::Null;
+        ir_json["cost_budget_usd"] = serde_json::json!(0.5);
+        let ir: WorkflowIr = serde_json::from_value(ir_json).expect("IR must parse");
+        let spent = BudgetState {
+            total_cost_usd: 0.5,
+            ..Default::default()
+        };
+
+        let refused = worker
+            .check_budget_before_execution(&eid, "n1", &ir, &spent)
+            .await;
+        assert!(
+            refused.expect("a spent cost budget must refuse").is_err(),
+            "refusal must be an Err"
+        );
+
+        let events = backend.get_events(&eid).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::TokenBudgetExceeded { .. })),
+            "a cost trip must not be recorded as a token trip"
+        );
+        let cost = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::CostBudgetExceeded {
+                    limit_usd,
+                    current_usd,
+                    ..
+                } => Some((*limit_usd, *current_usd)),
+                _ => None,
+            })
+            .expect("cost refusal must emit CostBudgetExceeded");
+        assert_eq!(cost, (0.5, 0.5), "dollar amounts must survive intact");
     }
 
     // ── Artifact spill tests ──────────────────────────────────────────────────

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -201,6 +201,7 @@ impl Worker {
                             kind,
                             node_def,
                             &ir,
+                            &item.payload,
                         )
                         .await
                     {
@@ -728,6 +729,7 @@ impl Worker {
         kind: &NodeKind,
         node_def: &NodeDef,
         ir: &WorkflowIr,
+        payload: &serde_json::Value,
     ) -> Option<Result<(), Box<dyn std::error::Error + Send + Sync>>> {
         let ctx = EvaluationContext::from_node_kind(node_id, kind);
 
@@ -754,6 +756,153 @@ impl Worker {
         }
         if sets.is_empty() {
             return None;
+        }
+
+        // ADK agent dispatch nodes hide their tool names behind a single
+        // python_fn / java_fn, so `ctx` above carries no tool_name and every
+        // blocked_tools / require_approval_for rule silently misses (C1).
+        // Evaluate the frozen pending calls from the work item instead. Those
+        // are the same bytes the executor will hand the dispatch, so there is
+        // no time-of-check-to-time-of-use window: we deliberately do NOT
+        // re-read state from the backend or from a snapshot here.
+        if is_agent_tool_dispatch(kind) {
+            let input = payload_input(payload);
+            let calls = match jamjet_policy::dispatch::pending_tool_calls(&input) {
+                Some(calls) => calls,
+                None => {
+                    // Fail closed, mirroring hold_for_approval's unavailable-state
+                    // arm: never run a node whose policy-relevant state we cannot
+                    // read. `Some(vec![])` (genuinely nothing to run) is distinct
+                    // and falls through to Allow below — do not collapse the two
+                    // with unwrap_or_default.
+                    warn!(
+                        execution_id = %execution_id,
+                        node_id,
+                        "agent dispatch tool calls unreadable — refusing to run"
+                    );
+                    return Some(Err(
+                        "policy blocked: agent dispatch tool calls unreadable".into(),
+                    ));
+                }
+            };
+
+            return match jamjet_policy::dispatch::evaluate_dispatch(node_id, &calls, &sets) {
+                jamjet_policy::dispatch::DispatchDecision::Allow => None,
+
+                jamjet_policy::dispatch::DispatchDecision::Block { tool_name, reason } => {
+                    // Attribute the scope using the same per-call context
+                    // `evaluate_dispatch` matched on; `ctx` has no tool_name, so
+                    // reusing it would record every dispatch block as "unknown".
+                    let blocked_ctx = EvaluationContext {
+                        node_id: node_id.to_string(),
+                        node_kind_tag: "tool".to_string(),
+                        tool_name: Some(tool_name.clone()),
+                        model_ref: None,
+                    };
+                    let policy_scope = self.identify_policy_scope(
+                        &blocked_ctx,
+                        tenant_policy_set.as_ref(),
+                        ir.policy.as_ref(),
+                        node_def.policy.as_ref(),
+                    );
+                    warn!(execution_id = %execution_id, node_id, %tool_name, %reason, %policy_scope, "Policy blocked agent tool call");
+                    // Best-effort audit. The block is enforced regardless of
+                    // whether recording the violation succeeds.
+                    if let Ok(latest) = self.backend.latest_sequence(execution_id).await {
+                        let _ = self
+                            .backend
+                            .append_event(jamjet_state::Event::new(
+                                execution_id.clone(),
+                                latest + 1,
+                                EventKind::PolicyViolation {
+                                    node_id: node_id.to_string(),
+                                    rule: reason.clone(),
+                                    decision: "blocked".to_string(),
+                                    policy_scope,
+                                },
+                            ))
+                            .await;
+                    }
+                    Some(Err(format!("policy blocked: {reason}").into()))
+                }
+
+                jamjet_policy::dispatch::DispatchDecision::RequireApproval { approver, gated } => {
+                    // Bind the approval to the exact calls it authorises, so a
+                    // settled approval cannot be replayed against a different
+                    // payload (approval-loop hardening: decision not bound to
+                    // resolved params).
+                    let calls_json = serde_json::json!(calls
+                        .iter()
+                        .map(|c| serde_json::json!({"name": c.name, "arguments": c.arguments}))
+                        .collect::<Vec<_>>());
+                    let current_hash = content_hash(&calls_json);
+
+                    // An existing approval authorised one specific call set. If
+                    // the pending calls differ, the approval must not carry over
+                    // — otherwise a settled approval authorises whatever happens
+                    // to be pending when the node re-fires.
+                    match self.backend.get_events(execution_id).await {
+                        Err(e) => {
+                            return Some(Err(format!(
+                                "approval state unavailable; refusing to run unapproved: {e}"
+                            )
+                            .into()))
+                        }
+                        Ok(events) => {
+                            if matches!(
+                                jamjet_state::approvals::node_approval_status(&events, node_id),
+                                NodeApprovalStatus::Approved { .. }
+                            ) {
+                                // The latest request for this node is the one the
+                                // approval settled, so its hash is the authorised
+                                // call set. A request with no hash (e.g. from the
+                                // non-dispatch path) yields None and blocks.
+                                let approved_hash =
+                                    events.iter().rev().find_map(|e| match &e.kind {
+                                        EventKind::ToolApprovalRequired {
+                                            node_id: n,
+                                            context,
+                                            ..
+                                        } if n == node_id => context
+                                            .get("calls_hash")
+                                            .and_then(|h| h.as_str())
+                                            .map(|s| s.to_string()),
+                                        _ => None,
+                                    });
+                                if approved_hash.as_deref() != Some(current_hash.as_str()) {
+                                    warn!(
+                                        execution_id = %execution_id,
+                                        node_id,
+                                        "approved call set does not match pending calls — refusing"
+                                    );
+                                    return Some(Err(
+                                        "policy blocked: approved tool calls do not match pending calls".into(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+
+                    // `gated` carries tool NAMES only: two calls to the same
+                    // gated tool render as ["send_wire", "send_wire"] with no
+                    // discriminator. `calls` below is what identifies them.
+                    let context = serde_json::json!({
+                        "node_id": node_id,
+                        "gated_tools": gated,
+                        "calls": calls_json,
+                        "calls_hash": current_hash,
+                    });
+                    self.hold_for_approval(
+                        execution_id,
+                        node_id,
+                        item_id,
+                        gated.join(", "),
+                        approver,
+                        context,
+                    )
+                    .await
+                }
+            };
         }
 
         let decision = PolicyEvaluator.evaluate(&ctx, &sets);
@@ -1282,6 +1431,37 @@ fn parse_payload(payload: &serde_json::Value) -> (String, String) {
         .unwrap_or("1.0.0")
         .to_string();
     (workflow_id, workflow_version)
+}
+
+/// The frozen accumulated state the scheduler enriched onto a PythonFn/JavaFn
+/// work item (`runtime/scheduler/src/runner.rs:441-480`). This is the exact
+/// input the dispatch will consume, which is what makes policy evaluation over
+/// it free of a time-of-check-to-time-of-use window.
+///
+/// It MUST be `payload["input"]`, never `payload`. The pending calls live one
+/// level down; reading the whole payload would leave both call keys absent, so
+/// `pending_tool_calls` would return `Some(vec![])` and every tool would be
+/// allowed while the code read like a correct allow. When the key is missing,
+/// this yields `Value::Null`, which `pending_tool_calls` rejects as unreadable.
+fn payload_input(payload: &serde_json::Value) -> serde_json::Value {
+    payload
+        .get("input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null)
+}
+
+/// True for nodes that run a whole agent turn's model-chosen tool calls.
+fn is_agent_tool_dispatch(kind: &NodeKind) -> bool {
+    matches!(
+        kind,
+        NodeKind::PythonFn {
+            agent_tool_dispatch: true,
+            ..
+        } | NodeKind::JavaFn {
+            agent_tool_dispatch: true,
+            ..
+        }
+    )
 }
 
 #[cfg(test)]
@@ -2860,5 +3040,471 @@ mod tests {
             *event_output, small_output,
             "inline output must equal the original value"
         );
+    }
+
+    // ── C1: agent tool-dispatch policy enforcement ────────────────────────────
+
+    /// Records every tool dispatch so a test can prove one never happened.
+    #[derive(Clone, Default)]
+    struct CountingDispatchExecutor {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl NodeExecutor for CountingDispatchExecutor {
+        async fn execute(&self, _item: &WorkItem) -> Result<ExecutionResult, ExecutorError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(ExecutionResult {
+                output: serde_json::json!({}),
+                state_patch: serde_json::json!({}),
+                duration_ms: 0,
+                gen_ai_system: None,
+                gen_ai_model: None,
+                input_tokens: None,
+                output_tokens: None,
+                finish_reason: None,
+            })
+        }
+    }
+
+    /// IR with a single marked agent tool-dispatch node under a workflow policy.
+    fn dispatch_ir_json(
+        kind_type: &str,
+        marked: bool,
+        blocked: &[&str],
+        approval: &[&str],
+    ) -> serde_json::Value {
+        let kind = if kind_type == "java_fn" {
+            serde_json::json!({
+                "type": "java_fn",
+                "class_name": "C",
+                "method": "dispatch",
+                "output_schema": "",
+                "agent_tool_dispatch": marked
+            })
+        } else {
+            serde_json::json!({
+                "type": "python_fn",
+                "module": "jamjet.agents.tool_runtime",
+                "function": "dispatch_tool_calls",
+                "output_schema": "",
+                "agent_tool_dispatch": marked
+            })
+        };
+        serde_json::json!({
+            "workflow_id": "adk-wf",
+            "version": "1.0.0",
+            "state_schema": "{}",
+            "start_node": "n1",
+            "nodes": { "n1": { "id": "n1", "kind": kind } },
+            "edges": [],
+            "retry_policies": {},
+            "models": {},
+            "tools": {},
+            "mcp_servers": {},
+            "remote_agents": {},
+            "policy": {
+                "blocked_tools": blocked,
+                "require_approval_for": approval,
+                "model_allowlist": []
+            }
+        })
+    }
+
+    /// Drive one marked dispatch node and return (result, events, dispatch count).
+    ///
+    /// `seed` events are appended before the item is claimed, which is how a test
+    /// stages an already-settled approval for the node.
+    async fn run_dispatch_node_seeded(
+        ir: serde_json::Value,
+        input: serde_json::Value,
+        seed: Vec<EventKind>,
+    ) -> (
+        Result<(), Box<dyn std::error::Error + Send + Sync>>,
+        Vec<jamjet_state::Event>,
+        usize,
+    ) {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        let now = Utc::now();
+        backend
+            .create_execution(WorkflowExecution {
+                execution_id: eid.clone(),
+                workflow_id: "adk-wf".into(),
+                workflow_version: "1.0.0".into(),
+                status: WorkflowStatus::Running,
+                initial_input: serde_json::json!({}),
+                current_state: serde_json::json!({}),
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                session_type: None,
+                parent_execution_id: None,
+                segment_number: 0,
+            })
+            .await
+            .unwrap();
+        backend
+            .store_workflow(WorkflowDefinition {
+                workflow_id: "adk-wf".into(),
+                version: "1.0.0".into(),
+                ir,
+                created_at: now,
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        for kind in seed {
+            // InMemoryBackend assigns the sequence itself, so 0 is a placeholder.
+            backend
+                .append_event(jamjet_state::Event::new(eid.clone(), 0, kind))
+                .await
+                .unwrap();
+        }
+        backend
+            .enqueue_work_item(WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                payload: serde_json::json!({
+                    "workflow_id": "adk-wf",
+                    "workflow_version": "1.0.0",
+                    "input": input
+                }),
+                attempt: 0,
+                max_attempts: 1,
+                created_at: now,
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        let exec = CountingDispatchExecutor::default();
+        let counter = exec.calls.clone();
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("python_fn", Arc::new(exec.clone()))
+        .register_executor("java_fn", Arc::new(exec));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        let result = worker.execute_item(item).await;
+        let events = backend.get_events(&eid).await.unwrap();
+        let count = counter.load(std::sync::atomic::Ordering::SeqCst);
+        (result, events, count)
+    }
+
+    async fn run_dispatch_node(
+        ir: serde_json::Value,
+        input: serde_json::Value,
+    ) -> (
+        Result<(), Box<dyn std::error::Error + Send + Sync>>,
+        Vec<jamjet_state::Event>,
+        usize,
+    ) {
+        run_dispatch_node_seeded(ir, input, Vec::new()).await
+    }
+
+    fn one_call(name: &str) -> serde_json::Value {
+        serde_json::json!({"id": "c1", "name": name, "arguments": {}})
+    }
+
+    /// C1 core: a blocked tool must never execute.
+    #[tokio::test]
+    async fn blocked_tool_in_dispatch_never_executes() {
+        let (result, events, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        assert_eq!(count, 0, "the blocked tool dispatch must not run");
+        assert!(result.is_err(), "a blocked node must not succeed");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::PolicyViolation { .. })),
+            "a PolicyViolation must be recorded"
+        );
+    }
+
+    /// C1 core: an approval-gated tool must hold, not fire.
+    #[tokio::test]
+    async fn approval_gated_tool_in_dispatch_holds_and_never_executes() {
+        let (_, events, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &[], &["send_wire"]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        assert_eq!(count, 0, "a gated tool dispatch must not run");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })),
+            "a ToolApprovalRequired must be recorded"
+        );
+    }
+
+    /// One gated call holds the whole batch; none of the three run.
+    #[tokio::test]
+    async fn one_gated_call_holds_the_whole_batch() {
+        let (_, events, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &[], &["send_wire"]),
+            serde_json::json!({"tool_calls": [
+                one_call("read_file"), one_call("send_wire"), one_call("log")
+            ]}),
+        )
+        .await;
+        assert_eq!(count, 0, "no call in a held batch may run");
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::ToolApprovalRequired { .. })));
+    }
+
+    /// Fail closed: unreadable pending calls must block, not pass.
+    #[tokio::test]
+    async fn unreadable_tool_calls_block() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": "not-an-array"}),
+        )
+        .await;
+        assert_eq!(count, 0);
+        assert!(result.is_err(), "unreadable calls must block");
+    }
+
+    /// Fail closed: a call we cannot name is a call we cannot police.
+    #[tokio::test]
+    async fn nameless_call_blocks() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": [{"id": "c1", "arguments": {}}]}),
+        )
+        .await;
+        assert_eq!(count, 0);
+        assert!(result.is_err(), "a nameless call must block");
+    }
+
+    /// Fail closed: the payload's `input` is where the frozen calls live. Reading
+    /// the whole payload instead would make both call keys absent and read as
+    /// "nothing to run", allowing every tool through while looking like a
+    /// correct allow. A missing `input` must therefore block, not allow.
+    #[tokio::test]
+    async fn missing_payload_input_blocks() {
+        let backend = Arc::new(InMemoryBackend::new());
+        let eid = ExecutionId::new();
+        let now = Utc::now();
+        backend
+            .create_execution(WorkflowExecution {
+                execution_id: eid.clone(),
+                workflow_id: "adk-wf".into(),
+                workflow_version: "1.0.0".into(),
+                status: WorkflowStatus::Running,
+                initial_input: serde_json::json!({}),
+                current_state: serde_json::json!({}),
+                started_at: now,
+                updated_at: now,
+                completed_at: None,
+                session_type: None,
+                parent_execution_id: None,
+                segment_number: 0,
+            })
+            .await
+            .unwrap();
+        backend
+            .store_workflow(WorkflowDefinition {
+                workflow_id: "adk-wf".into(),
+                version: "1.0.0".into(),
+                ir: dispatch_ir_json("python_fn", true, &["send_wire"], &[]),
+                created_at: now,
+                tenant_id: "default".into(),
+            })
+            .await
+            .unwrap();
+        backend
+            .enqueue_work_item(WorkItem {
+                id: Uuid::new_v4(),
+                execution_id: eid.clone(),
+                node_id: "n1".into(),
+                queue_type: "default".into(),
+                // No "input" key at all, but a top-level tool_calls decoy: if the
+                // worker read the whole payload this would be readable and allow.
+                payload: serde_json::json!({
+                    "workflow_id": "adk-wf",
+                    "workflow_version": "1.0.0",
+                    "tool_calls": []
+                }),
+                attempt: 0,
+                max_attempts: 1,
+                created_at: now,
+                lease_expires_at: None,
+                worker_id: None,
+                tenant_id: "default".into(),
+                lease_fence: 0,
+            })
+            .await
+            .unwrap();
+
+        let exec = CountingDispatchExecutor::default();
+        let counter = exec.calls.clone();
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor("python_fn", Arc::new(exec));
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        let result = worker.execute_item(item).await;
+        assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(
+            result.is_err(),
+            "an absent payload input must block, not allow"
+        );
+    }
+
+    /// Narrowness: an ordinary python_fn is unaffected by the new branch.
+    #[tokio::test]
+    async fn unmarked_python_fn_is_unaffected() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("python_fn", false, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        assert_eq!(count, 1, "a non-ADK python_fn must still run");
+        assert!(result.is_ok());
+    }
+
+    /// The approval must be bound to the calls it authorises.
+    #[tokio::test]
+    async fn approval_context_carries_resolved_calls_and_hash() {
+        let (_, events, _) = run_dispatch_node(
+            dispatch_ir_json("python_fn", true, &[], &["send_wire"]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        let ctx = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::ToolApprovalRequired { context, .. } => Some(context.clone()),
+                _ => None,
+            })
+            .expect("ToolApprovalRequired must exist");
+        assert_eq!(ctx["gated_tools"][0], "send_wire");
+        assert!(
+            ctx["calls_hash"].as_str().is_some_and(|h| !h.is_empty()),
+            "the approval must be bound to a hash of the resolved calls"
+        );
+    }
+
+    /// The Java dispatch arm has the identical hole and the identical fix.
+    #[tokio::test]
+    async fn blocked_tool_in_java_dispatch_never_executes() {
+        let (result, _, count) = run_dispatch_node(
+            dispatch_ir_json("java_fn", true, &["send_wire"], &[]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+        )
+        .await;
+        assert_eq!(count, 0, "the blocked Java tool dispatch must not run");
+        assert!(result.is_err());
+    }
+
+    /// The exact `calls_json` shape the enforcement hashes. Both the recorded
+    /// approval context and the re-fire check must hash this same shape, or the
+    /// binding never matches and an approved node can never proceed.
+    fn calls_json_for(names: &[&str]) -> serde_json::Value {
+        serde_json::json!(names
+            .iter()
+            .map(|n| serde_json::json!({"name": n, "arguments": {}}))
+            .collect::<Vec<_>>())
+    }
+
+    /// An approval authorises a specific set of calls, not the node forever.
+    #[tokio::test]
+    async fn approval_does_not_authorise_a_different_call_set() {
+        // The node was already approved for `read_file`. It now re-fires with
+        // `send_wire` pending — a different call set, so the settled approval
+        // must not carry over.
+        let approved_hash = content_hash(&calls_json_for(&["read_file"]));
+        let (result, _, count) = run_dispatch_node_seeded(
+            dispatch_ir_json("python_fn", true, &[], &["send_wire", "read_file"]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+            vec![
+                EventKind::ToolApprovalRequired {
+                    node_id: "n1".into(),
+                    tool_name: "read_file".into(),
+                    approver: "human".into(),
+                    context: serde_json::json!({
+                        "node_id": "n1",
+                        "gated_tools": ["read_file"],
+                        "calls": calls_json_for(&["read_file"]),
+                        "calls_hash": approved_hash,
+                    }),
+                },
+                EventKind::ApprovalReceived {
+                    node_id: "n1".into(),
+                    user_id: "approver".into(),
+                    decision: jamjet_state::event::ApprovalDecision::Approved,
+                    comment: None,
+                    state_patch: None,
+                },
+            ],
+        )
+        .await;
+        assert_eq!(
+            count, 0,
+            "an approval for one call set must not release a different one"
+        );
+        assert!(
+            result.is_err(),
+            "a mismatched approved call set must block, not run"
+        );
+    }
+
+    /// The dual: the approval DOES release the exact call set it authorised.
+    /// Without this, the binding check could be satisfied by blocking always.
+    #[tokio::test]
+    async fn approval_releases_the_call_set_it_authorised() {
+        let approved_hash = content_hash(&calls_json_for(&["send_wire"]));
+        let (result, _, count) = run_dispatch_node_seeded(
+            dispatch_ir_json("python_fn", true, &[], &["send_wire"]),
+            serde_json::json!({"tool_calls": [one_call("send_wire")]}),
+            vec![
+                EventKind::ToolApprovalRequired {
+                    node_id: "n1".into(),
+                    tool_name: "send_wire".into(),
+                    approver: "human".into(),
+                    context: serde_json::json!({
+                        "node_id": "n1",
+                        "gated_tools": ["send_wire"],
+                        "calls": calls_json_for(&["send_wire"]),
+                        "calls_hash": approved_hash,
+                    }),
+                },
+                EventKind::ApprovalReceived {
+                    node_id: "n1".into(),
+                    user_id: "approver".into(),
+                    decision: jamjet_state::event::ApprovalDecision::Approved,
+                    comment: None,
+                    state_patch: None,
+                },
+            ],
+        )
+        .await;
+        assert!(result.is_ok(), "an approved, matching call set must run");
+        assert_eq!(count, 1, "the approved dispatch must execute exactly once");
     }
 }

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -537,8 +537,18 @@ class Agent:
                      from scratch — existing behaviour unchanged.
         """
         # T3-6: approval_required parity — the in-process path cannot enforce
-        # tool-level approval gates (the @gate mechanism is opt-in per function;
-        # the durable Rust engine enforces require_approval_for via the IR).
+        # tool-level approval gates (the @gate mechanism is opt-in per function).
+        # The loop below calls tools directly with no policy engine in it, so an
+        # approval gate can be neither evaluated nor held here.
+        #
+        # run_durable() IS enforced — but by the ENGINE, and not by this SDK.
+        # ADK dispatch nodes run on the `python_tool` queue, which has no
+        # in-process worker; the guard on POST /work-items/claim decides a
+        # dispatch node's pending tool calls, so a gated call's payload never
+        # reaches the external worker at all.  That is why it holds even against
+        # a stale or hostile worker build.  Do not restate any of it as a
+        # property of the code below: nothing here inherits it.
+        #
         # Fail LOUD rather than silently no-op so the developer knows approval
         # won't fire here.  See follow-up F-t3-inprocess-approval for full
         # in-process enforcement.
@@ -547,8 +557,8 @@ class Agent:
             warnings.warn(
                 f"Agent {self.name!r}: approval_required is set but agent.run() uses "
                 "the in-process path, which does not enforce approval gates. "
-                "Use agent.run_durable() — the durable IR carries "
-                "require_approval_for and the Rust engine enforces it fail-closed. "
+                "Use agent.run_durable(), where the engine evaluates every tool call "
+                "against policy server-side, before any worker receives the payload. "
                 "Follow-up: F-t3-inprocess-approval.",
                 UserWarning,
                 stacklevel=2,

--- a/sdk/python/jamjet/agents/governance.py
+++ b/sdk/python/jamjet/agents/governance.py
@@ -58,6 +58,11 @@ class GovernanceConfig:
         ``True``   – every tool call requires approval.
         ``list``   – tool-name globs that require approval (e.g.
                      ``["delete_*", "send_*"]``).
+        Enforced on the DURABLE path (``agent.run_durable``): the compiled
+        ``require_approval_for`` is evaluated engine-side, before any worker
+        receives the tool-dispatch payload.  The in-process ``agent.run()`` path
+        has no policy engine in its loop and CANNOT enforce a gate; it warns
+        loudly instead (F-t3-inprocess-approval).
     budget
         Optional per-run spending cap.  ``None`` when uncapped.
     pii

--- a/sdk/python/jamjet/agents/governance.py
+++ b/sdk/python/jamjet/agents/governance.py
@@ -58,11 +58,11 @@ class GovernanceConfig:
         ``True``   – every tool call requires approval.
         ``list``   – tool-name globs that require approval (e.g.
                      ``["delete_*", "send_*"]``).
-        Enforced on the DURABLE path (``agent.run_durable``): the compiled
-        ``require_approval_for`` is evaluated engine-side, before any worker
-        receives the tool-dispatch payload.  The in-process ``agent.run()`` path
-        has no policy engine in its loop and CANNOT enforce a gate; it warns
-        loudly instead (F-t3-inprocess-approval).
+        Enforced engine-side on the DURABLE path (``agent.run_durable``) only.
+        The in-process ``agent.run()`` path has no policy engine in its loop and
+        CANNOT enforce a gate; it warns loudly instead (F-t3-inprocess-approval).
+        The mechanism — and why it holds even against an untrusted worker — is
+        documented once, at the warning site in :meth:`jamjet.Agent.run`.
     budget
         Optional per-run spending cap.  ``None`` when uncapped.
     pii

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -306,9 +306,8 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
                 # Tells the engine this python_fn runs a whole turn's
                 # model-chosen tool calls, so tool policy and approval must be
                 # evaluated against the pending calls in the work-item payload
-                # rather than against this node's (nameless) static kind.  That
-                # evaluation is server-side, on the work-item claim route, so it
-                # happens before any worker receives the payload.
+                # rather than against this node's (nameless) static kind.  Where
+                # that evaluation happens, and why: `Agent.run`.
                 "agent_tool_dispatch": True,
                 # Descriptor of the data the dispatch coroutine consumes. The
                 # engine passes the full accumulated state to PythonFn nodes
@@ -381,10 +380,11 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
     # ── Governance IR fields (T3-5) ────────────────────────────────────────────
     # Emit policy / budget / data_policy from the agent's GovernanceConfig — the
     # compile-side wiring that turns the engine's own enforcement on.  Honest
-    # scope: `policy` and `budget` are enforced engine-side (a dispatch node's
-    # tool policy is decided by the shared guard the work-item claim route runs
-    # before any worker receives the payload); `data_policy` is metadata, NOT an
-    # enforcement point — see `_compile_governance_ir` above.
+    # scope, per field: `policy` is enforced engine-side (where, and why it holds
+    # against an untrusted worker: `Agent.run`); `budget` is checked by the
+    # engine AFTER each node, so a single node can overshoot the cap;
+    # `data_policy` is metadata, NOT an enforcement point — see
+    # `_compile_governance_ir` above.
     # These are merged BEFORE content-versioning so the cache key changes when
     # governance config changes (a different budget or policy must NOT reuse a
     # cached graph compiled without those constraints).

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -303,10 +303,12 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
                 "module": _DISPATCH_MODULE,
                 "function": _DISPATCH_FUNCTION,
                 "output_schema": "",
-                # Tells the Rust worker this python_fn runs a whole turn's
+                # Tells the engine this python_fn runs a whole turn's
                 # model-chosen tool calls, so tool policy and approval must be
                 # evaluated against the pending calls in the work-item payload
-                # rather than against this node's (nameless) static kind.
+                # rather than against this node's (nameless) static kind.  That
+                # evaluation is server-side, on the work-item claim route, so it
+                # happens before any worker receives the payload.
                 "agent_tool_dispatch": True,
                 # Descriptor of the data the dispatch coroutine consumes. The
                 # engine passes the full accumulated state to PythonFn nodes
@@ -377,9 +379,12 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
     }
 
     # ── Governance IR fields (T3-5) ────────────────────────────────────────────
-    # Emit policy / budget / data_policy from the agent's GovernanceConfig so the
-    # Rust engine enforces them fail-closed (enforcement already exists in
-    # workers/src/worker.rs; this is the compile-side wiring that turns it on).
+    # Emit policy / budget / data_policy from the agent's GovernanceConfig — the
+    # compile-side wiring that turns the engine's own enforcement on.  Honest
+    # scope: `policy` and `budget` are enforced engine-side (a dispatch node's
+    # tool policy is decided by the shared guard the work-item claim route runs
+    # before any worker receives the payload); `data_policy` is metadata, NOT an
+    # enforcement point — see `_compile_governance_ir` above.
     # These are merged BEFORE content-versioning so the cache key changes when
     # governance config changes (a different budget or policy must NOT reuse a
     # cached graph compiled without those constraints).

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -303,6 +303,11 @@ def compile_agent_to_ir(agent: Agent, prompt: str, max_turns: int = 8) -> dict[s
                 "module": _DISPATCH_MODULE,
                 "function": _DISPATCH_FUNCTION,
                 "output_schema": "",
+                # Tells the Rust worker this python_fn runs a whole turn's
+                # model-chosen tool calls, so tool policy and approval must be
+                # evaluated against the pending calls in the work-item payload
+                # rather than against this node's (nameless) static kind.
+                "agent_tool_dispatch": True,
                 # Descriptor of the data the dispatch coroutine consumes. The
                 # engine passes the full accumulated state to PythonFn nodes
                 # (no per-node input mapping), so `dispatch_tool_calls` reads

--- a/sdk/python/tests/test_adk_dispatch_constant_parity.py
+++ b/sdk/python/tests/test_adk_dispatch_constant_parity.py
@@ -1,0 +1,87 @@
+"""Binds the ADK tool-dispatch coordinates across the Python/Rust boundary.
+
+The Python compiler stamps every tool-dispatch node with
+``_DISPATCH_MODULE`` / ``_DISPATCH_FUNCTION``
+(:mod:`jamjet.compiler.agent_ir`). Rust's IR validation re-derives "this node is
+an ADK dispatch node" from exactly that pair, in
+``runtime/ir/src/validate.rs``, because it is the only signal that survives
+serialization: the compiler nests its ``tools`` resolver map inside the *kind*
+dict, ``NodeKind::PythonFn`` has no such field, and serde drops unknown keys.
+
+Nothing mechanically ties the two copies, and the drift **fails open**: rename
+the coroutine on the Python side and the Rust pass silently matches nothing, so
+an unmarked dispatch node sails through registration and runs a whole turn's
+model-chosen tool calls with no tool policy — the precise hole that pass exists
+to close. Comments on both sides do not fail builds. This test does.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from jamjet.compiler.agent_ir import _DISPATCH_FUNCTION, _DISPATCH_MODULE
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RUST_VALIDATE = _REPO_ROOT / "runtime" / "ir" / "src" / "validate.rs"
+
+
+def _rust_const(text: str, name: str) -> str:
+    """Return the string literal bound to a Rust `const NAME: &str = "...";`.
+
+    Missing constant is a hard failure, never a skip: a rename on the Rust side
+    is exactly the drift this test exists to catch.
+    """
+    match = re.search(rf'const\s+{name}\s*:\s*&str\s*=\s*"([^"]*)"\s*;', text)
+    assert match is not None, (
+        f"{name} not found in {_RUST_VALIDATE}. If it was renamed or removed, the "
+        "Rust dispatch-marker validation no longer keys on the Python compiler's "
+        "coordinates and fails OPEN — unmarked ADK dispatch nodes would register "
+        "and run unpoliced."
+    )
+    return match.group(1)
+
+
+def _rust_source() -> str:
+    if not _RUST_VALIDATE.exists():
+        pytest.skip(f"runtime workspace not present at {_RUST_VALIDATE}")
+    return _RUST_VALIDATE.read_text()
+
+
+def test_dispatch_module_matches_rust() -> None:
+    assert _rust_const(_rust_source(), "ADK_DISPATCH_MODULE") == _DISPATCH_MODULE
+
+
+def test_dispatch_function_matches_rust() -> None:
+    assert _rust_const(_rust_source(), "ADK_DISPATCH_FUNCTION") == _DISPATCH_FUNCTION
+
+
+def test_python_constants_are_the_ones_the_compiler_emits() -> None:
+    """Guards the other half of the binding.
+
+    Matching Rust against the Python *constants* proves nothing if the compiler
+    stopped using those constants and hard-coded something else. This pins the
+    constants to the node the compiler actually emits.
+    """
+    from jamjet.agents.agent import Agent
+    from jamjet.compiler.agent_ir import compile_agent_to_ir
+    from jamjet.tools.decorators import tool
+
+    @tool
+    async def echo(text: str) -> str:
+        """Echo the input."""
+        return text
+
+    agent = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[echo], strategy="react")
+    ir = compile_agent_to_ir(agent, "hi", max_turns=2)
+    dispatch = [
+        node["kind"]
+        for node in ir["nodes"].values()
+        if node["kind"].get("agent_tool_dispatch") is True
+    ]
+    assert dispatch, "the compiler must emit at least one marked dispatch node"
+    for kind in dispatch:
+        assert kind["module"] == _DISPATCH_MODULE
+        assert kind["function"] == _DISPATCH_FUNCTION

--- a/sdk/python/tests/test_adk_dispatch_constant_parity.py
+++ b/sdk/python/tests/test_adk_dispatch_constant_parity.py
@@ -76,11 +76,7 @@ def test_python_constants_are_the_ones_the_compiler_emits() -> None:
 
     agent = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[echo], strategy="react")
     ir = compile_agent_to_ir(agent, "hi", max_turns=2)
-    dispatch = [
-        node["kind"]
-        for node in ir["nodes"].values()
-        if node["kind"].get("agent_tool_dispatch") is True
-    ]
+    dispatch = [node["kind"] for node in ir["nodes"].values() if node["kind"].get("agent_tool_dispatch") is True]
     assert dispatch, "the compiler must emit at least one marked dispatch node"
     for kind in dispatch:
         assert kind["module"] == _DISPATCH_MODULE

--- a/sdk/python/tests/test_agent.py
+++ b/sdk/python/tests/test_agent.py
@@ -103,6 +103,61 @@ class TestAgent:
         assert agent.limits.timeout_seconds == 60
 
 
+# ── approval_required warning copy ────────────────────────────────────────────
+#
+# The warning on agent.run() is security guidance, so its wording is under test.
+# It has to say two things and no more: (a) THIS call is not enforced, and (b)
+# where enforcement actually lives. The durable path is genuinely enforced now,
+# but by the engine server-side — the guard on the work-item claim route runs
+# before the external tool worker ever receives the payload — not by the SDK.
+# The old copy promised "the Rust engine enforces it fail-closed" while
+# sitting on the unenforced in-process path, which reads as a guarantee about
+# the call the developer just made.
+
+
+def _agent_with_approval_required() -> Agent:
+    return Agent(
+        "approval_copy",
+        model="gpt-5.2",
+        tools=[search],
+        approval_required=True,
+    )
+
+
+def _approval_warning(record: list) -> str:
+    """The one approval warning out of everything run() emits (audit warns too)."""
+    matches = [w for w in record if "approval_required" in str(w.message)]
+    assert len(matches) == 1, f"expected exactly one approval warning, got {len(matches)}"
+    return str(matches[0].message)
+
+
+def test_in_process_run_warning_does_not_promise_enforcement_here():
+    """run() must warn without implying the in-process path is enforced."""
+    agent = _agent_with_approval_required()
+    with pytest.warns(UserWarning) as record:
+        asyncio.run(agent.run("hi"))
+    message = _approval_warning(record)
+    assert "does not enforce approval gates" in message
+    # The durable path is now genuinely enforced (C1), but this warning is on
+    # the in-process path and must not read as a guarantee about this call.
+    assert "fail-closed" not in message
+
+
+def test_in_process_run_warning_points_at_the_real_enforcement_point():
+    """The redirect must name where enforcement lives, accurately.
+
+    Server-side, before the payload leaves the engine — that is what makes the
+    durable claim true even for a stale or hostile external tool worker. Copy
+    that credits the worker would be both weaker and wrong.
+    """
+    agent = _agent_with_approval_required()
+    with pytest.warns(UserWarning) as record:
+        asyncio.run(agent.run("hi"))
+    message = _approval_warning(record)
+    assert "run_durable" in message
+    assert "before any worker" in message
+
+
 # ── @task tests ───────────────────────────────────────────────────────────────
 
 

--- a/sdk/python/tests/test_agent.py
+++ b/sdk/python/tests/test_agent.py
@@ -1,6 +1,9 @@
 """Tests for the Agent and @task syntactic sugar."""
 
 import asyncio
+import re
+import warnings
+from collections.abc import Iterable
 
 import pytest
 
@@ -124,38 +127,67 @@ def _agent_with_approval_required() -> Agent:
     )
 
 
-def _approval_warning(record: list) -> str:
+def _approval_warning(record: Iterable[warnings.WarningMessage]) -> str:
     """The one approval warning out of everything run() emits (audit warns too)."""
     matches = [w for w in record if "approval_required" in str(w.message)]
     assert len(matches) == 1, f"expected exactly one approval warning, got {len(matches)}"
     return str(matches[0].message)
 
 
-def test_in_process_run_warning_does_not_promise_enforcement_here():
-    """run() must warn without implying the in-process path is enforced."""
-    agent = _agent_with_approval_required()
-    with pytest.warns(UserWarning) as record:
-        asyncio.run(agent.run("hi"))
-    message = _approval_warning(record)
-    assert "does not enforce approval gates" in message
-    # The durable path is now genuinely enforced (C1), but this warning is on
-    # the in-process path and must not read as a guarantee about this call.
-    assert "fail-closed" not in message
+# "worker" is allowed in the copy — "before any worker receives the payload" is
+# the whole point. What is banned is the worker appearing as the SUBJECT of the
+# enforcing, in either voice ("the worker enforces it" / "enforced by the tool
+# worker"). Matched as a class rather than as one literal: the reword that
+# actually happened on this branch said "Tells the Rust worker ... policy must be
+# evaluated", which no single banned phrase would have caught. `[^.]` keeps each
+# match inside one sentence so an innocent "worker" cannot pair with an enforcing
+# verb from the next one.
+_ENFORCE = r"(?:enforc|evaluat|check|block|gate|decid|den|held|hold)\w*"
+_WORKER_CREDITED = re.compile(
+    rf"\bworkers?\b[^.]{{0,40}}?{_ENFORCE}|{_ENFORCE}[^.]{{0,40}}?\bby\b[^.]{{0,20}}?\bworkers?\b",
+    re.IGNORECASE,
+)
 
 
-def test_in_process_run_warning_points_at_the_real_enforcement_point():
-    """The redirect must name where enforcement lives, accurately.
+class TestApprovalWarningCopy:
+    def test_in_process_run_warning_does_not_promise_enforcement_here(self):
+        """run() must warn without implying the in-process path is enforced."""
+        agent = _agent_with_approval_required()
+        with pytest.warns(UserWarning) as record:
+            asyncio.run(agent.run("hi"))
+        message = _approval_warning(record)
+        assert "does not enforce approval gates" in message
+        # The durable path is now genuinely enforced (C1), but this warning is on
+        # the in-process path and must not read as a guarantee about this call.
+        assert "fail-closed" not in message
 
-    Server-side, before the payload leaves the engine — that is what makes the
-    durable claim true even for a stale or hostile external tool worker. Copy
-    that credits the worker would be both weaker and wrong.
-    """
-    agent = _agent_with_approval_required()
-    with pytest.warns(UserWarning) as record:
-        asyncio.run(agent.run("hi"))
-    message = _approval_warning(record)
-    assert "run_durable" in message
-    assert "before any worker" in message
+    def test_in_process_run_warning_points_at_the_real_enforcement_point(self):
+        """The redirect must name where enforcement lives, accurately.
+
+        Server-side, before the payload leaves the engine — that is what makes
+        the durable claim true even for a stale or hostile external tool worker.
+        """
+        agent = _agent_with_approval_required()
+        with pytest.warns(UserWarning) as record:
+            asyncio.run(agent.run("hi"))
+        message = _approval_warning(record)
+        assert "run_durable" in message
+        assert "before any worker" in message
+
+    def test_in_process_run_warning_never_credits_the_worker(self):
+        """The durable guarantee belongs to the engine, never to the worker.
+
+        Crediting the worker is not just imprecise, it inverts the property:
+        enforcement holds BECAUSE the external worker is untrusted and the
+        decision is made before it sees the payload. Copy that reads "the worker
+        enforces it" describes a system where a stale worker build could opt out.
+        """
+        agent = _agent_with_approval_required()
+        with pytest.warns(UserWarning) as record:
+            asyncio.run(agent.run("hi"))
+        message = _approval_warning(record)
+        hit = _WORKER_CREDITED.search(message)
+        assert hit is None, f"warning credits the worker with enforcing: {hit.group(0)!r}"
 
 
 # ── @task tests ───────────────────────────────────────────────────────────────

--- a/sdk/python/tests/test_agent_ir.py
+++ b/sdk/python/tests/test_agent_ir.py
@@ -166,6 +166,27 @@ def test_three_tool_dispatch_nodes_with_resolver_map():
         assert kind["input"]["messages"] == "$state.messages"
 
 
+def test_tool_dispatch_nodes_are_marked_for_policy():
+    """Every tool-dispatch node must carry agent_tool_dispatch=True.
+
+    Without the marker the Rust worker treats the node as an opaque python_fn
+    and enforces no tool policy on it (review finding C1).
+    """
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    dispatch_nodes = [node for node in ir["nodes"].values() if node["kind"].get("function") == "dispatch_tool_calls"]
+    assert len(dispatch_nodes) == 3
+    for node in dispatch_nodes:
+        assert node["kind"]["agent_tool_dispatch"] is True
+
+
+def test_model_nodes_are_not_marked_as_tool_dispatch():
+    """The marker must be narrow: only the dispatch nodes carry it."""
+    ir = compile_agent_to_ir(_agent(), "hi", max_turns=3)
+    for node in ir["nodes"].values():
+        if node["kind"].get("function") != "dispatch_tool_calls":
+            assert node["kind"].get("agent_tool_dispatch") in (None, False)
+
+
 # ── Edges / loop topology ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes the two Criticals from the 2026-07-02 ADK review (`workspace/reviews/2026-07-02-adk-design-implementation-review.md`).

## C1 — tool policy and approval were enforced nowhere for the ADK `Agent`

An ADK agent compiles a whole turn's model-chosen tool calls into a single `python_fn` / `java_fn` node, so the tool names never appear in the static node kind. `EvaluationContext::from_node_kind` produced no `tool_name`, the `blocked_tools` and `require_approval_for` branches were skipped entirely, and every call executed unpoliced — on both the in-process and durable paths.

Enforcement now happens where the scheduler has already frozen the pending calls into the work-item payload, which is the same bytes the dispatch consumes, so there is no time-of-check-to-time-of-use window. The decision lives in `jamjet_worker::dispatch_guard` and is shared by the two transports that can run these nodes: `Worker::check_policy` and `POST /work-items/claim`. Neither settles the item the same way, so the guard deliberately does not settle — the call site does.

Approval is bound to the exact calls it authorises, by content hash over `(name, arguments)` per call, in order. A settled approval cannot be replayed against a different payload. Call `id` is deliberately unbound so a benign re-issue still matches.

## C2 — budget ceiling by continue-as-new was an unbounded spend loop

The budget tripped only *after* a node executed, discarded the tripping turn, and rolled over into a child that inherited the pinned counters — one real, paid model call per segment, forever. A node now refuses to fire when the budget is already spent, with `>=` rather than `>`: a run can settle exactly at its limit, and the point is to refuse the *next* call from that state. A ceiling of literally zero now means zero, where it previously bought one call.

## Second adversarial review

Per the standing rule that enforcement code gets an independent pass before merge. Findings fixed in `a2b75c7`:

**The marker was the only execution-time signal.** `agent_tool_dispatch` is `#[serde(default)]`, and `validate_agent_tool_dispatch` runs on the registration route only — nothing re-validates an IR already in the backend. A workflow registered before this change and started from stored IR (a scheduled fleet, or `start_execution` without a fresh `create_workflow`) reached the executor unmarked and ran unpoliced: C1 still open for exactly the workflows that predate the fix. Enforcement now also keys on the dispatch coordinates, shared from one definition with the validator.

**Two tests asserted that fail-open.** Both narrowness tests described themselves as covering "an ordinary `python_fn`", but their fixtures were the ADK dispatch coroutine's coordinates with the marker dropped — pinning the behaviour where a blocked tool is handed out with its payload and nothing audited. Fixtures corrected to a real application function, each with a sibling asserting the unmarked dispatch node is enforced.

**Model-controlled input reached an unmemoized recursive matcher.** Tool names are model output, so prompt injection chooses them, and C1 is what starts feeding them to `glob_match` — which recurses per character. Depth is linear in the name and a Rust stack overflow aborts rather than unwinds; multi-star patterns backtrack superlinearly. Names are now capped at 512 chars, batches at 256 calls, both refused as unreadable, which the guard already fails closed on.

What I probed and could not break: the approval replay dual. Approving set A then re-firing with set B does not carry the approval over, because `node_approval_status` resets to `Pending` on each new request, so `Approved` can only refer to the latest one.

## Known limits, deliberately not fixed here

- **A claim-route block stalls the execution.** `fail_work_item` sets `status='failed'` with no `NodeFailed`, so the execution stays `Running` rather than going terminal. This is the outcome of every successful enforcement on that route, not an edge case. Safety is unaffected — the tool does not run and the denial is audited — but closing it means emitting a fence-committed terminal event from the claim route, which is a scheduler-interaction change and does not belong inside a security fix. Same root cause as review item 3 (external tool tier).
- **The budget pre-check is worker-only.** The claim route enforces policy but not budget. Model nodes route to `QueueType::Model`, which the in-process worker drains, so C2's spend path is covered.
- **Duplicate approval requests on the claim route.** Documented at the `NotRequested` arm; two concurrent claims can both append a request.

## Verification

Rust 490 passed / 0 failed across 40 suites; Python 1445 passed, 1 skipped. `cargo fmt --all` applied — the branch was drifted in 12 places before these changes and would have failed CI on first push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy enforcement for agent tool dispatch during durable workflow execution.
  * Blocked tools are denied, approval-required tools are held, and unsafe or unreadable requests fail closed.
  * Added token and cost budget checks before task execution.
  * Workflow validation now requires explicit dispatch markers for recognized agent tool operations.
  * Added approval binding to exact tool calls and improved policy-scope reporting.

* **Documentation**
  * Clarified that approval gates apply to durable execution, not in-process runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->