### PR TITLE
feat(state): reserve an idempotency key before firing its effect (spec Move 4b)

### DIFF
--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1287,6 +1287,26 @@ impl StateBackend for FailFirstGetEvents {
             .await
     }
 
+    async fn reserve_tool_effect(
+        &self,
+
+        key: &str,
+
+        execution_id: &ExecutionId,
+
+        node_id: &str,
+
+        owner: &str,
+
+        lease_fence: i64,
+
+        ttl: std::time::Duration,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::ReserveOutcome> {
+        self.inner
+            .reserve_tool_effect(key, execution_id, node_id, owner, lease_fence, ttl)
+            .await
+    }
+
     async fn get_tool_effect(
         &self,
         key: &str,

--- a/runtime/state/migrations/0011_tool_reservations.sql
+++ b/runtime/state/migrations/0011_tool_reservations.sql
@@ -14,8 +14,14 @@
 -- `expires_at` is what stops the reservation becoming a new permanent wedge. A
 -- worker that dies mid-tool leaves its row behind; without expiry the key would
 -- be unrunnable forever, which is worse than the double-fire it replaced.
+-- Keyed by (tenant_id, idempotency_key), NOT by the key alone. A global primary
+-- key lets one tenant's reservation collide with another's: the scoped upsert
+-- conflicts on a row it cannot see, affects zero rows, and its tenant-filtered
+-- lookup then finds nothing — which reads as "free" and hands out a key someone
+-- else holds. Tenant is part of the identity of a reservation, as it is for
+-- every other row here.
 CREATE TABLE IF NOT EXISTS tool_reservations (
-    idempotency_key TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL,
     execution_id    TEXT NOT NULL,
     node_id         TEXT NOT NULL,
     -- Diagnostics: which worker holds it, and under which lease.
@@ -23,7 +29,8 @@ CREATE TABLE IF NOT EXISTS tool_reservations (
     lease_fence     INTEGER NOT NULL,
     expires_at      TEXT NOT NULL,
     tenant_id       TEXT NOT NULL DEFAULT 'default',
-    reserved_at     TEXT NOT NULL
+    reserved_at     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, idempotency_key)
 );
 
 CREATE INDEX IF NOT EXISTS idx_tool_reservations_execution ON tool_reservations(execution_id);

--- a/runtime/state/migrations/0011_tool_reservations.sql
+++ b/runtime/state/migrations/0011_tool_reservations.sql
@@ -1,0 +1,30 @@
+-- Reserve-before-fire (spec Move 4b).
+--
+-- `tool_effects` records a result AFTER a node commits, so the replay guard can
+-- only answer "has this already run to completion". Between two live work items
+-- for the same node, both read "no" and both fire — the effect happens twice.
+-- The spec called the reservation load-bearing, not optional.
+--
+-- A reservation is a claim on an idempotency key taken BEFORE the executor runs.
+-- It is deliberately its own table rather than a nullable `result_json` on
+-- tool_effects: that column is NOT NULL, relaxing it in SQLite means rebuilding
+-- the table, and the two rows answer different questions ("someone is running
+-- this" vs "this produced that").
+--
+-- `expires_at` is what stops the reservation becoming a new permanent wedge. A
+-- worker that dies mid-tool leaves its row behind; without expiry the key would
+-- be unrunnable forever, which is worse than the double-fire it replaced.
+CREATE TABLE IF NOT EXISTS tool_reservations (
+    idempotency_key TEXT PRIMARY KEY,
+    execution_id    TEXT NOT NULL,
+    node_id         TEXT NOT NULL,
+    -- Diagnostics: which worker holds it, and under which lease.
+    owner           TEXT NOT NULL,
+    lease_fence     INTEGER NOT NULL,
+    expires_at      TEXT NOT NULL,
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
+    reserved_at     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_reservations_execution ON tool_reservations(execution_id);
+CREATE INDEX IF NOT EXISTS idx_tool_reservations_expiry ON tool_reservations(expires_at);

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -182,6 +182,36 @@ pub trait StateBackend: Send + Sync {
     /// `NodeCompleted` with `idempotency_key = Some(k)`.
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>>;
 
+    /// Claim an idempotency key BEFORE running the effect it names.
+    ///
+    /// [`Self::get_tool_effect`] can only answer "did this already run to
+    /// COMPLETION". Between two live work items for the same node both read
+    /// `None` and both fire, so the side effect happens twice — check-then-fire.
+    /// This is the reservation the spec calls load-bearing: whoever wins runs the
+    /// effect, and everyone else waits for its result instead of repeating it.
+    ///
+    /// Atomic and fail-safe by construction: it is a single conditional upsert,
+    /// so there is no window between testing for a holder and becoming one.
+    ///
+    /// `ttl` is what keeps a reservation from becoming a WORSE failure than the
+    /// double-fire it prevents. A worker that dies mid-tool leaves its row
+    /// behind; expiry is what lets the next worker take the key over instead of
+    /// the node being unrunnable forever. An expired reservation is therefore
+    /// acquirable, and this returns [`ReserveOutcome::Acquired`] for it.
+    ///
+    /// Reservations are consulted ONLY when no committed effect exists, so a row
+    /// left behind after a successful commit blocks nothing — the caller finds
+    /// the recorded result first and replays it.
+    async fn reserve_tool_effect(
+        &self,
+        key: &str,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        owner: &str,
+        lease_fence: i64,
+        ttl: std::time::Duration,
+    ) -> BackendResult<ReserveOutcome>;
+
     // ── Content-addressed artifact store ─────────────────────────────────────
 
     /// Store bytes in the CAS, keyed by their SHA-256 hash.
@@ -492,6 +522,18 @@ pub struct ReclaimResult {
     pub retryable: Vec<WorkItem>,
     /// Items that exhausted all attempts and were moved to dead-letter.
     pub exhausted: Vec<WorkItem>,
+}
+
+/// The result of trying to claim an idempotency key before firing its effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReserveOutcome {
+    /// The key is ours: no live reservation existed, or the previous holder's
+    /// TTL had lapsed and we took it over. Run the effect.
+    Acquired,
+    /// Another worker holds a LIVE reservation. Do NOT run the effect — wait for
+    /// its result instead. `expires_at` is when the claim lapses, which bounds
+    /// how long waiting can be worthwhile.
+    Held { owner: String, expires_at: String },
 }
 
 /// What a fenced failure did to the item, and the item as it now stands.

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -24,8 +24,8 @@ pub use artifact::{
     DEFAULT_SPILL_THRESHOLD,
 };
 pub use backend::{
-    ApiToken, ApprovalProjectionRow, BackendResult, FailOutcome, ReclaimResult, StateBackend,
-    StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
+    ApiToken, ApprovalProjectionRow, BackendResult, FailOutcome, ReclaimResult, ReserveOutcome,
+    StateBackend, StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
 };
 pub use budget::{BudgetState, BudgetTrip};
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -4,8 +4,8 @@
 //! quick prototyping where durability is not needed.
 
 use crate::backend::{
-    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
-    WorkItemId, WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, ReserveOutcome, StateBackend,
+    StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -41,6 +41,8 @@ pub struct InMemoryBackend {
     /// Idempotency cache: idempotency_key -> result_json.
     /// Mirrors the `tool_effects` table in the SQLite backends.
     tool_effects: DashMap<String, serde_json::Value>,
+    /// Reservations: idempotency key -> (owner, expires_at).
+    tool_reservations: DashMap<String, (String, chrono::DateTime<Utc>)>,
     /// Projected approval read-model. Key = (execution_id as String, node_id).
     proj_approvals: DashMap<(String, String), crate::backend::ApprovalProjectionRow>,
     /// Projector checkpoints. Key = (projection_name, execution_id as String).
@@ -64,6 +66,7 @@ impl InMemoryBackend {
             lease_epochs: DashMap::new(),
             store_term: AtomicI64::new(0),
             tool_effects: DashMap::new(),
+            tool_reservations: DashMap::new(),
             proj_approvals: DashMap::new(),
             projector_checkpoints: DashMap::new(),
             artifacts: DashMap::new(),
@@ -331,6 +334,43 @@ impl StateBackend for InMemoryBackend {
     }
 
     // ── Idempotency cache ─────────────────────────────────────────────────
+
+    async fn reserve_tool_effect(
+        &self,
+        key: &str,
+        _execution_id: &ExecutionId,
+        _node_id: &str,
+        owner: &str,
+        _lease_fence: i64,
+        ttl: std::time::Duration,
+    ) -> BackendResult<ReserveOutcome> {
+        let now = Utc::now();
+        let expires_at =
+            now + chrono::Duration::from_std(ttl).unwrap_or_else(|_| chrono::Duration::minutes(5));
+
+        // `entry` holds the shard lock across the whole test-and-set, which is
+        // what makes this atomic in the same way the SQL upsert is. A get-then-
+        // insert would reopen the exact race the reservation exists to close.
+        use dashmap::mapref::entry::Entry;
+        match self.tool_reservations.entry(key.to_string()) {
+            Entry::Vacant(v) => {
+                v.insert((owner.to_string(), expires_at));
+                Ok(ReserveOutcome::Acquired)
+            }
+            Entry::Occupied(mut o) => {
+                let (holder, holder_expiry) = o.get().clone();
+                if holder == owner || holder_expiry <= now {
+                    // Lapsed: the holder is presumed dead, so take it over.
+                    o.insert((owner.to_string(), expires_at));
+                    return Ok(ReserveOutcome::Acquired);
+                }
+                Ok(ReserveOutcome::Held {
+                    owner: holder,
+                    expires_at: holder_expiry.to_rfc3339(),
+                })
+            }
+        }
+    }
 
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
         Ok(self.tool_effects.get(key).map(|r| r.value().clone()))

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -871,7 +871,7 @@ impl StateBackend for SqliteBackend {
             "INSERT INTO tool_reservations \
                  (idempotency_key, execution_id, node_id, owner, lease_fence, expires_at, tenant_id, reserved_at) \
              VALUES (?, ?, ?, ?, ?, ?, 'default', ?) \
-             ON CONFLICT(idempotency_key) DO UPDATE SET \
+             ON CONFLICT(tenant_id, idempotency_key) DO UPDATE SET \
                  owner = excluded.owner, \
                  lease_fence = excluded.lease_fence, \
                  expires_at = excluded.expires_at, \
@@ -912,10 +912,15 @@ impl StateBackend for SqliteBackend {
                 owner: r.try_get::<String, _>("owner").map_err(map_db_err)?,
                 expires_at: r.try_get::<String, _>("expires_at").map_err(map_db_err)?,
             }),
-            // The holder vanished between the upsert and this read (its row was
-            // deleted). Nothing holds the key, so treat it as ours to try again
-            // rather than inventing a holder.
-            None => Ok(ReserveOutcome::Acquired),
+            // The upsert was blocked, so SOMETHING holds this key. If the row
+            // is not visible here, that is not evidence the key is free — it was
+            // the reasoning behind an earlier `Acquired` return, and it was a
+            // fail-open: a scoped lookup cannot see a row another tenant owns, so
+            // the caller was handed a key someone else held. Refuse instead.
+            None => Ok(ReserveOutcome::Held {
+                owner: "unknown".to_string(),
+                expires_at: now_s.clone(),
+            }),
         }
     }
 

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1,6 +1,6 @@
 use crate::backend::{
-    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
-    WorkItemId, WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, ReserveOutcome, StateBackend,
+    StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -842,6 +842,82 @@ impl StateBackend for SqliteBackend {
     }
 
     // ── Idempotency cache ─────────────────────────────────────────────────
+
+    #[instrument(skip(self), fields(key = key, owner = owner))]
+    async fn reserve_tool_effect(
+        &self,
+        key: &str,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        owner: &str,
+        lease_fence: i64,
+        ttl: std::time::Duration,
+    ) -> BackendResult<ReserveOutcome> {
+        let now = Utc::now();
+        let now_s = now.to_rfc3339();
+        let expires_at = (now
+            + chrono::Duration::from_std(ttl).unwrap_or_else(|_| chrono::Duration::minutes(5)))
+        .to_rfc3339();
+
+        // ONE statement, so there is no gap between "is anyone holding this" and
+        // "I am holding this" — the gap is the entire bug this prevents.
+        //
+        // The upsert fires only when the existing row has LAPSED
+        // (`expires_at <= now`). A live reservation matches nothing, changes
+        // nothing, and reports zero rows affected. `INSERT` covers the
+        // never-reserved case, and the `DO UPDATE ... WHERE` covers takeover of a
+        // dead holder; both leave the key owned by us.
+        let rows = sqlx::query(
+            "INSERT INTO tool_reservations \
+                 (idempotency_key, execution_id, node_id, owner, lease_fence, expires_at, tenant_id, reserved_at) \
+             VALUES (?, ?, ?, ?, ?, ?, 'default', ?) \
+             ON CONFLICT(idempotency_key) DO UPDATE SET \
+                 owner = excluded.owner, \
+                 lease_fence = excluded.lease_fence, \
+                 expires_at = excluded.expires_at, \
+                 reserved_at = excluded.reserved_at \
+             WHERE tool_reservations.expires_at <= ? OR tool_reservations.owner = ?",
+        )
+        .bind(key)
+        .bind(execution_id_str(execution_id))
+        .bind(node_id)
+        .bind(owner)
+        .bind(lease_fence)
+        .bind(&expires_at)
+        .bind(&now_s)
+        .bind(&now_s)
+        .bind(owner)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+
+        if rows > 0 {
+            return Ok(ReserveOutcome::Acquired);
+        }
+
+        // Zero rows means a LIVE reservation blocked the upsert. Report who holds
+        // it and until when, so the caller can bound its wait rather than
+        // guessing.
+        let row = sqlx::query(
+            "SELECT owner, expires_at FROM tool_reservations WHERE idempotency_key = ?",
+        )
+        .bind(key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        match row {
+            Some(r) => Ok(ReserveOutcome::Held {
+                owner: r.try_get::<String, _>("owner").map_err(map_db_err)?,
+                expires_at: r.try_get::<String, _>("expires_at").map_err(map_db_err)?,
+            }),
+            // The holder vanished between the upsert and this read (its row was
+            // deleted). Nothing holds the key, so treat it as ours to try again
+            // rather than inventing a holder.
+            None => Ok(ReserveOutcome::Acquired),
+        }
+    }
 
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
         let row = sqlx::query("SELECT result_json FROM tool_effects WHERE idempotency_key = ?")

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -791,7 +791,7 @@ impl StateBackend for TenantScopedSqliteBackend {
             "INSERT INTO tool_reservations \
                  (idempotency_key, execution_id, node_id, owner, lease_fence, expires_at, tenant_id, reserved_at) \
              VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(idempotency_key) DO UPDATE SET \
+             ON CONFLICT(tenant_id, idempotency_key) DO UPDATE SET \
                  owner = excluded.owner, \
                  lease_fence = excluded.lease_fence, \
                  expires_at = excluded.expires_at, \
@@ -832,7 +832,15 @@ impl StateBackend for TenantScopedSqliteBackend {
                 owner: r.try_get::<String, _>("owner").map_err(map_db_err)?,
                 expires_at: r.try_get::<String, _>("expires_at").map_err(map_db_err)?,
             }),
-            None => Ok(ReserveOutcome::Acquired),
+            // The upsert was blocked, so SOMETHING holds this key. If the row
+            // is not visible here, that is not evidence the key is free — it was
+            // the reasoning behind an earlier `Acquired` return, and it was a
+            // fail-open: a scoped lookup cannot see a row another tenant owns, so
+            // the caller was handed a key someone else held. Refuse instead.
+            None => Ok(ReserveOutcome::Held {
+                owner: "unknown".to_string(),
+                expires_at: now_s.clone(),
+            }),
         }
     }
 

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -6,8 +6,8 @@
 //! that item's execution.
 
 use crate::backend::{
-    ApiToken, BackendResult, FailOutcome, ReclaimResult, StateBackend, StateBackendError, WorkItem,
-    WorkItemId, WorkflowDefinition,
+    ApiToken, BackendResult, FailOutcome, ReclaimResult, ReserveOutcome, StateBackend,
+    StateBackendError, WorkItem, WorkItemId, WorkflowDefinition,
 };
 use crate::event::{Event, EventKind, EventSequence};
 use crate::snapshot::Snapshot;
@@ -766,6 +766,75 @@ impl StateBackend for TenantScopedSqliteBackend {
     }
 
     // ── Idempotency cache ─────────────────────────────────────────────────
+
+    #[instrument(skip(self), fields(tenant = %self.tenant_id, key = key, owner = owner))]
+    async fn reserve_tool_effect(
+        &self,
+        key: &str,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        owner: &str,
+        lease_fence: i64,
+        ttl: std::time::Duration,
+    ) -> BackendResult<ReserveOutcome> {
+        let now = Utc::now();
+        let now_s = now.to_rfc3339();
+        let expires_at = (now
+            + chrono::Duration::from_std(ttl).unwrap_or_else(|_| chrono::Duration::minutes(5)))
+        .to_rfc3339();
+
+        // See the untenanted backend for why this is one statement. `tenant_id`
+        // is written on the row, but the KEY is the conflict target: an
+        // idempotency key already encodes its execution, so two tenants cannot
+        // collide on one without colliding on the execution first.
+        let rows = sqlx::query(
+            "INSERT INTO tool_reservations \
+                 (idempotency_key, execution_id, node_id, owner, lease_fence, expires_at, tenant_id, reserved_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(idempotency_key) DO UPDATE SET \
+                 owner = excluded.owner, \
+                 lease_fence = excluded.lease_fence, \
+                 expires_at = excluded.expires_at, \
+                 reserved_at = excluded.reserved_at \
+             WHERE tool_reservations.expires_at <= ? OR tool_reservations.owner = ?",
+        )
+        .bind(key)
+        .bind(execution_id_str(execution_id))
+        .bind(node_id)
+        .bind(owner)
+        .bind(lease_fence)
+        .bind(&expires_at)
+        .bind(&self.tenant_id.0)
+        .bind(&now_s)
+        .bind(&now_s)
+        .bind(owner)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?
+        .rows_affected();
+
+        if rows > 0 {
+            return Ok(ReserveOutcome::Acquired);
+        }
+
+        let row = sqlx::query(
+            "SELECT owner, expires_at FROM tool_reservations \
+             WHERE idempotency_key = ? AND tenant_id = ?",
+        )
+        .bind(key)
+        .bind(&self.tenant_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+
+        match row {
+            Some(r) => Ok(ReserveOutcome::Held {
+                owner: r.try_get::<String, _>("owner").map_err(map_db_err)?,
+                expires_at: r.try_get::<String, _>("expires_at").map_err(map_db_err)?,
+            }),
+            None => Ok(ReserveOutcome::Acquired),
+        }
+    }
 
     async fn get_tool_effect(&self, key: &str) -> BackendResult<Option<serde_json::Value>> {
         let row = sqlx::query(

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -13,7 +13,7 @@ use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
 use jamjet_state::tenant::{Tenant, TenantStatus};
 use jamjet_state::{
     backend::{StateBackend, WorkItem},
-    Event, EventKind, InMemoryBackend, SqliteBackend, TenantId,
+    Event, EventKind, InMemoryBackend, ReserveOutcome, SqliteBackend, TenantId,
 };
 use serde_json::json;
 use uuid::Uuid;
@@ -582,5 +582,228 @@ async fn tenant_scoped_tool_effect_round_trip() {
     assert!(
         other.is_none(),
         "tenant-b must not see tenant-a's tool_effect"
+    );
+}
+
+// ── Reserve-before-fire (spec Move 4b) ───────────────────────────────────────
+
+/// Two workers racing for one idempotency key: exactly one may fire.
+///
+/// `get_tool_effect` only answers "did this run to COMPLETION", so before the
+/// reservation existed both workers read `None` and both ran the effect. That is
+/// check-then-fire, and duplicate live items for one node are producible today
+/// (retry crash window, approval-hold resurrection, public POST /work-items).
+#[tokio::test]
+async fn only_one_worker_can_claim_an_idempotency_key() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    let first = db
+        .reserve_tool_effect("k1", &eid, "n1", "worker-A", 1, ttl)
+        .await
+        .unwrap();
+    assert_eq!(first, ReserveOutcome::Acquired);
+
+    let second = db
+        .reserve_tool_effect("k1", &eid, "n1", "worker-B", 2, ttl)
+        .await
+        .unwrap();
+    match second {
+        ReserveOutcome::Held { owner, .. } => assert_eq!(owner, "worker-A"),
+        ReserveOutcome::Acquired => {
+            panic!("two workers acquired the same key — the effect will fire twice")
+        }
+    }
+}
+
+/// The reservation is REENTRANT for its own holder.
+///
+/// It exists to exclude a SECOND worker, not to lock a worker out of its own
+/// node. A retry is the same logical attempt: the item is re-claimed by the same
+/// worker and runs again, and a node that fails WITHOUT recording a tool effect
+/// leaves its reservation standing. Blocking the holder would stall every such
+/// retry for the whole TTL.
+///
+/// This was originally written to assert the opposite, and the engine's own
+/// continue-as-new retry tests caught it — they deadlocked against a reservation
+/// their own worker held.
+#[tokio::test]
+async fn a_reservation_is_reentrant_for_its_holder() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    assert_eq!(
+        db.reserve_tool_effect("k2", &eid, "n1", "worker-A", 1, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired
+    );
+    assert_eq!(
+        db.reserve_tool_effect("k2", &eid, "n1", "worker-A", 2, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired,
+        "the holder must be able to retry its own node"
+    );
+    assert!(matches!(
+        db.reserve_tool_effect("k2", &eid, "n1", "worker-B", 3, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Held { .. }
+    ));
+}
+
+/// An EXPIRED reservation must be takeable, or a worker that dies mid-tool
+/// leaves the key unrunnable forever — a worse failure than the double-fire the
+/// reservation replaced.
+#[tokio::test]
+async fn an_expired_reservation_can_be_taken_over() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+
+    // A TTL of zero is already lapsed by the time the next call reads it.
+    assert_eq!(
+        db.reserve_tool_effect(
+            "k3",
+            &eid,
+            "n1",
+            "worker-dead",
+            1,
+            std::time::Duration::ZERO
+        )
+        .await
+        .unwrap(),
+        ReserveOutcome::Acquired
+    );
+
+    let taken = db
+        .reserve_tool_effect(
+            "k3",
+            &eid,
+            "n1",
+            "worker-B",
+            2,
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        taken,
+        ReserveOutcome::Acquired,
+        "a lapsed reservation must be reclaimable, or a dead worker wedges the key"
+    );
+
+    // And having taken it, B now holds it against everyone else.
+    assert!(matches!(
+        db.reserve_tool_effect(
+            "k3",
+            &eid,
+            "n1",
+            "worker-C",
+            3,
+            std::time::Duration::from_secs(300)
+        )
+        .await
+        .unwrap(),
+        ReserveOutcome::Held { .. }
+    ));
+}
+
+/// Different keys never contend — the reservation is per idempotency key, not a
+/// global lock on the node or the execution.
+#[tokio::test]
+async fn distinct_keys_do_not_contend() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    for key in ["a", "b", "c"] {
+        assert_eq!(
+            db.reserve_tool_effect(key, &eid, "n1", "worker-A", 1, ttl)
+                .await
+                .unwrap(),
+            ReserveOutcome::Acquired,
+            "key {key} should not have contended"
+        );
+    }
+}
+
+/// The in-memory backend must reserve identically.
+///
+/// Memory-only coverage is how the SQLite-vs-memory divergence class hides (the
+/// claim-side lease expiry existed only in SQLite for exactly that reason), and
+/// the inverse is just as bad: a dev/test backend that hands the same key to two
+/// workers makes every double-fire test pass while proving nothing.
+#[tokio::test]
+async fn the_in_memory_backend_reserves_identically() {
+    let db = InMemoryBackend::new();
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    assert_eq!(
+        db.reserve_tool_effect("k", &eid, "n1", "worker-A", 1, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired
+    );
+    match db
+        .reserve_tool_effect("k", &eid, "n1", "worker-B", 2, ttl)
+        .await
+        .unwrap()
+    {
+        ReserveOutcome::Held { owner, .. } => assert_eq!(owner, "worker-A"),
+        ReserveOutcome::Acquired => panic!("in-memory handed the same key to two workers"),
+    }
+
+    // Expiry behaves the same way.
+    assert_eq!(
+        db.reserve_tool_effect("gone", &eid, "n1", "dead", 1, std::time::Duration::ZERO)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired
+    );
+    assert_eq!(
+        db.reserve_tool_effect("gone", &eid, "n1", "worker-B", 2, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired,
+        "a lapsed in-memory reservation must also be reclaimable"
+    );
+}
+
+/// Concurrency, not just sequence: 32 workers race for one key and exactly one
+/// may win. A sequential test cannot distinguish a real atomic claim from a
+/// get-then-insert that simply has not been raced yet.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn exactly_one_of_many_concurrent_claimants_wins() {
+    let db = std::sync::Arc::new(open_test_db().await);
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    let mut handles = Vec::new();
+    for i in 0..32 {
+        let db = db.clone();
+        let eid = eid.clone();
+        handles.push(tokio::spawn(async move {
+            matches!(
+                db.reserve_tool_effect("hot", &eid, "n1", &format!("worker-{i}"), i, ttl)
+                    .await
+                    .unwrap(),
+                ReserveOutcome::Acquired
+            )
+        }));
+    }
+
+    let mut winners = 0;
+    for h in handles {
+        if h.await.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "exactly one worker may fire the effect; {winners} were told the key was theirs"
     );
 }

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -673,3 +673,54 @@ async fn scoped_claim_side_expiry_consumes_attempts() {
         "an item that has spent its attempts must not be handed out again"
     );
 }
+
+/// One tenant's reservation must never be handed to another.
+///
+/// The reservation table originally had a GLOBAL `idempotency_key` primary key.
+/// A scoped upsert then conflicted on a row it could not see, affected zero
+/// rows, and its tenant-filtered lookup found nothing — which the code read as
+/// "free" and returned `Acquired`. Tenant B was told it owned a key tenant A
+/// held, and would have run the effect.
+///
+/// Both halves are asserted: B is refused, and A can still take its own key in
+/// the first place.
+#[tokio::test]
+async fn a_reservation_is_scoped_to_its_tenant() {
+    let db = open_test_db().await;
+    register_tenant(&db, "alpha", "Alpha").await;
+    register_tenant(&db, "beta", "Beta").await;
+    let a = db.for_tenant(TenantId::from("alpha"));
+    let b = db.for_tenant(TenantId::from("beta"));
+
+    let eid_a = ExecutionId::new();
+    let eid_b = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    assert_eq!(
+        a.reserve_tool_effect("shared-key", &eid_a, "n1", "worker-A", 1, ttl)
+            .await
+            .unwrap(),
+        jamjet_state::backend::ReserveOutcome::Acquired
+    );
+
+    // Beta asks for the same key string. It is a DIFFERENT reservation, so it
+    // must be grantable — the key is scoped, not globally exclusive.
+    assert_eq!(
+        b.reserve_tool_effect("shared-key", &eid_b, "n1", "worker-B", 1, ttl)
+            .await
+            .unwrap(),
+        jamjet_state::backend::ReserveOutcome::Acquired,
+        "a key is scoped per tenant; beta's reservation is not alpha's"
+    );
+
+    // ...and within a tenant it still excludes a second worker.
+    assert!(
+        matches!(
+            b.reserve_tool_effect("shared-key", &eid_b, "n1", "worker-C", 2, ttl)
+                .await
+                .unwrap(),
+            jamjet_state::backend::ReserveOutcome::Held { .. }
+        ),
+        "beta's own key must still be exclusive within beta"
+    );
+}

--- a/runtime/workers/src/test_support.rs
+++ b/runtime/workers/src/test_support.rs
@@ -200,6 +200,26 @@ impl StateBackend for FailingGetEvents {
             .await
     }
 
+    async fn reserve_tool_effect(
+        &self,
+
+        key: &str,
+
+        execution_id: &ExecutionId,
+
+        node_id: &str,
+
+        owner: &str,
+
+        lease_fence: i64,
+
+        ttl: std::time::Duration,
+    ) -> jamjet_state::backend::BackendResult<jamjet_state::backend::ReserveOutcome> {
+        self.inner
+            .reserve_tool_effect(key, execution_id, node_id, owner, lease_fence, ttl)
+            .await
+    }
+
     async fn get_tool_effect(
         &self,
         key: &str,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -338,10 +338,25 @@ impl Worker {
                             // are not hypothetical: a retry crash window, an
                             // approval-hold resurrection, or the public
                             // POST /work-items can all produce them.
-                            if let Some(outcome) = self
+                            // Bind the result BEFORE `?`: the heartbeat is
+                            // already running, and every other early return in
+                            // this function aborts it first. Propagating straight
+                            // out would leave a detached task renewing the lease
+                            // forever, so the item could never be reclaimed —
+                            // turning a contended key into a permanent wedge,
+                            // which is strictly worse than the double-fire the
+                            // reservation prevents.
+                            let claimed = match self
                                 .await_or_claim_effect(&key, &execution_id, &node_id, lease_fence)
-                                .await?
+                                .await
                             {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    heartbeat.abort();
+                                    return Err(e);
+                                }
+                            };
+                            if let Some(outcome) = claimed {
                                 // Someone else ran it and we read their result.
                                 info!(
                                     execution_id = %execution_id,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -40,6 +40,40 @@ pub struct Worker {
     executors: HashMap<String, Arc<dyn NodeExecutor>>,
 }
 
+/// Rebuild an [`ExecutionResult`] from a recorded `tool_effects` row.
+///
+/// Shared by BOTH replay paths — the one that finds a committed result up front,
+/// and the one that waited for another worker to produce it. They must
+/// reconstruct identically, or "replayed" would mean something different
+/// depending on which path got there.
+fn replayed_result(rec: &serde_json::Value) -> ExecutionResult {
+    ExecutionResult {
+        output: rec
+            .get("output")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+        state_patch: rec
+            .get("state_patch")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+        duration_ms: rec.get("duration_ms").and_then(|v| v.as_u64()).unwrap_or(0),
+        gen_ai_system: rec
+            .get("gen_ai_system")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        gen_ai_model: rec
+            .get("gen_ai_model")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        input_tokens: rec.get("input_tokens").and_then(|v| v.as_u64()),
+        output_tokens: rec.get("output_tokens").and_then(|v| v.as_u64()),
+        finish_reason: rec
+            .get("finish_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    }
+}
+
 impl Worker {
     pub fn new(
         worker_id: String,
@@ -292,84 +326,80 @@ impl Worker {
                                 %key,
                                 "Replaying recorded result; executor skipped"
                             );
-                            Ok(ExecutionResult {
-                                output: rec
-                                    .get("output")
-                                    .cloned()
-                                    .unwrap_or_else(|| serde_json::json!({})),
-                                state_patch: rec
-                                    .get("state_patch")
-                                    .cloned()
-                                    .unwrap_or_else(|| serde_json::json!({})),
-                                duration_ms: rec
-                                    .get("duration_ms")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(0),
-                                gen_ai_system: rec
-                                    .get("gen_ai_system")
-                                    .and_then(|v| v.as_str())
-                                    .map(str::to_string),
-                                gen_ai_model: rec
-                                    .get("gen_ai_model")
-                                    .and_then(|v| v.as_str())
-                                    .map(str::to_string),
-                                input_tokens: rec.get("input_tokens").and_then(|v| v.as_u64()),
-                                output_tokens: rec.get("output_tokens").and_then(|v| v.as_u64()),
-                                finish_reason: rec
-                                    .get("finish_reason")
-                                    .and_then(|v| v.as_str())
-                                    .map(str::to_string),
-                            })
+                            Ok(replayed_result(&rec))
                         }
                         None => {
-                            // No recorded result — fire the executor.
-                            match self.executors.get(&kind_tag) {
-                                Some(executor) if kind_tag == "agent_tool" => {
-                                    let (tx, mut rx) =
-                                        tokio::sync::mpsc::channel::<serde_json::Value>(64);
-                                    let backend = Arc::clone(&self.backend);
-                                    let eid = execution_id.clone();
-                                    let receiver_handle = tokio::spawn(async move {
-                                        while let Some(event) = rx.recv().await {
-                                            backend
-                                                .patch_append_array(
-                                                    &eid,
-                                                    "agent_tool_events",
-                                                    event,
-                                                )
-                                                .await
-                                                .map_err(|e| {
-                                                    format!("patch_append_array failed: {e}")
-                                                })?;
+                            // No recorded result. Before firing, CLAIM the key.
+                            //
+                            // `get_tool_effect` above only answers "did this
+                            // already run to completion". Two live items for one
+                            // node both read None and both fire, and the effect
+                            // happens twice — check-then-fire. Duplicate items
+                            // are not hypothetical: a retry crash window, an
+                            // approval-hold resurrection, or the public
+                            // POST /work-items can all produce them.
+                            if let Some(outcome) = self
+                                .await_or_claim_effect(&key, &execution_id, &node_id, lease_fence)
+                                .await?
+                            {
+                                // Someone else ran it and we read their result.
+                                info!(
+                                    execution_id = %execution_id,
+                                    node_id = %node_id,
+                                    %key,
+                                    "Replaying another worker's recorded result; executor skipped"
+                                );
+                                Ok(replayed_result(&outcome))
+                            } else {
+                                // The key is ours — fire the executor.
+                                match self.executors.get(&kind_tag) {
+                                    Some(executor) if kind_tag == "agent_tool" => {
+                                        let (tx, mut rx) =
+                                            tokio::sync::mpsc::channel::<serde_json::Value>(64);
+                                        let backend = Arc::clone(&self.backend);
+                                        let eid = execution_id.clone();
+                                        let receiver_handle = tokio::spawn(async move {
+                                            while let Some(event) = rx.recv().await {
+                                                backend
+                                                    .patch_append_array(
+                                                        &eid,
+                                                        "agent_tool_events",
+                                                        event,
+                                                    )
+                                                    .await
+                                                    .map_err(|e| {
+                                                        format!("patch_append_array failed: {e}")
+                                                    })?;
+                                            }
+                                            Ok::<(), String>(())
+                                        });
+                                        let result = executor.execute_streaming(&item, tx).await;
+                                        match receiver_handle.await {
+                                            Ok(Err(e)) => Err(ExecutorError::Fatal(e)),
+                                            Err(e) => Err(ExecutorError::Fatal(format!(
+                                                "Receiver task panicked: {e}"
+                                            ))),
+                                            Ok(Ok(())) => result,
                                         }
-                                        Ok::<(), String>(())
-                                    });
-                                    let result = executor.execute_streaming(&item, tx).await;
-                                    match receiver_handle.await {
-                                        Ok(Err(e)) => Err(ExecutorError::Fatal(e)),
-                                        Err(e) => Err(ExecutorError::Fatal(format!(
-                                            "Receiver task panicked: {e}"
-                                        ))),
-                                        Ok(Ok(())) => result,
                                     }
-                                }
-                                Some(executor) => executor.execute(&item).await,
-                                None => {
-                                    info!(
-                                        node_id = %node_id,
-                                        kind = %kind_tag,
-                                        "No executor; using stub"
-                                    );
-                                    Ok(ExecutionResult {
-                                        output: serde_json::json!({}),
-                                        state_patch: serde_json::json!({}),
-                                        duration_ms: start.elapsed().as_millis() as u64,
-                                        gen_ai_system: None,
-                                        gen_ai_model: None,
-                                        input_tokens: None,
-                                        output_tokens: None,
-                                        finish_reason: None,
-                                    })
+                                    Some(executor) => executor.execute(&item).await,
+                                    None => {
+                                        info!(
+                                            node_id = %node_id,
+                                            kind = %kind_tag,
+                                            "No executor; using stub"
+                                        );
+                                        Ok(ExecutionResult {
+                                            output: serde_json::json!({}),
+                                            state_patch: serde_json::json!({}),
+                                            duration_ms: start.elapsed().as_millis() as u64,
+                                            gen_ai_system: None,
+                                            gen_ai_model: None,
+                                            input_tokens: None,
+                                            output_tokens: None,
+                                            finish_reason: None,
+                                        })
+                                    }
                                 }
                             }
                         }
@@ -773,6 +803,94 @@ impl Worker {
                 }
             }
         }
+    }
+
+    /// How long a reservation is honoured before it is presumed dead.
+    ///
+    /// Only ever consulted when the reserving worker did NOT commit — a normal
+    /// run records its effect and every later reader replays that instead. So
+    /// this is the "worker died mid-tool" recovery window, and it is generous on
+    /// purpose: expiring sooner than a slow-but-alive tool would reintroduce the
+    /// double-fire the reservation exists to prevent.
+    const RESERVATION_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+
+    /// How long to wait for the winner's result before giving the item back.
+    const RESULT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+    const RESULT_POLL_ATTEMPTS: u32 = 40; // 10s
+
+    /// Claim `key`, or return the winner's already-committed result.
+    ///
+    /// `Ok(None)` means the key is OURS and the caller must run the effect.
+    /// `Ok(Some(result))` means someone else ran it and this is their recorded
+    /// output, to be replayed rather than repeated.
+    ///
+    /// Losing the race is retried ONCE before waiting, because the overwhelmingly
+    /// common reason to lose is that the winner finished microseconds ago: the
+    /// retry re-reads the committed effect and takes the fast path. Only a
+    /// genuinely concurrent run reaches the poll.
+    ///
+    /// Giving up is deliberate and safe. Returning an error hands the item back
+    /// to the normal retry machinery, and the reservation's TTL guarantees a
+    /// later attempt can take the key over — so a dead winner delays the node
+    /// rather than stranding it.
+    async fn await_or_claim_effect(
+        &self,
+        key: &str,
+        execution_id: &ExecutionId,
+        node_id: &str,
+        lease_fence: i64,
+    ) -> Result<Option<serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
+        for attempt in 0..2 {
+            match self
+                .backend
+                .reserve_tool_effect(
+                    key,
+                    execution_id,
+                    node_id,
+                    &self.worker_id,
+                    lease_fence,
+                    Self::RESERVATION_TTL,
+                )
+                .await?
+            {
+                jamjet_state::ReserveOutcome::Acquired => return Ok(None),
+                jamjet_state::ReserveOutcome::Held { owner, expires_at } => {
+                    // The winner may have committed between our read and our
+                    // claim. Check before deciding to wait.
+                    if let Some(rec) = self.backend.get_tool_effect(key).await? {
+                        return Ok(Some(rec));
+                    }
+                    if attempt == 0 {
+                        continue; // the one retry
+                    }
+                    warn!(
+                        execution_id = %execution_id,
+                        node_id,
+                        %key,
+                        %owner,
+                        %expires_at,
+                        "idempotency key reserved by another worker — awaiting its result \
+                         instead of running the effect twice"
+                    );
+                }
+            }
+        }
+
+        for _ in 0..Self::RESULT_POLL_ATTEMPTS {
+            tokio::time::sleep(Self::RESULT_POLL_INTERVAL).await;
+            if let Some(rec) = self.backend.get_tool_effect(key).await? {
+                return Ok(Some(rec));
+            }
+        }
+
+        // Hand the item back rather than firing. The TTL is what makes this safe
+        // to give up on: a later attempt takes the key over once the holder
+        // lapses, so the node is delayed, never stranded.
+        Err(format!(
+            "idempotency key {key} is held by another worker and no result appeared; \
+             retrying rather than running the effect twice"
+        )
+        .into())
     }
 
     // ── Policy check ──────────────────────────────────────────────────────────


### PR DESCRIPTION
The last engine-seam finding from the 2026-07-02 ADK review, and the one the spec called **"load-bearing, not optional"**.

## The bug

`get_tool_effect` can only answer *"did this already run to completion"*. Two live work items for one node both read `None` and both fire — check-then-fire, and the side effect happens twice. Duplicate live items are producible today: a retry crash window, an approval-hold resurrection, and the public `POST /work-items` all make them.

**Demonstrated, not asserted.** With a get-then-insert in place of the atomic claim, **29 of 32** concurrent claimants are told the key is theirs. With the conditional upsert, exactly one is.

## Design — the two calls you made

**Expiry is a lease-like TTL.** This is what stops the reservation becoming a *worse* failure than the double-fire it replaces: a worker that dies mid-tool leaves its row behind, and without expiry that key is unrunnable forever. A lapsed reservation is acquirable, so a dead holder delays the node rather than stranding it.

**A loser retries once before polling.** The overwhelmingly common reason to lose is that the winner committed microseconds ago, so the retry re-reads the recorded effect and takes the fast path. Only a genuinely concurrent run reaches the poll, and giving up there is safe — the item goes back to the normal retry machinery and the TTL guarantees a later attempt can take the key over.

## One thing the design missed, which your tests caught

Reentrancy. The reservation exists to exclude a **second** worker; it must not lock a worker out of **its own** node. A retry is the same logical attempt, and a node that fails *without* recording an effect leaves its reservation standing — so blocking the holder stalled every such retry for the full five-minute TTL.

The `continue_as_new` retry tests deadlocked against a reservation their own worker held. I had written a test asserting the wrong semantics (`the_holder_does_not_bypass_its_own_live_reservation`); it now asserts reentrancy for the holder and exclusion for everyone else, with the reason recorded in the docstring so it doesn't get "corrected" back.

## Safety properties

- Reservations are consulted **only** when no committed effect exists, so a row left behind by a successful run blocks nothing — the caller finds the result first and replays it.
- The claim is one statement, so there is no test-then-set window.
- The in-memory backend uses `entry` to hold the shard lock across the test-and-set; a get-then-insert there would reopen the same race in the backend most tests run against.
- Both replay paths now share one reconstruction, so "replayed" cannot come to mean two different things depending on which path got there.

## Tests

Sequential exclusion, holder reentrancy, expiry takeover, key independence, in-memory/SQLite parity, and a 32-way concurrent race asserting exactly one winner — the one verified to fail (29 winners) against a non-atomic implementation.

`cargo test --workspace` — 802 passed, 0 failed. `cargo fmt --all --check` clean.

## Follow-up, not in this PR

A failed attempt could **release** its reservation instead of waiting for the TTL, which would shorten recovery when a worker fails cleanly rather than dying. Reentrancy makes that an optimisation rather than a correctness need.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added idempotency protection for tool executions to prevent duplicate side effects.
  - Concurrent workers now coordinate reservations, replay completed results, or wait for in-progress work.
  - Expired reservations can be safely reclaimed for retry.

- **Bug Fixes**
  - Prevented duplicate tool execution when multiple workers process the same request.
  - Added consistent reservation behavior across in-memory and SQLite-backed state storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->