### PR TITLE
Exactly-once for external tool effects, and the Bun CI job green again

### DIFF
--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -53,5 +53,14 @@ jobs:
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
       - uses: oven-sh/setup-bun@v2
       - run: pnpm install --frozen-lockfile
-      - run: bun --bun pnpm test
+      # `bun run --bun test`, not `bun --bun pnpm test`. Bun resolves the first
+      # argument as a package.json script or a node_modules/.bin entry, and
+      # pnpm/action-setup v6 installs pnpm globally instead — so `pnpm` was not
+      # a name Bun could resolve and the job died with `Script not found "pnpm"`
+      # on every commit from 2026-05-13 onward.
+      #
+      # Going through the package's own `test` script drops pnpm out of the
+      # invocation entirely, and `--bun` still forces the Bun runtime, which is
+      # the only thing this job exists to check.
+      - run: bun run --bun test
         working-directory: sdk/typescript/packages/cloud

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -53,14 +53,21 @@ jobs:
           cache-dependency-path: sdk/typescript/pnpm-lock.yaml
       - uses: oven-sh/setup-bun@v2
       - run: pnpm install --frozen-lockfile
-      # `bun run --bun test`, not `bun --bun pnpm test`. Bun resolves the first
-      # argument as a package.json script or a node_modules/.bin entry, and
-      # pnpm/action-setup v6 installs pnpm globally instead — so `pnpm` was not
-      # a name Bun could resolve and the job died with `Script not found "pnpm"`
-      # on every commit from 2026-05-13 onward.
+      # Build first: the smoke check imports the emitted bundle, which is what a
+      # Bun user actually installs.
+      - run: pnpm build
+      # A plain Bun script, not `vitest` under `--bun`.
       #
-      # Going through the package's own `test` script drops pnpm out of the
-      # invocation entirely, and `--bun` still forces the Bun runtime, which is
-      # the only thing this job exists to check.
-      - run: bun run --bun test
+      # This step used to be `bun --bun pnpm test`. Bun resolves the first
+      # argument as a package.json script or a node_modules/.bin entry, and
+      # pnpm/action-setup v6 installs pnpm globally instead, so it died with
+      # `Script not found "pnpm"` on every commit from 2026-05-13 onward.
+      #
+      # Fixing the invocation revealed why it was worth fixing: vitest under the
+      # Bun runtime cannot resolve zod's named export, so every suite failed on
+      # `z.object`. That is a property of vitest's module runner, not of this
+      # SDK — it says nothing about whether the package works for a Bun user,
+      # which is the only question this job exists to answer. So ask that
+      # question directly.
+      - run: bun run scripts/bun-smoke.ts
         working-directory: sdk/typescript/packages/cloud

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1069,6 +1069,21 @@ async fn claim_work_item(
         return Ok(nothing_to_claim());
     }
 
+    // The idempotency key for THIS node occurrence, computed here because claim
+    // time is fire time for the external tier — the moment the payload leaves
+    // the engine is the moment the effect becomes possible.
+    //
+    // Without it, an external tool's result was recorded with
+    // `idempotency_key: None`, so nothing ever landed in `tool_effects` and the
+    // replay guard covered the in-process tier only. Re-running a node re-fired
+    // the tool, on the transport ADK nodes actually take.
+    //
+    // Best effort: if the state needed to compute it cannot be read, the item is
+    // still handed out. That is the behaviour this route had all along, and
+    // withholding real work because a replay OPTIMISATION could not be prepared
+    // would trade a live queue for a hygiene property.
+    let idem_key = compute_idempotency_key(backend.as_ref(), &wi).await;
+
     Ok(Json(json!({
         "claimed": true,
         "work_item": {
@@ -1081,8 +1096,25 @@ async fn claim_work_item(
             // The lease fence the external worker echoes on complete so the
             // engine can prove the lease is still held (exactly-once-COMMIT).
             "lease_fence": wi.lease_fence,
+            // Echoed on complete so the result is recorded against it and a
+            // re-run replays instead of re-firing the tool.
+            "idempotency_key": idem_key,
         }
     })))
+}
+
+/// The idempotency key for a claimed item, or `None` if it cannot be computed.
+///
+/// Delegates to `jamjet_state::derive_idempotency_key`, the SAME function
+/// `Worker::execute_item` uses, so the in-process and external transports
+/// cannot drift into filing effects under different keys.
+async fn compute_idempotency_key(
+    backend: &dyn jamjet_state::backend::StateBackend,
+    wi: &WorkItem,
+) -> Option<String> {
+    jamjet_state::derive_idempotency_key(backend, &wi.execution_id, &wi.node_id)
+        .await
+        .ok()
 }
 
 /// Run the shared agent-dispatch guard over a freshly claimed item.
