### PR TITLE
fix(api): stop stranding every external tool failure (fence /fail, emit NodeFailed, apply retry semantics)

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -22,7 +22,7 @@ use chrono::Utc;
 use jamjet_agents::{AgentCard, AgentFilter, AgentStatus};
 use jamjet_audit::backend::AuditQuery;
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
-use jamjet_state::{Tenant, TenantId, TenantStatus, WorkItem, WorkflowDefinition};
+use jamjet_state::{FailOutcome, Tenant, TenantId, TenantStatus, WorkItem, WorkflowDefinition};
 use jamjet_worker::DispatchGuardOutcome;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -1552,20 +1552,135 @@ async fn enqueue_work_item(
 #[derive(Deserialize)]
 struct FailWorkItemRequest {
     error: String,
+    /// Lease fence echoed from the claim response. Gates the failure on still
+    /// holding the lease, exactly as `/complete` does.
+    ///
+    /// Absent means the legacy unfenced path: the item is settled `'failed'` and
+    /// NO event is emitted, which strands the node. It is kept only so callers
+    /// that predate the fence keep working, and it is deprecated — a caller that
+    /// echoes the fence gets retry semantics and a terminal event instead.
+    #[serde(default)]
+    lease_fence: Option<i64>,
 }
 
-/// `POST /work-items/:id/fail` — mark a work item as failed.
+/// `POST /work-items/:id/fail` — a worker reports that its node failed.
+///
+/// The fenced path applies the SAME retry, backoff and dead-letter rules that
+/// lease reclamation applies, and emits the SAME events, so a node whose worker
+/// reported a failure and a node whose worker died converge on one state machine.
+///
+/// Before this, the whole endpoint was `fail_work_item` and nothing else: no
+/// fence, so any caller holding an id could settle someone else's item, and no
+/// event, so the scheduler fold kept the node in `scheduled` while the row sat in
+/// a `'failed'` status that no sweep ever selects. Every legitimate tool failure
+/// stranded its execution as `Running`, permanently.
 async fn fail_work_item(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(id): Path<String>,
     Json(body): Json<FailWorkItemRequest>,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<(StatusCode, Json<Value>), ApiError> {
     let item_id = Uuid::parse_str(&id)
         .map_err(|_| ApiError::BadRequest(format!("invalid work item id: {id}")))?;
     let backend = state.backend_for(&tenant_id);
-    backend.fail_work_item(item_id, &body.error).await?;
-    Ok(Json(json!({ "failed": true, "work_item_id": id })))
+
+    let Some(fence) = body.lease_fence else {
+        // Legacy unfenced path, deprecated. Preserved verbatim so existing
+        // callers do not break, and deliberately NOT given the new event
+        // emission: without a fence we cannot show the item was ours to fail, and
+        // emitting a terminal event on an item another worker may now hold is
+        // worse than the stranding this path already causes.
+        warn!(
+            work_item_id = %id,
+            "fail: unfenced legacy path — the node will be stranded; echo lease_fence to get retry semantics"
+        );
+        backend.fail_work_item(item_id, &body.error).await?;
+        return Ok((
+            StatusCode::OK,
+            Json(json!({
+                "failed": true,
+                "work_item_id": id,
+                "retryable": false,
+                "warning": "unfenced fail: no NodeFailed emitted and the node is not rescheduled; echo lease_fence",
+            })),
+        ));
+    };
+
+    let Some(outcome) = backend
+        .fail_work_item_fenced(item_id, fence, &body.error)
+        .await?
+    else {
+        // Someone else owns it now — reclaimed, already settled, or a forged
+        // fence. Emit nothing: the holder decides this item's fate.
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "failed": false,
+                "work_item_id": id,
+                "reason": "stale or invalid lease fence",
+            })),
+        ));
+    };
+
+    // Emit exactly what `SchedulerRunner::reclaim_expired_leases` emits for the
+    // same transition, so the fold cannot tell the two apart.
+    let (item, retryable, delay_ms) = match &outcome {
+        FailOutcome::Retryable { item, delay_ms } => (item, true, Some(*delay_ms)),
+        FailOutcome::Exhausted { item } => (item, false, None),
+    };
+
+    let seq = backend.latest_sequence(&item.execution_id).await? + 1;
+    backend
+        .append_event(jamjet_state::Event::new(
+            item.execution_id.clone(),
+            seq,
+            jamjet_state::EventKind::NodeFailed {
+                node_id: item.node_id.clone(),
+                error: body.error.clone(),
+                // Retryable reports the attempt that just failed; exhausted
+                // reports the final count. Mirrors the reclaimer's arithmetic.
+                attempt: if retryable {
+                    item.attempt.saturating_sub(1)
+                } else {
+                    item.attempt
+                },
+                retryable,
+            },
+        ))
+        .await?;
+
+    if let Some(delay_ms) = delay_ms {
+        let seq = backend.latest_sequence(&item.execution_id).await? + 1;
+        backend
+            .append_event(jamjet_state::Event::new(
+                item.execution_id.clone(),
+                seq,
+                jamjet_state::EventKind::RetryScheduled {
+                    node_id: item.node_id.clone(),
+                    attempt: item.attempt,
+                    delay_ms,
+                },
+            ))
+            .await?;
+    }
+
+    warn!(
+        execution_id = %item.execution_id,
+        node_id = %item.node_id,
+        attempt = item.attempt,
+        retryable,
+        "fail: worker reported a node failure"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(json!({
+            "failed": true,
+            "work_item_id": id,
+            "retryable": retryable,
+            "attempt": item.attempt,
+        })),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1360,6 +1360,17 @@ impl StateBackend for FailFirstGetEvents {
         self.inner.fail_work_item(item_id, error).await
     }
 
+    async fn fail_work_item_fenced(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+        lease_fence: i64,
+        error: &str,
+    ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::FailOutcome>> {
+        self.inner
+            .fail_work_item_fenced(item_id, lease_fence, error)
+            .await
+    }
+
     async fn commit_turn(
         &self,
         item_id: jamjet_state::backend::WorkItemId,

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -1,0 +1,432 @@
+//! `POST /work-items/:id/fail` — the external worker tier's failure path.
+//!
+//! The endpoint used to be a single unfenced `fail_work_item` call. That wrote
+//! `status = 'failed'`, a status no sweep ever selects, and appended NOTHING —
+//! so the scheduler fold kept the node in `scheduled`, the execution stayed
+//! `Running` forever, and the item could never be reclaimed. Every legitimate
+//! Python/Java tool failure stranded its workflow permanently.
+//!
+//! These tests pin the two properties that fix requires: a worker-reported
+//! failure produces the SAME events as a lease that expired (so the fold cannot
+//! tell them apart), and a worker that no longer holds the lease cannot settle
+//! or narrate the item at all.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use jamjet_agents::InMemoryAgentRegistry;
+use jamjet_api::{routes::build_router_with_opts, state::AppState};
+use jamjet_audit::{AuditEnricher, NoopAuditBackend};
+use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+use jamjet_state::backend::{StateBackend, WorkItem};
+use jamjet_state::event::EventKind;
+use jamjet_state::{Event, InMemoryBackend, DEFAULT_TENANT};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn make_state(backend: Arc<dyn StateBackend>) -> AppState {
+    let backend_for_fn = backend.clone();
+    let audit: Arc<dyn jamjet_audit::AuditBackend> = Arc::new(NoopAuditBackend);
+    let enricher = Arc::new(AuditEnricher::new(Arc::clone(&audit)));
+    AppState {
+        backend: backend.clone(),
+        backend_for_fn: Arc::new(move |_t: &jamjet_state::TenantId| backend_for_fn.clone()),
+        agents: Arc::new(InMemoryAgentRegistry::new()),
+        audit,
+        enricher,
+        protocols: jamjet_api::state::default_protocol_registry(),
+        cron_store: None,
+    }
+}
+
+/// Enqueue one claimable item, then claim it so the test holds a real fence.
+async fn seed_and_claim(
+    backend: &Arc<dyn StateBackend>,
+    max_attempts: u32,
+    attempt: u32,
+) -> (ExecutionId, Uuid, i64) {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    let id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id,
+            execution_id: execution_id.clone(),
+            node_id: "n1".into(),
+            queue_type: "python_tool".into(),
+            payload: json!({"node_id": "n1"}),
+            attempt,
+            max_attempts,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+
+    let claimed = backend
+        .claim_work_item("external-python-worker-0", &["python_tool"])
+        .await
+        .expect("claim")
+        .expect("an item must be claimable");
+    assert_eq!(claimed.id, id, "the seeded item must be the claimed one");
+    (execution_id, id, claimed.lease_fence)
+}
+
+async fn post_fail(state: &AppState, id: Uuid, body: Value) -> (StatusCode, Value) {
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post(format!("/work-items/{id}/fail"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+async fn events(backend: &Arc<dyn StateBackend>, execution_id: &ExecutionId) -> Vec<Event> {
+    backend.get_events(execution_id).await.expect("get_events")
+}
+
+fn node_failed(events: &[Event]) -> Option<(String, bool, u32)> {
+    events.iter().find_map(|e| match &e.kind {
+        EventKind::NodeFailed {
+            error,
+            retryable,
+            attempt,
+            ..
+        } => Some((error.clone(), *retryable, *attempt)),
+        _ => None,
+    })
+}
+
+fn retry_scheduled(events: &[Event]) -> Option<(u32, u64)> {
+    events.iter().find_map(|e| match &e.kind {
+        EventKind::RetryScheduled {
+            attempt, delay_ms, ..
+        } => Some((*attempt, *delay_ms)),
+        _ => None,
+    })
+}
+
+// ── The wedge itself ─────────────────────────────────────────────────────────
+
+/// The regression that matters: a failure must leave a terminal event behind.
+///
+/// Without one the node stays in the fold's `scheduled` set and the execution
+/// never completes, which is what stranded every external tool failure.
+#[tokio::test]
+async fn a_fenced_failure_emits_node_failed_and_reschedules() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, body) = post_fail(
+        &state,
+        id,
+        json!({"error": "tool raised ValueError", "lease_fence": fence}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["failed"], json!(true));
+    assert_eq!(body["retryable"], json!(true), "attempts remain, so retry");
+
+    let evs = events(&backend, &execution_id).await;
+    let (error, retryable, attempt) =
+        node_failed(&evs).expect("a failure MUST append NodeFailed — without it the node strands");
+    assert_eq!(
+        error, "tool raised ValueError",
+        "the worker's reason survives"
+    );
+    assert!(retryable);
+    assert_eq!(attempt, 0, "the attempt that just failed");
+
+    let (retry_attempt, delay_ms) =
+        retry_scheduled(&evs).expect("a retryable failure MUST also schedule the retry");
+    assert_eq!(retry_attempt, 1);
+    assert!(delay_ms > 0, "the retry must back off, got {delay_ms}ms");
+}
+
+/// The last attempt is terminal: NodeFailed{retryable:false} and NO retry.
+#[tokio::test]
+async fn the_final_attempt_dead_letters_without_scheduling_a_retry() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    // attempt 2 of max 3 — failing it makes 3, which exhausts the budget.
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 2).await;
+    let state = make_state(backend.clone());
+
+    let (status, body) = post_fail(
+        &state,
+        id,
+        json!({"error": "still broken", "lease_fence": fence}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["retryable"], json!(false));
+
+    let evs = events(&backend, &execution_id).await;
+    let (_, retryable, attempt) = node_failed(&evs).expect("NodeFailed");
+    assert!(!retryable, "an exhausted node is permanently dead");
+    assert_eq!(attempt, 3, "the final attempt count");
+    assert!(
+        retry_scheduled(&evs).is_none(),
+        "a dead-lettered node must NOT be rescheduled"
+    );
+}
+
+// ── The fence ────────────────────────────────────────────────────────────────
+
+/// A worker that lost its lease cannot fail the item, and cannot narrate it
+/// either: emitting NodeFailed for an item another worker now holds would let a
+/// zombie kill a live node.
+#[tokio::test]
+async fn a_stale_fence_is_refused_and_emits_nothing() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, body) = post_fail(
+        &state,
+        id,
+        json!({"error": "zombie worker", "lease_fence": fence + 1}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["failed"], json!(false));
+    assert!(
+        events(&backend, &execution_id).await.is_empty(),
+        "a refused failure must leave no trace in the log"
+    );
+}
+
+/// `lease_fence: 0` is the shape a forged or defaulted request takes. A pending
+/// item carries fence 0, so a fence-only check would match it; the still-claimed
+/// guard is what refuses this.
+#[tokio::test]
+async fn a_zero_fence_does_not_match_an_unclaimed_item() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, _fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, _) = post_fail(&state, id, json!({"error": "forged", "lease_fence": 0})).await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(events(&backend, &execution_id).await.is_empty());
+}
+
+/// Failing twice with the same fence must not double-emit: the first failure
+/// releases the lease, so the replay finds nothing of its own to settle.
+#[tokio::test]
+async fn replaying_a_failure_with_the_same_fence_is_refused() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (first, _) = post_fail(&state, id, json!({"error": "boom", "lease_fence": fence})).await;
+    assert_eq!(first, StatusCode::OK);
+
+    let (second, _) = post_fail(&state, id, json!({"error": "boom", "lease_fence": fence})).await;
+    assert_eq!(
+        second,
+        StatusCode::CONFLICT,
+        "the second report no longer holds the lease"
+    );
+
+    let failures = events(&backend, &execution_id)
+        .await
+        .iter()
+        .filter(|e| matches!(e.kind, EventKind::NodeFailed { .. }))
+        .count();
+    assert_eq!(failures, 1, "exactly one NodeFailed, not one per replay");
+}
+
+// ── The durable backend ──────────────────────────────────────────────────────
+//
+// Everything above runs on the in-memory backend, which is exactly how the
+// SQLite-vs-memory divergence class hides (review finding 2: claim-side lease
+// expiry exists only in SQLite, so memory-only tests are blind to it). The
+// status transitions below can ONLY be observed in the table, so they are
+// asserted against the real backend.
+
+/// A durable backend plus the raw pool, since `StateBackend` exposes no
+/// work-item read and `'pending'` vs `'dead_lettered'` is the whole point.
+struct Durable {
+    backend: Arc<dyn StateBackend>,
+    pool: sqlx::SqlitePool,
+    db_path: std::path::PathBuf,
+}
+
+impl Durable {
+    async fn new() -> Self {
+        let db_path = std::env::temp_dir().join(format!("jjtest-fail-{}.db", Uuid::new_v4()));
+        let url = format!("sqlite://{}", db_path.display());
+        let backend: Arc<dyn StateBackend> = Arc::new(
+            jamjet_state::SqliteBackend::open(&url)
+                .await
+                .expect("open sqlite"),
+        );
+        let pool = sqlx::SqlitePool::connect(&url).await.expect("open pool");
+        Self {
+            backend,
+            pool,
+            db_path,
+        }
+    }
+
+    async fn status(&self, item_id: Uuid) -> String {
+        sqlx::query_scalar::<_, String>("SELECT status FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&self.pool)
+            .await
+            .expect("the work item row must exist")
+    }
+
+    async fn attempt(&self, item_id: Uuid) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT attempt FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&self.pool)
+            .await
+            .expect("the work item row must exist")
+    }
+
+    async fn dead_letter_rows(&self, item_id: Uuid) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM dead_letter_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&self.pool)
+            .await
+            .expect("count")
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        let _ = std::fs::remove_file(&self.db_path);
+    }
+}
+
+/// On the durable backend a retryable failure must return the item to the queue,
+/// not leave it in the `'failed'` dead end nothing selects.
+#[tokio::test]
+async fn durable_retryable_failure_returns_the_item_to_pending() {
+    let d = Durable::new().await;
+    let (_execution_id, id, fence) = seed_and_claim(&d.backend, 3, 0).await;
+    let state = make_state(d.backend.clone());
+
+    let (status, _) = post_fail(&state, id, json!({"error": "boom", "lease_fence": fence})).await;
+    assert_eq!(status, StatusCode::OK);
+
+    assert_eq!(
+        d.status(id).await,
+        "pending",
+        "a retryable failure must be claimable again — 'failed' is the dead end this fixes"
+    );
+    assert_eq!(d.attempt(id).await, 1, "the attempt must be consumed");
+    assert_eq!(
+        d.dead_letter_rows(id).await,
+        0,
+        "a retryable failure is not dead-lettered"
+    );
+    d.cleanup().await;
+}
+
+/// The exhausting failure must dead-letter durably, in both tables.
+#[tokio::test]
+async fn durable_exhausted_failure_dead_letters() {
+    let d = Durable::new().await;
+    let (_execution_id, id, fence) = seed_and_claim(&d.backend, 3, 2).await;
+    let state = make_state(d.backend.clone());
+
+    let (status, body) =
+        post_fail(&state, id, json!({"error": "final", "lease_fence": fence})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["retryable"], json!(false));
+
+    assert_eq!(d.status(id).await, "dead_lettered");
+    assert_eq!(
+        d.dead_letter_rows(id).await,
+        1,
+        "the dead-letter queue is what makes an exhausted node recoverable by an operator"
+    );
+    d.cleanup().await;
+}
+
+/// A refused failure must not leave a half-written dead-letter row behind — the
+/// settle is guarded first precisely so the insert cannot outlive it.
+#[tokio::test]
+async fn durable_stale_fence_writes_nothing_at_all() {
+    let d = Durable::new().await;
+    let (execution_id, id, fence) = seed_and_claim(&d.backend, 3, 2).await;
+    let state = make_state(d.backend.clone());
+
+    let (status, _) = post_fail(
+        &state,
+        id,
+        json!({"error": "zombie", "lease_fence": fence + 7}),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        d.status(id).await,
+        "claimed",
+        "the real holder still owns the item"
+    );
+    assert_eq!(d.dead_letter_rows(id).await, 0, "no orphan dead-letter row");
+    assert!(events(&d.backend, &execution_id).await.is_empty());
+    d.cleanup().await;
+}
+
+// ── Legacy path ──────────────────────────────────────────────────────────────
+
+/// The unfenced path still works for callers that predate the fence, but it is
+/// honest about what it does not do. Pinning this keeps the deprecation
+/// deliberate rather than accidental.
+#[tokio::test]
+async fn the_unfenced_legacy_path_still_settles_but_warns() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, _fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, body) = post_fail(&state, id, json!({"error": "old client"})).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["failed"], json!(true));
+    assert_eq!(body["retryable"], json!(false));
+    assert!(
+        body["warning"]
+            .as_str()
+            .is_some_and(|w| w.contains("lease_fence")),
+        "the response must tell the caller how to stop stranding nodes; got {body}"
+    );
+    assert!(
+        events(&backend, &execution_id).await.is_empty(),
+        "the legacy path emits nothing — that is exactly why it is deprecated"
+    );
+}

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -243,8 +243,42 @@ pub trait StateBackend: Send + Sync {
         lease_fence: i64,
     ) -> BackendResult<bool>;
 
