### PR TITLE
fix(sdk): glob the model allowlist in-process, matching the durable engine

### DIFF
--- a/runtime/policy/src/lib.rs
+++ b/runtime/policy/src/lib.rs
@@ -392,4 +392,44 @@ mod tests {
             PolicyDecision::Allow
         ));
     }
+
+    /// The mirror of `PARITY_TABLE` in
+    /// `sdk/python/tests/middleware/test_model_allowlist_parity.py`.
+    ///
+    /// The SAME allowlist is evaluated by the Python seam for an in-process run
+    /// and here for a durable one. A row that changes on one side and not the
+    /// other means one policy now behaves two ways depending on transport, which
+    /// is the class of bug this table exists to catch. Keep the two in step.
+    #[test]
+    fn model_allowlist_parity_table() {
+        const OPUS: &str = "anthropic/claude-opus-4-8";
+        let cases: &[(&str, &str, bool)] = &[
+            ("anthropic", OPUS, true),
+            ("openai", OPUS, false),
+            ("anthropic/*", OPUS, true),
+            ("openai/*", OPUS, false),
+            ("anthropic/claude-opus-4-8", OPUS, true),
+            ("anthropic/claude-haiku-4-5", OPUS, false),
+            ("*", OPUS, true),
+            ("anthropi?", OPUS, true),
+            ("anthropi??", OPUS, false),
+        ];
+        for (pattern, model, expected) in cases {
+            assert_eq!(
+                model_matches(pattern, model),
+                *expected,
+                "{pattern:?} vs {model:?} must be {expected}"
+            );
+        }
+    }
+
+    /// `[seq]` is a literal here, not a character class. Python's matcher is
+    /// hand-written rather than `fnmatch` for exactly this reason.
+    #[test]
+    fn a_character_class_is_literal_not_a_class() {
+        assert!(!model_matches(
+            "anthropic/[abc]laude-opus-4-8",
+            "anthropic/claude-opus-4-8"
+        ));
+    }
 }

--- a/sdk/python/jamjet/model/middleware.py
+++ b/sdk/python/jamjet/model/middleware.py
@@ -65,11 +65,69 @@ class BaseModelMiddleware:
         return response
 
 
+def _glob_match(pattern: str, value: str) -> bool:
+    """``*``/``?`` glob, matching ``glob_match`` in ``runtime/policy/src/lib.rs``.
+
+    Deliberately NOT :func:`fnmatch.fnmatchcase`: fnmatch also honours ``[seq]``
+    character classes, which the Rust matcher treats as literal characters. Using
+    it would fix one divergence by introducing another, subtler one — and the
+    whole point of this function is that both sides agree.
+
+    Iterative rather than recursive, so an adversarial pattern cannot blow the
+    stack or backtrack exponentially on a long model name.
+    """
+    p = v = 0
+    star = -1
+    resume = 0
+    while v < len(value):
+        if p < len(pattern) and pattern[p] in (value[v], "?"):
+            p += 1
+            v += 1
+        elif p < len(pattern) and pattern[p] == "*":
+            star = p
+            resume = v
+            p += 1
+        elif star >= 0:
+            p = star + 1
+            resume += 1
+            v = resume
+        else:
+            return False
+    while p < len(pattern) and pattern[p] == "*":
+        p += 1
+    return p == len(pattern)
+
+
+def model_allowlist_matches(pattern: str, provider: str, litellm_model: str) -> bool:
+    """Does one allowlist entry admit this model?
+
+    Mirrors ``model_matches`` in ``runtime/policy/src/lib.rs`` exactly, because
+    the SAME allowlist is evaluated here for an in-process run and there for a
+    durable one. When the two disagree, a policy means different things depending
+    on which transport happened to run it — and the disagreement surfaces in
+    production, since development usually stays in-process.
+
+    Entries are globs (``*``/``?``) matched against the full ``provider/model``
+    reference, and an entry with no ``/`` is also matched against the provider
+    alone, so ``"anthropic"`` admits every Anthropic model.
+    """
+    if _glob_match(pattern, litellm_model):
+        return True
+    if "/" in pattern:
+        return False
+    return _glob_match(pattern, provider)
+
+
 class ModelAllowlistMiddleware(BaseModelMiddleware):
     """Deny model calls whose provider or full model string is not allowed.
 
     ``allowed=None`` allows everything (the Track 1 default; Track 3 wires the
     real policy-derived allowlist).
+
+    Entries are globs, matched against the full reference or the provider alone —
+    the same rule the durable engine applies. Membership used to be exact, so
+    ``"anthropic/*"`` matched nothing and ``"*"`` denied every model, while both
+    were accepted durable-side.
     """
 
     def __init__(self, allowed: set[str] | None) -> None:
@@ -79,7 +137,7 @@ class ModelAllowlistMiddleware(BaseModelMiddleware):
         if self._allowed is None:
             return request
         ref = request.ref
-        if ref.provider in self._allowed or ref.litellm_model in self._allowed:
+        if any(model_allowlist_matches(pattern, ref.provider, ref.litellm_model) for pattern in self._allowed):
             return request
         raise ModelDeniedError(
             f"model {ref.litellm_model!r} is not in the allowlist",

--- a/sdk/python/tests/middleware/test_model_allowlist_parity.py
+++ b/sdk/python/tests/middleware/test_model_allowlist_parity.py
@@ -1,0 +1,116 @@
+"""The model allowlist must mean the same thing in-process and durable.
+
+The SAME allowlist is evaluated by `ModelAllowlistMiddleware` for an in-process
+run and by `PolicyEvaluator` (runtime/policy/src/lib.rs) for a durable one. When
+they disagree, a policy means different things depending on which transport
+happened to run it — and because development usually stays in-process, the
+disagreement surfaces in production.
+
+Two divergences existed, in opposite directions:
+
+  * `["anthropic"]` — the built-in "strict" policy's entire allowlist — was
+    allowed here and BLOCKED durable-side, because the Rust matcher globbed the
+    full `provider/model` ref and a wildcard-free entry compared literally.
+  * `["anthropic/*"]` and `["*"]` were allowed durable-side and BLOCKED here,
+    because membership was exact and did not glob at all. `["*"]` — the natural
+    way to write "allow everything" — denied every model.
+
+The table below is the contract. Keep it in step with
+`runtime/policy/src/lib.rs`; a row that changes on one side and not the other is
+the bug this file exists to catch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from jamjet.model.middleware import ModelAllowlistMiddleware, model_allowlist_matches
+from jamjet.model.types import ModelRef, ModelRequest
+
+OPUS = ModelRef(
+    provider="anthropic",
+    model="claude-opus-4-8",
+    litellm_model="anthropic/claude-opus-4-8",
+)
+
+# (allowlist entry, model ref, allowed?) — mirrored by the Rust tests.
+PARITY_TABLE = [
+    # A provider-only entry admits that provider's whole catalogue.
+    ("anthropic", OPUS, True),
+    # ...and still denies another provider. The provider rule must not widen
+    # into an allow-all.
+    ("openai", OPUS, False),
+    # An explicit provider glob.
+    ("anthropic/*", OPUS, True),
+    ("openai/*", OPUS, False),
+    # A full ref pins exactly that model — pinning one must NOT silently admit
+    # the provider's whole catalogue.
+    ("anthropic/claude-opus-4-8", OPUS, True),
+    ("anthropic/claude-haiku-4-5", OPUS, False),
+    # The natural "allow everything".
+    ("*", OPUS, True),
+    # `?` matches exactly one character.
+    ("anthropi?", OPUS, True),
+    ("anthropi??", OPUS, False),
+]
+
+
+@pytest.mark.parametrize(("pattern", "ref", "expected"), PARITY_TABLE)
+def test_matcher_parity(pattern: str, ref: ModelRef, expected: bool) -> None:
+    assert model_allowlist_matches(pattern, ref.provider, ref.litellm_model) is expected, (
+        f"{pattern!r} vs {ref.litellm_model!r} must be {expected}"
+    )
+
+
+@pytest.mark.parametrize(("pattern", "ref", "expected"), PARITY_TABLE)
+def test_middleware_enforces_the_same_table(pattern: str, ref: ModelRef, expected: bool) -> None:
+    """The matcher is only useful if the middleware actually applies it."""
+    mw = ModelAllowlistMiddleware({pattern})
+
+    async def call() -> bool:
+        try:
+            await mw.before(ModelRequest(ref=ref, messages=[]))
+            return True
+        except Exception:
+            return False
+
+    assert asyncio.run(call()) is expected
+
+
+def test_a_character_class_is_literal_not_a_class() -> None:
+    """`[seq]` must NOT be honoured — the Rust matcher treats it literally.
+
+    This is why the matcher is hand-written rather than `fnmatch`, which would
+    fix one divergence by quietly introducing another.
+    """
+    assert not model_allowlist_matches("anthropic/[abc]laude-opus-4-8", "anthropic", "anthropic/claude-opus-4-8")
+
+
+def test_an_empty_allowlist_denies() -> None:
+    """An empty set is not the same as `None`.
+
+    `None` means "no allowlist configured, allow everything"; an empty set means
+    a policy was resolved and admits nothing.
+    """
+    mw = ModelAllowlistMiddleware(set())
+
+    async def call() -> bool:
+        try:
+            await mw.before(ModelRequest(ref=OPUS, messages=[]))
+            return True
+        except Exception:
+            return False
+
+    assert asyncio.run(call()) is False
+
+
+def test_none_allows_everything() -> None:
+    mw = ModelAllowlistMiddleware(None)
+
+    async def call() -> bool:
+        await mw.before(ModelRequest(ref=OPUS, messages=[]))
+        return True
+
+    assert asyncio.run(call()) is True


### PR DESCRIPTION
#121 fixed one direction of the allowlist divergence and left the other open. This closes it and pins both sides to one table.

## The remaining half

The Python seam matched by **exact set membership** — no globbing at all:

| allowlist | in-process | durable (after #121) |
|---|---|---|
| `["anthropic"]` | ALLOW | ALLOW ✅ (fixed by #121) |
| `["anthropic/*"]` | **BLOCK** | ALLOW |
| `["*"]` | **BLOCK** | ALLOW |

`["*"]` is the natural way to write "allow everything", and in-process it denied every model. Fail-closed, so not a security hole — but it is the same class of bug #121 closed: one policy meaning two different things depending on which transport ran it, with the disagreement surfacing in production because development stays in-process.

## The fix

`model_allowlist_matches` mirrors `model_matches` in `runtime/policy/src/lib.rs`: glob the full `provider/model` ref, and for an entry with no `/` also glob the provider alone.

**Deliberately not `fnmatch`.** It honours `[seq]` character classes, which the Rust matcher treats as literal characters — using it would have fixed one divergence by quietly introducing a subtler one, which is self-defeating for a parity fix. The hand-written matcher is also iterative rather than recursive, so a long model name cannot blow the stack or backtrack exponentially.

## One table, mirrored on both sides

`PARITY_TABLE` in `tests/middleware/test_model_allowlist_parity.py` and `model_allowlist_parity_table` in `runtime/policy/src/lib.rs` are the same nine rows. A row that changes on one side and not the other is now a failing test rather than a production surprise.

Covered in both: provider entries admit a catalogue but still deny other providers; a full ref pins one model **without** widening to that provider's catalogue; `?` is exactly one character; `[seq]` is literal. Python additionally pins that an empty allowlist denies while `None` allows, since that distinction is easy to erase.

The middleware is tested against the same table as the matcher — a matcher is only useful if the thing enforcing policy actually applies it.

## How this was found

By auditing #119, #120 and #121 for the "fixed one copy, missed the twin" pattern. Those three merged **without a CodeRabbit pass** — the account was rate-limited — and #119 turned out to have exactly that gap (its tenant-scoped twin, now #122). This is the same audit applied to #121.

## Verification

Rust 788 passed, 0 failed. Python 1470 passed, 1 skipped. `cargo fmt --all --check`, `ruff format --check` and `ruff check` all clean.