@@ -1394,6 +1426,15 @@ struct CompleteWorkItemRequest {
     /// (backward-compat for callers not yet echoing the fence).
     #[serde(default)]
     lease_fence: Option<i64>,
+    /// Idempotency key echoed from the claim response.
+    ///
+    /// With it, `commit_turn` records the result in `tool_effects` in the same
+    /// transaction, so a re-run of this node replays the recorded output instead
+    /// of firing the tool again. Without it nothing is recorded and the replay
+    /// guard simply does not cover this node — which was the case for EVERY
+    /// external tool effect until now.
+    #[serde(default)]
+    idempotency_key: Option<String>,
     // ── GenAI telemetry (forwarded from the python_tool worker or other callers) ──
     /// AI provider system (e.g. "anthropic", "openai").
     #[serde(default)]
@@ -1441,7 +1482,7 @@ async fn complete_work_item(
                 finish_reason: body.finish_reason.clone(),
                 cost_usd: None,
                 provenance: None,
-                idempotency_key: None,
+                idempotency_key: body.idempotency_key.clone(),
             },
         )
     };

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1509,6 +1509,16 @@ async fn complete_work_item(
         ));
     }
 
+    // An empty key is never something this engine issued — every key it mints is
+    // a sha256 hex digest. Recording an effect under "" would file a row no
+    // reader can ever derive, so reject it rather than accumulate junk that
+    // looks like a recorded effect.
+    if body.idempotency_key.as_deref().is_some_and(str::is_empty) {
+        return Err(ApiError::BadRequest(
+            "idempotency_key must not be empty".to_string(),
+        ));
+    }
+
     let committed_atomically = match (
         body.lease_fence,
         body.execution_id.as_deref(),

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1509,14 +1509,23 @@ async fn complete_work_item(
         ));
     }
 
-    // An empty key is never something this engine issued — every key it mints is
-    // a sha256 hex digest. Recording an effect under "" would file a row no
-    // reader can ever derive, so reject it rather than accumulate junk that
-    // looks like a recorded effect.
-    if body.idempotency_key.as_deref().is_some_and(str::is_empty) {
-        return Err(ApiError::BadRequest(
-            "idempotency_key must not be empty".to_string(),
-        ));
+    // Every key this engine mints is `content_hash`'s output: 64 lowercase hex
+    // characters. Anything else was never issued here, so an effect recorded
+    // under it is a row no reader can ever derive — junk that looks like a
+    // recorded effect and silently covers nothing.
+    //
+    // This is a shape check, not proof of provenance: a well-formed key from a
+    // DIFFERENT claim still passes. Binding the key to the claimed item is #130.
+    if let Some(key) = body.idempotency_key.as_deref() {
+        if key.len() != 64
+            || !key
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(ApiError::BadRequest(
+                "idempotency_key must be 64 lowercase hex characters".to_string(),
+            ));
+        }
     }
 
     let committed_atomically = match (

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -822,3 +822,41 @@ async fn the_claim_route_key_matches_the_shared_formula() {
          shape is now unreadable and its tool will re-fire on replay"
     );
 }
+
+/// Two segments of one run derive DIFFERENT keys for the same node.
+///
+/// `derive_idempotency_key` hashes a constant `segment: 0`, which looks like a
+/// dropped field. It is safe only because `start_next_segment` gives each
+/// continuation its own execution id (`{parent}:{n}`), so `run` separates the
+/// segments by itself. If that ever stopped being true, segment 2 would replay
+/// segment 1's tool output for the same node — this test fails first.
+#[tokio::test]
+async fn a_later_segment_derives_a_different_key() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (first, _) = seed_unclaimed(&backend).await;
+
+    // The id a continuation of `first` would be given.
+    let second = jamjet_state::segment::segment_execution_id(&first, 1);
+    assert_ne!(
+        first.to_string(),
+        second.to_string(),
+        "each segment must get its own execution id, or the key's constant \
+         `segment: 0` stops being safe"
+    );
+
+    let key_of = |run: &ExecutionId| {
+        jamjet_state::idempotency_key(
+            &run.to_string(),
+            0,
+            0,
+            "n1",
+            &jamjet_state::content_hash(&json!({})),
+        )
+    };
+    assert_ne!(
+        key_of(&first),
+        key_of(&second),
+        "the same node in a later segment must not reuse the earlier segment's \
+         effect"
+    );
+}

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -860,3 +860,73 @@ async fn a_later_segment_derives_a_different_key() {
          effect"
     );
 }