-    /// Mark a work item as failed. The scheduler will decide whether to retry.
+    /// Mark a work item as failed by writing the terminal `'failed'` status.
+    ///
+    /// WARNING — this settles the item and NOTHING ELSE. No `NodeFailed` is
+    /// appended, and no sweep ever selects `status = 'failed'`, so the scheduler
+    /// fold keeps the node in `scheduled` and the execution never reaches a
+    /// terminal state. It is the right call only where the caller emits the
+    /// terminal event itself.
+    ///
+    /// For a worker reporting that its node failed, use
+    /// [`Self::fail_work_item_fenced`], which applies the same retry and
+    /// dead-letter semantics as lease reclamation and tells the caller which
+    /// events to emit.
     async fn fail_work_item(&self, item_id: WorkItemId, error: &str) -> BackendResult<()>;
+
+    /// Fence-guarded failure of a claimed work item, with retry semantics.
+    ///
+    /// The failure counterpart of [`Self::complete_work_item_fenced`], and the
+    /// per-item counterpart of [`Self::reclaim_expired_leases`]: it applies the
+    /// SAME attempt/backoff/dead-letter rules that reclamation applies to a lease
+    /// that expired, so a worker that reports a failure and a worker that dies
+    /// holding the item converge on identical state and identical events.
+    ///
+    /// Returns `Ok(None)` — never an error — when the fence does not match or the
+    /// item is no longer `claimed`, exactly like `complete_work_item_fenced`, so a
+    /// reclaimed or replayed worker cannot fail an item it no longer owns or
+    /// double-emit its terminal event.
+    ///
+    /// The returned [`FailOutcome`] carries the updated item so the caller can
+    /// emit `NodeFailed` (and `RetryScheduled`) with the right attempt number
+    /// without re-reading it.
+    async fn fail_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        error: &str,
+    ) -> BackendResult<Option<FailOutcome>>;
 
     /// Atomically settle a work item, append the terminal event, and optionally
     /// compute and write a snapshot from the committed state, all in ONE
