### PR TITLE
fix(sdk): fail closed on approval, and enforce blocked_tools in-process

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -68,6 +68,7 @@ The full ADK feature set. A plain `Agent` is now durable and governed by default
 ### Added
 
 - Governance on by default. `Agent(policy=, approval_required=, budget=, pii=, audit=, receipts=)`: a model allowlist, fail-closed budget caps, PII redaction at the model seam, a signed hash-chained audit record per action, and an AgentBoundary receipt per turn. Enforced on both `run()` and `run_durable()`.
+  (Corrected later: approval was **not** enforced on `run()` — it warned and ran ungated. See the Unreleased entry above.)
 - Sessions and memory. `Session` + a persistent `SessionStore` continue a conversation thread across runs and restarts; `memory=` wires the Engram bridge with an automatic, governed retrieve/record loop keyed by the session.
 - Team multi-agent API: `Sequential`, `Parallel` (with `MergeStrategy`), `Team` (coordinator), and `Loop`. Each sub-agent runs as its own governed durable execution; `run()` / `run_durable()` return a `TeamResult` with per-agent isolation.
 - `agent.deploy(runtime="local" | "self-host" | "cloud" | "<url>")` and `Team.deploy(...)`: ship the same compiled IR to any runtime over the durable engine. Artifacts API (`POST/GET /artifacts`).

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Changed (breaking)
+
+- **`approval_required` now raises on `agent.run()` instead of warning.** It emitted a
+  `UserWarning` and then ran every tool ungated, so the knob read as configured and did
+  nothing. A warning cannot carry that: Python prints a given one once per location, and
+  `-W ignore`, `PYTHONWARNINGS` or a pytest config drop it entirely — the caller who most
+  needed the signal was the least likely to see it. `run()` executes tools with no policy
+  engine between the model and the call, so a gate can be neither evaluated nor held
+  there; it now refuses with `ApprovalNotEnforceableError` and points at `run_durable`,
+  where the engine decides before any worker receives the payload. To run without gates
+  deliberately, drop `approval_required`.
+
+### Fixed
+
+- **`blocked_tools` is enforced on `agent.run()`.** It was enforced only on the durable
+  path, so a tool the policy forbids ran normally in-process — silently, without even the
+  warning `approval_required` gave. `blocked_tools` is a *tool* control, so the seam
+  middleware chain could never carry it: that chain sits at the *model* boundary and
+  enforces budget, allowlist and PII. Blocked tools are now dropped before the strategy
+  runner sees them, which makes them neither offered to the model nor dispatchable, and
+  patterns are globbed with the same matcher the engine uses. Both paths resolve the
+  effective policy through one shared function, so an `Agent(...)` cannot mean one thing
+  in-process and another durable.
+
 ## 0.12.0 — 2026-08-22
 
 Enforcement and exactly-once correctness. The ADK's governance knobs were

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -70,7 +70,7 @@ from jamjet.team import Loop, Parallel, Sequential, Team, TeamResult
 from jamjet.tools.decorators import tool
 from jamjet.workflow.workflow import Workflow
 from jamjet.decorators import DurableAgent, workflow  # noqa: F401, E402
-from jamjet.agents.agent import ApprovalNotEnforceableError  # noqa: F401, E402
+from jamjet.agents.governance import ApprovalNotEnforceableError  # noqa: F401, E402
 from jamjet.gate import PolicyDeniedError, gate, stderr_emitter  # noqa: F401, E402
 # isort: on
 

--- a/sdk/python/jamjet/__init__.py
+++ b/sdk/python/jamjet/__init__.py
@@ -70,6 +70,7 @@ from jamjet.team import Loop, Parallel, Sequential, Team, TeamResult
 from jamjet.tools.decorators import tool
 from jamjet.workflow.workflow import Workflow
 from jamjet.decorators import DurableAgent, workflow  # noqa: F401, E402
+from jamjet.agents.agent import ApprovalNotEnforceableError  # noqa: F401, E402
 from jamjet.gate import PolicyDeniedError, gate, stderr_emitter  # noqa: F401, E402
 # isort: on
 