+
+/// A key the engine never minted is refused, not filed.
+///
+/// Every key it issues is `content_hash`'s output — 64 lowercase hex characters.
+/// Anything else records an effect under a string no reader can ever derive:
+/// junk that looks like a recorded effect while covering nothing.
+#[tokio::test]
+async fn a_malformed_idempotency_key_is_refused() {
+    let upper = "A".repeat(64);
+    let not_hex = "g".repeat(64);
+    let too_long = "a".repeat(65);
+    let cases = [
+        ("", "empty"),
+        ("abc123", "too short"),
+        (upper.as_str(), "uppercase hex"),
+        (not_hex.as_str(), "not hex"),
+        (too_long.as_str(), "too long"),
+    ];
+
+    for (key, why) in cases {
+        let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+        let (execution_id, id) = seed_unclaimed(&backend).await;
+        let state = make_state(backend.clone());
+        let claim = claim_via_route(&state).await;
+        let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
+
+        let (status, _) = post_complete(
+            &state,
+            id,
+            json!({
+                "execution_id": execution_id.to_string(),
+                "node_id": "n1",
+                "output": {},
+                "state_patch": {},
+                "lease_fence": fence,
+                "idempotency_key": key,
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "a {why} key must be refused, not filed as an effect"
+        );
+    }
+
+    // ...and the well-formed one the claim actually handed out still works.
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    let (status, _) = post_complete(
+        &state,
+        id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {},
+            "state_patch": {},
+            "lease_fence": claim["work_item"]["lease_fence"].as_i64().unwrap(),
+            "idempotency_key": claim["work_item"]["idempotency_key"].as_str().unwrap(),
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the engine's own key must be accepted"
+    );
+}

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -18,7 +18,7 @@ use jamjet_agents::InMemoryAgentRegistry;
 use jamjet_api::{routes::build_router_with_opts, state::AppState};
 use jamjet_audit::{AuditEnricher, NoopAuditBackend};
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
-use jamjet_state::backend::{StateBackend, WorkItem};
+use jamjet_state::backend::{StateBackend, WorkItem, WorkflowDefinition};
 use jamjet_state::event::EventKind;
 use jamjet_state::{Event, InMemoryBackend, DEFAULT_TENANT};
 use serde_json::{json, Value};
@@ -637,5 +637,188 @@ async fn a_zero_fence_cannot_complete_an_unclaimed_item() {
             .unwrap()
             .is_some(),
         "the item must remain claimable — a forged completion must not consume it"
+    );
+}
+
+/// Seed an execution and a claimable item WITHOUT claiming it, so the route's
+/// own claim path can be exercised.
+///
+/// Not `seed_and_claim` + a reset: `fail_work_item` writes the terminal
+/// `'failed'` status, which no sweep ever selects, so the item would never come
+/// back — the dead end this suite exists to keep fixed.
+async fn seed_unclaimed(backend: &Arc<dyn StateBackend>) -> (ExecutionId, Uuid) {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    // The claim route's enforcement gate resolves policy from the workflow
+    // catalogue and WITHHOLDS the payload when it cannot read it. An
+    // unregistered workflow yields `{"claimed": false}` — no error, no item —
+    // so a fixture that skips this looks like "the route hands out no key"
+    // when the truth is "the route was handed no work".
+    backend
+        .store_workflow(WorkflowDefinition {
+            workflow_id: "wf".into(),
+            version: "1.0.0".into(),
+            ir: json!({
+                "workflow_id": "wf",
+                "version": "1.0.0",
+                "state_schema": "{}",
+                "start_node": "n1",
+                // A plain, unpoliced tool node: the gate must pass it through.
+                "nodes": { "n1": { "id": "n1", "kind": {
+                    "type": "python_fn",
+                    "module": "tools",
+                    "function": "lookup",
+                    "output_schema": ""
+                }}},
+                "edges": [],
+                "retry_policies": {},
+                "models": {},
+                "tools": {},
+                "mcp_servers": {},
+                "remote_agents": {}
+            }),
+            created_at: now,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("store_workflow");
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .expect("create_execution");
+    let id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id,
+            execution_id: execution_id.clone(),
+            node_id: "n1".into(),
+            queue_type: "python_tool".into(),
+            payload: json!({"node_id": "n1"}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
+    (execution_id, id)
+}
+
+async fn claim_via_route(state: &AppState) -> Value {
+    let resp = build_router_with_opts(state.clone(), true)
+        .oneshot(
+            Request::post("/work-items/claim")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(
+                        &json!({"worker_id": "ext-worker", "queue_types": ["python_tool"]}),
+                    )
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    serde_json::from_slice(&resp.into_body().collect().await.unwrap().to_bytes()).unwrap()
+}
+
+// ── External tool effects are recorded, so a re-run replays ──────────────────
+
+/// The claim hands out an idempotency key, and completing with it records the
+/// effect — so the next reader replays instead of firing the tool again.
+///
+/// Before this, `/complete` always sent `idempotency_key: None`, nothing landed
+/// in `tool_effects`, and the replay guard covered the in-process tier only.
+#[tokio::test]
+async fn a_claimed_item_carries_a_key_and_completing_records_the_effect() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+
+    let key = claim["work_item"]["idempotency_key"]
+        .as_str()
+        .expect("the claim must hand out an idempotency key")
+        .to_string();
+    let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
+
+    // Nothing recorded yet.
+    assert!(backend.get_tool_effect(&key).await.unwrap().is_none());
+
+    let (status, _) = post_complete(
+        &state,
+        id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {"answer": 42},
+            "state_patch": {},
+            "lease_fence": fence,
+            "idempotency_key": key,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let recorded = backend
+        .get_tool_effect(&key)
+        .await
+        .unwrap()
+        .expect("completing with a key must record the effect, or a re-run re-fires the tool");
+    assert_eq!(recorded["output"]["answer"], json!(42));
+}
+
+/// The claim route's key is the documented formula, spelled out independently.
+///
+/// Both transports now call one `derive_idempotency_key`, so they cannot drift
+/// from each other — but they can drift together. The key is a persisted
+/// identity: effects recorded under yesterday's formula are invisible to
+/// today's reader, so every in-flight run silently re-fires its tools on the
+/// deploy that changes it. This spells the shape out by hand so that change
+/// has to be deliberate.
+#[tokio::test]
+async fn the_claim_route_key_matches_the_shared_formula() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, _id) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    let from_route = claim["work_item"]["idempotency_key"].as_str().unwrap();
+
+    let current_state = backend
+        .get_execution(&execution_id)
+        .await
+        .unwrap()
+        .map(|e| e.current_state)
+        .unwrap();
+    // Written out literally, NOT via `jamjet_state::idempotency_key` — calling
+    // the function under test to compute the expectation would make this pass
+    // for any formula, which is exactly the tautology it must avoid.
+    let expected = jamjet_state::content_hash(&json!({
+        "run": execution_id.to_string(),
+        "segment": 0,
+        "step": 0, // no NodeCompleted yet
+        "node": "n1",
+        "input": jamjet_state::content_hash(&current_state),
+    }));
+    assert_eq!(
+        from_route, expected,
+        "the idempotency-key formula changed; every effect recorded under the old \
+         shape is now unreadable and its tool will re-fire on replay"
     );
 }

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -71,6 +71,32 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex
 }
 
+/// The deterministic idempotency key for one node occurrence.
+///
+/// ONE definition, because two transports compute it: `Worker::execute_item`
+/// for an in-process node, and `POST /work-items/claim` for a node handed to an
+/// external tool worker. If the two ever disagreed the replay guard would look
+/// present and do nothing — the recorded effect would be filed under a key no
+/// reader ever asks for.
+///
+/// `step` is the number of `NodeCompleted` events already logged for this node.
+/// Retries do not complete, so it is stable across them and advances exactly
+/// once per successful loop occurrence.
+///
+/// `input_hash` is `content_hash` of the execution state at FIRE time — claim
+/// time for the external tier, which is the same moment for that transport.
+pub fn idempotency_key(run: &str, segment: u64, step: u64, node: &str, input_hash: &str) -> String {
+    content_hash(&serde_json::json!({
+        "run": run,
+        "segment": segment,
+        "step": step,
+        "node": node,
+        // "input", not "input_hash" — the field name is part of the hashed
+        // shape, so renaming it silently changes every key ever computed.
+        "input": input_hash,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,4 +131,46 @@ mod tests {
         let b = json!({ "step": 4 });
         assert_ne!(content_hash(&a), content_hash(&b));
     }
+}
+
+/// The idempotency key for the NEXT occurrence of `node_id` in this run.
+///
+/// Both enforcement transports call this: `Worker::execute_item` for the
+/// in-process tier and the claim route for the external one. It exists as one
+/// function because a key is only useful if the writer and the reader agree —
+/// two call sites deriving `step` or `input_hash` slightly differently would
+/// file effects under a key no reader asks for, leaving a replay guard that
+/// looks present and does nothing.
+///
+/// `step` counts this node's prior `NodeCompleted` events, so a retry of the
+/// same occurrence hashes the same and a genuine second visit (a loop) does
+/// not. `input_hash` covers the accumulated state the node will read, so a
+/// node whose input changed is a different effect.
+pub async fn derive_idempotency_key(
+    backend: &dyn crate::backend::StateBackend,
+    execution_id: &jamjet_core::workflow::ExecutionId,
+    node_id: &str,
+) -> crate::backend::BackendResult<String> {
+    let events = backend.get_events(execution_id).await?;
+    let step = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                &e.kind,
+                crate::event::EventKind::NodeCompleted { node_id: nid, .. } if nid == node_id
+            )
+        })
+        .count() as u64;
+    let current_state = backend
+        .get_execution(execution_id)
+        .await?
+        .map(|e| e.current_state)
+        .unwrap_or_else(|| serde_json::json!({}));
+    Ok(idempotency_key(
+        &execution_id.to_string(),
+        0,
+        step,
+        node_id,
+        &content_hash(&current_state),
+    ))
 }

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -146,6 +146,16 @@ mod tests {
 /// same occurrence hashes the same and a genuine second visit (a loop) does
 /// not. `input_hash` covers the accumulated state the node will read, so a
 /// node whose input changed is a different effect.
+///
+/// `segment` is passed as 0 deliberately, NOT because the segment is unknown.
+/// `start_next_segment` derives each continuation's execution id from
+/// `{parent}:{n}` (`runtime/state/src/segment.rs`), so every segment already
+/// has a distinct id and `run` alone separates them — passing
+/// `segment_number` here would add a component that `run` fully determines.
+/// The field stays in the hashed shape because the key is persisted: changing
+/// what is hashed makes every effect recorded under the old shape unreadable,
+/// and its tool re-fires. `a_later_segment_derives_a_different_key` pins the
+/// separation that makes the constant safe.
 pub async fn derive_idempotency_key(
     backend: &dyn crate::backend::StateBackend,
     execution_id: &jamjet_core::workflow::ExecutionId,

--- a/runtime/state/src/lib.rs
+++ b/runtime/state/src/lib.rs
@@ -29,7 +29,9 @@ pub use backend::{
 };
 pub use budget::{BudgetState, BudgetTrip};
 pub use event::{Event, EventKind, EventSequence, ProvenanceMetadata};
-pub use hashing::{canonical_json, content_hash, sha256_hex};
+pub use hashing::{
+    canonical_json, content_hash, derive_idempotency_key, idempotency_key, sha256_hex,
+};
 pub use materializer::{
     apply_events, apply_events_seeded, materialize, should_snapshot, MaterializedState,
 };

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -81,6 +81,21 @@ const SEGMENT_NS: Uuid = Uuid::from_u128(0x6a8e_f5c3_d3a4_4b9c_8b2e_4f5d_6e7a_8c
 /// The `ExecutionId` of the newly created (or pre-existing idempotent) segment.
 // Nine parameters are required by the plan interface; suppressing the lint rather
 // than breaking the caller signature with a builder/struct at this stage.
+
+/// The DETERMINISTIC execution id of segment `n` of the run rooted at `parent_id`.
+///
+/// Deterministic so a re-run after a crash always targets the same child row,
+/// rather than forking the chain with a second random child.
+///
+/// Also the reason `derive_idempotency_key` can hash a constant `segment`: every
+/// segment has its own id, so the `run` component separates them by itself.
+pub fn segment_execution_id(parent_id: &ExecutionId, next_segment_number: u32) -> ExecutionId {
+    ExecutionId(Uuid::new_v5(
+        &SEGMENT_NS,
+        format!("{}:{}", parent_id.0, next_segment_number).as_bytes(),
+    ))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn start_next_segment(
     backend: &dyn StateBackend,
@@ -93,14 +108,7 @@ pub async fn start_next_segment(
     queue_type: &str,
     tenant_id: &str,
 ) -> BackendResult<ExecutionId> {
-    // Derive a DETERMINISTIC child id from the parent id + segment number.
-    // This guarantees that a re-run after a crash always targets the same
-    // child row, preventing a second random child from forking the chain.
-    let child_uuid = Uuid::new_v5(
-        &SEGMENT_NS,
-        format!("{}:{}", parent_id.0, next_segment_number).as_bytes(),
-    );
-    let new_id = ExecutionId(child_uuid);
+    let new_id = segment_execution_id(parent_id, next_segment_number);
 
     // Idempotency guard: if the child execution row already exists, a prior
     // create_segment_atomic committed successfully — the row exists if and

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -290,30 +290,17 @@ impl Worker {
                     // nodes a sibling's state_patch landing between fire and replay changes
                     // current_state and thus the key, so zero-outbound replay is exact for linear
                     // runs in v1 (parallel-sibling replay exactness is a follow-up, see F-2c-3). [I2]
-                    let events_for_key = self.backend.get_events(&execution_id).await?;
-                    let step = events_for_key
-                        .iter()
-                        .filter(|e| {
-                            matches!(
-                                &e.kind,
-                                EventKind::NodeCompleted { node_id: nid, .. } if nid == &node_id
-                            )
-                        })
-                        .count() as u64;
-                    let current_state = self
-                        .backend
-                        .get_execution(&execution_id)
-                        .await?
-                        .map(|e| e.current_state)
-                        .unwrap_or_else(|| serde_json::json!({}));
-                    let input_hash = content_hash(&current_state);
-                    let key = content_hash(&serde_json::json!({
-                        "run": execution_id.to_string(),
-                        "segment": 0,
-                        "step": step,
-                        "node": node_id,
-                        "input": input_hash,
-                    }));
+                    // Shared with the claim route: one function derives the
+                    // key for BOTH transports, so `step` and the input hash
+                    // cannot drift between them. Two copies that disagreed
+                    // would leave the replay guard filing effects under a key
+                    // no reader asks for.
+                    let key = jamjet_state::derive_idempotency_key(
+                        self.backend.as_ref(),
+                        &execution_id,
+                        &node_id,
+                    )
+                    .await?;
                     computed_key = Some(key.clone());
 
                     // Replay-or-fire: if a result was already committed for this key,

--- a/sdk/python/jamjet/cli/main.py
+++ b/sdk/python/jamjet/cli/main.py
@@ -1786,6 +1786,8 @@ async def _worker_loop(
             node_id: str = work_item["node_id"]
             payload: dict[str, Any] = work_item.get("payload", {})
             lease_fence: int = work_item.get("lease_fence", 0)
+            # Echoed on complete so the engine records the result against it.
+            idempotency_key: str | None = work_item.get("idempotency_key")
 
             console.print(f"[cyan]Claimed[/cyan] id={item_id} node=[bold]{node_id}[/bold] exec={exec_id}")
 
@@ -1864,6 +1866,7 @@ async def _worker_loop(
                         # the completion (reject a stale/reclaimed lease). Omitted when
                         # 0/absent, keeping the unfenced fallback backward-compatible.
                         lease_fence=lease_fence,
+                        idempotency_key=idempotency_key,
                     )
                 except Exception as complete_exc:
                     # A 409 means our echoed fence no longer matches: the lease was

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -312,10 +312,15 @@ class JamjetClient:
             body["finish_reason"] = finish_reason
         if lease_fence:
             body["lease_fence"] = lease_fence
-        if idempotency_key:
+        if idempotency_key is not None:
             # Echoed from the claim so the engine records this result against it.
             # Without it nothing lands in tool_effects and a re-run fires the tool
             # again — the replay guard covers the in-process path only.
+            #
+            # `is not None`, not a truthiness check: the caller echoes whatever the
+            # claim handed out, and silently dropping a falsy-but-present value
+            # would turn a malformed key into "no key" — the failure mode this
+            # whole change exists to remove, and invisible at the call site.
             body["idempotency_key"] = idempotency_key
         r = await self._client.post(
             f"/work-items/{item_id}/complete",

--- a/sdk/python/jamjet/client.py
+++ b/sdk/python/jamjet/client.py
@@ -288,6 +288,7 @@ class JamjetClient:
         gen_ai_model: str | None = None,
         finish_reason: str | None = None,
         lease_fence: int | None = None,
+        idempotency_key: str | None = None,
     ) -> None:
         """Mark a work item as completed and emit a NodeCompleted event.
 
@@ -311,6 +312,11 @@ class JamjetClient:
             body["finish_reason"] = finish_reason
         if lease_fence:
             body["lease_fence"] = lease_fence
+        if idempotency_key:
+            # Echoed from the claim so the engine records this result against it.
+            # Without it nothing lands in tool_effects and a re-run fires the tool
+            # again — the replay guard covers the in-process path only.
+            body["idempotency_key"] = idempotency_key
         r = await self._client.post(
             f"/work-items/{item_id}/complete",
             json=body,

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -78,6 +78,7 @@ class _StubClient:
         gen_ai_model: str | None = None,
         finish_reason: str | None = None,
         lease_fence: int | None = None,
+        idempotency_key: str | None = None,
     ) -> None:
         self.complete_calls.append(
             {
@@ -89,6 +90,7 @@ class _StubClient:
                 "gen_ai_model": gen_ai_model,
                 "finish_reason": finish_reason,
                 "lease_fence": lease_fence,
+                "idempotency_key": idempotency_key,
             }
         )
 
@@ -383,3 +385,34 @@ async def test_worker_dispatch_tool_calls_return_reaches_state() -> None:
     assert msgs[3]["content"] == "echo:hi", "the resolved tool's result must be carried forward"
     # output mirrors the same dict (the worker coerces a dict return as-is).
     assert call["output"]["messages"] == msgs
+
+
+async def test_worker_echoes_idempotency_key_on_complete() -> None:
+    """The claim's idempotency key must reach /complete.
+
+    Without it the engine records the result with `idempotency_key: None`,
+    nothing lands in `tool_effects`, and the replay guard does not cover this
+    node at all — so a re-run fires the tool a second time. That was the state of
+    every external tool effect before this was threaded through.
+    """
+    item = dict(_ADD_ITEM, id="wi-008", idempotency_key="abc123")
+    stub = _StubClient(claimed_item=item)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    assert stub.complete_calls[0]["idempotency_key"] == "abc123", (
+        "the claim's key must reach the engine, or the effect is recorded under nothing and the tool re-fires on replay"
+    )
+
+
+async def test_worker_tolerates_a_claim_without_an_idempotency_key() -> None:
+    """An older engine omits the field; the worker must still complete.
+
+    Forwarded as None, which is exactly the pre-existing behaviour: no recorded
+    effect, no replay protection, but a working queue.
+    """
+    stub = _StubClient(claimed_item=_ADD_ITEM)
+    await _worker_loop(stub, "test-worker", ["python_tool"], once=True)
+
+    assert len(stub.complete_calls) == 1
+    assert stub.complete_calls[0]["idempotency_key"] is None

--- a/sdk/python/tests/test_worker.py
+++ b/sdk/python/tests/test_worker.py
@@ -13,9 +13,12 @@ No live runtime is required; a _StubClient records all outbound calls.
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 
 from jamjet.cli.main import _worker_loop  # noqa: E402
+from jamjet.client import JamjetClient
 
 # ── Test handler functions ────────────────────────────────────────────────────
 
@@ -416,3 +419,38 @@ async def test_worker_tolerates_a_claim_without_an_idempotency_key() -> None:
 
     assert len(stub.complete_calls) == 1
     assert stub.complete_calls[0]["idempotency_key"] is None
+
+
+async def test_client_sends_a_present_key_even_when_falsy() -> None:
+    """The client echoes what the claim handed it, rather than judging it.
+
+    A truthiness check would turn a falsy-but-present key into "no key" — the
+    exact failure this change removes, and invisible at the call site. Rejecting
+    a malformed key is the engine's job, and it does (HTTP 400); silently
+    dropping it here would hide the bug instead.
+    """
+    sent: dict[str, Any] = {}
+
+    class _Resp:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _HTTP:
+        async def post(self, url: str, json: dict[str, Any]) -> _Resp:
+            sent.update(json)
+            return _Resp()
+
+    client = JamjetClient.__new__(JamjetClient)
+    client._client = _HTTP()  # type: ignore[attr-defined]
+
+    await client.complete_work_item(
+        "item-1",
+        execution_id="exec-1",
+        node_id="n1",
+        output={},
+        state_patch={},
+        duration_ms=1,
+        idempotency_key="",
+    )
+    assert "idempotency_key" in sent, "a present key must be sent, not judged for truthiness"
+    assert sent["idempotency_key"] == ""

--- a/sdk/typescript/packages/cloud/scripts/bun-smoke.ts
+++ b/sdk/typescript/packages/cloud/scripts/bun-smoke.ts
@@ -1,0 +1,59 @@
+/**
+ * Does @jamjet/cloud actually work on the Bun runtime?
+ *
+ * Imports the BUILT bundle — what a user installs — rather than the sources, and
+ * exercises real behaviour rather than only checking that the module loads.
+ *
+ * A plain script, not a test-runner file, on purpose. This job used to run
+ * `vitest` under `--bun`; vitest drives its own module runner, and its
+ * interop with Bun is a property of vitest, not of this SDK. A failure there
+ * says nothing about whether the package works for a Bun user, which is the
+ * only question this job exists to answer.
+ *
+ * Merely importing the bundle is itself a real check: `config.ts` builds its
+ * zod schemas at module scope, so a broken ESM/CJS interop fails here.
+ */
+import assert from 'node:assert/strict'
+
+import { VERSION, redact, estimateCost, ConfigError, PolicyEvaluator } from '../dist/index.js'
+
+const checks: [string, () => void][] = [
+  ['VERSION is published', () => {
+    assert.equal(typeof VERSION, 'string')
+    assert.match(VERSION, /^\d+\.\d+\.\d+/)
+  }],
+  ['zod-backed config module loaded', () => {
+    // ConfigError comes from config.ts, whose zod schemas are built at module
+    // scope. If zod's named export did not resolve under Bun, the import above
+    // has already thrown; this pins the symbol as well.
+    assert.equal(typeof ConfigError, 'function')
+    assert.ok(new ConfigError('x') instanceof Error)
+  }],
+  ['redaction behaves', () => {
+    assert.equal(redact('contact alice@example.com please'), 'contact [EMAIL_ADDRESS] please')
+    assert.equal(redact('call 555-123-4567'), 'call [PHONE_NUMBER]')
+  }],
+  ['cost estimation behaves', () => {
+    const c = estimateCost('gpt-4o', 100, 50)
+    assert.ok(Math.abs(c - 0.00075) < 1e-8, `expected ~0.00075, got ${c}`)
+  }],
+  ['classes construct', () => {
+    assert.equal(typeof PolicyEvaluator, 'function')
+  }],
+]
+
+let failed = 0
+for (const [name, run] of checks) {
+  try {
+    run()
+    console.log(`ok - ${name}`)
+  } catch (err) {
+    failed++
+    console.error(`not ok - ${name}`)
+    console.error(err instanceof Error ? err.stack : String(err))
+  }
+}
+
+const bun = (globalThis as { Bun?: { version: string } }).Bun
+console.log(`\n${checks.length - failed}/${checks.length} passed on ${bun ? `Bun ${bun.version}` : process.version}`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
Session batch. Two independent tracks that both close long-standing gaps; grouped into one PR rather than a chain of small ones.

---

# 1. External tool effects get an idempotency key

`POST /work-items/:id/complete` always sent `idempotency_key: None`. Nothing ever landed in `tool_effects` for an externally executed tool, so there was nothing to replay: re-running a node re-fired its tool.

That is the transport ADK agents actually take. `python_tool` and `java_tool` are registered with **zero in-process workers**, so an agent's tool-dispatch node reaches production down the claim route and never through `Worker::execute_item` — the tier the replay guard already covered.

### How

- The claim response carries `idempotency_key` for the node occurrence being handed out. Claim time is fire time here: the moment the payload leaves the engine is the moment the effect becomes possible.
- `CompleteWorkItemRequest` accepts the key back and records the result against it.
- The Python worker (`client.py`, `cli/main.py`) threads it through.
- Both transports derive the key through one `jamjet_state::derive_idempotency_key`. They were two copies of one formula; a key is only useful if writer and reader agree, and copies that drifted would file effects under a key no reader asks for — a guard that looks present and does nothing.
- `/complete` rejects a key this engine never minted (not 64 lowercase hex). A **shape** check, not proof of provenance — a well-formed key from a different claim still passes, which is #130.

### Deliberate choices

**Best effort.** If the state needed to compute the key cannot be read, the item still goes out. That is the behaviour this route already had, and withholding real work because a replay optimisation could not be prepared trades a live queue for a hygiene property.

**Backward compatible.** A worker that does not send the key still completes — it just records no effect, exactly as today. No claim, complete, or fence semantics change.

**`segment` is hashed as a constant 0, deliberately.** `start_next_segment` derives each continuation id as `uuid5({parent}:{n})`, so every segment already has its own execution id and `run` separates them by itself. Passing `segment_number` would add a component `run` fully determines, while changing what is hashed makes every effect recorded under the old shape unreadable. Documented, and pinned by a test that fails if two segments ever share an id.

---

# 2. The Bun CI job, green for the first time since 2026-05-13

The **Test (Bun)** job has failed on every commit since `pnpm/action-setup` went v4 → v6 (#55). Node 20 and 22 passed throughout — they never wrapped the command.

**Two bugs, one behind the other.** Bun resolves the first argument to `run` as a package.json script or a `node_modules/.bin` entry; v6 installs pnpm **globally**, so `bun --bun pnpm test` had no `pnpm` to find. Fixing that let vitest actually run under Bun — and every suite failed on `z.object`, because vitest's module runner cannot resolve zod's named export under the Bun runtime. Three months of red had been hiding a second, unrelated failure.

That second failure is a property of **vitest**, not of this SDK, and answers no question worth asking. So the job now asks its real question directly: build the package and run a plain Bun script against the **emitted bundle** — what a user installs — exercising real behaviour. Importing it is itself a check, since `config.ts` builds its zod schemas at module scope.

A permanently red job is a broken gate: it cannot report that Bun support regressed, because it already reports failure. Every SDK PR since May inherited the red status and was merged past it.

Closes #64

---

## Tests

Every guard below was mutation-checked — the bug was re-introduced and the test watched to fail — because several early drafts passed against the bug.

| Test | Fails when |
|---|---|
| `a_claimed_item_carries_a_key_and_completing_records_the_effect` | `/complete` passes `None` again |
| `the_claim_route_key_matches_the_shared_formula` | `step`, `segment`, or the `input` field name changes (all three) |
| `a_later_segment_derives_a_different_key` | two segments ever share an execution id |
| `a_malformed_idempotency_key_is_refused` | the shape validation is removed |
| `test_client_sends_a_present_key_even_when_falsy` | the client reverts to a truthiness check |
| Bun smoke check | any expectation breaks (verified: exits 1) |

`the_claim_route_key_matches_the_shared_formula` writes the hashed shape out **literally** rather than calling `idempotency_key` to build its own expectation — the first version did, and passed under every mutation. It guards a persisted identity: effects recorded under an old shape are invisible to a new reader, so a formula change silently re-fires the tools of every in-flight run.

## Verification

- `cargo test --workspace` — 815 passed, 0 failed
- `cargo fmt --all --check` clean; clippy adds no new warnings (the `engram/tests` unused-import warnings pre-date this)
- Python: 1476 passed, ruff check + format clean
- mypy unchanged: the 6 errors under `jamjet/cloud` are all present on `main` (compared directly)
- All three `ts-sdk.yml` jobs green, including Bun

## Follow-ups filed

- **#130** — bind the key to the claimed item server-side. Real: the engine derives the key at claim time then trusts the echo. Not a one-liner, because a parallel sibling's `state_patch` landing between claim and complete legitimately changes the key, which is *why* the claim hands it out; "derive again and reject on mismatch" would strand valid completions. Two sound options written up.
- **#131** — `derive_idempotency_key` scans the full event log on every claim.
- **jamjet-runtime-java#14** — the Java worker echoes the key (and the lease fence on `/fail`).
