### PR TITLE
fix(sdk): stop swallowing an explicitly requested $1.00 cost ceiling

### DIFF
--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -51,6 +51,12 @@ if TYPE_CHECKING:
 _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "limit_exceeded"})
 # How often run_durable polls get_execution while waiting for a terminal state.
 _POLL_INTERVAL_SECONDS = 0.5
+# StrategyLimits requires a concrete cost figure and validates it > 0, so an
+# omitted ``max_cost_usd`` still needs one for the strategy runners' iteration
+# budget. This is ONLY that placeholder — it is deliberately not folded into
+# GovernanceConfig.budget, so omitting the argument still means "no enforced
+# ceiling", exactly as before.
+_DEFAULT_STRATEGY_MAX_COST_USD = 1.0
 
 
 class Agent:
@@ -73,7 +79,12 @@ class Agent:
         instructions: str = "",
         strategy: str = "plan-and-execute",
         max_iterations: int = 10,
-        max_cost_usd: float = 1.0,
+        # None, not 1.0. The old default doubled as the "not set" sentinel — the
+        # budget was folded in only when the value differed from 1.0 — so a caller
+        # who explicitly asked for a $1.00 ceiling got NO ceiling, silently, which
+        # is the one number a reader of the old signature was most likely to type.
+        # `None` cannot collide with a ceiling anyone means.
+        max_cost_usd: float | None = None,
         timeout_seconds: int = 300,
         on_limit_exceeded: Callable[[str | None, str, Any, Any], str | None] | None = None,
         # Governance knobs (T3-1).  T3-2..6 read self.governance to enforce.
@@ -142,7 +153,10 @@ class Agent:
 
         self.limits = StrategyLimits(
             max_iterations=max_iterations,
-            max_cost_usd=max_cost_usd,
+            # StrategyLimits requires a concrete float (it validates > 0), and the
+            # strategy runners' iteration budget has always used 1.0 when nothing
+            # was passed. Keep that; only the GOVERNANCE fold below changes.
+            max_cost_usd=(_DEFAULT_STRATEGY_MAX_COST_USD if max_cost_usd is None else max_cost_usd),
             timeout_seconds=timeout_seconds,
         )
 
@@ -157,8 +171,10 @@ class Agent:
         # the same ceiling without requiring callers to set both.  T3-2 will
         # reconcile and document the authoritative enforcement point.
         _effective_budget: Budget | float | int | dict | None = budget
