### PR TITLE
fix(state): consume attempts on claim-side lease expiry, guard the reclaim writes

### DIFF
--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -955,10 +955,27 @@ impl StateBackend for SqliteBackend {
 
         // Expire stale leases first; bump lease_epoch so a re-claim mints a
         // strictly greater fence than the zombie worker's stale token.
+        //
+        // `attempt + 1` matters as much as the epoch. This reset races the
+        // scheduler's reclaim sweep — the only OTHER place attempts increment —
+        // and normally wins, because it runs on every claim poll while the sweep
+        // runs on an interval. Without the increment, a node that reliably kills
+        // its worker is resurrected forever at attempt 0: max_attempts is never
+        // reached, the dead-letter queue never sees it, and the loop is
+        // unbounded.
+        //
+        // `attempt + 1 < max_attempts` then stops this fast path from
+        // resurrecting an item that has spent its budget. Such an item keeps
+        // `status = 'claimed'` with an expired lease, which is precisely what the
+        // reclaim sweep selects — so it dead-letters there, WITH the NodeFailed
+        // the sweep emits and this path cannot. The division is deliberate: the
+        // claim path handles the retryable case cheaply, the sweep owns anything
+        // terminal, because only the sweep's caller writes events.
         let now = Utc::now().to_rfc3339();
         sqlx::query(
-            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, lease_epoch = lease_epoch + 1 \
-             WHERE status = 'claimed' AND lease_expires_at < ?",
+            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, \
+             lease_epoch = lease_epoch + 1, attempt = attempt + 1 \
+             WHERE status = 'claimed' AND lease_expires_at < ? AND attempt + 1 < max_attempts",
         )
         .bind(&now)
         .execute(&self.pool)
@@ -1492,7 +1509,33 @@ impl StateBackend for SqliteBackend {
             let id_str = item.id.to_string();
 
             if new_attempt >= item.max_attempts {
-                // Exhausted — move to dead-letter (caller emits the event)
+                // Settle FIRST, guarded, then record. `AND status = 'claimed'`
+                // is what makes this safe: the SELECT above ran in its own
+                // statement, so a worker can settle between the two, and an
+                // unguarded UPDATE would flip a COMPLETED item back into the
+                // queue — re-claimed, re-run at a shifted step ordinal, so a
+                // different idempotency key, so the side effect fires twice.
+                // The guard turns that race into a no-op: zero rows, item stays
+                // settled. Doing the settle before the dead-letter insert is
+                // what keeps a lost race from leaving an orphan row describing
+                // a node that actually succeeded.
+                let rows = sqlx::query(
+                    "UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL \
+                     WHERE id = ? AND status = 'claimed'",
+                )
+                .bind(new_attempt as i64)
+                .bind(&id_str)
+                .execute(&self.pool)
+                .await
+                .map_err(map_db_err)?
+                .rows_affected();
+                if rows == 0 {
+                    // Settled under us. Do NOT report it: the caller emits
+                    // NodeFailed from this list, and a terminal event for a node
+                    // that actually completed is worse than a missed sweep.
+                    continue;
+                }
+
                 let dead_lettered_at = Utc::now().to_rfc3339();
                 sqlx::query(
                     r#"INSERT OR IGNORE INTO dead_letter_items
@@ -1512,13 +1555,6 @@ impl StateBackend for SqliteBackend {
                 .await
                 .map_err(map_db_err)?;
 
-                sqlx::query("UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL WHERE id = ?")
-                    .bind(new_attempt as i64)
-                    .bind(&id_str)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(map_db_err)?;
-
                 let mut exhausted_item = item;
                 exhausted_item.attempt = new_attempt;
                 result.exhausted.push(exhausted_item);
@@ -1529,15 +1565,25 @@ impl StateBackend for SqliteBackend {
                 let retry_after =
                     (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
 
-                sqlx::query(
-                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ?, lease_epoch = lease_epoch + 1 WHERE id = ?",
+                // Same `status = 'claimed'` guard as the exhausted branch, and
+                // for the sharper reason: requeueing a COMPLETED item is exactly
+                // the double-execution path — it goes straight back on the queue
+                // and runs its side effect again.
+                let rows = sqlx::query(
+                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
+                     retry_after = ?, lease_epoch = lease_epoch + 1 \
+                     WHERE id = ? AND status = 'claimed'",
                 )
                 .bind(new_attempt as i64)
                 .bind(&retry_after)
                 .bind(&id_str)
                 .execute(&self.pool)
                 .await
-                .map_err(map_db_err)?;
+                .map_err(map_db_err)?
+                .rows_affected();
+                if rows == 0 {
+                    continue;
+                }
 
                 let mut retry_item = item;
                 retry_item.attempt = new_attempt;

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -722,3 +722,170 @@ async fn set_store_term_at_least_monotonic_in_memory() {
     assert_eq!(db.set_store_term_at_least(4), 7); // lower is a no-op
     assert_eq!(db.set_store_term_at_least(9), 9);
 }
+
+// ── Work-item lifecycle: attempts and the reclaim race ───────────────────────
+
+/// A node that reliably kills its worker must EXHAUST its attempts, not loop.
+///
+/// `claim_work_item` expires stale leases itself, and that fast path races the
+/// scheduler's reclaim sweep — the only other place attempts increment — and
+/// normally wins, because it runs on every poll while the sweep runs on an
+/// interval. When it reset the item without incrementing, the item came back at
+/// attempt 0 forever: max_attempts unreachable, dead-letter never entered, loop
+/// unbounded. This walks the exact loop and asserts it terminates.
+#[tokio::test]
+async fn claim_side_lease_expiry_consumes_attempts() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    let mut item = sample_item(&eid);
+    item.max_attempts = 3;
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    // Attempt 0: claim, then die without settling.
+    let first = db
+        .claim_work_item("worker-dies", &["model"])
+        .await
+        .unwrap()
+        .expect("first claim");
+    assert_eq!(first.attempt, 0);
+    db.force_lease_expired_for_test(item_id).await.unwrap();
+
+    // Attempt 1: the claim-side expiry must have consumed an attempt.
+    let second = db
+        .claim_work_item("worker-dies", &["model"])
+        .await
+        .unwrap()
+        .expect("second claim");
+    assert_eq!(
+        second.attempt, 1,
+        "the claim-side lease expiry must consume an attempt, or the node loops forever"
+    );
+    db.force_lease_expired_for_test(item_id).await.unwrap();
+
+    // Attempt 2 is the last one under max_attempts = 3.
+    let third = db
+        .claim_work_item("worker-dies", &["model"])
+        .await
+        .unwrap()
+        .expect("third claim");
+    assert_eq!(third.attempt, 2);
+    db.force_lease_expired_for_test(item_id).await.unwrap();
+
+    // Budget spent: the fast path must NOT resurrect it. The item stays
+    // 'claimed' with an expired lease, which is exactly what the reclaim sweep
+    // selects — so the sweep dead-letters it, WITH the NodeFailed only the
+    // sweep's caller can emit.
+    let fourth = db.claim_work_item("worker-dies", &["model"]).await.unwrap();
+    assert!(
+        fourth.is_none(),
+        "an item that has spent its attempts must not be handed out again"
+    );
+
+    let reclaimed = db.reclaim_expired_leases().await.unwrap();
+    assert_eq!(
+        reclaimed.exhausted.len(),
+        1,
+        "the sweep must dead-letter it so a NodeFailed is emitted"
+    );
+    assert!(reclaimed.retryable.is_empty());
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The reclaim sweep must never resurrect an item settled under it.
+///
+/// The sweep does ONE SELECT for every expired item, then UPDATEs them one at a
+/// time. A worker that commits inside that loop used to have its COMPLETED item
+/// flipped back to pending by an unguarded `WHERE id = ?`, then re-claimed and
+/// re-run at a shifted step ordinal — a different idempotency key, so the replay
+/// guard did not catch it and the side effect fired twice.
+///
+/// Opening the window deterministically takes volume: a settle done BEFORE the
+/// call also changes `status`, which the sweep\'s own SELECT then filters out, so
+/// nothing races. With many expired items the update loop is long enough for a
+/// concurrent settle to land inside it, against a row the SELECT already
+/// captured. Verified to fail against the unguarded UPDATE before being kept.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reclaim_cannot_resurrect_an_item_settled_under_it() {
+    const ITEMS: usize = 400;
+
+    let path = temp_db_path();
+    let db = std::sync::Arc::new(open_db(&path).await);
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+
+    // Every item is expired and claimed, so the sweep captures all of them.
+    let mut ids = Vec::with_capacity(ITEMS);
+    for _ in 0..ITEMS {
+        let item = sample_item(&eid);
+        let id = item.id;
+        db.enqueue_work_item(item).await.unwrap();
+        ids.push(id);
+    }
+    let mut fences = Vec::with_capacity(ITEMS);
+    for _ in 0..ITEMS {
+        let c = db
+            .claim_work_item("worker-slow", &["model"])
+            .await
+            .unwrap()
+            .expect("claim");
+        fences.push((c.id, c.lease_fence));
+        db.force_lease_expired_for_test(c.id).await.unwrap();
+    }
+
+    // Settle the LAST items the sweep will reach, while it is still working
+    // through the earlier ones.
+    let victims: Vec<(uuid::Uuid, i64)> = fences.iter().rev().take(40).copied().collect();
+    let settler = {
+        let db = db.clone();
+        let victims = victims.clone();
+        tokio::spawn(async move {
+            let mut settled = Vec::new();
+            for (id, fence) in victims {
+                if db.complete_work_item_fenced(id, fence).await.unwrap() {
+                    settled.push(id);
+                }
+            }
+            settled
+        })
+    };
+
+    let reclaimed = db.reclaim_expired_leases().await.unwrap();
+    let settled = settler.await.unwrap();
+
+    // Whatever the interleaving, an item whose completion won its fence is
+    // finished: it must not be back in the queue, and must not be reported as
+    // reclaimed, because the caller emits NodeFailed from those lists.
+    let reported: std::collections::HashSet<uuid::Uuid> = reclaimed
+        .retryable
+        .iter()
+        .chain(reclaimed.exhausted.iter())
+        .map(|i| i.id)
+        .collect();
+    for id in &settled {
+        assert!(
+            !reported.contains(id),
+            "a COMPLETED item was reported as reclaimed ({id}) — its node \
+             succeeded, and the caller will now emit NodeFailed for it"
+        );
+        let status: String = sqlx::query_scalar("SELECT status FROM work_items WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "completed",
+            "a COMPLETED item was resurrected to {status:?} ({id}) — it will be \
+             re-claimed and fire its side effect a second time"
+        );
+    }
+    assert!(
+        !settled.is_empty(),
+        "the race never opened; the test proved nothing"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
Two work-item lifecycle bugs from the engine-seam section of the 2026-07-02 ADK review (findings 2 and 3). Both are in the SQLite backend, both can run a side effect more than once, and both are independent of #114/#118 — this branches off `main` so CI and CodeRabbit run for real.

## 1. Claim-side lease expiry never consumed an attempt

`claim_work_item` expires stale leases itself before claiming:

```sql
UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL,
       lease_epoch = lease_epoch + 1
 WHERE status = 'claimed' AND lease_expires_at < ?
```

`lease_epoch` is bumped; `attempt` is not. That fast path races the scheduler's reclaim sweep — the only *other* place attempts increment — and normally wins, because it runs on every claim poll while the sweep runs on an interval.

So a node that reliably kills its worker was resurrected forever at attempt 0. `max_attempts` was unreachable, the dead-letter queue never saw it, and the loop was unbounded.

It now increments, and stops resurrecting an item whose budget is spent (`AND attempt + 1 < max_attempts`). Such an item keeps `status = 'claimed'` with an expired lease, which is exactly what the reclaim sweep selects — so it dead-letters there, **with** the `NodeFailed` that only the sweep's caller emits. The division is deliberate: the claim path takes the cheap retryable case, anything terminal belongs to the sweep, because only the sweep writes events.

## 2. The reclaim sweep could resurrect an item settled under it

The sweep does one SELECT for every expired item, then UPDATEs them one at a time — and both updates keyed on `WHERE id = ?` alone. A worker committing inside that loop had its **completed** item flipped back to `pending`, re-claimed, and re-run at a shifted step ordinal. Different step ordinal means a different idempotency key, so the replay guard did not catch it and the side effect fired a second time.

Both updates now carry `AND status = 'claimed'` and `continue` when they match nothing, so the race becomes a no-op and the item stays settled. The dead-letter branch was also reordered to settle **before** it records, so a lost race cannot leave an orphan dead-letter row describing a node that actually succeeded.

## On the tests

Both were verified to **fail against the old code** before being kept — that check is the point of including them.

The race test is worth a note, because my first version was a false guard: it settled the item, then called the sweep, and passed against the bug. It had to. A settle done *before* the call also changes `status`, which the sweep's own SELECT then filters out, so the race never opens. A plain `tokio::join!` of settle-and-sweep passed against the bug too.

What works is volume. With 400 expired items the update loop is long enough for a concurrent settle to land inside it, against a row the SELECT already captured. The test also asserts the race actually opened (`!settled.is_empty()`), so it cannot silently degrade back into proving nothing. Stable across 8 consecutive runs.

## Verification

`cargo test --workspace` — 655 passed, 0 failed. `cargo fmt --all --check` clean.

## Still open in the same section

Findings 4, 5 and 6 are untouched: reserve-before-fire (spec Move 4b) was never implemented; the approval hold settles unfenced; a zombie unfenced `NodeStarted` can wedge completion detection.
