### PR TITLE
perf(api): read one node kind before the whole IR on the claim path

### DIFF
--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1214,7 +1214,7 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
         .await;
     }
 
-    let ir = match backend.get_workflow(workflow_id, workflow_version).await {
+    let ir_value = match backend.get_workflow(workflow_id, workflow_version).await {
         // Infrastructure, not a decision: the engine could not read its own
         // catalogue. Settle NOTHING — failing the item would kill work that was
         // never evaluated, and completing it would silently drop it. The lease
@@ -1241,18 +1241,36 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
             )
             .await;
         }
-        Ok(Some(def)) => match serde_json::from_value::<jamjet_ir::WorkflowIr>(def.ir) {
-            Ok(ir) => ir,
+        Ok(Some(def)) => def.ir,
+    };
+
+    // Read ONLY this node's kind first. Deciding "is this a dispatch node" needs
+    // one node; `guard_dispatch` needs the whole graph, but it only runs for the
+    // dispatch nodes. Every model / tool / retrieval / general claim used to pay
+    // a full `WorkflowIr` deserialization to reach a check that hands it straight
+    // back, on the hot path every external worker polls.
+    //
+    // NOT gated on `wi.queue_type`, which is the obvious version of this and is
+    // unsafe: `POST /work-items` copies a caller-supplied `queue_type` verbatim,
+    // so enqueueing a dispatch node as `queue_type: "model"` would skip policy
+    // evaluation entirely. The node's KIND comes from the engine-written
+    // catalogue and cannot be forged that way. See #116.
+    let kind: jamjet_core::NodeKind = match ir_value
+        .get("nodes")
+        .and_then(|nodes| nodes.get(&wi.node_id))
+        .and_then(|node| node.get("kind"))
+    {
+        // The node id selects both the policy set and the dispatch marker, so a
+        // node that is not in the IR has neither and cannot be evaluated.
+        None => {
+            return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
+        }
+        Some(raw) => match serde_json::from_value(raw.clone()) {
+            Ok(kind) => kind,
             Err(e) => {
                 return fail_closed(backend, wi, format!("failed to load IR: {e}")).await;
             }
         },
-    };
-
-    // The node id selects both the policy set and the dispatch marker, so a
-    // node that is not in the IR has neither and cannot be evaluated.
-    let Some(node_def) = ir.node(&wi.node_id) else {
-        return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
     };
 
     // NARROWNESS. This route serves every queue. Everything that is not an agent
@@ -1270,9 +1288,21 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
     // coordinate tripwire and the execution-not-found fail-closed for those
     // queues, which is a behaviour change and not one to make inside a security
     // fix. Tracked in #116.