-        if _effective_budget is None and max_cost_usd != 1.0:
-            # Non-default max_cost_usd -> carry it forward as the budget cap.
+        if _effective_budget is None and max_cost_usd is not None:
+            # Explicitly provided -> carry it forward as the budget cap. The test
+            # is `is not None`, never a comparison against the default: comparing
+            # against 1.0 is what made an explicit $1.00 ceiling vanish.
             _effective_budget = max_cost_usd
 
         self.governance: GovernanceConfig = normalize_governance(

--- a/sdk/python/jamjet/agents/task.py
+++ b/sdk/python/jamjet/agents/task.py
@@ -37,7 +37,11 @@ def task(
     tools: list[Callable[..., Any]] | None = None,
     strategy: str = "plan-and-execute",
     max_iterations: int = 10,
-    max_cost_usd: float = 1.0,
+    # Mirrors ``Agent``: None means "not set", so omitting it leaves no enforced
+    # ceiling. Defaulting to 1.0 here would forward an EXPLICIT 1.0 to Agent,
+    # which now honours explicit values — silently capping every @task agent at a
+    # dollar, a cap none of them had before.
+    max_cost_usd: float | None = None,
     timeout_seconds: int = 300,
 ) -> Any:
     """

--- a/sdk/python/jamjet/eval/runner.py
+++ b/sdk/python/jamjet/eval/runner.py
@@ -356,6 +356,11 @@ class AgentEvalRunner:
                 instructions=self.instructions,
                 strategy=strategy,
                 max_iterations=10,
+                # NOW LOAD-BEARING. This was written as a limit but silently did
+                # nothing, because 1.0 was also the "not set" sentinel. It is a
+                # real per-case ceiling now, which is what it always said. A
+                # single eval case sits well under a dollar; raise it here if a
+                # suite genuinely needs more, rather than removing the cap.
                 max_cost_usd=1.0,
                 timeout_seconds=int(self.timeout_s),
             )

--- a/sdk/python/tests/test_agent.py
+++ b/sdk/python/tests/test_agent.py
@@ -102,6 +102,34 @@ class TestAgent:
         assert agent.limits.max_cost_usd == 0.5
         assert agent.limits.timeout_seconds == 60
 
+    def test_explicit_one_dollar_ceiling_is_enforced(self):
+        """The old default (1.0) doubled as the "not set" sentinel.
+
+        The fold ran only when ``max_cost_usd != 1.0``, so a caller who
+        explicitly asked for a $1.00 ceiling got NO ceiling — silently, and for
+        the one figure a reader of the signature was most likely to copy. The
+        sentinel is ``None`` now, so an explicit value is always honoured.
+        """
+        agent = Agent("dollar", model="gpt-5.2", tools=[search], max_cost_usd=1.0)
+        assert agent.governance.budget is not None, (
+            "an explicitly requested $1.00 ceiling must be enforced, not swallowed by a sentinel collision"
+        )
+        assert agent.governance.budget.cost_usd == 1.0
+
+    def test_omitting_max_cost_usd_leaves_no_governance_ceiling(self):
+        """Omitting it still means no enforced ceiling — unchanged behaviour.
+
+        The strategy runners still get a concrete figure for their iteration
+        budget; only the governance fold is gated on the argument being given.
+        """
+        agent = Agent("nocap", model="gpt-5.2", tools=[search])
+        assert agent.governance.budget is None
+        assert agent.limits.max_cost_usd == 1.0
+
+    def test_budget_takes_precedence_over_max_cost_usd(self):
+        agent = Agent("both", model="gpt-5.2", tools=[search], max_cost_usd=5.0, budget=2.0)
+        assert agent.governance.budget.cost_usd == 2.0
+
 
 # ── @task tests ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes the review's "default `max_cost_usd=1.0` is a decoy" finding — the enforce-or-remove one. The site copy was corrected separately; this is the SDK half.

## The bug is sharper than "the default isn't enforced"

`Agent.__init__` took `max_cost_usd: float = 1.0`, and the governance fold ran only when the value **differed** from the default:

```python
if _effective_budget is None and max_cost_usd != 1.0:
    _effective_budget = max_cost_usd
```

So the default value was also the "not set" sentinel. Which means:

```python
Agent("x", model=..., tools=[...], max_cost_usd=1.0)   # -> governance.budget = None
```

A caller who **explicitly asked for a $1.00 ceiling got no ceiling at all**, silently — for the one figure a reader of the signature is most likely to copy, on the argument whose entire purpose is to bound spend. `5.0` and `0.5` worked fine; `1.0` was swallowed.

## The fix

The sentinel is `None`, so the fold keys on *was it given* rather than on a value comparison. Behaviour table:

| call | before | after |
|---|---|---|
| omitted | no ceiling | no ceiling (unchanged) |
| `max_cost_usd=1.0` | **no ceiling** | ceiling of $1.00 |
| `max_cost_usd=5.0` | ceiling of $5.00 | ceiling of $5.00 (unchanged) |
| `budget=2.0, max_cost_usd=5.0` | budget wins | budget wins (unchanged) |

`StrategyLimits` still receives a concrete figure, since it requires one and validates it `> 0` — only the governance fold changed.

## Two knock-ons, from checking every forwarding call site

**`@task` would have silently capped every task agent at a dollar.** It defaulted to `1.0` and forwarded it *explicitly*, so once `Agent` started honouring explicit values, every `@task` agent would have gained a $1.00 ceiling it never had. It now mirrors the `None` sentinel. Verified directly: a `@task` agent still has `governance.budget is None`.

**`eval/runner.py` is an intentional behaviour change.** It passes `max_cost_usd=1.0` deliberately, next to `max_iterations=10` and a timeout — clearly written as a limit, and inert until now. It is a real per-case ceiling from here, which is what the line always said. Marked load-bearing at the call site so a suite that needs more raises it rather than discovering it.

## Verification

Python: 1440 passed, 1 skipped. `ruff format --check` and `ruff check` clean. `mypy jamjet/cloud` reports the same 12 pre-existing errors before and after this change (compared against a clean tree).

Three new tests, including the explicit-$1.00 case that was the actual defect.