@@ -104,6 +105,7 @@ __all__ = [
     "ToolSpec",
     "Workflow",
     "WorkflowSpec",
+    "ApprovalNotEnforceableError",
     "PolicyDeniedError",
     "durable",
     "durable_run",

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -35,22 +35,18 @@ from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from jamjet.agents.governance import UNSET, Budget, GovernanceConfig, _Unset, normalize_governance
+from jamjet.agents.governance import (
+    UNSET,
+    Budget,
+    GovernanceConfig,
+    _Unset,
+    normalize_governance,
+    require_enforceable_approval,
+)
 from jamjet.agents.session import Session, SessionStore, persist_session_turn, seed_messages_for_run
 from jamjet.compiler.strategies import StrategyLimits
 from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
-
-
-class ApprovalNotEnforceableError(RuntimeError):
-    """Raised when ``approval_required`` is set but the chosen path cannot gate.
-
-    ``agent.run()`` executes tools in-process with no policy engine between the
-    model and the call, so a gate can be neither evaluated nor held. Raising is
-    the fail-closed answer: an approval gate that silently does not exist is
-    worse than a run that does not start.
-    """
-
 
 if TYPE_CHECKING:
     from jamjet.deploy import DeployResult
@@ -582,24 +578,12 @@ class Agent:
         # a stale or hostile worker build.  Do not restate any of it as a
         # property of the code below: nothing here inherits it.
         #
-        # Fail CLOSED. This used to warn and then run every tool ungated, which
-        # is the worst of both: `approval_required` reads as configured, no error
-        # is raised, and nothing is gated. A warning cannot carry that — Python
-        # prints a given one once per location, and `-W ignore`, PYTHONWARNINGS
-        # or a pytest config drops it entirely — so the caller who most needs to
-        # know is the one least likely to see it.
-        #
-        # Refusing is safe in the direction that matters: an approval gate that
-        # does not exist is worse than a run that does not start.
-        ar = self.governance.approval_required
-        if ar is not False and ar != []:
-            raise ApprovalNotEnforceableError(
-                f"Agent {self.name!r}: approval_required is set, but agent.run() uses "
-                "the in-process path, which cannot hold a run at a gate. Use "
-                "agent.run_durable(), where the engine evaluates every tool call "
-                "against policy before any worker receives the payload. To run "
-                "without gates deliberately, drop approval_required."
-            )
+        # Fail CLOSED, early, so a caller sees the refusal before any session or
+        # audit setup happens. The authoritative check is the identical one at
+        # the executor chokepoint (`_run_agent`), which also covers callers who
+        # reach LocalRuntime.execute() directly — one function, two call sites,
+        # so the two cannot drift.
+        require_enforceable_approval(self.governance, where=f"Agent {self.name!r}.run()")
 
         # T4-2/T4-3: resolve session + memory and build the seed messages.  The
         # seed carries the session thread (T4-2) plus, when memory is on, the

--- a/sdk/python/jamjet/agents/agent.py
+++ b/sdk/python/jamjet/agents/agent.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-import warnings
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -41,6 +40,17 @@ from jamjet.agents.session import Session, SessionStore, persist_session_turn, s
 from jamjet.compiler.strategies import StrategyLimits
 from jamjet.runtime.local import LocalRuntime
 from jamjet.tools.decorators import ToolDefinition
+
+
+class ApprovalNotEnforceableError(RuntimeError):
+    """Raised when ``approval_required`` is set but the chosen path cannot gate.
+
+    ``agent.run()`` executes tools in-process with no policy engine between the
+    model and the call, so a gate can be neither evaluated nor held. Raising is
+    the fail-closed answer: an approval gate that silently does not exist is
+    worse than a run that does not start.
+    """
+
 
 if TYPE_CHECKING:
     from jamjet.deploy import DeployResult
@@ -572,19 +582,23 @@ class Agent:
         # a stale or hostile worker build.  Do not restate any of it as a
         # property of the code below: nothing here inherits it.
         #
-        # Fail LOUD rather than silently no-op so the developer knows approval
-        # won't fire here.  See follow-up F-t3-inprocess-approval for full
-        # in-process enforcement.
+        # Fail CLOSED. This used to warn and then run every tool ungated, which
+        # is the worst of both: `approval_required` reads as configured, no error
+        # is raised, and nothing is gated. A warning cannot carry that — Python
+        # prints a given one once per location, and `-W ignore`, PYTHONWARNINGS
+        # or a pytest config drops it entirely — so the caller who most needs to
+        # know is the one least likely to see it.
+        #
+        # Refusing is safe in the direction that matters: an approval gate that
+        # does not exist is worse than a run that does not start.
         ar = self.governance.approval_required
         if ar is not False and ar != []:
-            warnings.warn(
-                f"Agent {self.name!r}: approval_required is set but agent.run() uses "
-                "the in-process path, which does not enforce approval gates. "
-                "Use agent.run_durable(), where the engine evaluates every tool call "
-                "against policy server-side, before any worker receives the payload. "
-                "Follow-up: F-t3-inprocess-approval.",
-                UserWarning,
-                stacklevel=2,
+            raise ApprovalNotEnforceableError(
+                f"Agent {self.name!r}: approval_required is set, but agent.run() uses "
+                "the in-process path, which cannot hold a run at a gate. Use "
+                "agent.run_durable(), where the engine evaluates every tool call "
+                "against policy before any worker receives the payload. To run "
+                "without gates deliberately, drop approval_required."
             )
 
         # T4-2/T4-3: resolve session + memory and build the seed messages.  The

--- a/sdk/python/jamjet/agents/governance.py
+++ b/sdk/python/jamjet/agents/governance.py
@@ -86,7 +86,9 @@ class GovernanceConfig:
                      ``["delete_*", "send_*"]``).
         Enforced engine-side on the DURABLE path (``agent.run_durable``) only.
         The in-process ``agent.run()`` path has no policy engine in its loop and
-        CANNOT enforce a gate; it warns loudly instead (F-t3-inprocess-approval).
+        CANNOT enforce a gate: it refuses with ``ApprovalNotEnforceableError``
+        rather than running ungated. ``run_durable()`` is the enforceable path,
+        where the engine decides before any worker receives the payload.
         The mechanism — and why it holds even against an untrusted worker — is
         documented once, at the warning site in :meth:`jamjet.Agent.run`.
     budget
@@ -223,3 +225,41 @@ def _parse_approval_required(value: ApprovalRequired) -> ApprovalRequired:
             raise TypeError("approval_required list entries must be strings (tool-name globs)")
         return list(value)
     raise TypeError(f"approval_required must be bool or list[str] — got {type(value).__name__!r}")
+
+
+class ApprovalNotEnforceableError(RuntimeError):
+    """Raised when an approval gate is declared on a path that cannot hold a run.
+
+    The in-process path executes tools directly, with no policy engine between
+    the model and the call, so a gate can be neither evaluated nor held there.
+    Raising is the fail-closed answer: an approval gate that silently does not
+    exist is worse than a run that does not start.
+    """
+
+
+def require_enforceable_approval(governance: object | None, *, where: str) -> None:
+    """Refuse if *governance* declares an approval gate this path cannot honour.
+
+    Keyed on the RESOLVED policy rather than on ``approval_required`` alone,
+    because the same control has two spellings: ``approval_required=[...]`` and
+    ``policy={"require_approval_for": [...]}``. Checking only the first left the
+    second running ungated — the same half-fix this function exists to prevent.
+
+    Called at the executor chokepoint, so it also covers callers who reach
+    ``LocalRuntime.execute(..., governance=...)`` directly instead of going
+    through ``Agent.run()``.
+    """
+    if governance is None:
+        return
+    from jamjet.compiler.agent_ir import effective_policy
+
+    policy = effective_policy(governance)  # type: ignore[arg-type]
+    if not (policy or {}).get("require_approval_for"):
+        return
+    raise ApprovalNotEnforceableError(
+        f"{where}: an approval gate is declared (require_approval_for="
+        f"{(policy or {}).get('require_approval_for')!r}), but the in-process path "
+        "cannot hold a run at a gate. Use run_durable(), where the engine evaluates "
+        "every tool call against policy before any worker receives the payload. To "
+        "run without gates deliberately, remove the approval rules."
+    )

--- a/sdk/python/jamjet/compiler/agent_ir.py
+++ b/sdk/python/jamjet/compiler/agent_ir.py
@@ -96,6 +96,19 @@ _DEFAULT_DATA_POLICY_IR: dict[str, Any] = {
 }
 
 
+def effective_policy(gov: GovernanceConfig) -> dict[str, Any] | None:
+    """The policy rules *gov* resolves to, or ``None`` when it declares none.
+
+    Shared deliberately. The durable path compiles this into the IR for the engine
+    to enforce, and the in-process path (``agent.run``) reads the same result to
+    enforce ``blocked_tools`` locally. Two resolvers would let the same
+    ``Agent(...)`` declaration mean different things depending on which path
+    happened to run it — the divergence class of #121 and #123, which surfaces in
+    production because development usually stays in-process.
+    """
+    return _compile_agent_policy_ir(gov)
+
+
 def _compile_agent_policy_ir(gov: GovernanceConfig) -> dict[str, Any] | None:
     """Build a PolicySetIr dict from *gov*, or ``None`` when no policy rules are needed.
 

--- a/sdk/python/jamjet/runtime/local/executor.py
+++ b/sdk/python/jamjet/runtime/local/executor.py
@@ -124,6 +124,12 @@ class LocalRuntime:
         # every strategy builds its dispatch table from `spec.tools`
         # (`resolve_tool_map`), so a blocked tool is neither offered to the model
         # nor resolvable if one is asked for anyway.
+        # The chokepoint for BOTH tool controls. LocalRuntime is public, so a
+        # gate that lived only in Agent.run() left `LocalRuntime.execute(...,
+        # governance=...)` running approval-gated agents ungated.
+        from jamjet.agents.governance import require_enforceable_approval
+
+        require_enforceable_approval(governance, where="LocalRuntime in-process run")
         spec = self._apply_blocked_tools(spec, governance)
         openai_tools = [self._tool_to_openai_schema(t) for t in spec.tools]
         prompt = input if isinstance(input, str) else json.dumps(input)

--- a/sdk/python/jamjet/runtime/local/executor.py
+++ b/sdk/python/jamjet/runtime/local/executor.py
@@ -112,6 +112,19 @@ class LocalRuntime:
         adapter = get_adapter(spec.llm, governance)
         runner = get_strategy_runner(spec.strategy.name)
         tool_calls_log: list[dict[str, Any]] = []
+
+        # blocked_tools is a TOOL control, so the seam adapter above cannot carry
+        # it: that chain sits at the MODEL boundary and enforces budget /
+        # allowlist / PII. Nothing enforced blocked_tools here, so a tool the
+        # policy forbids ran normally on agent.run() while being refused on
+        # run_durable() — silently, without even the warning approval_required
+        # gets.
+        #
+        # Dropping the tool before the runner sees it closes both halves at once:
+        # every strategy builds its dispatch table from `spec.tools`
+        # (`resolve_tool_map`), so a blocked tool is neither offered to the model
+        # nor resolvable if one is asked for anyway.
+        spec = self._apply_blocked_tools(spec, governance)
         openai_tools = [self._tool_to_openai_schema(t) for t in spec.tools]
         prompt = input if isinstance(input, str) else json.dumps(input)
         output = await runner(
@@ -222,6 +235,30 @@ class LocalRuntime:
             duration_ms=duration_ms,
         )
         return output, [record], [], []
+
+    @staticmethod
+    def _apply_blocked_tools(spec: Any, governance: Any | None) -> Any:
+        """Return *spec* with policy-blocked tools removed.
+
+        Patterns are globs matched with the same matcher the engine uses
+        (`glob_match` in `runtime/policy/src/lib.rs`), and the policy is resolved
+        with the same function the durable path compiles into the IR, so a given
+        `Agent(...)` cannot mean one thing in-process and another durable.
+        """
+        if governance is None:
+            return spec
+        from jamjet.compiler.agent_ir import effective_policy
+        from jamjet.model.middleware import _glob_match
+
+        policy = effective_policy(governance)
+        patterns = list((policy or {}).get("blocked_tools") or [])
+        if not patterns:
+            return spec
+
+        kept = [t for t in spec.tools if not any(_glob_match(pat, t.name) for pat in patterns)]
+        if len(kept) == len(spec.tools):
+            return spec
+        return spec.model_copy(update={"tools": kept})
 
     async def _run_workflow(
         self,

--- a/sdk/python/tests/model/test_policy_allowlist.py
+++ b/sdk/python/tests/model/test_policy_allowlist.py
@@ -228,8 +228,13 @@ class TestUnknownNamedPolicyFails:
 # ---------------------------------------------------------------------------
 
 
-class TestApprovalRequiredInProcessWarning:
-    """approval_required must never silently no-op on agent.run()."""
+class TestApprovalRequiredInProcessRefusal:
+    """approval_required must never silently no-op on agent.run().
+
+    It now REFUSES rather than warning. A UserWarning prints once per location
+    and is dropped by `-W ignore` / PYTHONWARNINGS / a pytest config, so the old
+    behaviour announced the gap to nobody and then ran every tool ungated.
+    """
 
     @pytest.fixture
     def dummy_tool(self):
@@ -242,11 +247,12 @@ class TestApprovalRequiredInProcessWarning:
 
         return noop
 
-    def test_approval_required_true_warns_on_run(self, dummy_tool):
-        """approval_required=True on agent.run() emits a UserWarning."""
+    def test_approval_required_true_refuses_on_run(self, dummy_tool):
+        """approval_required=True on agent.run() raises before anything runs."""
         import asyncio
         from unittest.mock import AsyncMock, patch
 
+        from jamjet import ApprovalNotEnforceableError
         from jamjet.agents.agent import Agent
         from jamjet.runtime.local import LocalRuntime
 
@@ -257,32 +263,27 @@ class TestApprovalRequiredInProcessWarning:
             approval_required=True,
         )
 
-        # Mock LocalRuntime.execute so we don't need a real model.
-        fake_result = AsyncMock(
-            output="ok",
-            tool_calls=[],
-            duration_ms=1,
-        )
+        # Patched so the refusal is proven to come BEFORE any execution: if the
+        # gate ever moved after the runtime call, this mock would record a call.
+        fake_result = AsyncMock(output="ok", tool_calls=[], duration_ms=1)
 
         async def _run():
-            with patch.object(LocalRuntime, "execute", return_value=fake_result):
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
+            with patch.object(LocalRuntime, "execute", return_value=fake_result) as ex:
+                with pytest.raises(ApprovalNotEnforceableError) as excinfo:
                     await agent.run("test prompt")
-            return w
+                assert ex.call_count == 0, "refused too late; the run had already started"
+            return str(excinfo.value)
 
-        caught = asyncio.run(_run())
-        user_warnings = [x for x in caught if issubclass(x.category, UserWarning)]
-        assert len(user_warnings) >= 1
-        msg = str(user_warnings[0].message)
+        msg = asyncio.run(_run())
         assert "approval_required" in msg
-        assert "in-process" in msg.lower() or "run_durable" in msg
+        assert "run_durable" in msg
 
-    def test_approval_required_list_warns_on_run(self, dummy_tool):
-        """approval_required=[...] on agent.run() emits a UserWarning."""
+    def test_approval_required_list_refuses_on_run(self, dummy_tool):
+        """approval_required=["delete_*"] on agent.run() raises before anything runs."""
         import asyncio
         from unittest.mock import AsyncMock, patch
 
+        from jamjet import ApprovalNotEnforceableError
         from jamjet.agents.agent import Agent
         from jamjet.runtime.local import LocalRuntime
 
@@ -293,22 +294,20 @@ class TestApprovalRequiredInProcessWarning:
             approval_required=["delete_*"],
         )
 
-        fake_result = AsyncMock(
-            output="ok",
-            tool_calls=[],
-            duration_ms=1,
-        )
+        # Patched so the refusal is proven to come BEFORE any execution: if the
+        # gate ever moved after the runtime call, this mock would record a call.
+        fake_result = AsyncMock(output="ok", tool_calls=[], duration_ms=1)
 
         async def _run():
-            with patch.object(LocalRuntime, "execute", return_value=fake_result):
-                with warnings.catch_warnings(record=True) as w:
-                    warnings.simplefilter("always")
-                    await agent.run("test")
-            return w
+            with patch.object(LocalRuntime, "execute", return_value=fake_result) as ex:
+                with pytest.raises(ApprovalNotEnforceableError) as excinfo:
+                    await agent.run("test prompt")
+                assert ex.call_count == 0, "refused too late; the run had already started"
+            return str(excinfo.value)
 
-        caught = asyncio.run(_run())
-        user_warnings = [x for x in caught if issubclass(x.category, UserWarning)]
-        assert len(user_warnings) >= 1
+        msg = asyncio.run(_run())
+        assert "approval_required" in msg
+        assert "run_durable" in msg
 
     def test_approval_required_false_does_not_warn(self, dummy_tool):
         """approval_required=False (default) -> NO warning on agent.run()."""

--- a/sdk/python/tests/model/test_policy_allowlist.py
+++ b/sdk/python/tests/model/test_policy_allowlist.py
@@ -275,7 +275,11 @@ class TestApprovalRequiredInProcessRefusal:
             return str(excinfo.value)
 
         msg = asyncio.run(_run())
-        assert "approval_required" in msg
+        # The message names the RESOLVED rule, not the knob that spelled it:
+        # approval_required=... and policy={"require_approval_for": ...} both
+        # arrive here, and only one of them is literally "approval_required".
+        assert "approval gate is declared" in msg
+        assert "require_approval_for" in msg
         assert "run_durable" in msg
 
     def test_approval_required_list_refuses_on_run(self, dummy_tool):
@@ -306,7 +310,11 @@ class TestApprovalRequiredInProcessRefusal:
             return str(excinfo.value)
 
         msg = asyncio.run(_run())
-        assert "approval_required" in msg
+        # The message names the RESOLVED rule, not the knob that spelled it:
+        # approval_required=... and policy={"require_approval_for": ...} both
+        # arrive here, and only one of them is literally "approval_required".
+        assert "approval gate is declared" in msg
+        assert "require_approval_for" in msg
         assert "run_durable" in msg
 
     def test_approval_required_false_does_not_warn(self, dummy_tool):

--- a/sdk/python/tests/test_agent.py
+++ b/sdk/python/tests/test_agent.py
@@ -3,11 +3,10 @@
 import asyncio
 import re
 import warnings
-from collections.abc import Iterable
 
 import pytest
 
-from jamjet import Agent, task, tool
+from jamjet import Agent, ApprovalNotEnforceableError, task, tool
 from jamjet.agents.agent import AgentResult
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -155,11 +154,16 @@ def _agent_with_approval_required() -> Agent:
     )
 
 
-def _approval_warning(record: Iterable[warnings.WarningMessage]) -> str:
-    """The one approval warning out of everything run() emits (audit warns too)."""
-    matches = [w for w in record if "approval_required" in str(w.message)]
-    assert len(matches) == 1, f"expected exactly one approval warning, got {len(matches)}"
-    return str(matches[0].message)
+def _approval_refusal(agent: Agent) -> str:
+    """The message run() refuses with when approval_required is set.
+
+    It raises rather than warning: a UserWarning prints once per location and is
+    dropped by `-W ignore`, PYTHONWARNINGS or a pytest config, so the old
+    behaviour was to announce the gap to nobody and then run every tool ungated.
+    """
+    with pytest.raises(ApprovalNotEnforceableError) as excinfo:
+        asyncio.run(agent.run("hi"))
+    return str(excinfo.value)
 
 
 # "worker" is allowed in the copy — "before any worker receives the payload" is
@@ -177,32 +181,26 @@ _WORKER_CREDITED = re.compile(
 )
 
 
-class TestApprovalWarningCopy:
-    def test_in_process_run_warning_does_not_promise_enforcement_here(self):
-        """run() must warn without implying the in-process path is enforced."""
-        agent = _agent_with_approval_required()
-        with pytest.warns(UserWarning) as record:
-            asyncio.run(agent.run("hi"))
-        message = _approval_warning(record)
-        assert "does not enforce approval gates" in message
-        # The durable path is now genuinely enforced (C1), but this warning is on
+class TestApprovalRefusalCopy:
+    def test_in_process_run_does_not_promise_enforcement_here(self):
+        """run() must refuse without implying the in-process path is enforced."""
+        message = _approval_refusal(_agent_with_approval_required())
+        assert "cannot hold a run at a gate" in message
+        # The durable path is genuinely enforced (C1), but this message is about
         # the in-process path and must not read as a guarantee about this call.
         assert "fail-closed" not in message
 
-    def test_in_process_run_warning_points_at_the_real_enforcement_point(self):
+    def test_in_process_run_points_at_the_real_enforcement_point(self):
         """The redirect must name where enforcement lives, accurately.
 
         Server-side, before the payload leaves the engine — that is what makes
         the durable claim true even for a stale or hostile external tool worker.
         """
-        agent = _agent_with_approval_required()
-        with pytest.warns(UserWarning) as record:
-            asyncio.run(agent.run("hi"))
-        message = _approval_warning(record)
+        message = _approval_refusal(_agent_with_approval_required())
         assert "run_durable" in message
         assert "before any worker" in message
 
-    def test_in_process_run_warning_never_credits_the_worker(self):
+    def test_in_process_run_never_credits_the_worker(self):
         """The durable guarantee belongs to the engine, never to the worker.
 
         Crediting the worker is not just imprecise, it inverts the property:
@@ -210,12 +208,21 @@ class TestApprovalWarningCopy:
         decision is made before it sees the payload. Copy that reads "the worker
         enforces it" describes a system where a stale worker build could opt out.
         """
-        agent = _agent_with_approval_required()
-        with pytest.warns(UserWarning) as record:
-            asyncio.run(agent.run("hi"))
-        message = _approval_warning(record)
+        message = _approval_refusal(_agent_with_approval_required())
         hit = _WORKER_CREDITED.search(message)
-        assert hit is None, f"warning credits the worker with enforcing: {hit.group(0)!r}"
+        assert hit is None, f"the refusal credits the worker with enforcing: {hit.group(0)!r}"
+
+    def test_it_refuses_rather_than_running_ungated(self):
+        """The property the message copy exists to serve.
+
+        Before this, the same agent warned and then executed every tool with no
+        gate — the knob read as configured and did nothing.
+        """
+        agent = _agent_with_approval_required()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # the old signal died here
+            with pytest.raises(ApprovalNotEnforceableError):
+                asyncio.run(agent.run("hi"))
 
 
 # ── @task tests ───────────────────────────────────────────────────────────────

--- a/sdk/python/tests/test_governance_parity.py
+++ b/sdk/python/tests/test_governance_parity.py
@@ -24,7 +24,10 @@ knob              in-process (agent.run)      durable (compile_agent_to_ir)
 budget=           BudgetExceededError (deny)  cost_budget_usd / token_budget
 policy= allowlist ModelDeniedError    (deny)  policy.model_allowlist
 pii=              redacted before backend     data_policy
-approval_required UserWarning (fail-LOUD)     policy.require_approval_for
+approval_required ApprovalNotEnforceable    policy.require_approval_for
+                  Error (fail-CLOSED)
+policy= blocked   tool dropped before the    policy.blocked_tools
+                  model is offered it
 ================  ==========================  ===============================
 
 Run:
@@ -43,7 +46,7 @@ from typing import Any
 
 import pytest
 
-from jamjet import Agent, tool
+from jamjet import Agent, ApprovalNotEnforceableError, tool
 from jamjet.agents.audit import AuditSigner, ChainError, resolve_signer, verify_chain
 from jamjet.agents.governance import Budget, normalize_governance
 from jamjet.compiler.agent_ir import compile_agent_to_ir
@@ -318,18 +321,26 @@ class TestPiiParity:
 
 
 # ===========================================================================
-# 6. APPROVAL_REQUIRED PARITY — in-process fails LOUD (UserWarning), durable IR
-#    carries require_approval_for.  It NEVER silently no-ops.
+# 6. APPROVAL_REQUIRED PARITY — in-process fails CLOSED, durable IR carries
+#    require_approval_for.  It NEVER silently no-ops.
+#
+#    This used to WARN and then run every tool ungated, which is the worst
+#    outcome available: the knob reads as configured, no error is raised, and
+#    nothing is gated.  A warning cannot carry that weight — Python prints a
+#    given one once per location, and `-W ignore` / PYTHONWARNINGS / a pytest
+#    config drop it entirely, so the caller who most needs to know is the one
+#    least likely to see it.
 # ===========================================================================
 
 
 class TestApprovalParity:
-    def test_inprocess_run_warns_never_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """approval_required on agent.run() emits a UserWarning (fail-LOUD).
+    def test_inprocess_run_refuses_rather_than_running_ungated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """approval_required on agent.run() raises instead of running ungated.
 
-        The in-process strategy runner cannot enforce tool-level approval gates
-        (F-t3-inprocess-approval); rather than silently no-op, it warns and points
-        the developer at run_durable().
+        The in-process runner calls tools directly with no policy engine between
+        the model and the call, so a gate can be neither evaluated nor held. The
+        only honest options are refuse or silently proceed, and refusing is safe
+        in the direction that matters.
         """
         _install_backend(monkeypatch)
         agent = Agent(
@@ -339,15 +350,32 @@ class TestApprovalParity:
             strategy="react",
             approval_required=["delete_*"],
         )
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with pytest.raises(ApprovalNotEnforceableError) as excinfo:
             asyncio.run(agent.run("q"))
-        approval = [w for w in caught if issubclass(w.category, UserWarning) and "approval_required" in str(w.message)]
-        assert len(approval) >= 1
-        assert "run_durable" in str(approval[0].message)
+        assert "run_durable" in str(excinfo.value), "the error must name the path that does gate"
 
-    def test_no_approval_no_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The dual: a plain agent does NOT emit a spurious approval warning."""
+    def test_a_warning_filter_cannot_suppress_the_refusal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The reason this is an exception and not a warning.
+
+        `-W ignore` is ordinary in CI and in application logging setups. Under it
+        the old UserWarning vanished and every tool ran ungated, so the caller who
+        most needed the signal was the least likely to receive it.
+        """
+        _install_backend(monkeypatch)
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            approval_required=True,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(ApprovalNotEnforceableError):
+                asyncio.run(agent.run("q"))
+
+    def test_no_approval_runs_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dual: a plain agent is not refused, and warns about nothing."""
         _install_backend(monkeypatch)
         agent = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react")
         with warnings.catch_warnings(record=True) as caught:
@@ -498,6 +526,7 @@ class TestNoKnobSilentlyNoOps:
             asyncio.run(agent.run("q"))
 
     def test_approval_does_not_silently_noop_inprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """It refuses. It used to warn and then run every tool ungated."""
         _install_backend(monkeypatch)
         agent = Agent(
             "n",
@@ -506,10 +535,22 @@ class TestNoKnobSilentlyNoOps:
             strategy="react",
             approval_required=True,
         )
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with pytest.raises(ApprovalNotEnforceableError):
             asyncio.run(agent.run("q"))
-        assert any("approval_required" in str(w.message) for w in caught)
+
+    def test_blocked_tools_does_not_silently_noop_inprocess(self) -> None:
+        """The knob that had no signal at all — not even a warning."""
+        from jamjet.runtime.local.executor import LocalRuntime
+
+        agent = Agent(
+            "n",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            policy={"blocked_tools": ["search"]},
+        )
+        filtered = LocalRuntime._apply_blocked_tools(agent.compile(), agent.governance)
+        assert [t.name for t in filtered.tools] == []
 
     def test_every_knob_compiles_into_the_durable_ir(self) -> None:
         """One fully-governed agent -> every knob lands in the durable IR."""
@@ -667,3 +708,104 @@ class TestStreamGovernanceParity:
         flat = json.dumps(backend.seen.messages, default=str)
         assert "a@b.com" not in flat
         assert "[REDACTED:EMAIL]" in flat
+
+
+# ===========================================================================
+# 7. BLOCKED_TOOLS PARITY — the tool the policy forbids is unreachable
+#    in-process, exactly as the engine refuses it durable.
+#
+#    blocked_tools is a TOOL control, so the seam middleware chain could never
+#    carry it: that chain sits at the MODEL boundary and enforces budget,
+#    allowlist and PII. Nothing enforced blocked_tools on agent.run(), so a
+#    forbidden tool ran normally in-process while being refused on the durable
+#    path — silently, without even the warning approval_required used to give.
+# ===========================================================================
+
+
+@tool
+def send_email(to: str) -> str:
+    """Send an email."""
+    return f"sent to {to}"
+
+
+class TestBlockedToolsParity:
+    def _agent(self, **kw: object) -> Agent:
+        return Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search, send_email],
+            strategy="react",
+            **kw,  # type: ignore[arg-type]
+        )
+
+    def test_a_blocked_tool_is_not_offered_to_the_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dropped before the runner sees it.
+
+        Every strategy builds its dispatch table from ``spec.tools``
+        (``resolve_tool_map``), so removing it there makes the tool both
+        un-offered and un-dispatchable in one place — a model cannot call what it
+        was never shown, and cannot reach it if it asks anyway.
+        """
+        from jamjet.runtime.local.executor import LocalRuntime
+
+        agent = self._agent(policy={"blocked_tools": ["send_*"]})
+        spec = agent.compile()
+        assert {t.name for t in spec.tools} == {"search", "send_email"}
+
+        filtered = LocalRuntime._apply_blocked_tools(spec, agent.governance)
+        assert {t.name for t in filtered.tools} == {"search"}, "a policy-blocked tool must not survive into the runner"
+
+    def test_patterns_are_globs_matching_the_engine(self) -> None:
+        """Same matcher as ``glob_match`` in runtime/policy/src/lib.rs.
+
+        A literal-only comparison here would make ``send_*`` mean nothing
+        in-process while blocking durable — the divergence class of #121/#123.
+        """
+        from jamjet.runtime.local.executor import LocalRuntime
+
+        for pattern, blocked in [("send_*", True), ("send_email", True), ("send", False), ("*", True)]:
+            agent = self._agent(policy={"blocked_tools": [pattern]})
+            filtered = LocalRuntime._apply_blocked_tools(agent.compile(), agent.governance)
+            names = {t.name for t in filtered.tools}
+            assert ("send_email" not in names) is blocked, f"{pattern!r} should block={blocked}"
+
+    def test_no_policy_leaves_every_tool_reachable(self) -> None:
+        """The dual: enforcement must not quietly drop tools nobody blocked."""
+        from jamjet.runtime.local.executor import LocalRuntime
+
+        agent = self._agent()
+        spec = agent.compile()
+        assert LocalRuntime._apply_blocked_tools(spec, agent.governance) is spec
+
+    def test_durable_ir_carries_the_same_blocked_list(self) -> None:
+        agent = self._agent(policy={"blocked_tools": ["send_*"]})
+        ir = compile_agent_to_ir(agent, "q")
+        assert ir["policy"]["blocked_tools"] == ["send_*"]
+
+    def test_run_actually_applies_the_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Through agent.run(), not the helper in isolation.
+
+        The helper being correct proves nothing if nothing calls it. Deleting the
+        `_apply_blocked_tools` line from `_run_agent` left every other test in this
+        class green, which is the "guard present, never wired" failure this suite
+        exists to catch — so this one goes through the real path and inspects what
+        the provider was actually offered.
+        """
+        lm = sys.modules["litellm"]
+        original = lm.acompletion
+        offered: list[list[str]] = []
+
+        async def _acompletion(model: str, messages: list, tools: list | None = None, **kw: object) -> object:
+            offered.append([t["function"]["name"] for t in (tools or [])])
+            return await original(model=model, messages=messages, tools=tools, **kw)
+
+        monkeypatch.setattr(lm, "acompletion", _acompletion)
+        monkeypatch.setattr(lm, "completion_cost", lambda completion_response=None, **kw: 0.0)
+
+        agent = self._agent(policy={"blocked_tools": ["send_*"]})
+        asyncio.run(agent.run("q"))
+
+        assert offered, "the model was never called, so this asserts nothing"
+        for names in offered:
+            assert "send_email" not in names, "a blocked tool reached the provider"
+            assert "search" in names, "an unblocked tool must still be offered"

--- a/sdk/python/tests/test_governance_parity.py
+++ b/sdk/python/tests/test_governance_parity.py
@@ -374,6 +374,50 @@ class TestApprovalParity:
             with pytest.raises(ApprovalNotEnforceableError):
                 asyncio.run(agent.run("q"))
 
+    def test_the_other_spelling_of_the_same_control_also_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``policy={"require_approval_for": [...]}`` is the same gate.
+
+        The first version of this fix keyed on ``governance.approval_required``
+        alone, so declaring the gate through ``policy=`` sailed straight past it
+        and ran ungated — a half-fix of the very bug being fixed. The check now
+        reads the RESOLVED policy, which is where both spellings converge.
+        """
+        _install_backend(monkeypatch)
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            policy={"require_approval_for": ["payments.*"]},
+        )
+        with pytest.raises(ApprovalNotEnforceableError):
+            asyncio.run(agent.run("q"))
+
+    def test_the_runtime_cannot_be_used_to_skip_the_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """LocalRuntime is public, so the gate cannot live only in Agent.run().
+
+        Calling the runtime directly with the same governance used to get the old
+        behaviour back: approval configured, tools ungated.
+        """
+        _install_backend(monkeypatch)
+        from jamjet.runtime.local import LocalRuntime
+
+        agent = Agent(
+            "a",
+            model="anthropic/claude-sonnet-4-6",
+            tools=[search],
+            strategy="react",
+            approval_required=True,
+        )
+        with pytest.raises(ApprovalNotEnforceableError):
+            asyncio.run(LocalRuntime().execute(agent.compile(), "q", governance=agent.governance))
+
+    def test_a_policy_without_approval_rules_still_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The dual: refusing must key on approval rules, not on having a policy."""
+        _install_backend(monkeypatch)
+        agent = Agent("a", model="anthropic/claude-sonnet-4-6", tools=[search], strategy="react", policy="strict")
+        asyncio.run(agent.run("q"))
+
     def test_no_approval_runs_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The dual: a plain agent is not refused, and warns about nothing."""
         _install_backend(monkeypatch)