-    if !jamjet_worker::dispatch_guard::is_agent_tool_dispatch(&node_def.kind) {
+    if !jamjet_worker::dispatch_guard::is_agent_tool_dispatch(&kind) {
         return ClaimGate::Release;
     }
+
+    // A dispatch node: now the whole graph is genuinely needed, because the
+    // policy chain `guard_dispatch` evaluates is workflow-wide.
+    let ir = match serde_json::from_value::<jamjet_ir::WorkflowIr>(ir_value) {
+        Ok(ir) => ir,
+        Err(e) => {
+            return fail_closed(backend, wi, format!("failed to load IR: {e}")).await;
+        }
+    };
+    let Some(node_def) = ir.node(&wi.node_id) else {
+        return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
+    };
 
     let input = jamjet_worker::dispatch_guard::payload_input(&wi.payload);
     match jamjet_worker::dispatch_guard::guard_dispatch(

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1261,14 +1261,27 @@ async fn gate_claimed_item(backend: &dyn jamjet_state::StateBackend, wi: &WorkIt
         .and_then(|node| node.get("kind"))
     {
         // The node id selects both the policy set and the dispatch marker, so a
-        // node that is not in the IR has neither and cannot be evaluated.
+        // node whose kind cannot be read has neither and cannot be evaluated.
+        //
+        // This arm covers three shapes at once — no such node, `nodes` not an
+        // object, node present without a `kind` — so it does not claim to know
+        // which. Saying "node not found" would send an on-call reader looking
+        // for a missing node when the IR may simply be malformed.
         None => {
-            return fail_closed(backend, wi, format!("node {} not found in IR", wi.node_id)).await;
+            return fail_closed(
+                backend,
+                wi,
+                format!("no readable kind for node {} in IR", wi.node_id),
+            )
+            .await;
         }
         Some(raw) => match serde_json::from_value(raw.clone()) {
             Ok(kind) => kind,
+            // Distinct from the full-graph parse below, which keeps the worker's
+            // wording. Naming which parse failed is the difference between
+            // "this node's kind is malformed" and "the whole workflow is".
             Err(e) => {
-                return fail_closed(backend, wi, format!("failed to load IR: {e}")).await;
+                return fail_closed(backend, wi, format!("failed to load node kind: {e}")).await;
             }
         },
     };

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1632,7 +1632,6 @@ async fn a_dispatch_node_is_gated_even_when_the_item_claims_another_queue() {
     assert_withheld(&resp);
     // ...and it must not simply come back on the next poll.
     assert_withheld(&claim(&state, "model").await);
-    let _ = id;
 }
 
 /// The unblocked case still comes back, so the gate is not simply refusing.

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1594,3 +1594,59 @@ async fn a_backend_failure_withholds_without_auditing_or_settling() {
         "the item was failed back onto the queue instead of being left leased"
     );
 }
+
+// ── #116: cheaper claim path, without the bypass the obvious version opens ───
+
+/// A dispatch node is gated even when its work item claims another queue.
+///
+/// The obvious optimisation for #116 is to short-circuit `gate_claimed_item` on
+/// `wi.queue_type`, since only `python_tool` / `java_tool` can carry a dispatch
+/// node. That is unsafe: `POST /work-items` copies a caller-supplied
+/// `queue_type` verbatim, so enqueueing a dispatch node as `queue_type: "model"`
+/// would skip policy evaluation entirely — a complete bypass of the enforcement
+/// this route exists to apply.
+///
+/// The node's KIND comes from the engine-written catalogue and cannot be forged
+/// that way, which is why the gate reads that instead.
+#[tokio::test]
+async fn a_dispatch_node_is_gated_even_when_the_item_claims_another_queue() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    store(
+        &backend,
+        WF,
+        VERSION,
+        dispatch_ir(true, &["send_wire"], &[]),
+    )
+    .await;
+    // Enqueued on the model queue, but the IR says this node is a dispatch.
+    let (_execution_id, id) = seed_item(
+        &backend,
+        "model",
+        dispatch_payload(calls_input(&["send_wire"])),
+    )
+    .await;
+
+    let state = make_state(backend.clone());
+    let resp = claim(&state, "model").await;
+
+    assert_withheld(&resp);
+    // ...and it must not simply come back on the next poll.
+    assert_withheld(&claim(&state, "model").await);
+    let _ = id;
+}
+
+/// The unblocked case still comes back, so the gate is not simply refusing.
+#[tokio::test]
+async fn an_ordinary_model_item_is_still_handed_out() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    store(&backend, WF, VERSION, policed_condition_ir()).await;
+    let (_execution_id, _id) = seed_item(&backend, "model", json!({"node_id": "n1"})).await;
+
+    let state = make_state(backend.clone());
+    let resp = claim(&state, "model").await;
+    assert_eq!(
+        resp["claimed"],
+        json!(true),
+        "a non-dispatch item must be released, and released without a full IR parse"
+    );
+}

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -97,42 +97,6 @@ pub fn idempotency_key(run: &str, segment: u64, step: u64, node: &str, input_has
     }))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn canonical_json_sorts_object_keys() {
-        let a = json!({ "b": 1, "a": 2, "c": { "y": 1, "x": 2 } });
-        assert_eq!(canonical_json(&a), r#"{"a":2,"b":1,"c":{"x":2,"y":1}}"#);
-    }
-
-    #[test]
-    fn canonical_json_is_key_order_independent() {
-        let a = json!({ "x": 1, "y": [1, 2, { "p": 1, "q": 2 }] });
-        let b = json!({ "y": [1, 2, { "q": 2, "p": 1 }], "x": 1 });
-        assert_eq!(canonical_json(&a), canonical_json(&b));
-    }
-
-    #[test]
-    fn content_hash_is_stable_and_order_independent() {
-        let a = json!({ "run": "r1", "segment": 0, "step": 3 });
-        let b = json!({ "step": 3, "run": "r1", "segment": 0 });
-        let h = content_hash(&a);
-        assert_eq!(h, content_hash(&b));
-        assert_eq!(h.len(), 64); // sha256 hex
-        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn content_hash_differs_on_value_change() {
-        let a = json!({ "step": 3 });
-        let b = json!({ "step": 4 });
-        assert_ne!(content_hash(&a), content_hash(&b));
-    }
-}
-
 /// The idempotency key for the NEXT occurrence of `node_id` in this run.
 ///
 /// Both enforcement transports call this: `Worker::execute_item` for the
@@ -183,4 +147,40 @@ pub async fn derive_idempotency_key(
         node_id,
         &content_hash(&current_state),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_json_sorts_object_keys() {
+        let a = json!({ "b": 1, "a": 2, "c": { "y": 1, "x": 2 } });
+        assert_eq!(canonical_json(&a), r#"{"a":2,"b":1,"c":{"x":2,"y":1}}"#);
+    }
+
+    #[test]
+    fn canonical_json_is_key_order_independent() {
+        let a = json!({ "x": 1, "y": [1, 2, { "p": 1, "q": 2 }] });
+        let b = json!({ "y": [1, 2, { "q": 2, "p": 1 }], "x": 1 });
+        assert_eq!(canonical_json(&a), canonical_json(&b));
+    }
+
+    #[test]
+    fn content_hash_is_stable_and_order_independent() {
+        let a = json!({ "run": "r1", "segment": 0, "step": 3 });
+        let b = json!({ "step": 3, "run": "r1", "segment": 0 });
+        let h = content_hash(&a);
+        assert_eq!(h, content_hash(&b));
+        assert_eq!(h.len(), 64); // sha256 hex
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn content_hash_differs_on_value_change() {
+        let a = json!({ "step": 3 });
+        let b = json!({ "step": 4 });
+        assert_ne!(content_hash(&a), content_hash(&b));
+    }
 }

--- a/runtime/state/src/segment.rs
+++ b/runtime/state/src/segment.rs
@@ -45,6 +45,20 @@ use uuid::Uuid;
 /// as a random v4 UUID and then frozen.
 const SEGMENT_NS: Uuid = Uuid::from_u128(0x6a8e_f5c3_d3a4_4b9c_8b2e_4f5d_6e7a_8c9bu128);
 
+/// The DETERMINISTIC execution id of segment `n` of the run rooted at `parent_id`.
+///
+/// Deterministic so a re-run after a crash always targets the same child row,
+/// rather than forking the chain with a second random child.
+///
+/// Also the reason `derive_idempotency_key` can hash a constant `segment`: every
+/// segment has its own id, so the `run` component separates them by itself.
+pub fn segment_execution_id(parent_id: &ExecutionId, next_segment_number: u32) -> ExecutionId {
+    ExecutionId(Uuid::new_v5(
+        &SEGMENT_NS,
+        format!("{}:{}", parent_id.0, next_segment_number).as_bytes(),
+    ))
+}
+
 /// Create segment N+1: a fresh execution linked to `parent_id`, seeded with the
 /// carried materialized state, ready to resume the workflow from its start node.
 ///
@@ -81,21 +95,6 @@ const SEGMENT_NS: Uuid = Uuid::from_u128(0x6a8e_f5c3_d3a4_4b9c_8b2e_4f5d_6e7a_8c
 /// The `ExecutionId` of the newly created (or pre-existing idempotent) segment.
 // Nine parameters are required by the plan interface; suppressing the lint rather
 // than breaking the caller signature with a builder/struct at this stage.
-
-/// The DETERMINISTIC execution id of segment `n` of the run rooted at `parent_id`.
-///
-/// Deterministic so a re-run after a crash always targets the same child row,
-/// rather than forking the chain with a second random child.
-///
-/// Also the reason `derive_idempotency_key` can hash a constant `segment`: every
-/// segment has its own id, so the `run` component separates them by itself.
-pub fn segment_execution_id(parent_id: &ExecutionId, next_segment_number: u32) -> ExecutionId {
-    ExecutionId(Uuid::new_v5(
-        &SEGMENT_NS,
-        format!("{}:{}", parent_id.0, next_segment_number).as_bytes(),
-    ))
-}
-
 #[allow(clippy::too_many_arguments)]
 pub async fn start_next_segment(
     backend: &dyn StateBackend,

--- a/runtime/workers/src/worker.rs
+++ b/runtime/workers/src/worker.rs
@@ -17,7 +17,6 @@ use jamjet_policy::{EvaluationContext, PolicyDecision, PolicyEvaluator};
 use jamjet_state::approvals::NodeApprovalStatus;
 use jamjet_state::backend::{StateBackend, StateBackendError, WorkItem, WorkItemId};
 use jamjet_state::budget::BudgetState;
-use jamjet_state::content_hash;
 use jamjet_state::event::EventKind;
 use jamjet_state::spill_bytes;
 use jamjet_state::{artifact_threshold, materialize, start_next_segment};
@@ -1636,6 +1635,7 @@ mod tests {
     use crate::executor::{ExecutionResult, ExecutorError, NodeExecutor};
     use chrono::Utc;
     use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
+    use jamjet_state::content_hash;
     use jamjet_state::{
         backend::{StateBackend, WorkItem, WorkflowDefinition},
         event::EventKind,


### PR DESCRIPTION
`gate_claimed_item` runs on every successful claim, for every queue, and paid a full `WorkflowIr` deserialization before it could decide the item was not an agent tool dispatch at all. Model, tool, retrieval and general items each paid that to be handed straight back — on the hot path every external worker polls.

Deciding *"is this a dispatch node"* needs **one node**. `guard_dispatch` needs the whole graph, but it only runs for dispatch nodes, so the full parse moves behind that check.

## The suggested fix is a bypass, and I have the receipt

#116 proposes short-circuiting on `wi.queue_type`, since only `python_tool` / `java_tool` can carry a dispatch node. That is unsafe:

**`POST /work-items` copies a caller-supplied `queue_type` verbatim.** So enqueueing a dispatch node as `queue_type: "model"` would skip policy evaluation entirely — a complete bypass of the C1 enforcement this route exists to apply.

Demonstrated rather than argued. Implementing the suggested short-circuit and running the new test:

```
assertion failed: the payload is the capability — a refusal that still returns it
has enforced nothing; got {"claimed":true,"work_item":{...
  "payload":{"input":{"tool_calls":[{"name":"send_wire"}]}},"queue_type":"model"}}
```

The route hands out the blocked `send_wire` dispatch payload. `a_dispatch_node_is_gated_even_when_the_item_claims_another_queue` fails against it.

The node's **kind** comes from the engine-written catalogue and cannot be forged that way, which is why the gate reads that instead.

## What does not change

The execution lookup, the coordinate tripwire, the execution-not-found fail-closed and the node-not-found fail-closed all still run for **every** queue. The only thing deferred is the full-graph deserialization, and only for nodes that cannot be dispatches.

## Also in here

Three clippy warnings I introduced earlier this session, cleared:

- an unused `content_hash` import left by the `derive_idempotency_key` collapse (now scoped to the test module that actually uses it)
- `segment_execution_id` inserted into the middle of another function's doc comment
- `derive_idempotency_key` appended after the test module

## Verification

- `cargo test --workspace` — 818 passed, 0 failed; `cargo fmt --all --check` clean
- New tests mutation-checked: implementing the `queue_type` short-circuit fails the bypass test; the unblocked model item still comes back

Closes #116

---

**Not** doing #131 here. `kind_json` is an unindexed JSON blob, so a `json_extract` COUNT that silently returns 0 would change every idempotency key and re-fire every in-flight tool. That needs a generated column, a migration and a parity test — its own change, noted on the issue.
