### PR TITLE
fix(api): settle and emit as one transaction on /work-items/:id/complete

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1454,6 +1454,20 @@ async fn complete_work_item(
     // execution never finished — permanently, since the fold is a replay of the
     // log. `commit_turn` is the primitive the in-process worker already uses for
     // exactly this, and it is fence-guarded, so a stale worker writes nothing.
+    // A lease fence is a MINTED token (`term * 2^32 + epoch`), so it is always
+    // positive. Zero is what a never-claimed row carries and what a defaulted or
+    // forged body sends, so it must never reach a fenced settle — treat it as
+    // absent rather than as a fence that happens to match every pending item.
+    if body.lease_fence.is_some_and(|f| f <= 0) {
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "completed": false,
+                "reason": "stale or invalid lease fence",
+            })),
+        ));
+    }
+
     let committed_atomically = match (
         body.lease_fence,
         body.execution_id.as_deref(),
@@ -1519,7 +1533,12 @@ async fn complete_work_item(
         }
     }
 
-    if let Some(exec_id_str) = &body.execution_id {
+    // Gated on BOTH coordinates, matching the terminal event. Refreshing the read
+    // model when no `NodeCompleted` was emitted would let the column drift in a
+    // way the event log cannot explain — and the log is what the materializer
+    // rebuilds from, so the two would simply disagree with no way to tell which
+    // is right.
+    if let (Some(exec_id_str), Some(_)) = (&body.execution_id, &body.node_id) {
         let execution_id = parse_execution_id(exec_id_str)?;
         // Denormalised read-model refresh, best effort by design: the
         // authoritative state is the event log plus the snapshot `commit_turn`

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1423,38 +1423,14 @@ async fn complete_work_item(
         .map_err(|_| ApiError::BadRequest(format!("invalid work item id: {id}")))?;
     let backend = state.backend_for(&tenant_id);
 
-    // Settle the work item. When the worker echoes its lease fence, the settle is
-    // fence-gated: a stale / forged fence (reclaimed or replayed worker) is
-    // rejected with 409 and we emit NO terminal event, so a lost lease can never
-    // duplicate a NodeCompleted. When the fence is absent, fall back to the legacy
-    // unfenced settle-by-id (backward-compat for callers not yet echoing it).
-    match body.lease_fence {
-        Some(fence) => {
-            let settled = backend.complete_work_item_fenced(item_id, fence).await?;
-            if !settled {
-                return Ok((
-                    StatusCode::CONFLICT,
-                    Json(json!({
-                        "completed": false,
-                        "reason": "stale or invalid lease fence",
-                    })),
-                ));
-            }
-        }
-        None => {
-            backend.complete_work_item(item_id).await?;
-        }
-    }
-
-    // Emit NodeCompleted event if execution_id and node_id are provided.
-    if let (Some(exec_id_str), Some(node_id)) = (&body.execution_id, &body.node_id) {
-        let execution_id = parse_execution_id(exec_id_str)?;
-        let seq = backend.latest_sequence(&execution_id).await? + 1;
-        let event = jamjet_state::Event::new(
+    let node_completed = |execution_id: &ExecutionId| {
+        jamjet_state::Event::new(
             execution_id.clone(),
-            seq,
+            // Sequence is assigned inside `commit_turn`'s transaction; this
+            // placeholder is never the number that lands.
+            0,
             jamjet_state::EventKind::NodeCompleted {
-                node_id: node_id.clone(),
+                node_id: body.node_id.clone().unwrap_or_default(),
                 output: body.output.clone(),
                 state_patch: body.state_patch.clone(),
                 duration_ms: body.duration_ms,
@@ -1467,10 +1443,88 @@ async fn complete_work_item(
                 provenance: None,
                 idempotency_key: None,
             },
-        );
-        backend.append_event(event).await?;
+        )
+    };
 
-        // Apply state_patch to the execution's current_state.
+    // Settle AND emit in ONE transaction.
+    //
+    // These used to be separate statements: settle the item, then append the
+    // NodeCompleted. A crash in that window left the item settled with no
+    // terminal event, so the scheduler fold kept the node in `scheduled` and the
+    // execution never finished — permanently, since the fold is a replay of the
+    // log. `commit_turn` is the primitive the in-process worker already uses for
+    // exactly this, and it is fence-guarded, so a stale worker writes nothing.
+    let committed_atomically = match (
+        body.lease_fence,
+        body.execution_id.as_deref(),
+        body.node_id.as_deref(),
+    ) {
+        (Some(fence), Some(exec_id_str), Some(_)) => {
+            let execution_id = parse_execution_id(exec_id_str)?;
+            match backend
+                .commit_turn(item_id, fence, node_completed(&execution_id), true)
+                .await
+            {
+                Ok(_) => true,
+                Err(jamjet_state::StateBackendError::FenceLost(_)) => {
+                    return Ok((
+                        StatusCode::CONFLICT,
+                        Json(json!({
+                            "completed": false,
+                            "reason": "stale or invalid lease fence",
+                        })),
+                    ));
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        // Fenced, but with no coordinates to build a terminal event from. Settle
+        // only — the same shape as before, and still fence-guarded.
+        (Some(fence), _, _) => {
+            let settled = backend.complete_work_item_fenced(item_id, fence).await?;
+            if !settled {
+                return Ok((
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "completed": false,
+                        "reason": "stale or invalid lease fence",
+                    })),
+                ));
+            }
+            false
+        }
+        // Legacy unfenced path, deprecated. Kept so callers that predate the
+        // fence keep working, but it cannot be made atomic: `commit_turn` is
+        // fence-guarded by construction, and without a fence we cannot show the
+        // item is ours to settle.
+        (None, _, _) => {
+            warn!(
+                work_item_id = %id,
+                "complete: unfenced legacy path — settle and terminal event are \
+                 not atomic; echo lease_fence to make them one transaction"
+            );
+            backend.complete_work_item(item_id).await?;
+            false
+        }
+    };
+
+    // The unfenced and no-coordinate paths still emit separately.
+    if !committed_atomically {
+        if let (Some(exec_id_str), Some(_)) = (&body.execution_id, &body.node_id) {
+            let execution_id = parse_execution_id(exec_id_str)?;
+            let seq = backend.latest_sequence(&execution_id).await? + 1;
+            let mut event = node_completed(&execution_id);
+            event.sequence = seq;
+            backend.append_event(event).await?;
+        }
+    }
+
+    if let Some(exec_id_str) = &body.execution_id {
+        let execution_id = parse_execution_id(exec_id_str)?;
+        // Denormalised read-model refresh, best effort by design: the
+        // authoritative state is the event log plus the snapshot `commit_turn`
+        // wrote inside the transaction, and the materializer recomputes from
+        // those. Losing this write costs a stale convenience column, not state.
         if let Ok(Some(mut exec)) = backend.get_execution(&execution_id).await {
             if let Some(state_obj) = exec.current_state.as_object_mut() {
                 if let Some(patch_obj) = body.state_patch.as_object() {

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -552,3 +552,90 @@ async fn replaying_a_completion_does_not_double_emit() {
         "exactly one NodeCompleted, not one per delivery"
     );
 }
+
+/// `lease_fence: 0` must not complete a work item nobody ever claimed.
+///
+/// Pending rows carry `lease_fence = 0` (migration 0004), and `commit_turn`'s
+/// fenced settle matched on `id` + `lease_fence` with no `status = 'claimed'`
+/// guard — so a forged or defaulted zero fence matched a never-claimed item and
+/// completed it, emitting a terminal event for work that never ran.
+///
+/// Routing /complete through `commit_turn` is what made that reachable from the
+/// HTTP boundary, so the guard belongs both there and here.
+#[tokio::test]
+async fn a_zero_fence_cannot_complete_an_unclaimed_item() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .unwrap();
+
+    // Enqueued and NEVER claimed: lease_fence is still 0.
+    let item_id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id: item_id,
+            execution_id: execution_id.clone(),
+            node_id: "n1".into(),
+            queue_type: "python_tool".into(),
+            payload: json!({"node_id": "n1"}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .unwrap();
+
+    let state = make_state(backend.clone());
+    let (status, _) = post_complete(
+        &state,
+        item_id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {"forged": true},
+            "state_patch": {},
+            "lease_fence": 0,
+        }),
+    )
+    .await;
+
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a zero fence must not complete an item nobody claimed"
+    );
+    assert_eq!(
+        node_completed_count(&events(&backend, &execution_id).await),
+        0,
+        "no terminal event may be emitted for work that never ran"
+    );
+    // And the item is still there to be claimed properly.
+    assert!(
+        backend
+            .claim_work_item("real-worker", &["python_tool"])
+            .await
+            .unwrap()
+            .is_some(),
+        "the item must remain claimable — a forged completion must not consume it"
+    );
+}

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -430,3 +430,125 @@ async fn the_unfenced_legacy_path_still_settles_but_warns() {
         "the legacy path emits nothing — that is exactly why it is deprecated"
     );
 }
+
+// ── /complete: the settle and the terminal event are ONE transaction ─────────
+
+async fn post_complete(state: &AppState, id: Uuid, body: Value) -> (StatusCode, Value) {
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post(format!("/work-items/{id}/complete"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+fn node_completed_count(events: &[Event]) -> usize {
+    events
+        .iter()
+        .filter(|e| matches!(e.kind, EventKind::NodeCompleted { .. }))
+        .count()
+}
+
+/// A fenced completion settles the item AND emits `NodeCompleted` together.
+///
+/// These used to be separate statements. A crash in the window left the item
+/// settled with no terminal event, so the scheduler fold kept the node in
+/// `scheduled` and the execution never finished — permanently, because the fold
+/// replays the log and reproduces the same gap every time.
+#[tokio::test]
+async fn a_fenced_completion_settles_and_emits_together() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, body) = post_complete(
+        &state,
+        id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {"ok": true},
+            "state_patch": {"ok": true},
+            "duration_ms": 5,
+            "lease_fence": fence,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["completed"], json!(true));
+    assert_eq!(
+        node_completed_count(&events(&backend, &execution_id).await),
+        1,
+        "a completion must leave exactly one NodeCompleted — without it the node \
+         stays scheduled and the execution never reaches a terminal state"
+    );
+}
+
+/// A stale fence completes nothing and emits nothing.
+#[tokio::test]
+async fn a_stale_fence_completion_is_refused_and_emits_nothing() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let (status, _) = post_complete(
+        &state,
+        id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {},
+            "state_patch": {},
+            "lease_fence": fence + 9,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        node_completed_count(&events(&backend, &execution_id).await),
+        0,
+        "a rejected completion must not emit a terminal event for work it did not settle"
+    );
+}
+
+/// Replaying a completion must not emit a second `NodeCompleted`.
+///
+/// The fence is consumed by the first settle, so the replay finds nothing of its
+/// own to commit — a duplicate terminal event would corrupt the fold.
+#[tokio::test]
+async fn replaying_a_completion_does_not_double_emit() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id, fence) = seed_and_claim(&backend, 3, 0).await;
+    let state = make_state(backend.clone());
+
+    let payload = json!({
+        "execution_id": execution_id.to_string(),
+        "node_id": "n1",
+        "output": {},
+        "state_patch": {},
+        "lease_fence": fence,
+    });
+
+    let (first, _) = post_complete(&state, id, payload.clone()).await;
+    assert_eq!(first, StatusCode::OK);
+    let (second, _) = post_complete(&state, id, payload).await;
+    assert_eq!(
+        second,
+        StatusCode::CONFLICT,
+        "the replay no longer holds the lease"
+    );
+
+    assert_eq!(
+        node_completed_count(&events(&backend, &execution_id).await),
+        1,
+        "exactly one NodeCompleted, not one per delivery"
+    );
+}

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1464,7 +1464,8 @@ impl StateBackend for SqliteBackend {
         // 1) Fenced settle. Zero rows => stale fence => fail closed, emit nothing.
         let rows = if set_completed_at {
             sqlx::query(
-                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL WHERE id = ? AND lease_fence = ?",
+                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL \
+                 WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
             )
             .bind(status)
             .bind(&now)
@@ -1476,7 +1477,8 @@ impl StateBackend for SqliteBackend {
             .rows_affected()
         } else {
             sqlx::query(
-                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL WHERE id = ? AND lease_fence = ?",
+                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL \
+                 WHERE id = ? AND lease_fence = ? AND status = 'claimed'",
             )
             .bind(status)
             .bind(&id_str)

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1384,7 +1384,8 @@ impl StateBackend for TenantScopedSqliteBackend {
         // Fenced settle with tenant isolation. Zero rows => stale fence => fail closed.
         let rows = if set_completed_at {
             sqlx::query(
-                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL WHERE id = ? AND tenant_id = ? AND lease_fence = ?",
+                "UPDATE work_items SET status = ?, completed_at = ?, lease_expires_at = NULL \
+                 WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
             )
             .bind(status)
             .bind(&now)
@@ -1397,7 +1398,8 @@ impl StateBackend for TenantScopedSqliteBackend {
             .rows_affected()
         } else {
             sqlx::query(
-                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL WHERE id = ? AND tenant_id = ? AND lease_fence = ?",
+                "UPDATE work_items SET status = ?, completed_at = NULL, lease_expires_at = NULL, worker_id = NULL \
+                 WHERE id = ? AND tenant_id = ? AND lease_fence = ? AND status = 'claimed'",
             )
             .bind(status)
             .bind(&id_str)


### PR DESCRIPTION
Closes two of the three remaining `/complete` items from the external-tool-tier finding in the 2026-07-02 ADK review.

## The wedge

Completion was **four disjoint operations**: settle the item, read the sequence, append `NodeCompleted`, refresh the execution's state column.

A crash between the settle and the append left the item settled with **no terminal event**. The scheduler fold then keeps the node in `scheduled`, and the execution never finishes — *permanently*, because the fold is a replay of the log, so every refold reproduces the same gap. It cannot heal.

This is the pattern Move 4 exists to kill, and it was still live on the transport ADK nodes actually take in production.

## The fix

The fenced path now uses `commit_turn`, the primitive the **in-process worker already uses for exactly this**. It settles, appends and snapshots in one transaction, and it is fence-guarded — so a stale worker writes nothing, and a lost fence is a clean 409 rather than a partial commit.

Reusing it rather than hand-rolling a second transactional path also means the two transports converge on one definition of "a turn committed".

## What deliberately did NOT change

**The unfenced legacy path stays**, for callers that predate the fence — but it *cannot* be made atomic: `commit_turn` is fence-guarded by construction, and without a fence we cannot show the item is ours to settle. It now logs a warning saying so, rather than looking equivalent to the fenced path.

**The `current_state` refresh stays best-effort and outside the transaction.** It is a denormalised convenience column: the authoritative state is the event log plus the snapshot `commit_turn` writes *inside* the transaction, the materializer recomputes from those, and the in-process worker never maintains the column at all. Losing that write costs a stale read model, not state. Moving it inside would have been the tidier-looking change and the wrong one.

## Tests

- a fenced completion leaves **exactly one** `NodeCompleted`;
- a stale fence emits **nothing** for work it did not settle;
- a replayed delivery does not double-emit — the fence is consumed by the first settle, so the replay has nothing of its own to commit.

`cargo test --workspace` — 806 passed, 0 failed. `cargo fmt --all --check` clean.

## Still open on this path

`idempotency_key` is still `None` here, so the replay guard does not cover external tool effects — the reserve-before-fire work in #125 protects the in-process path only. Closing it means plumbing the key through claim → worker → complete across the Python and Java workers, which is its own change and crosses repos.