@@ -458,4 +492,29 @@ pub struct ReclaimResult {
     pub retryable: Vec<WorkItem>,
     /// Items that exhausted all attempts and were moved to dead-letter.
     pub exhausted: Vec<WorkItem>,
+}
+
+/// What a fenced failure did to the item, and the item as it now stands.
+///
+/// The caller emits the terminal events from this, so the variants mirror the
+/// two arms of [`ReclaimResult`] deliberately: a worker-reported failure and an
+/// expired lease must leave the same event trail, or the scheduler fold learns a
+/// different story depending on how the node died.
+#[derive(Debug, Clone)]
+pub enum FailOutcome {
+    /// Attempts remain: the item is back to `pending` with an incremented
+    /// attempt and a backoff, and a fresh lease epoch. Emit
+    /// `NodeFailed { retryable: true }` then `RetryScheduled`.
+    Retryable {
+        /// The item with its NEW attempt number.
+        item: Box<WorkItem>,
+        /// Backoff applied before the item becomes claimable again.
+        delay_ms: u64,
+    },
+    /// Attempts are spent: the item is dead-lettered. Emit
+    /// `NodeFailed { retryable: false }` and nothing else.
+    Exhausted {
+        /// The item with its FINAL attempt number.
+        item: Box<WorkItem>,
+    },
 }

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -24,8 +24,8 @@ pub use artifact::{
     DEFAULT_SPILL_THRESHOLD,
 };
 pub use backend::{
-    ApiToken, ApprovalProjectionRow, BackendResult, ReclaimResult, StateBackend, StateBackendError,
-    WorkItem, WorkItemId, WorkflowDefinition,
+    ApiToken, ApprovalProjectionRow, BackendResult, FailOutcome, ReclaimResult, StateBackend,
+    StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
 };
 pub use budget::{BudgetState, BudgetTrip};
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -4,8 +4,8 @@
 //! quick prototyping where durability is not needed.
 
 use crate::backend::{
-    ApiToken, BackendResult, ReclaimResult, StateBackend, StateBackendError, WorkItem, WorkItemId,
-    WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
+    WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -613,6 +613,61 @@ impl StateBackend for InMemoryBackend {
             }
             None => Err(StateBackendError::NotFound(item_id.to_string())),
         }
