### PR TITLE
fix(worker): release the reservation when an attempt parks without committing

### DIFF
--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1289,12 +1289,13 @@ impl StateBackend for FailFirstGetEvents {
 
     async fn release_tool_reservation(
         &self,
-
         key: &str,
-
         owner: &str,
+        lease_fence: i64,
     ) -> jamjet_state::backend::BackendResult<()> {
-        self.inner.release_tool_reservation(key, owner).await
+        self.inner
+            .release_tool_reservation(key, owner, lease_fence)
+            .await
     }
 
     async fn reserve_tool_effect(

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1287,6 +1287,16 @@ impl StateBackend for FailFirstGetEvents {
             .await
     }
 
+    async fn release_tool_reservation(
+        &self,
+
+        key: &str,
+
+        owner: &str,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.release_tool_reservation(key, owner).await
+    }
+
     async fn reserve_tool_effect(
         &self,
 

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -202,20 +202,6 @@ pub trait StateBackend: Send + Sync {
     /// Reservations are consulted ONLY when no committed effect exists, so a row
     /// left behind after a successful commit blocks nothing — the caller finds
     /// the recorded result first and replays it.
-    /// Give up a reservation this worker holds, without having recorded a result.
-    ///
-    /// A reservation left standing is not a correctness problem — it is
-    /// reentrant for its holder, and it lapses on its TTL — but until then a
-    /// DIFFERENT worker that picks the node up must wait it out. Releasing on a
-    /// path that ends without committing (a park, a failure) turns that wait
-    /// from minutes into nothing.
-    ///
-    /// Owner-guarded: releasing is a claim about ownership, so a worker whose
-    /// lease was stolen must not be able to free the key for the worker that
-    /// took over. A non-matching owner is a silent no-op, like every other fenced
-    /// write here.
-    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()>;
-
     async fn reserve_tool_effect(
         &self,
         key: &str,
@@ -225,6 +211,29 @@ pub trait StateBackend: Send + Sync {
         lease_fence: i64,
         ttl: std::time::Duration,
     ) -> BackendResult<ReserveOutcome>;
+
+    /// Give up a reservation this worker holds, without having recorded a result.
+    ///
+    /// A reservation left standing is not a correctness problem — it is
+    /// reentrant for its holder, and it lapses on its TTL — but until then a
+    /// DIFFERENT worker that picks the node up must wait it out. Releasing on a
+    /// path that ends without committing (a park, a failure) turns that wait
+    /// from minutes into nothing.
+    ///
+    /// Guarded by owner AND lease fence, because the owner alone is not enough.
+    /// Worker ids are configurable and reused, and `reserve_tool_effect` is
+    /// reentrant for the same owner — it REPLACES the reservation with the newer
+    /// lease. So an older attempt from the same worker id finishing late would
+    /// otherwise delete the NEWER attempt's reservation and let a third worker
+    /// acquire a key that is actively held. The fence is what distinguishes the
+    /// two attempts. A non-matching owner or fence is a silent no-op, like every
+    /// other fenced write here.
+    async fn release_tool_reservation(
+        &self,
+        key: &str,
+        owner: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()>;
 
     // ── Content-addressed artifact store ─────────────────────────────────────
 

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -202,6 +202,20 @@ pub trait StateBackend: Send + Sync {
     /// Reservations are consulted ONLY when no committed effect exists, so a row
     /// left behind after a successful commit blocks nothing — the caller finds
     /// the recorded result first and replays it.
+    /// Give up a reservation this worker holds, without having recorded a result.
+    ///
+    /// A reservation left standing is not a correctness problem — it is
+    /// reentrant for its holder, and it lapses on its TTL — but until then a
+    /// DIFFERENT worker that picks the node up must wait it out. Releasing on a
+    /// path that ends without committing (a park, a failure) turns that wait
+    /// from minutes into nothing.
+    ///
+    /// Owner-guarded: releasing is a claim about ownership, so a worker whose
+    /// lease was stolen must not be able to free the key for the worker that
+    /// took over. A non-matching owner is a silent no-op, like every other fenced
+    /// write here.
+    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()>;
+
     async fn reserve_tool_effect(
         &self,
         key: &str,

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -41,8 +41,8 @@ pub struct InMemoryBackend {
     /// Idempotency cache: idempotency_key -> result_json.
     /// Mirrors the `tool_effects` table in the SQLite backends.
     tool_effects: DashMap<String, serde_json::Value>,
-    /// Reservations: idempotency key -> (owner, expires_at).
-    tool_reservations: DashMap<String, (String, chrono::DateTime<Utc>)>,
+    /// Reservations: idempotency key -> (owner, lease_fence, expires_at).
+    tool_reservations: DashMap<String, (String, i64, chrono::DateTime<Utc>)>,
     /// Projected approval read-model. Key = (execution_id as String, node_id).
     proj_approvals: DashMap<(String, String), crate::backend::ApprovalProjectionRow>,
     /// Projector checkpoints. Key = (projection_name, execution_id as String).
@@ -335,12 +335,19 @@ impl StateBackend for InMemoryBackend {
 
     // ── Idempotency cache ─────────────────────────────────────────────────
 
-    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
+    async fn release_tool_reservation(
+        &self,
+        key: &str,
+        owner: &str,
+        _lease_fence: i64,
+    ) -> BackendResult<()> {
         // Owner-guarded remove: `remove_if` holds the shard lock across the
         // predicate, so a stale worker cannot free a key another worker took over
         // in the gap between checking and removing.
         self.tool_reservations
-            .remove_if(&key.to_string(), |_k, (holder, _)| holder == owner);
+            .remove_if(&key.to_string(), |_k, (holder, fence, _)| {
+                holder == owner && *fence == _lease_fence
+            });
         Ok(())
     }
 
@@ -350,7 +357,7 @@ impl StateBackend for InMemoryBackend {
         _execution_id: &ExecutionId,
         _node_id: &str,
         owner: &str,
-        _lease_fence: i64,
+        lease_fence: i64,
         ttl: std::time::Duration,
     ) -> BackendResult<ReserveOutcome> {
         let now = Utc::now();
@@ -363,14 +370,17 @@ impl StateBackend for InMemoryBackend {
         use dashmap::mapref::entry::Entry;
         match self.tool_reservations.entry(key.to_string()) {
             Entry::Vacant(v) => {
-                v.insert((owner.to_string(), expires_at));
+                v.insert((owner.to_string(), lease_fence, expires_at));
                 Ok(ReserveOutcome::Acquired)
             }
             Entry::Occupied(mut o) => {
-                let (holder, holder_expiry) = o.get().clone();
+                let (holder, _, holder_expiry) = o.get().clone();
                 if holder == owner || holder_expiry <= now {
-                    // Lapsed: the holder is presumed dead, so take it over.
-                    o.insert((owner.to_string(), expires_at));
+                    // Reentrant for the holder, or lapsed and presumed dead.
+                    // Either way the reservation is REPLACED, so it now carries
+                    // the newer fence — which is what makes a late release from
+                    // the older attempt a no-op.
+                    o.insert((owner.to_string(), lease_fence, expires_at));
                     return Ok(ReserveOutcome::Acquired);
                 }
                 Ok(ReserveOutcome::Held {

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -335,6 +335,15 @@ impl StateBackend for InMemoryBackend {
 
     // ── Idempotency cache ─────────────────────────────────────────────────
 
+    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
+        // Owner-guarded remove: `remove_if` holds the shard lock across the
+        // predicate, so a stale worker cannot free a key another worker took over
+        // in the gap between checking and removing.
+        self.tool_reservations
+            .remove_if(&key.to_string(), |_k, (holder, _)| holder == owner);
+        Ok(())
+    }
+
     async fn reserve_tool_effect(
         &self,
         key: &str,

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -844,13 +844,27 @@ impl StateBackend for SqliteBackend {
     // ── Idempotency cache ─────────────────────────────────────────────────
 
     #[instrument(skip(self), fields(key = key, owner = owner))]
-    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
-        sqlx::query("DELETE FROM tool_reservations WHERE idempotency_key = ? AND owner = ?")
-            .bind(key)
-            .bind(owner)
-            .execute(&self.pool)
-            .await
-            .map_err(map_db_err)?;
+    async fn release_tool_reservation(
+        &self,
+        key: &str,
+        owner: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()> {
+        // `tenant_id` is part of the key here, so it must be part of the delete.
+        // This backend writes its rows as 'default'; without the filter a default
+        // release could remove a TENANT-scoped row that happens to share the key
+        // and owner — the same cross-tenant shape the reservation PK was fixed
+        // for.
+        sqlx::query(
+            "DELETE FROM tool_reservations \
+             WHERE idempotency_key = ? AND owner = ? AND lease_fence = ? AND tenant_id = 'default'",
+        )
+        .bind(key)
+        .bind(owner)
+        .bind(lease_fence)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
         Ok(())
     }
     #[instrument(skip(self), fields(key = key, owner = owner))]

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -844,6 +844,16 @@ impl StateBackend for SqliteBackend {
     // ── Idempotency cache ─────────────────────────────────────────────────
 
     #[instrument(skip(self), fields(key = key, owner = owner))]
+    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
+        sqlx::query("DELETE FROM tool_reservations WHERE idempotency_key = ? AND owner = ?")
+            .bind(key)
+            .bind(owner)
+            .execute(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        Ok(())
+    }
+    #[instrument(skip(self), fields(key = key, owner = owner))]
     async fn reserve_tool_effect(
         &self,
         key: &str,

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -768,14 +768,23 @@ impl StateBackend for TenantScopedSqliteBackend {
     // ── Idempotency cache ─────────────────────────────────────────────────
 
     #[instrument(skip(self), fields(key = key, owner = owner))]
-    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
-        sqlx::query("DELETE FROM tool_reservations WHERE idempotency_key = ? AND owner = ? AND tenant_id = ?")
-            .bind(key)
-            .bind(owner)
-            .bind(&self.tenant_id.0)
-            .execute(&self.pool)
-            .await
-            .map_err(map_db_err)?;
+    async fn release_tool_reservation(
+        &self,
+        key: &str,
+        owner: &str,
+        lease_fence: i64,
+    ) -> BackendResult<()> {
+        sqlx::query(
+            "DELETE FROM tool_reservations \
+             WHERE idempotency_key = ? AND owner = ? AND lease_fence = ? AND tenant_id = ?",
+        )
+        .bind(key)
+        .bind(owner)
+        .bind(lease_fence)
+        .bind(&self.tenant_id.0)
+        .execute(&self.pool)
+        .await
+        .map_err(map_db_err)?;
         Ok(())
     }
     #[instrument(skip(self), fields(tenant = %self.tenant_id, key = key, owner = owner))]

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -767,6 +767,17 @@ impl StateBackend for TenantScopedSqliteBackend {
 
     // ── Idempotency cache ─────────────────────────────────────────────────
 
+    #[instrument(skip(self), fields(key = key, owner = owner))]
+    async fn release_tool_reservation(&self, key: &str, owner: &str) -> BackendResult<()> {
+        sqlx::query("DELETE FROM tool_reservations WHERE idempotency_key = ? AND owner = ? AND tenant_id = ?")
+            .bind(key)
+            .bind(owner)
+            .bind(&self.tenant_id.0)
+            .execute(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        Ok(())
+    }
     #[instrument(skip(self), fields(tenant = %self.tenant_id, key = key, owner = owner))]
     async fn reserve_tool_effect(
         &self,

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -833,7 +833,7 @@ async fn releasing_a_reservation_frees_it_immediately() {
         ReserveOutcome::Held { .. }
     ));
 
-    db.release_tool_reservation("rel", "worker-A")
+    db.release_tool_reservation("rel", "worker-A", 1)
         .await
         .unwrap();
 
@@ -860,7 +860,7 @@ async fn a_non_holder_cannot_release_someone_elses_reservation() {
         .unwrap();
 
     // A stale worker tries to free it.
-    db.release_tool_reservation("guarded", "worker-stale")
+    db.release_tool_reservation("guarded", "worker-stale", 1)
         .await
         .unwrap();
 
@@ -886,7 +886,7 @@ async fn the_in_memory_backend_releases_identically() {
     db.reserve_tool_effect("m", &eid, "n1", "worker-A", 1, ttl)
         .await
         .unwrap();
-    db.release_tool_reservation("m", "worker-stale")
+    db.release_tool_reservation("m", "worker-stale", 1)
         .await
         .unwrap();
     assert!(
@@ -899,7 +899,9 @@ async fn the_in_memory_backend_releases_identically() {
         "a non-holder's release must be a no-op in memory too"
     );
 
-    db.release_tool_reservation("m", "worker-A").await.unwrap();
+    db.release_tool_reservation("m", "worker-A", 1)
+        .await
+        .unwrap();
     assert_eq!(
         db.reserve_tool_effect("m", &eid, "n1", "worker-B", 2, ttl)
             .await

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -807,3 +807,103 @@ async fn exactly_one_of_many_concurrent_claimants_wins() {
         "exactly one worker may fire the effect; {winners} were told the key was theirs"
     );
 }
+
+/// A released reservation is immediately available to another worker.
+///
+/// Parking or failing ends an attempt WITHOUT recording an effect, so the
+/// reservation must not outlive it. It is reentrant for its holder and lapses on
+/// its TTL either way, but until then a DIFFERENT worker picking the node up
+/// would wait out the remaining TTL for a key nobody is working on.
+#[tokio::test]
+async fn releasing_a_reservation_frees_it_immediately() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    assert_eq!(
+        db.reserve_tool_effect("rel", &eid, "n1", "worker-A", 1, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired
+    );
+    assert!(matches!(
+        db.reserve_tool_effect("rel", &eid, "n1", "worker-B", 2, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Held { .. }
+    ));
+
+    db.release_tool_reservation("rel", "worker-A")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        db.reserve_tool_effect("rel", &eid, "n1", "worker-B", 2, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired,
+        "a released key must be takeable at once, not after the TTL"
+    );
+}
+
+/// Only the holder may release. A worker whose lease was stolen must not be able
+/// to free the key for the worker that took over — that would hand a live
+/// reservation to a third party.
+#[tokio::test]
+async fn a_non_holder_cannot_release_someone_elses_reservation() {
+    let db = open_test_db().await;
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    db.reserve_tool_effect("guarded", &eid, "n1", "worker-A", 1, ttl)
+        .await
+        .unwrap();
+
+    // A stale worker tries to free it.
+    db.release_tool_reservation("guarded", "worker-stale")
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(
+            db.reserve_tool_effect("guarded", &eid, "n1", "worker-C", 3, ttl)
+                .await
+                .unwrap(),
+            ReserveOutcome::Held { .. }
+        ),
+        "a non-holder's release must be a no-op — A still owns this key"
+    );
+}
+
+/// The in-memory backend must release identically, or every worker test runs
+/// against different semantics from production.
+#[tokio::test]
+async fn the_in_memory_backend_releases_identically() {
+    let db = InMemoryBackend::new();
+    let eid = ExecutionId::new();
+    let ttl = std::time::Duration::from_secs(300);
+
+    db.reserve_tool_effect("m", &eid, "n1", "worker-A", 1, ttl)
+        .await
+        .unwrap();
+    db.release_tool_reservation("m", "worker-stale")
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            db.reserve_tool_effect("m", &eid, "n1", "worker-B", 2, ttl)
+                .await
+                .unwrap(),
+            ReserveOutcome::Held { .. }
+        ),
+        "a non-holder's release must be a no-op in memory too"
+    );
+
+    db.release_tool_reservation("m", "worker-A").await.unwrap();
+    assert_eq!(
+        db.reserve_tool_effect("m", &eid, "n1", "worker-B", 2, ttl)
+            .await
+            .unwrap(),
+        ReserveOutcome::Acquired
+    );
+}

--- a/runtime/workers/src/test_support.rs
+++ b/runtime/workers/src/test_support.rs
@@ -202,12 +202,13 @@ impl StateBackend for FailingGetEvents {
 
     async fn release_tool_reservation(
         &self,
-
         key: &str,
-
         owner: &str,
+        lease_fence: i64,
     ) -> jamjet_state::backend::BackendResult<()> {
-        self.inner.release_tool_reservation(key, owner).await
+        self.inner
+            .release_tool_reservation(key, owner, lease_fence)
+            .await
     }
 
     async fn reserve_tool_effect(

--- a/runtime/workers/src/test_support.rs
+++ b/runtime/workers/src/test_support.rs
@@ -200,6 +200,16 @@ impl StateBackend for FailingGetEvents {
             .await
     }
 
+    async fn release_tool_reservation(
+        &self,
+
+        key: &str,
+
+        owner: &str,
+    ) -> jamjet_state::backend::BackendResult<()> {
+        self.inner.release_tool_reservation(key, owner).await
+    }
+
     async fn reserve_tool_effect(
         &self,
 

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -631,6 +631,27 @@ impl Worker {
                         + chrono::Duration::seconds(retry_after_secs as i64))
                     .to_rfc3339();
 
+                    // Parking ends this attempt WITHOUT recording an effect, so
+                    // the reservation this worker took must not outlive it. It is
+                    // reentrant for us and lapses on its TTL either way, but a
+                    // DIFFERENT worker picking the node up after the backoff
+                    // would otherwise wait out the remaining TTL for a key nobody
+                    // is working on. Owner-guarded, so a stale worker cannot free
+                    // a key that has already been taken over.
+                    if let Some(k) = computed_key.as_deref() {
+                        if let Err(e) = self
+                            .backend
+                            .release_tool_reservation(k, &self.worker_id)
+                            .await
+                        {
+                            warn!(
+                                execution_id = %execution_id,
+                                node_id = %node_id,
+                                "could not release the reservation on park; it will lapse on its TTL: {e}"
+                            );
+                        }
+                    }
+
                     // Fence-guarded reset to pending with retry_after backoff.
                     // Park first; only append NodeParked if the park actually succeeds.
                     // A stale-fence park (Ok(false)) must NOT produce a false audit record.

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -631,27 +631,6 @@ impl Worker {
                         + chrono::Duration::seconds(retry_after_secs as i64))
                     .to_rfc3339();
 
-                    // Parking ends this attempt WITHOUT recording an effect, so
-                    // the reservation this worker took must not outlive it. It is
-                    // reentrant for us and lapses on its TTL either way, but a
-                    // DIFFERENT worker picking the node up after the backoff
-                    // would otherwise wait out the remaining TTL for a key nobody
-                    // is working on. Owner-guarded, so a stale worker cannot free
-                    // a key that has already been taken over.
-                    if let Some(k) = computed_key.as_deref() {
-                        if let Err(e) = self
-                            .backend
-                            .release_tool_reservation(k, &self.worker_id)
-                            .await
-                        {
-                            warn!(
-                                execution_id = %execution_id,
-                                node_id = %node_id,
-                                "could not release the reservation on park; it will lapse on its TTL: {e}"
-                            );
-                        }
-                    }
-
                     // Fence-guarded reset to pending with retry_after backoff.
                     // Park first; only append NodeParked if the park actually succeeds.
                     // A stale-fence park (Ok(false)) must NOT produce a false audit record.
@@ -661,6 +640,36 @@ impl Worker {
                         .await
                     {
                         Ok(true) => {
+                            // Park landed, so this attempt is over WITHOUT having
+                            // recorded an effect: give the key back. Ordering
+                            // matters — releasing BEFORE the park would free the
+                            // key even when the park is rejected on a stale
+                            // fence, letting another item acquire it while this
+                            // one is still claimed.
+                            //
+                            // Guarded by owner AND fence: `reserve_tool_effect`
+                            // is reentrant for the same worker id and REPLACES
+                            // the reservation with the newer lease, so an older
+                            // attempt finishing late would otherwise delete the
+                            // newer attempt's claim.
+                            //
+                            // Latency, not correctness: the reservation lapses on
+                            // its TTL regardless, which is why a failure here is
+                            // logged and swallowed rather than failing the node.
+                            if let Some(k) = computed_key.as_deref() {
+                                if let Err(e) = self
+                                    .backend
+                                    .release_tool_reservation(k, &self.worker_id, lease_fence)
+                                    .await
+                                {
+                                    warn!(
+                                        execution_id = %execution_id,
+                                        node_id = %node_id,
+                                        "could not release the reservation on park; it will lapse on its TTL: {e}"
+                                    );
+                                }
+                            }
+
                             // Park succeeded — now record the audit event.
                             let seq = match self.backend.latest_sequence(&execution_id).await {
                                 Ok(s) => s + 1,
@@ -2085,6 +2094,88 @@ mod tests {
     ///
     /// The in-memory backend does not enforce the `retry_after` not-before window,
     /// so the item is immediately re-claimable in this test.
+    /// A parked node gives its idempotency key back.
+    ///
+    /// Asserted at the WORKER level on purpose: the backend-level release tests
+    /// exercise `release_tool_reservation` directly, so a regression that removed
+    /// or misplaced the call in `execute_item` would leave them all green while
+    /// the key stayed held for the whole five-minute TTL.
+    ///
+    /// Verified by taking the key afterwards as a DIFFERENT worker — the holder
+    /// could re-take it either way, since reservations are reentrant, so
+    /// re-reserving as the same worker would prove nothing.
+    #[tokio::test]
+    async fn parking_releases_the_idempotency_key() {
+        let (backend, eid) = setup_backend().await;
+        let worker = Worker::new(
+            "test-worker".into(),
+            backend.clone() as Arc<dyn StateBackend>,
+            vec!["default".into()],
+        )
+        .register_executor(
+            "tool",
+            Arc::new(RateLimitingExecutor {
+                retry_after_secs: 5,
+            }),
+        );
+
+        let item = backend
+            .claim_work_item("test-worker", &["default"])
+            .await
+            .unwrap()
+            .expect("item must be claimable");
+        worker.execute_item(item).await.unwrap();
+
+        // The park happened...
+        assert!(
+            backend
+                .get_events(&eid)
+                .await
+                .unwrap()
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::NodeParked { .. })),
+            "precondition: the node must have parked"
+        );
+
+        // ...and it left no reservation standing. Reconstruct the key the worker
+        // computed: content_hash({run, segment, step, node, input_hash}) with
+        // step = 0, since a parked node never completed.
+        let current_state = backend
+            .get_execution(&eid)
+            .await
+            .unwrap()
+            .map(|e| e.current_state)
+            .unwrap_or_else(|| serde_json::json!({}));
+        let key = jamjet_state::content_hash(&serde_json::json!({
+            "run": eid.to_string(),
+            "segment": 0,
+            "step": 0,
+            "node": "n1",
+            // The field is "input", not "input_hash" — see the key construction
+            // in `execute_item`. Getting it wrong here does not fail loudly: it
+            // reserves a key nobody ever took, so the assertion below passes for
+            // the wrong reason. This test was briefly doing exactly that.
+            "input": jamjet_state::content_hash(&current_state),
+        }));
+
+        assert_eq!(
+            backend
+                .reserve_tool_effect(
+                    &key,
+                    &eid,
+                    "n1",
+                    "another-worker",
+                    99,
+                    std::time::Duration::from_secs(300)
+                )
+                .await
+                .unwrap(),
+            jamjet_state::ReserveOutcome::Acquired,
+            "a parked node must release its key — another worker had to wait out \
+             the whole TTL for work nobody was doing"
+        );
+    }
+
     #[tokio::test]
     async fn park_on_rate_limit_under_max_attempts() {
         let (backend, eid) = setup_backend().await; // item: attempt=0, max_attempts=3


### PR DESCRIPTION
Closes the one review point from #125 that I deferred rather than fixed. Its acute half — a leaked heartbeat renewing the lease forever — shipped with that PR; this is the remainder. Leaving it as a merged-PR TODO is how such things get lost.

## What it fixes

Parking ends an attempt **without recording an effect**, so the reservation it took outlived it.

That was never a correctness problem — the reservation is reentrant for its holder and lapses on its TTL. But until then a *different* worker picking the node up after the backoff waits out the remaining TTL for a key **nobody is working on**: up to five minutes of nothing, for a node that merely hit a rate limit.

## Design

`release_tool_reservation` is **owner-guarded**, because releasing is a claim about ownership. A worker whose lease was stolen must not be able to free the key for the worker that took over — that would hand a live reservation to a third party. A non-matching owner is a silent no-op, like every other fenced write here.

The in-memory backend uses `remove_if`, so the predicate and the removal are one locked step rather than reopening that gap in the backend most tests run against.

Failing to release is logged and swallowed: the reservation still lapses on its TTL, so the fallback is the previous behaviour, not a stuck node.

## Tests

Five, including **both directions** of the ownership guard — a release frees the key immediately, and a non-holder's release is a no-op — plus in-memory parity. A dev backend that released more freely than production would make every worker test pass against semantics that don't ship.

`cargo test --workspace` — 810 passed, 0 failed. `cargo fmt --all --check` clean.

## Review status across the batch

With this, every inline finding on #114, #118, #125 and #126 is resolved:

| PR | findings | outcome |
|---|---|---|
| #114 | 5 | all fixed in-PR |
| #118 | 4 | 2 in-PR, 2 in #122 |
| #125 | 5 | 4 in-PR, this one here |
| #126 | 2 | both fixed in-PR |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limited work items now release their tool reservations before retrying, allowing other workers to proceed sooner.
  * Reservations can only be released by their owner; unauthorized release attempts leave them unchanged.
  * Reservation handling is consistent across supported storage backends.
* **Tests**
  * Added coverage for reservation release, ownership protection, and immediate reacquisition by another worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->