### PR DESCRIPTION
Closes #132, plus a second hole found next to it.

## 1. `approval_required` warned, then ran every tool ungated

The knob read as configured, no error was raised, and nothing was gated.

A `UserWarning` cannot carry that weight. Python prints a given one **once per location**, and `-W ignore`, `PYTHONWARNINGS` or a pytest config drop it entirely — so the caller who most needed the signal was the least likely to receive it. Someone writing `approval_required=["issue_refund"]` had ungated refunds and no error.

`run()` executes tools with no policy engine between the model and the call, so a gate can be neither evaluated nor held there. It now raises `ApprovalNotEnforceableError` and names `run_durable`, where the engine decides **before any worker receives the payload**.

Refusing is safe in the direction that matters: an approval gate that silently does not exist is worse than a run that does not start.

## 2. `blocked_tools` was worse — no enforcement *and* no signal

Found by asking what else shares the shape of #132 rather than fixing only what was reported.

`blocked_tools` is a **tool** control, so the seam middleware chain could never have carried it: that chain sits at the **model** boundary and enforces budget, allowlist and PII. Nothing enforced it in-process, so a tool the policy forbids ran normally on `agent.run()` while being refused on `run_durable()` — silently, without even the warning approval got.

Unlike approval, this one *can* be enforced in-process, so it is **enforced rather than refused**. Blocked tools are dropped before the strategy runner sees them: every strategy builds its dispatch table from `spec.tools` (`resolve_tool_map`), so a single filter makes them neither offered to the model nor dispatchable if one is asked for anyway.