+    }
+
+    async fn fail_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        error: &str,
+    ) -> BackendResult<Option<FailOutcome>> {
+        let Some(mut entry) = self.work_items.get_mut(&item_id) else {
+            return Ok(None);
+        };
+        // Same guard as `complete_work_item_fenced`: the fence AND still-claimed
+        // (`worker_id.is_some()`). Fence alone would let a forged `lease_fence: 0`
+        // match a never-claimed pending item, and would accept a stale fence after
+        // a reclaim, since reclaim clears `worker_id` but leaves `lease_fence`.
+        if entry.worker_id.is_none() || entry.lease_fence != lease_fence {
+            return Ok(None);
+        }
+
+        let new_attempt = entry.attempt + 1;
+        entry.attempt = new_attempt;
+        entry.worker_id = None;
+        entry.lease_expires_at = None;
+        if let Some(obj) = entry.payload.as_object_mut() {
+            obj.insert(
+                "last_error".into(),
+                serde_json::Value::String(error.to_string()),
+            );
+        }
+        // Bump the epoch so any re-claim mints a strictly greater fence than the
+        // token the failing worker still holds.
+        let next = self
+            .lease_epochs
+            .get(&item_id)
+            .map(|e| *e.value())
+            .unwrap_or(0)
+            + 1;
+        self.lease_epochs.insert(item_id, next);
+
+        let item = entry.clone();
+        let exhausted = new_attempt >= item.max_attempts;
+        drop(entry);
+
+        if exhausted {
+            // Mirror SQLite: a dead-lettered item leaves the live queue entirely,
+            // so it can never be claimed again.
+            self.work_items.remove(&item_id);
+            return Ok(Some(FailOutcome::Exhausted {
+                item: Box::new(item),
+            }));
+        }
+        Ok(Some(FailOutcome::Retryable {
+            delay_ms: (1u64 << new_attempt.min(6)) * 1000,
+            item: Box::new(item),
+        }))
     }
 
     async fn park_work_item(

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1,6 +1,6 @@
 use crate::backend::{
-    ApiToken, BackendResult, ReclaimResult, StateBackend, StateBackendError, WorkItem, WorkItemId,
-    WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
+    WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -1144,6 +1144,123 @@ impl StateBackend for SqliteBackend {
             return Err(StateBackendError::NotFound(id_str));
         }
         Ok(())
+    }
+
+    #[instrument(skip(self, error), fields(item_id = %item_id, fence = lease_fence))]
+    async fn fail_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        error: &str,
+    ) -> BackendResult<Option<FailOutcome>> {
+        let id_str = item_id.to_string();
+
+        // BEGIN IMMEDIATE: this reads the item, decides retry-vs-dead-letter from
+        // its attempt count, and writes — a deferred BEGIN would upgrade from read
+        // to write mid-way, where SQLite skips the busy handler entirely. The
+        // transaction is also what keeps the decision and the settle atomic, so a
+        // concurrent reclaim cannot land between them and leave the item retried
+        // AND dead-lettered.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // The fence + status guard lives on the READ as well as the write. Reading
+        // an item this worker no longer owns and then refusing is correct but
+        // wasteful; refusing here keeps the not-ours case to a single statement.
+        let Some(row) = sqlx::query(
+            "SELECT * FROM work_items WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(&id_str)
+        .bind(lease_fence)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        else {
+            return Ok(None);
+        };
+
+        let item = row_to_work_item(&row)?;
+        let new_attempt = item.attempt + 1;
+
+        // Identical rule to `reclaim_expired_leases`, deliberately: a node that
+        // died with its worker and a node whose worker reported the failure must
+        // not get different retry budgets.
+        if new_attempt >= item.max_attempts {
+            let dead_lettered_at = Utc::now().to_rfc3339();
+            let rows = sqlx::query(
+                "UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL \
+                 WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
+            )
+            .bind(new_attempt as i64)
+            .bind(&id_str)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected();
+            if rows == 0 {
+                return Ok(None);
+            }
+
+            // Only after the settle actually landed, so a refused failure never
+            // leaves an orphan dead-letter row behind.
+            sqlx::query(
+                r#"INSERT OR IGNORE INTO dead_letter_items
+                   (id, execution_id, node_id, queue_type, payload_json, attempt, last_error, created_at, dead_lettered_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(&id_str)
+            .bind(execution_id_str(&item.execution_id))
+            .bind(&item.node_id)
+            .bind(&item.queue_type)
+            .bind(serde_json::to_string(&item.payload)?)
+            .bind(new_attempt as i64)
+            .bind(error)
+            .bind(item.created_at.to_rfc3339())
+            .bind(dead_lettered_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            tx.commit().await.map_err(map_db_err)?;
+            let mut exhausted = item;
+            exhausted.attempt = new_attempt;
+            return Ok(Some(FailOutcome::Exhausted {
+                item: Box::new(exhausted),
+            }));
+        }
+
+        // Retryable — same exponential backoff the reclaimer applies.
+        let backoff_secs = 1u64 << new_attempt.min(6);
+        let retry_after =
+            (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
+        let rows = sqlx::query(
+            "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
+             retry_after = ?, lease_epoch = lease_epoch + 1 \
+             WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(new_attempt as i64)
+        .bind(&retry_after)
+        .bind(&id_str)
+        .bind(lease_fence)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        if rows == 0 {
+            return Ok(None);
+        }
+
+        tx.commit().await.map_err(map_db_err)?;
+        let mut retried = item;
+        retried.attempt = new_attempt;
+        Ok(Some(FailOutcome::Retryable {
+            item: Box::new(retried),
+            delay_ms: backoff_secs * 1000,
+        }))
     }
 
     #[instrument(skip(self), fields(item_id = %item_id, fence = lease_fence))]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -6,8 +6,8 @@
 //! that item's execution.
 
 use crate::backend::{
-    ApiToken, BackendResult, ReclaimResult, StateBackend, StateBackendError, WorkItem, WorkItemId,
-    WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
+    WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -1038,6 +1038,119 @@ impl StateBackend for TenantScopedSqliteBackend {
         .map_err(map_db_err)?
         .rows_affected();
         Ok(rows_affected > 0)
+    }
+
+    #[instrument(skip(self, error), fields(tenant = %self.tenant_id, item_id = %item_id, fence = lease_fence))]
+    async fn fail_work_item_fenced(
+        &self,
+        item_id: WorkItemId,
+        lease_fence: i64,
+        error: &str,
+    ) -> BackendResult<Option<FailOutcome>> {
+        let id_str = item_id.to_string();
+
+        // BEGIN IMMEDIATE: read-decide-write in one write transaction, so a
+        // concurrent reclaim cannot land between the attempt count we read and the
+        // settle we base on it. See the untenanted backend for the full note.
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(map_db_err)?;
+
+        // `tenant_id` is on every statement below, not just the read: a scoped
+        // backend must never settle another tenant's item even if an id and fence
+        // were somehow guessed.
+        let Some(row) = sqlx::query(
+            "SELECT * FROM work_items \
+             WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(&id_str)
+        .bind(&self.tenant_id.0)
+        .bind(lease_fence)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        else {
+            return Ok(None);
+        };
+
+        let item = row_to_work_item(&row)?;
+        let new_attempt = item.attempt + 1;
+
+        if new_attempt >= item.max_attempts {
+            let dead_lettered_at = Utc::now().to_rfc3339();
+            let rows = sqlx::query(
+                "UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL \
+                 WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
+            )
+            .bind(new_attempt as i64)
+            .bind(&id_str)
+            .bind(&self.tenant_id.0)
+            .bind(lease_fence)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?
+            .rows_affected();
+            if rows == 0 {
+                return Ok(None);
+            }
+
+            sqlx::query(
+                r#"INSERT OR IGNORE INTO dead_letter_items
+                   (id, execution_id, node_id, queue_type, payload_json, attempt, last_error, created_at, dead_lettered_at, tenant_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+            )
+            .bind(&id_str)
+            .bind(item.execution_id.to_string())
+            .bind(&item.node_id)
+            .bind(&item.queue_type)
+            .bind(serde_json::to_string(&item.payload)?)
+            .bind(new_attempt as i64)
+            .bind(error)
+            .bind(item.created_at.to_rfc3339())
+            .bind(dead_lettered_at)
+            .bind(&self.tenant_id.0)
+            .execute(&mut *tx)
+            .await
+            .map_err(map_db_err)?;
+
+            tx.commit().await.map_err(map_db_err)?;
+            let mut exhausted = item;
+            exhausted.attempt = new_attempt;
+            return Ok(Some(FailOutcome::Exhausted {
+                item: Box::new(exhausted),
+            }));
+        }
+
+        let backoff_secs = 1u64 << new_attempt.min(6);
+        let retry_after =
+            (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
+        let rows = sqlx::query(
+            "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
+             retry_after = ?, lease_epoch = lease_epoch + 1 \
+             WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
+        )
+        .bind(new_attempt as i64)
+        .bind(&retry_after)
+        .bind(&id_str)
+        .bind(&self.tenant_id.0)
+        .bind(lease_fence)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+        if rows == 0 {
+            return Ok(None);
+        }
+
+        tx.commit().await.map_err(map_db_err)?;
+        let mut retried = item;
+        retried.attempt = new_attempt;
+        Ok(Some(FailOutcome::Retryable {
+            item: Box::new(retried),
+            delay_ms: backoff_secs * 1000,
+        }))
     }
 
     #[instrument(skip(self, error), fields(tenant = %self.tenant_id, item_id = %item_id))]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1102,7 +1102,11 @@ impl StateBackend for TenantScopedSqliteBackend {
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
             )
             .bind(&id_str)
-            .bind(item.execution_id.to_string())
+            // `execution_id_str`, NOT `to_string()`: Display formats an
+            // ExecutionId as `exec_<simple>`, while every execution_id column
+            // stores the bare UUID. Display here would write a dead-letter row
+            // that joins to nothing and hides the item from per-execution queries.
+            .bind(execution_id_str(&item.execution_id))
             .bind(&item.node_id)
             .bind(&item.queue_type)
             .bind(serde_json::to_string(&item.payload)?)

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -366,3 +366,142 @@ async fn tokens_carry_tenant_id() {
     let validated = scoped.validate_token(&plaintext).await.unwrap().unwrap();
     assert_eq!(validated.tenant_id, "acme");
 }
+
+// ── Fenced failure, tenant-scoped ────────────────────────────────────────────
+
+/// The tenant-scoped dead-letter row must store the execution id in the SAME
+/// format every other row uses: the bare UUID from `execution_id_str`, not
+/// `ExecutionId`'s `Display`, which renders `exec_<simple>`.
+///
+/// Getting this wrong is silent. The insert succeeds, the item is correctly
+/// dead-lettered, and every assertion about status passes — but the row joins to
+/// nothing, so an operator listing an execution's dead-lettered work finds an
+/// empty result and concludes nothing failed. Caught in review on #118, which is
+/// why the assertion is on the STORED STRING rather than on a round-trip that
+/// would format both sides the same way and agree with itself.
+#[tokio::test]
+async fn scoped_dead_letter_stores_the_bare_execution_uuid() {
+    let db = open_test_db().await;
+    register_tenant(&db, "alpha", "Alpha").await;
+    let tenant = db.for_tenant(TenantId::from("alpha"));
+
+    let exec = sample_execution("wf-dl");
+    let execution_id = exec.execution_id.clone();
+    tenant.create_execution(exec).await.unwrap();
+
+    let item_id = uuid::Uuid::new_v4();
+    tenant
+        .enqueue_work_item(jamjet_state::WorkItem {
+            id: item_id,
+            execution_id: execution_id.clone(),
+            node_id: "node-dl".to_string(),
+            queue_type: "general".to_string(),
+            payload: json!({}),
+            // One attempt short of the cap, so failing it exhausts the budget
+            // and takes the dead-letter branch.
+            attempt: 2,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "alpha".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let claimed = tenant
+        .claim_work_item("worker-dl", &["general"])
+        .await
+        .unwrap()
+        .expect("the item must be claimable");
+
+    let outcome = tenant
+        .fail_work_item_fenced(item_id, claimed.lease_fence, "tool exploded")
+        .await
+        .unwrap()
+        .expect("a matching fence must settle the item");
+    assert!(
+        matches!(
+            outcome,
+            jamjet_state::backend::FailOutcome::Exhausted { .. }
+        ),
+        "attempt 3 of 3 is spent, so this must dead-letter"
+    );
+
+    let stored: String =
+        sqlx::query_scalar("SELECT execution_id FROM dead_letter_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .expect("the dead-letter row must exist");
+
+    assert_eq!(
+        stored,
+        execution_id.0.to_string(),
+        "the dead-letter row must store the bare UUID, like every other \
+         execution_id column; Display would write exec_<simple> and join to nothing"
+    );
+    assert_ne!(
+        stored,
+        execution_id.to_string(),
+        "Display is the wrong format here — this assertion is the regression guard"
+    );
+}
+
+/// A tenant must not be able to fail another tenant's work item, even holding a
+/// correct id and fence.
+#[tokio::test]
+async fn scoped_fail_cannot_reach_another_tenants_item() {
+    let db = open_test_db().await;
+    register_tenant(&db, "alpha", "Alpha").await;
+    register_tenant(&db, "beta", "Beta").await;
+    let tenant_a = db.for_tenant(TenantId::from("alpha"));
+    let tenant_b = db.for_tenant(TenantId::from("beta"));
+
+    let exec = sample_execution("wf-x");
+    let execution_id = exec.execution_id.clone();
+    tenant_a.create_execution(exec).await.unwrap();
+
+    let item_id = uuid::Uuid::new_v4();
+    tenant_a
+        .enqueue_work_item(jamjet_state::WorkItem {
+            id: item_id,
+            execution_id,
+            node_id: "node-x".to_string(),
+            queue_type: "general".to_string(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "alpha".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let claimed = tenant_a
+        .claim_work_item("worker-a", &["general"])
+        .await
+        .unwrap()
+        .expect("claimable");
+
+    // Beta knows the id and the real fence and still cannot touch it.
+    let cross = tenant_b
+        .fail_work_item_fenced(item_id, claimed.lease_fence, "not yours")
+        .await
+        .unwrap();
+    assert!(
+        cross.is_none(),
+        "a scoped backend must never settle another tenant's item"
+    );
+
+    // Alpha still can, which proves the refusal was tenancy and not a bad fence.
+    assert!(tenant_a
+        .fail_work_item_fenced(item_id, claimed.lease_fence, "mine")
+        .await
+        .unwrap()
+        .is_some());
+}

--- a/runtime/workers/src/dispatch_guard.rs
+++ b/runtime/workers/src/dispatch_guard.rs
@@ -947,6 +947,18 @@ mod tests {
             self.inner.fail_work_item(item_id, error).await
         }
 
+        async fn fail_work_item_fenced(
+            &self,
+            item_id: jamjet_state::backend::WorkItemId,
+            lease_fence: i64,
+            error: &str,
+        ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::FailOutcome>>
+        {
+            self.inner
+                .fail_work_item_fenced(item_id, lease_fence, error)
+                .await
+        }
+
         async fn commit_turn(
             &self,
             item_id: jamjet_state::backend::WorkItemId,

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1883,7 +1883,21 @@ async def _worker_loop(
                 console.print(f"[green]Completed[/green] id={item_id} node=[bold]{node_id}[/bold] {duration_ms}ms")
             except Exception as exc:
                 console.print(f"[red]Failed[/red] node={node_id}: {exc}")
-                await client.fail_work_item(item_id, str(exc))
+                try:
+                    # Echo the fence here for the same reason completion does: it
+                    # proves the lease is still ours. It also buys the retry and
+                    # dead-letter semantics — without it the runtime settles the
+                    # item, emits no NodeFailed, and the execution never finishes.
+                    await client.fail_work_item(item_id, str(exc), lease_fence=lease_fence)
+                except Exception as fail_exc:
+                    # 409: the lease was reclaimed while this node was failing, so
+                    # a new claimant owns the item. Reporting our failure would
+                    # kill work that is currently running under a newer fence.
+                    status = getattr(getattr(fail_exc, "response", None), "status_code", None)
+                    if status == 409:
+                        console.print(f"[yellow]Failure report rejected; lease lost[/yellow] id={item_id}")
+                    else:
+                        raise
             finally:
                 hb_task.cancel()
 

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -321,7 +321,7 @@ class JamjetClient:
         """Report that this work item's node failed.
 
         Echo ``lease_fence`` from the claim. With it, the runtime applies the
-        same retry / backoff / dead-letter rules a expired lease gets, and
+        same retry / backoff / dead-letter rules an expired lease gets, and
         appends ``NodeFailed`` so the execution can actually reach a terminal
         state. Without it the runtime takes the legacy path, which settles the
         item but emits nothing — leaving the node scheduled forever.

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -317,11 +317,24 @@ class JamjetClient:
         )
         r.raise_for_status()
 
-    async def fail_work_item(self, item_id: str, error: str) -> None:
-        """Mark a work item as failed."""
+    async def fail_work_item(self, item_id: str, error: str, lease_fence: int = 0) -> None:
+        """Report that this work item's node failed.
+
+        Echo ``lease_fence`` from the claim. With it, the runtime applies the
+        same retry / backoff / dead-letter rules a expired lease gets, and
+        appends ``NodeFailed`` so the execution can actually reach a terminal
+        state. Without it the runtime takes the legacy path, which settles the
+        item but emits nothing — leaving the node scheduled forever.
+
+        A 409 means the fence no longer matches: another worker owns this item,
+        and this one must not narrate its failure.
+        """
+        body: dict[str, Any] = {"error": error}
+        if lease_fence:
+            body["lease_fence"] = lease_fence
         r = await self._client.post(
             f"/work-items/{item_id}/fail",
-            json={"error": error},
+            json=body,
         )
         r.raise_for_status()
 

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -92,8 +92,8 @@ class _StubClient:
             }
         )
 
-    async def fail_work_item(self, item_id: str, error: str) -> None:
-        self.fail_calls.append({"item_id": item_id, "error": error})
+    async def fail_work_item(self, item_id: str, error: str, lease_fence: int = 0) -> None:
+        self.fail_calls.append({"item_id": item_id, "error": error, "lease_fence": lease_fence})
 
     async def heartbeat_work_item(self, item_id: str, worker_id: str, lease_fence: int = 0) -> None:
         self.heartbeat_calls.append({"item_id": item_id, "lease_fence": lease_fence})
@@ -208,6 +208,24 @@ async def test_worker_posts_fail_on_handler_exception() -> None:
     assert call["item_id"] == "wi-002"
     assert "intentional failure" in call["error"]
     assert len(stub.complete_calls) == 0, "complete must not be called on failure"
+
+
+async def test_worker_echoes_lease_fence_on_fail() -> None:
+    """The fence is echoed on FAILURE too, not just on completion.
+
+    Without it the runtime takes its legacy path: the item is settled but no
+    NodeFailed is appended, so the node stays scheduled and the execution never
+    reaches a terminal state. Echoing the fence is what buys retry, backoff and
+    dead-letter semantics for a tool that raised.
+    """
+    boom_fenced = dict(_BOOM_ITEM, id="wi-007", lease_fence=4_294_967_297)
+    stub = _StubClient(claimed_item=boom_fenced)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.fail_calls) == 1
+    assert stub.fail_calls[0]["lease_fence"] == 4_294_967_297, (
+        "the claim's fence must reach /fail, or the runtime cannot tell this worker still owns the item"
+    )
 
 
 async def test_worker_once_empty_queue_is_noop() -> None:


### PR DESCRIPTION
Closes the "external worker tier failure path is a black hole" finding from the 2026-07-02 ADK review — the one it escalates from non-blocking to **blocking for this tier**.

> **Stacked on #114.** Base is `fix/adk-tool-policy-enforcement`, so this diff shows only the failure-path commit. Merge #114 first and this retargets to `main` cleanly.

## The defect

`POST /work-items/:id/fail` was one unfenced `fail_work_item` call:

```rust
backend.fail_work_item(item_id, &body.error).await?;
Ok(Json(json!({ "failed": true, "work_item_id": id })))
```

That writes `status = 'failed'` and appends nothing. `'failed'` occurs exactly twice in `sqlite.rs` — once to SET it, once inside a `NOT IN` exclusion — and is never SELECTed by any sweep. So:

- no `NodeFailed`, therefore the scheduler fold keeps the node in `scheduled` and the execution stays `Running` forever;
- no reclaim path, therefore the item is unrecoverable;
- no fence, therefore any caller holding an item id could settle work it does not own.

Every legitimate Python or Java tool failure permanently wedged its workflow. The trait doc said "The scheduler will decide whether to retry", describing a decision nothing was positioned to make.

This is also what made #114's claim-route policy block stall an execution rather than end it — that PR documented it as a known limit and deferred it here.

## The fix

`fail_work_item_fenced` is the failure counterpart of `complete_work_item_fenced` and the per-item counterpart of `reclaim_expired_leases`. It applies the **same** attempt, backoff and dead-letter rules an expired lease gets, so a worker that reports a failure and a worker that dies holding the item converge on identical state and identical events — the fold cannot tell them apart, which is the point.

It returns `Ok(None)`, never an error, on a fence mismatch or a no-longer-claimed item, matching the completion path: a reclaimed or replayed worker can neither settle the item nor narrate its failure.

Implemented on all three backends. SQLite and tenant-scoped do the read, the decision and the settle in one `BEGIN IMMEDIATE` transaction, with the fence and status guard repeated on **every** write, so a concurrent reclaim cannot land between the attempt count read and the settle based on it. The dead-letter insert runs only after the settle actually lands, so a refused failure leaves no orphan row. The tenant-scoped variant carries `tenant_id` on every statement, not just the read.

The route then emits exactly what the reclaimer emits: `NodeFailed{retryable:true}` + `RetryScheduled` while attempts remain, `NodeFailed{retryable:false}` when spent.

## The legacy path is preserved, and stays eventless on purpose

An absent `lease_fence` still settles the item, so callers that predate the fence keep working. It deliberately does **not** get the new event emission: without a fence we cannot show the item was ours, and emitting a terminal event for an item another worker may now hold is worse than the stranding. The response now carries a warning naming `lease_fence` as the fix.

## Worker

The Python worker echoes the fence on failure, mirroring what it already did on completion, and treats a 409 the same way — the lease was reclaimed, so this worker stays quiet rather than killing work a newer claimant is running.

## Verification

Nine new route tests. Six run in-memory; **three run against the real SQLite backend**, because `'pending'` vs `'dead_lettered'` is observable nowhere else, and memory-only coverage is exactly how the SQLite-vs-memory divergence class hides (review finding 2 in the same section).

Covered: `NodeFailed` + `RetryScheduled` on a retryable failure; dead-letter with no retry on the final attempt; a stale fence refused with nothing written; a forged `lease_fence: 0` refused against a claimed item; a replayed failure emitting exactly one `NodeFailed`; the legacy path settling but warning; and the three durable status transitions.

Rust 777 passed / 0 failed. Python 1446 passed.

## Not in this change

- **The Java worker has the same gap.** `JamjetEngineClient.java` posts `{error}` with no fence, so it still takes the legacy stranding path. It lives in the separate `jamjet-runtime-java` repo and needs its own PR; the engine change is backward-compatible either way, so ordering is not load-bearing.
- `/complete`'s remaining review items — the unfenced legacy fallback, its three disjoint transactions, and the missing idempotency keys — are untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Work-item failure reporting now validates lease ownership to prevent stale workers from overwriting newer claims.
  - Failed items can automatically retry with backoff or move to the dead-letter queue after exhausting attempts.
  - Failure responses include retry status and attempt information.
  - Successful failures emit workflow events for failure and scheduled retries.

- **Bug Fixes**
  - Stale or invalid lease submissions are rejected with a conflict response.
  - Python workers now forward lease information and safely handle reclaimed work items.
  - Legacy failure requests remain supported with a deprecation warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->