### PR TITLE
fix(state): close the stale-fence park bypass, and apply #119 to the tenant-scoped backend

### DIFF
--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -974,7 +974,7 @@ impl StateBackend for SqliteBackend {
         let now = Utc::now().to_rfc3339();
         sqlx::query(
             "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, \
-             lease_epoch = lease_epoch + 1, attempt = attempt + 1 \
+             lease_epoch = lease_epoch + 1, lease_fence = 0, attempt = attempt + 1 \
              WHERE status = 'claimed' AND lease_expires_at < ? AND attempt + 1 < max_attempts",
         )
         .bind(&now)
@@ -1239,7 +1239,7 @@ impl StateBackend for SqliteBackend {
             (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
         let rows = sqlx::query(
             "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
-             retry_after = ?, lease_epoch = lease_epoch + 1 \
+             retry_after = ?, lease_epoch = lease_epoch + 1, lease_fence = 0 \
              WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
         )
         .bind(new_attempt as i64)
@@ -1280,7 +1280,7 @@ impl StateBackend for SqliteBackend {
             "UPDATE work_items \
              SET status = 'pending', retry_after = ?, attempt = ?, worker_id = NULL, \
                  lease_expires_at = NULL, lease_epoch = lease_epoch + 1, lease_fence = 0 \
-             WHERE id = ? AND lease_fence = ?",
+             WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
         )
         .bind(retry_after)
         .bind(next_attempt as i64)
@@ -1688,7 +1688,7 @@ impl StateBackend for SqliteBackend {
                 // and runs its side effect again.
                 let rows = sqlx::query(
                     "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
-                     retry_after = ?, lease_epoch = lease_epoch + 1 \
+                     retry_after = ?, lease_epoch = lease_epoch + 1, lease_fence = 0 \
                      WHERE id = ? AND status = 'claimed'",
                 )
                 .bind(new_attempt as i64)

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -887,8 +887,17 @@ impl StateBackend for TenantScopedSqliteBackend {
         // Expire stale leases for this tenant; bump lease_epoch so a re-claim
         // mints a strictly greater fence than any zombie worker's stale token.
         sqlx::query(
-            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, lease_epoch = lease_epoch + 1 \
-             WHERE status = 'claimed' AND lease_expires_at < ? AND tenant_id = ?",
+            // `attempt + 1` and the max_attempts bound mirror the untenanted
+            // backend: without the increment a node that reliably kills its
+            // worker is resurrected forever at attempt 0, because this fast path
+            // out-races the reclaim sweep that is the only other place attempts
+            // move. An item whose budget is spent stays 'claimed' with an expired
+            // lease, which is exactly what the sweep selects, so it dead-letters
+            // there WITH the NodeFailed only the sweep's caller emits.
+            "UPDATE work_items SET status = 'pending', worker_id = NULL, lease_expires_at = NULL, \
+             lease_epoch = lease_epoch + 1, lease_fence = 0, attempt = attempt + 1 \
+             WHERE status = 'claimed' AND lease_expires_at < ? AND tenant_id = ? \
+               AND attempt + 1 < max_attempts",
         )
         .bind(&now)
         .bind(&self.tenant_id.0)
@@ -1132,7 +1141,7 @@ impl StateBackend for TenantScopedSqliteBackend {
             (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
         let rows = sqlx::query(
             "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
-             retry_after = ?, lease_epoch = lease_epoch + 1 \
+             retry_after = ?, lease_epoch = lease_epoch + 1, lease_fence = 0 \
              WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
         )
         .bind(new_attempt as i64)
@@ -1192,7 +1201,7 @@ impl StateBackend for TenantScopedSqliteBackend {
             "UPDATE work_items \
              SET status = 'pending', retry_after = ?, attempt = ?, worker_id = NULL, \
                  lease_expires_at = NULL, lease_epoch = lease_epoch + 1, lease_fence = 0 \
-             WHERE id = ? AND lease_fence = ? AND tenant_id = ?",
+             WHERE id = ? AND lease_fence = ? AND tenant_id = ? AND status = 'claimed'",
         )
         .bind(retry_after)
         .bind(next_attempt as i64)
@@ -1548,6 +1557,35 @@ impl StateBackend for TenantScopedSqliteBackend {
 
             if new_attempt >= item.max_attempts {
                 let dead_lettered_at = Utc::now().to_rfc3339();
+                // Settle FIRST, guarded, then record — the same shape the
+                // untenanted backend uses. `AND status = 'claimed'` is what makes
+                // it safe: the SELECT above ran in its own statement, so a worker
+                // can settle between the two, and an unguarded UPDATE would flip
+                // a COMPLETED item back into the queue, where it is re-claimed and
+                // re-run at a shifted step ordinal — a different idempotency key,
+                // so the side effect fires twice. `tenant_id` belongs on the write
+                // as well as the read, so a scoped backend can never settle
+                // another tenant's row. Settling before the insert is what keeps a
+                // lost race from leaving an orphan dead-letter row describing a
+                // node that actually succeeded.
+                let rows = sqlx::query(
+                    "UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL \
+                     WHERE id = ? AND tenant_id = ? AND status = 'claimed'",
+                )
+                .bind(new_attempt as i64)
+                .bind(&id_str)
+                .bind(&self.tenant_id.0)
+                .execute(&self.pool)
+                .await
+                .map_err(map_db_err)?
+                .rows_affected();
+                if rows == 0 {
+                    // Settled under us. Do NOT report it: the caller emits
+                    // NodeFailed from this list, and a terminal event for a node
+                    // that actually completed is worse than a missed sweep.
+                    continue;
+                }
+
                 sqlx::query(
                     r#"INSERT OR IGNORE INTO dead_letter_items
                        (id, execution_id, node_id, queue_type, payload_json, attempt, last_error, created_at, dead_lettered_at, tenant_id)
@@ -1567,13 +1605,6 @@ impl StateBackend for TenantScopedSqliteBackend {
                 .await
                 .map_err(map_db_err)?;
 
-                sqlx::query("UPDATE work_items SET status = 'dead_lettered', attempt = ?, lease_expires_at = NULL, worker_id = NULL WHERE id = ?")
-                    .bind(new_attempt as i64)
-                    .bind(&id_str)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(map_db_err)?;
-
                 let mut exhausted_item = item;
                 exhausted_item.attempt = new_attempt;
                 result.exhausted.push(exhausted_item);
@@ -1582,15 +1613,27 @@ impl StateBackend for TenantScopedSqliteBackend {
                 let retry_after =
                     (Utc::now() + chrono::Duration::seconds(backoff_secs as i64)).to_rfc3339();
 
-                sqlx::query(
-                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, retry_after = ?, lease_epoch = lease_epoch + 1 WHERE id = ?",
+                // Same guards as the exhausted branch, and for the sharper
+                // reason: requeueing a COMPLETED item is exactly the
+                // double-execution path. `lease_fence = 0` clears the stale
+                // token so the worker that just lost this item cannot park over
+                // the requeued attempt.
+                let rows = sqlx::query(
+                    "UPDATE work_items SET status = 'pending', attempt = ?, worker_id = NULL, lease_expires_at = NULL, \
+                     retry_after = ?, lease_epoch = lease_epoch + 1, lease_fence = 0 \
+                     WHERE id = ? AND tenant_id = ? AND status = 'claimed'",
                 )
                 .bind(new_attempt as i64)
                 .bind(&retry_after)
                 .bind(&id_str)
+                .bind(&self.tenant_id.0)
                 .execute(&self.pool)
                 .await
-                .map_err(map_db_err)?;
+                .map_err(map_db_err)?
+                .rows_affected();
+                if rows == 0 {
+                    continue;
+                }
 
                 let mut retry_item = item;
                 retry_item.attempt = new_attempt;

--- a/runtime/state/tests/fencing.rs
+++ b/runtime/state/tests/fencing.rs
@@ -889,3 +889,83 @@ async fn reclaim_cannot_resurrect_an_item_settled_under_it() {
 
     let _ = std::fs::remove_file(&path);
 }
+
+// ── Stale fences after a requeue ─────────────────────────────────────────────
+
+/// A worker that just failed its item must not be able to park the requeue.
+///
+/// `fail_work_item_fenced`'s retryable branch puts the item back to `pending`.
+/// It used to leave `lease_fence` at the failing worker's value, and
+/// `park_work_item` matched on `id` + `lease_fence` with no status guard — so
+/// the worker that had just lost the item could park it, overwriting the
+/// `attempt` and `retry_after` of an attempt that is no longer its own.
+///
+/// Two independent guards now close it: the requeue clears the fence (as
+/// `park_work_item` itself always did), and park requires the item to still be
+/// claimed.
+#[tokio::test]
+async fn a_failed_worker_cannot_park_its_requeued_item() {
+    let path = temp_db_path();
+    let db = open_db(&path).await;
+    let eid = ExecutionId::new();
+    db.create_execution(sample_execution(&eid)).await.unwrap();
+    let item = sample_item(&eid);
+    let item_id = item.id;
+    db.enqueue_work_item(item).await.unwrap();
+
+    let claimed = db
+        .claim_work_item("worker-A", &["model"])
+        .await
+        .unwrap()
+        .expect("claim");
+
+    // The worker reports a failure; attempts remain, so the item is requeued.
+    let outcome = db
+        .fail_work_item_fenced(item_id, claimed.lease_fence, "boom")
+        .await
+        .unwrap()
+        .expect("the fence matched, so it settles");
+    assert!(matches!(
+        outcome,
+        jamjet_state::backend::FailOutcome::Retryable { .. }
+    ));
+
+    // Same worker, same (now stale) fence, tries to park what it no longer owns.
+    let parked = db
+        .park_work_item(
+            item_id,
+            claimed.lease_fence,
+            "2030-01-01T00:00:00+00:00",
+            99,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !parked,
+        "a worker that already failed this item must not park the requeue — it \
+         would overwrite the attempt and retry_after of an attempt that is not its own"
+    );
+
+    // And the requeued attempt is intact. Asserted on the row rather than by
+    // re-claiming: the retryable branch sets a backoff, so the item is
+    // deliberately NOT claimable yet, and a claim here would test the backoff
+    // instead of the clobber.
+    let (status, attempt, fence): (String, i64, i64) =
+        sqlx::query_as("SELECT status, attempt, lease_fence FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap();
+    assert_eq!(status, "pending", "the item is requeued");
+    assert_eq!(
+        attempt, 1,
+        "the failed attempt was consumed once — a successful park would have \
+         overwritten this with its own next_attempt"
+    );
+    assert_eq!(
+        fence, 0,
+        "the requeue must clear the stale fence, exactly as park_work_item does"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -505,3 +505,171 @@ async fn scoped_fail_cannot_reach_another_tenants_item() {
         .unwrap()
         .is_some());
 }
+
+// ── The tenant-scoped backend must match the untenanted one ──────────────────
+
+/// The tenant-scoped `reclaim_expired_leases` must not resurrect a settled item.
+///
+/// This is the same duplicate-execution bug fixed for the untenanted backend,
+/// which was fixed in ONE of the two copies: the scoped reclaim kept
+/// `WHERE id = ?` with no `status` guard and no `tenant_id` on the write. A
+/// worker committing inside the sweep's update loop had its COMPLETED item
+/// flipped back to pending, re-claimed, and re-run.
+///
+/// Needs volume for the same reason as its untenanted twin: a settle done
+/// BEFORE the call also changes `status`, which the sweep's own SELECT filters
+/// out, so nothing races. Verified to fail against the unguarded UPDATE.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn scoped_reclaim_cannot_resurrect_a_settled_item() {
+    const ITEMS: usize = 400;
+
+    let db = std::sync::Arc::new(open_test_db().await);
+    register_tenant(&db, "alpha", "Alpha").await;
+    let tenant = std::sync::Arc::new(db.for_tenant(TenantId::from("alpha")));
+
+    let exec = sample_execution("wf-race");
+    let execution_id = exec.execution_id.clone();
+    tenant.create_execution(exec).await.unwrap();
+
+    for _ in 0..ITEMS {
+        tenant
+            .enqueue_work_item(jamjet_state::WorkItem {
+                id: uuid::Uuid::new_v4(),
+                execution_id: execution_id.clone(),
+                node_id: "n1".to_string(),
+                queue_type: "general".to_string(),
+                payload: json!({}),
+                attempt: 0,
+                max_attempts: 3,
+                created_at: Utc::now(),
+                lease_expires_at: None,
+                worker_id: None,
+                lease_fence: 0,
+                tenant_id: "alpha".to_string(),
+            })
+            .await
+            .unwrap();
+    }
+
+    let mut claimed = Vec::with_capacity(ITEMS);
+    for _ in 0..ITEMS {
+        let c = tenant
+            .claim_work_item("worker-slow", &["general"])
+            .await
+            .unwrap()
+            .expect("claim");
+        claimed.push((c.id, c.lease_fence));
+    }
+    // Expire every lease so the sweep captures all of them.
+    sqlx::query("UPDATE work_items SET lease_expires_at = '2020-01-01T00:00:00+00:00'")
+        .execute(&db.pool())
+        .await
+        .unwrap();
+
+    // Settle the LAST items the sweep will reach, while it works through the rest.
+    let victims: Vec<(uuid::Uuid, i64)> = claimed.iter().rev().take(40).copied().collect();
+    let settler = {
+        let tenant = tenant.clone();
+        tokio::spawn(async move {
+            let mut settled = Vec::new();
+            for (id, fence) in victims {
+                if tenant.complete_work_item_fenced(id, fence).await.unwrap() {
+                    settled.push(id);
+                }
+            }
+            settled
+        })
+    };
+
+    let reclaimed = tenant.reclaim_expired_leases().await.unwrap();
+    let settled = settler.await.unwrap();
+
+    let reported: std::collections::HashSet<uuid::Uuid> = reclaimed
+        .retryable
+        .iter()
+        .chain(reclaimed.exhausted.iter())
+        .map(|i| i.id)
+        .collect();
+    for id in &settled {
+        assert!(
+            !reported.contains(id),
+            "a COMPLETED item was reported as reclaimed ({id}) — the caller will \
+             emit NodeFailed for a node that succeeded"
+        );
+        let status: String = sqlx::query_scalar("SELECT status FROM work_items WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_one(&db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            status, "completed",
+            "a COMPLETED item was resurrected to {status:?} ({id}) — it will re-run \
+             and fire its side effect twice"
+        );
+    }
+    assert!(
+        !settled.is_empty(),
+        "the race never opened; the test proved nothing"
+    );
+}
+
+/// The scoped claim path must consume attempts too, or a node that kills its
+/// worker loops forever — the same infinite-retry bug fixed for the untenanted
+/// backend, in the copy that was missed.
+#[tokio::test]
+async fn scoped_claim_side_expiry_consumes_attempts() {
+    let db = open_test_db().await;
+    register_tenant(&db, "alpha", "Alpha").await;
+    let tenant = db.for_tenant(TenantId::from("alpha"));
+
+    let exec = sample_execution("wf-attempts");
+    let execution_id = exec.execution_id.clone();
+    tenant.create_execution(exec).await.unwrap();
+
+    let item_id = uuid::Uuid::new_v4();
+    tenant
+        .enqueue_work_item(jamjet_state::WorkItem {
+            id: item_id,
+            execution_id,
+            node_id: "n1".to_string(),
+            queue_type: "general".to_string(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "alpha".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let mut seen = Vec::new();
+    for _ in 0..3 {
+        let Some(c) = tenant.claim_work_item("dies", &["general"]).await.unwrap() else {
+            break;
+        };
+        seen.push(c.attempt);
+        sqlx::query(
+            "UPDATE work_items SET lease_expires_at = '2020-01-01T00:00:00+00:00' WHERE id = ?",
+        )
+        .bind(item_id.to_string())
+        .execute(&db.pool())
+        .await
+        .unwrap();
+    }
+    assert_eq!(
+        seen,
+        vec![0, 1, 2],
+        "each claim-side expiry must consume exactly one attempt"
+    );
+    assert!(
+        tenant
+            .claim_work_item("dies", &["general"])
+            .await
+            .unwrap()
+            .is_none(),
+        "an item that has spent its attempts must not be handed out again"
+    );
+}


### PR DESCRIPTION
Both findings from CodeRabbit's review of #118, verified against `main` before fixing. Both can run a node's side effect more than once.

## 1. A failed worker could park its own requeue

`fail_work_item_fenced`'s retryable branch returns the item to `pending`, but left `lease_fence` at the failing worker's value. `park_work_item` matched on `id` + `lease_fence` with **no status guard**. So the worker that had just lost the item could still park it, overwriting the `attempt` and `retry_after` of an attempt that was no longer its own.

The asymmetry was the tell: `park_work_item` itself always cleared `lease_fence = 0` when it requeued. The requeue paths did not.

Closed twice over — every requeue now clears the fence, and park additionally requires `status = 'claimed'`. Verified: with both guards reverted, the stale park succeeds.

Every requeue in both backends was audited for the reset by parsing the statement literals rather than grepping, since the SQL spans lines and a line-wise grep reports false misses. Four sites needed it.

## 2. #119 was half-applied

#119 fixed the untenanted backend and left the tenant-scoped twin untouched. Three bugs it closed were **still live for scoped deployments**:

- `reclaim_expired_leases` kept `WHERE id = ?` on both updates — neither `status = 'claimed'` nor `tenant_id` on the write. A worker committing inside the sweep's update loop had its **completed** item requeued and re-run at a shifted step ordinal: different idempotency key, so the replay guard missed it and the side effect fired twice.
- the dead-letter row was written **before** the settle, so a lost race left an orphan row describing a node that had actually succeeded.
- the claim-side lease expiry never consumed an `attempt`, so a node that reliably kills its worker was resurrected forever at attempt 0 — `max_attempts` unreachable, dead-letter never entered.

All three now match the untenanted backend. CodeRabbit named the reclaim; the claim-side one came from checking the rest of the file rather than only the line it pointed at.

## Tests

Four, each verified to **FAIL against the pre-fix code** before being kept:

- `a_failed_worker_cannot_park_its_requeued_item`
- `scoped_reclaim_cannot_resurrect_a_settled_item`
- `scoped_claim_side_expiry_consumes_attempts`
- (plus the existing scoped dead-letter and cross-tenant tests still passing)

The scoped race test needs the same volume trick as its untenanted twin — a settle done *before* the call also changes `status`, which the sweep's own SELECT filters out, so nothing races and the test would pass against the bug.

`cargo test --workspace` — 789 passed, 0 failed. `cargo fmt --all --check` clean.