Patterns glob with the same matcher the engine uses (`glob_match` in `runtime/policy/src/lib.rs`), and **both paths resolve effective policy through one shared function** — two resolvers would let the same `Agent(...)` mean different things depending on which path ran it, the divergence class of #121 and #123.

## Breaking

`approval_required` + `run()` now raises where it warned. Deliberate, and the safe direction. Callers who want to run without gates drop `approval_required`.

## Tests

Every guard was mutation-checked — the bug re-introduced and the test watched to fail:

| Mutation | Fails |
|---|---|
| approval back to `warnings.warn` | 3 tests |
| `blocked_tools` filter removed from `_run_agent` | `test_run_actually_applies_the_filter` |
| glob matching → literal equality | `test_patterns_are_globs_matching_the_engine` |

**One of these caught a bad test of mine.** My first `blocked_tools` tests all called `_apply_blocked_tools` directly, so deleting the wiring from `_run_agent` left them **green** — the helper was correct and nothing called it. The added test drives `agent.run()` and asserts on the tool schemas the provider actually received.

The five pre-existing tests that asserted the warning are updated rather than deleted: their intent — that the message must not overclaim, must name the real enforcement point, and must never credit the *worker* with enforcing — carries over to the exception unchanged.

## Verification

- 1484 passed, 1 skipped; ruff check + format clean
- The parity matrix in `test_governance_parity.py` is updated, and `blocked_tools` added to it — it was absent, which is why the gap survived


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ApprovalNotEnforceableError` for approval settings that require durable execution.
  * `agent.run()` now directs callers to `run_durable` instead of proceeding without approval enforcement.
  * Blocked tools are filtered before being exposed to or executed by the model.
  * Added glob-pattern matching for blocked tool policies.

* **Documentation**
  * Updated the unreleased changelog with these behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->