### PR TITLE
fix(api): derive the effect key and the terminal event from the recorded item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ JamJet uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **The tool-effect idempotency key is derived by the engine, not taken from the request
+  body** (#130). `POST /work-items/:id/complete` persisted the caller's
+  `idempotency_key` verbatim, so a worker holding item B's lease could complete B while
+  echoing item A's key: the backend filed B's output under A, and a later replay for A
+  returned a result A never produced. The key is now derived from the coordinates the
+  engine recorded for the item — `StateBackend::get_work_item` was added so the route
+  can ask rather than believe the body, and the tenant-scoped backend filters that
+  lookup by tenant.
+
+  A worker that omits the field now gets replay coverage anyway, since the engine
+  derives it either way.
+
+  Derivation runs before `commit_turn` appends the `NodeCompleted`, so a linear run
+  reproduces the claim's key exactly. A node running beside a sibling whose
+  `state_patch` landed in between derives a different key and loses replay exactness —
+  already v1's documented posture (`F-2c-3`), and why a mismatch warns rather than
+  failing the completion.
+
 - **Dropped `hyper 0.14` and `h2 0.3.x` from the tree** (RUSTSEC-2026-0258, h2 unbounded
   empty DATA frames). The OTLP stack moved from opentelemetry 0.22 / tonic 0.11 to
   opentelemetry 0.32 / tonic 0.14, which was the only thing holding the pre-1.x hyper

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1507,6 +1507,49 @@ async fn complete_work_item(
         .map_err(|_| ApiError::BadRequest(format!("invalid work item id: {id}")))?;
     let backend = state.backend_for(&tenant_id);
 
+    // AUTHORITY. The idempotency key is derived from the coordinates the ENGINE
+    // recorded for this item, never from the request body.
+    //
+    // The body's key used to be persisted verbatim, so a worker holding item B's
+    // lease could complete B while echoing item A's key: the backend filed B's
+    // output under A, and a later replay for A returned the wrong result. Body
+    // coordinates are no better — they are the same caller's word.
+    //
+    // Derived here rather than trusted from the claim because `derive` runs
+    // BEFORE `commit_turn` appends this NodeCompleted, so the step count and the
+    // accumulated state are the same ones the claim saw. For a LINEAR run that
+    // reproduces the claim's key exactly. For a node running beside a sibling
+    // whose `state_patch` landed in between, it does not — that node loses replay
+    // exactness, which is already v1's documented posture (`F-2c-3` in
+    // `runtime/workers/src/worker.rs`), and is why a mismatch is not an error.
+    //
+    // Best effort: if the item cannot be read, no effect is recorded. A missing
+    // replay entry costs a re-fire; a wrong one costs the wrong answer.
+    let derived_key: Option<String> = match backend.get_work_item(item_id).await {
+        Ok(Some(wi)) => {
+            jamjet_state::derive_idempotency_key(backend.as_ref(), &wi.execution_id, &wi.node_id)
+                .await
+                .ok()
+        }
+        Ok(None) => None,
+        Err(e) => {
+            warn!(work_item_id = %id, error = %e, "complete: could not read the work item; recording no effect");
+            None
+        }
+    };
+
+    if let (Some(sent), Some(derived)) = (body.idempotency_key.as_deref(), derived_key.as_deref()) {
+        if sent != derived {
+            // Not an error: a parallel sibling legitimately moves the key. Worth
+            // saying out loud, because the other cause is a caller filing under
+            // someone else's key, and that used to succeed silently.
+            warn!(
+                work_item_id = %id,
+                "complete: the echoed idempotency_key differs from the engine-derived one;                  recording under the derived key"
+            );
+        }
+    }
+
     let node_completed = |execution_id: &ExecutionId| {
         jamjet_state::Event::new(
             execution_id.clone(),
@@ -1525,7 +1568,7 @@ async fn complete_work_item(
                 finish_reason: body.finish_reason.clone(),
                 cost_usd: None,
                 provenance: None,
-                idempotency_key: body.idempotency_key.clone(),
+                idempotency_key: derived_key.clone(),
             },
         )
     };

--- a/runtime/api/src/routes.rs
+++ b/runtime/api/src/routes.rs
@@ -1525,17 +1525,20 @@ async fn complete_work_item(
     //
     // Best effort: if the item cannot be read, no effect is recorded. A missing
     // replay entry costs a re-fire; a wrong one costs the wrong answer.
-    let derived_key: Option<String> = match backend.get_work_item(item_id).await {
-        Ok(Some(wi)) => {
+    let recorded = match backend.get_work_item(item_id).await {
+        Ok(item) => item,
+        Err(e) => {
+            warn!(work_item_id = %id, error = %e, "complete: could not read the work item");
+            None
+        }
+    };
+    let derived_key: Option<String> = match &recorded {
+        Some(wi) => {
             jamjet_state::derive_idempotency_key(backend.as_ref(), &wi.execution_id, &wi.node_id)
                 .await
                 .ok()
         }
-        Ok(None) => None,
-        Err(e) => {
-            warn!(work_item_id = %id, error = %e, "complete: could not read the work item; recording no effect");
-            None
-        }
+        None => None,
     };
 
     if let (Some(sent), Some(derived)) = (body.idempotency_key.as_deref(), derived_key.as_deref()) {
@@ -1550,14 +1553,14 @@ async fn complete_work_item(
         }
     }
 
-    let node_completed = |execution_id: &ExecutionId| {
+    let node_completed = |execution_id: &ExecutionId, node_id: &str| {
         jamjet_state::Event::new(
             execution_id.clone(),
             // Sequence is assigned inside `commit_turn`'s transaction; this
             // placeholder is never the number that lands.
             0,
             jamjet_state::EventKind::NodeCompleted {
-                node_id: body.node_id.clone().unwrap_or_default(),
+                node_id: node_id.to_string(),
                 output: body.output.clone(),
                 state_patch: body.state_patch.clone(),
                 duration_ms: body.duration_ms,
@@ -1595,34 +1598,32 @@ async fn complete_work_item(
         ));
     }
 
-    // Every key this engine mints is `content_hash`'s output: 64 lowercase hex
-    // characters. Anything else was never issued here, so an effect recorded
-    // under it is a row no reader can ever derive — junk that looks like a
-    // recorded effect and silently covers nothing.
-    //
-    // This is a shape check, not proof of provenance: a well-formed key from a
-    // DIFFERENT claim still passes. Binding the key to the claimed item is #130.
-    if let Some(key) = body.idempotency_key.as_deref() {
-        if key.len() != 64
-            || !key
-                .bytes()
-                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-        {
-            return Err(ApiError::BadRequest(
-                "idempotency_key must be 64 lowercase hex characters".to_string(),
-            ));
-        }
-    }
+    // No format check on `body.idempotency_key`. It earned one while that value
+    // was persisted; now that the engine derives its own, rejecting a malformed
+    // echo would fail a completion over a field nothing reads — losing real work
+    // to protect a value already ignored.
 
-    let committed_atomically = match (
-        body.lease_fence,
-        body.execution_id.as_deref(),
-        body.node_id.as_deref(),
-    ) {
-        (Some(fence), Some(exec_id_str), Some(_)) => {
-            let execution_id = parse_execution_id(exec_id_str)?;
+    // AUTHORITY, again. The terminal event's coordinates come from the item the
+    // ENGINE recorded, never from the body.
+    //
+    // `commit_turn` settles by `item_id` + `lease_fence` but appends the event
+    // under `terminal_event.execution_id`. Taking that from the request let a
+    // worker holding item B's lease settle B while appending its NodeCompleted
+    // to any execution it named — corrupting a different run's log and snapshot,
+    // which is worse than the key confusion this change set out to fix.
+    //
+    // No item, no event: without trustworthy coordinates the only honest options
+    // are settle-quietly or write into a run we cannot vouch for.
+    let committed_atomically = match (body.lease_fence, recorded.as_ref()) {
+        (Some(fence), Some(wi)) => {
+            let execution_id = wi.execution_id.clone();
             match backend
-                .commit_turn(item_id, fence, node_completed(&execution_id), true)
+                .commit_turn(
+                    item_id,
+                    fence,
+                    node_completed(&execution_id, &wi.node_id),
+                    true,
+                )
                 .await
             {
                 Ok(_) => true,
@@ -1638,9 +1639,9 @@ async fn complete_work_item(
                 Err(e) => return Err(e.into()),
             }
         }
-        // Fenced, but with no coordinates to build a terminal event from. Settle
-        // only — the same shape as before, and still fence-guarded.
-        (Some(fence), _, _) => {
+        // Fenced, but the item could not be read, so there are no coordinates we
+        // trust. Settle only — the same shape as before, and still fence-guarded.
+        (Some(fence), None) => {
             let settled = backend.complete_work_item_fenced(item_id, fence).await?;
             if !settled {
                 return Ok((
@@ -1657,7 +1658,7 @@ async fn complete_work_item(
         // fence keep working, but it cannot be made atomic: `commit_turn` is
         // fence-guarded by construction, and without a fence we cannot show the
         // item is ours to settle.
-        (None, _, _) => {
+        (None, _) => {
             warn!(
                 work_item_id = %id,
                 "complete: unfenced legacy path — settle and terminal event are \
@@ -1668,12 +1669,12 @@ async fn complete_work_item(
         }
     };
 
-    // The unfenced and no-coordinate paths still emit separately.
+    // The unfenced path still emits separately, and still only with coordinates
+    // the engine vouches for.
     if !committed_atomically {
-        if let (Some(exec_id_str), Some(_)) = (&body.execution_id, &body.node_id) {
-            let execution_id = parse_execution_id(exec_id_str)?;
-            let seq = backend.latest_sequence(&execution_id).await? + 1;
-            let mut event = node_completed(&execution_id);
+        if let Some(wi) = recorded.as_ref() {
+            let seq = backend.latest_sequence(&wi.execution_id).await? + 1;
+            let mut event = node_completed(&wi.execution_id, &wi.node_id);
             event.sequence = seq;
             backend.append_event(event).await?;
         }
@@ -1684,8 +1685,8 @@ async fn complete_work_item(
     // way the event log cannot explain — and the log is what the materializer
     // rebuilds from, so the two would simply disagree with no way to tell which
     // is right.
-    if let (Some(exec_id_str), Some(_)) = (&body.execution_id, &body.node_id) {
-        let execution_id = parse_execution_id(exec_id_str)?;
+    if let Some(wi) = recorded.as_ref() {
+        let execution_id = wi.execution_id.clone();
         // Denormalised read-model refresh, best effort by design: the
         // authoritative state is the event log plus the snapshot `commit_turn`
         // wrote inside the transaction, and the materializer recomputes from

--- a/runtime/api/tests/claim_route_policy.rs
+++ b/runtime/api/tests/claim_route_policy.rs
@@ -1366,6 +1366,13 @@ impl StateBackend for FailFirstGetEvents {
             .await
     }
 
+    async fn get_work_item(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+    ) -> jamjet_state::backend::BackendResult<Option<WorkItem>> {
+        self.inner.get_work_item(item_id).await
+    }
+
     async fn complete_work_item(
         &self,
         item_id: jamjet_state::backend::WorkItemId,

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -861,13 +861,14 @@ async fn a_later_segment_derives_a_different_key() {
     );
 }
 
-/// A key the engine never minted is refused, not filed.
+/// A key the engine never minted is ignored, not filed — and does not fail the run.
 ///
-/// Every key it issues is `content_hash`'s output — 64 lowercase hex characters.
-/// Anything else records an effect under a string no reader can ever derive:
-/// junk that looks like a recorded effect while covering nothing.
+/// This used to return 400. That was right while the value was persisted, but
+/// the engine now derives its own key, so rejecting a malformed echo would fail
+/// a real completion over a field nothing reads. The property that mattered
+/// survives: junk never becomes a recorded effect.
 #[tokio::test]
-async fn a_malformed_idempotency_key_is_refused() {
+async fn a_malformed_idempotency_key_is_ignored_not_filed() {
     let upper = "A".repeat(64);
     let not_hex = "g".repeat(64);
     let too_long = "a".repeat(65);
@@ -884,7 +885,10 @@ async fn a_malformed_idempotency_key_is_refused() {
         let (execution_id, id) = seed_unclaimed(&backend).await;
         let state = make_state(backend.clone());
         let claim = claim_via_route(&state).await;
-        let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
+        let derived = claim["work_item"]["idempotency_key"]
+            .as_str()
+            .unwrap()
+            .to_string();
 
         let (status, _) = post_complete(
             &state,
@@ -892,43 +896,28 @@ async fn a_malformed_idempotency_key_is_refused() {
             json!({
                 "execution_id": execution_id.to_string(),
                 "node_id": "n1",
-                "output": {},
+                "output": {"ok": true},
                 "state_patch": {},
-                "lease_fence": fence,
+                "lease_fence": claim["work_item"]["lease_fence"].as_i64().unwrap(),
                 "idempotency_key": key,
             }),
         )
         .await;
         assert_eq!(
             status,
-            StatusCode::BAD_REQUEST,
-            "a {why} key must be refused, not filed as an effect"
+            StatusCode::OK,
+            "a {why} echoed key must not fail the completion — the engine ignores it"
+        );
+
+        assert!(
+            backend.get_tool_effect(key).await.unwrap().is_none(),
+            "a {why} key was filed as an effect"
+        );
+        assert!(
+            backend.get_tool_effect(&derived).await.unwrap().is_some(),
+            "the effect must still land under the engine's own key"
         );
     }
-
-    // ...and the well-formed one the claim actually handed out still works.
-    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
-    let (execution_id, id) = seed_unclaimed(&backend).await;
-    let state = make_state(backend.clone());
-    let claim = claim_via_route(&state).await;
-    let (status, _) = post_complete(
-        &state,
-        id,
-        json!({
-            "execution_id": execution_id.to_string(),
-            "node_id": "n1",
-            "output": {},
-            "state_patch": {},
-            "lease_fence": claim["work_item"]["lease_fence"].as_i64().unwrap(),
-            "idempotency_key": claim["work_item"]["idempotency_key"].as_str().unwrap(),
-        }),
-    )
-    .await;
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "the engine's own key must be accepted"
-    );
 }
 
 // ── #130: the effect key is the engine's, not the caller's ──────────────────
@@ -943,16 +932,25 @@ async fn a_malformed_idempotency_key_is_refused() {
 async fn a_forged_idempotency_key_is_not_the_one_recorded() {
     let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
 
-    // Item A: never completed. Its key is the one the attacker wants to poison.
+    // ORDER MATTERS. Item B is seeded and claimed FIRST, while it is the only
+    // claimable item: `InMemoryBackend::claim_work_item` iterates a `DashMap`, so
+    // with two items pending the route could hand back A and the test would
+    // complete B with A's fence — passing or failing depending on hash order.
+    let (exec_b, id_b) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    assert_eq!(
+        claim["work_item"]["execution_id"].as_str().unwrap(),
+        exec_b.to_string(),
+        "the claim must be the item this test believes it holds"
+    );
+
+    // Only now the victim: item A, never completed, whose key is the one the
+    // caller will try to file under.
     let (exec_a, _id_a) = seed_unclaimed(&backend).await;
     let victim_key = jamjet_state::derive_idempotency_key(backend.as_ref(), &exec_a, "n1")
         .await
         .expect("derive victim key");
-
-    // Item B: a different execution, which this caller legitimately holds.
-    let (exec_b, id_b) = seed_unclaimed(&backend).await;
-    let state = make_state(backend.clone());
-    let claim = claim_via_route(&state).await;
     let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
 
     let (status, _) = post_complete(
@@ -1031,4 +1029,66 @@ async fn an_absent_key_no_longer_costs_the_effect() {
         .unwrap()
         .expect("the engine derives the key, so an absent field costs nothing");
     assert_eq!(recorded["output"]["answer"], json!(7));
+}
+
+/// A forged `execution_id` cannot append a terminal event to another run.
+///
+/// `commit_turn` settles by `item_id` + `lease_fence`, but appends the event
+/// under `terminal_event.execution_id`. While that came from the request body, a
+/// worker holding item B's lease could settle B and write its `NodeCompleted`
+/// into any execution it named — corrupting a different run's log and the
+/// snapshot rebuilt from it. Worse than the key confusion, and reachable with a
+/// perfectly valid fence.
+#[tokio::test]
+async fn a_forged_execution_id_cannot_write_into_another_run() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+
+    // The item this caller legitimately holds — claimed while it is the only one.
+    let (exec_b, id_b) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
+
+    // A bystander run the caller has no lease on.
+    let (victim, _) = seed_unclaimed(&backend).await;
+    let before = backend.get_events(&victim).await.unwrap().len();
+
+    let (status, _) = post_complete(
+        &state,
+        id_b,
+        json!({
+            // Someone else's execution, with a fence that is genuinely ours.
+            "execution_id": victim.to_string(),
+            "node_id": "n1",
+            "output": {"trespass": true},
+            "state_patch": {"poisoned": true},
+            "lease_fence": fence,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "our own item must still settle");
+
+    assert_eq!(
+        backend.get_events(&victim).await.unwrap().len(),
+        before,
+        "a NodeCompleted was appended to a run the caller holds no lease on"
+    );
+    let victim_state = backend
+        .get_execution(&victim)
+        .await
+        .unwrap()
+        .map(|e| e.current_state)
+        .unwrap();
+    assert!(
+        victim_state.get("poisoned").is_none(),
+        "the caller's state_patch reached another run's current_state"
+    );
+
+    // ...and the event landed on the run that actually owns the item.
+    let ours = backend.get_events(&exec_b).await.unwrap();
+    assert!(
+        ours.iter()
+            .any(|e| matches!(&e.kind, EventKind::NodeCompleted { .. })),
+        "our own terminal event went missing"
+    );
 }

--- a/runtime/api/tests/fail_route.rs
+++ b/runtime/api/tests/fail_route.rs
@@ -930,3 +930,105 @@ async fn a_malformed_idempotency_key_is_refused() {
         "the engine's own key must be accepted"
     );
 }
+
+// ── #130: the effect key is the engine's, not the caller's ──────────────────
+
+/// A worker cannot file its output under another item's key.
+///
+/// The body's `idempotency_key` used to be persisted verbatim, so a worker
+/// holding item B's lease could complete B while echoing item A's key. The
+/// backend filed B's output under A, and a later replay for A returned the wrong
+/// result — a worker poisoning a node it never ran.
+#[tokio::test]
+async fn a_forged_idempotency_key_is_not_the_one_recorded() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+
+    // Item A: never completed. Its key is the one the attacker wants to poison.
+    let (exec_a, _id_a) = seed_unclaimed(&backend).await;
+    let victim_key = jamjet_state::derive_idempotency_key(backend.as_ref(), &exec_a, "n1")
+        .await
+        .expect("derive victim key");
+
+    // Item B: a different execution, which this caller legitimately holds.
+    let (exec_b, id_b) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    let fence = claim["work_item"]["lease_fence"].as_i64().unwrap();
+
+    let (status, _) = post_complete(
+        &state,
+        id_b,
+        json!({
+            "execution_id": exec_b.to_string(),
+            "node_id": "n1",
+            "output": {"stolen": true},
+            "state_patch": {},
+            "lease_fence": fence,
+            // Item A's key, echoed while completing item B.
+            "idempotency_key": victim_key,
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the completion itself must still succeed"
+    );
+
+    assert!(
+        backend
+            .get_tool_effect(&victim_key)
+            .await
+            .unwrap()
+            .is_none(),
+        "item B's output was filed under item A's key — a replay of A would now \
+         return a result A never produced"
+    );
+
+    // ...and B's own effect IS recorded, under the key the engine derived.
+    let own_key = claim["work_item"]["idempotency_key"].as_str().unwrap();
+    let recorded = backend
+        .get_tool_effect(own_key)
+        .await
+        .unwrap()
+        .expect("the item's own effect must still be recorded");
+    assert_eq!(recorded["output"]["stolen"], json!(true));
+}
+
+/// Omitting the key entirely no longer means "record nothing".
+///
+/// The engine derives it either way, so a worker that never learned to echo the
+/// field still gets replay coverage.
+#[tokio::test]
+async fn an_absent_key_no_longer_costs_the_effect() {
+    let backend: Arc<dyn StateBackend> = Arc::new(InMemoryBackend::new());
+    let (execution_id, id) = seed_unclaimed(&backend).await;
+    let state = make_state(backend.clone());
+    let claim = claim_via_route(&state).await;
+    let expected = claim["work_item"]["idempotency_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (status, _) = post_complete(
+        &state,
+        id,
+        json!({
+            "execution_id": execution_id.to_string(),
+            "node_id": "n1",
+            "output": {"answer": 7},
+            "state_patch": {},
+            "lease_fence": claim["work_item"]["lease_fence"].as_i64().unwrap(),
+            // no idempotency_key at all
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let recorded = backend
+        .get_tool_effect(&expected)
+        .await
+        .unwrap()
+        .expect("the engine derives the key, so an absent field costs nothing");
+    assert_eq!(recorded["output"]["answer"], json!(7));
+}

--- a/runtime/api/tests/work_item_genai.rs
+++ b/runtime/api/tests/work_item_genai.rs
@@ -10,7 +10,7 @@ use jamjet_agents::InMemoryAgentRegistry;
 use jamjet_api::{routes::build_router_with_opts, state::AppState};
 use jamjet_audit::{AuditEnricher, NoopAuditBackend};
 use jamjet_core::workflow::{ExecutionId, WorkflowExecution, WorkflowStatus};
-use jamjet_state::backend::StateBackend;
+use jamjet_state::backend::{StateBackend, WorkItem};
 use jamjet_state::event::EventKind;
 use jamjet_state::{Event, InMemoryBackend};
 use serde_json::Value;
@@ -81,7 +81,28 @@ async fn complete_work_item_threads_gen_ai_fields() {
         .expect("append WorkflowStarted");
 
     // POST /work-items/:id/complete with all five GenAI telemetry fields.
+    // The item must actually exist: `/complete` takes the terminal event's
+    // coordinates from the item the ENGINE recorded, so a made-up id now settles
+    // nothing and emits nothing. That is the point — otherwise inventing an id
+    // would let a caller append a NodeCompleted to any execution it named.
     let work_item_id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id: work_item_id,
+            execution_id: execution_id.clone(),
+            node_id: "genai-node".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: jamjet_state::DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
     let body = serde_json::json!({
         "execution_id": execution_id.to_string(),
         "node_id": "genai-node",
@@ -199,7 +220,28 @@ async fn complete_work_item_without_gen_ai_fields_keeps_backward_compat() {
         .await
         .expect("append WorkflowStarted");
 
+    // The item must actually exist: `/complete` takes the terminal event's
+    // coordinates from the item the ENGINE recorded, so a made-up id now settles
+    // nothing and emits nothing. That is the point — otherwise inventing an id
+    // would let a caller append a NodeCompleted to any execution it named.
     let work_item_id = Uuid::new_v4();
+    backend
+        .enqueue_work_item(WorkItem {
+            id: work_item_id,
+            execution_id: execution_id.clone(),
+            node_id: "compat-node".into(),
+            queue_type: "general".into(),
+            payload: serde_json::json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: now,
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: jamjet_state::DEFAULT_TENANT.into(),
+        })
+        .await
+        .expect("enqueue_work_item");
     // Old-style body with no GenAI fields.
     let body = serde_json::json!({
         "execution_id": execution_id.to_string(),

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -277,6 +277,32 @@ pub trait StateBackend: Send + Sync {
         lease_fence: i64,
     ) -> BackendResult<()>;
 
+    /// How many times this node has already completed in this execution.
+    ///
+    /// The `step` component of a tool-effect idempotency key. The default
+    /// materialises the whole log and counts, which is correct everywhere and
+    /// what every backend did before; SQL backends override it so the claim path
+    /// stops transferring and deserializing every event body to reach a number.
+    ///
+    /// An override MUST return exactly what the default returns. The key is a
+    /// persisted identity, so a count that is off by one — or that silently
+    /// returns 0 because a JSON predicate stopped matching — changes every key
+    /// and re-fires every in-flight tool. `count_node_completions_matches_the_scan`
+    /// pins the two against each other.
+    async fn count_node_completions(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+    ) -> BackendResult<u64> {
+        let events = self.get_events(execution_id).await?;
+        Ok(events
+            .iter()
+            .filter(|e| {
+                matches!(&e.kind, crate::event::EventKind::NodeCompleted { node_id: nid, .. } if nid == node_id)
+            })
+            .count() as u64)
+    }
+
     /// The work item as the ENGINE recorded it, or `None` if there is no such
     /// item (for this tenant, on a tenant-scoped backend).
     ///

--- a/runtime/state/src/backend.rs
+++ b/runtime/state/src/backend.rs
@@ -277,6 +277,16 @@ pub trait StateBackend: Send + Sync {
         lease_fence: i64,
     ) -> BackendResult<()>;
 
+    /// The work item as the ENGINE recorded it, or `None` if there is no such
+    /// item (for this tenant, on a tenant-scoped backend).
+    ///
+    /// Exists so a route can answer "which execution and node is this item"
+    /// without believing the request body. `POST /work-items/:id/complete`
+    /// derives the tool-effect idempotency key from these coordinates: taking
+    /// them from the body would let a caller holding one item's lease file its
+    /// output under another item's key.
+    async fn get_work_item(&self, item_id: WorkItemId) -> BackendResult<Option<WorkItem>>;
+
     /// Mark a work item as completed and release the lease.
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()>;
 

--- a/runtime/state/src/hashing.rs
+++ b/runtime/state/src/hashing.rs
@@ -125,16 +125,9 @@ pub async fn derive_idempotency_key(
     execution_id: &jamjet_core::workflow::ExecutionId,
     node_id: &str,
 ) -> crate::backend::BackendResult<String> {
-    let events = backend.get_events(execution_id).await?;
-    let step = events
-        .iter()
-        .filter(|e| {
-            matches!(
-                &e.kind,
-                crate::event::EventKind::NodeCompleted { node_id: nid, .. } if nid == node_id
-            )
-        })
-        .count() as u64;
+    let step = backend
+        .count_node_completions(execution_id, node_id)
+        .await?;
     let current_state = backend
         .get_execution(execution_id)
         .await?

--- a/runtime/state/src/memory.rs
+++ b/runtime/state/src/memory.rs
@@ -486,6 +486,10 @@ impl StateBackend for InMemoryBackend {
         }
     }
 
+    async fn get_work_item(&self, item_id: WorkItemId) -> BackendResult<Option<WorkItem>> {
+        Ok(self.work_items.get(&item_id).map(|r| r.value().clone()))
+    }
+
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()> {
         self.work_items.remove(&item_id);
         Ok(())

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1184,6 +1184,28 @@ impl StateBackend for SqliteBackend {
         Ok(())
     }
 
+    async fn count_node_completions(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+    ) -> BackendResult<u64> {
+        // `EventKind` is `#[serde(tag = "type", rename_all = "snake_case")]`, so a
+        // NodeCompleted stores `"type":"node_completed"` alongside its `node_id`.
+        // Counting in SQL avoids shipping every event's output payload back just
+        // to length-check a filter.
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events WHERE execution_id = ? \
+             AND json_extract(kind_json, '$.type') = 'node_completed' \
+             AND json_extract(kind_json, '$.node_id') = ?",
+        )
+        .bind(execution_id_str(execution_id))
+        .bind(node_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+        Ok(n as u64)
+    }
+
     #[instrument(skip(self), fields(item_id = %item_id))]
     async fn get_work_item(&self, item_id: WorkItemId) -> BackendResult<Option<WorkItem>> {
         let row = sqlx::query("SELECT * FROM work_items WHERE id = ?")

--- a/runtime/state/src/sqlite.rs
+++ b/runtime/state/src/sqlite.rs
@@ -1185,6 +1185,15 @@ impl StateBackend for SqliteBackend {
     }
 
     #[instrument(skip(self), fields(item_id = %item_id))]
+    async fn get_work_item(&self, item_id: WorkItemId) -> BackendResult<Option<WorkItem>> {
+        let row = sqlx::query("SELECT * FROM work_items WHERE id = ?")
+            .bind(item_id.to_string())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        row.map(|r| row_to_work_item(&r)).transpose()
+    }
+
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()> {
         let id_str = item_id.to_string();
         let completed_at = Utc::now().to_rfc3339();

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1099,6 +1099,19 @@ impl StateBackend for TenantScopedSqliteBackend {
     }
 
     #[instrument(skip(self), fields(tenant = %self.tenant_id, item_id = %item_id))]
+    async fn get_work_item(&self, item_id: WorkItemId) -> BackendResult<Option<WorkItem>> {
+        // Tenant-filtered. An unfiltered lookup here would let one tenant read
+        // another's item coordinates, and the caller derives an idempotency key
+        // from them — the same cross-tenant shape as the reservation PK bug.
+        let row = sqlx::query("SELECT * FROM work_items WHERE id = ? AND tenant_id = ?")
+            .bind(item_id.to_string())
+            .bind(&self.tenant_id.0)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(map_db_err)?;
+        row.map(|r| row_to_work_item(&r)).transpose()
+    }
+
     async fn complete_work_item(&self, item_id: WorkItemId) -> BackendResult<()> {
         let id_str = item_id.to_string();
         let completed_at = Utc::now().to_rfc3339();

--- a/runtime/state/src/tenant_scoped.rs
+++ b/runtime/state/src/tenant_scoped.rs
@@ -1069,6 +1069,29 @@ impl StateBackend for TenantScopedSqliteBackend {
         Ok(Some(claimed))
     }
 
+    async fn count_node_completions(
+        &self,
+        execution_id: &ExecutionId,
+        node_id: &str,
+    ) -> BackendResult<u64> {
+        // `EventKind` is `#[serde(tag = "type", rename_all = "snake_case")]`, so a
+        // NodeCompleted stores `"type":"node_completed"` alongside its `node_id`.
+        // Counting in SQL avoids shipping every event's output payload back just
+        // to length-check a filter.
+        let n: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events WHERE execution_id = ? AND tenant_id = ? \
+             AND json_extract(kind_json, '$.type') = 'node_completed' \
+             AND json_extract(kind_json, '$.node_id') = ?",
+        )
+        .bind(execution_id_str(execution_id))
+        .bind(&self.tenant_id.0)
+        .bind(node_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(map_db_err)?;
+        Ok(n as u64)
+    }
+
     #[instrument(skip(self), fields(tenant = %self.tenant_id, item_id = %item_id))]
     async fn renew_lease(
         &self,

--- a/runtime/state/tests/idempotency.rs
+++ b/runtime/state/tests/idempotency.rs
@@ -909,3 +909,137 @@ async fn the_in_memory_backend_releases_identically() {
         ReserveOutcome::Acquired
     );
 }
+
+// ── #131: counting in SQL must equal counting by scan ───────────────────────
+
+/// The SQL `COUNT` must return exactly what materialising and filtering returns.
+///
+/// `step` is a component of a PERSISTED identity. A count that is off by one, or
+/// that silently returns 0 because the JSON predicate stopped matching the serde
+/// representation, changes every idempotency key ever derived — which orphans
+/// every recorded effect and re-fires every in-flight tool. Nothing else in the
+/// system would report that; the keys would simply stop matching.
+///
+/// So the optimisation is pinned against the thing it replaced, over a log that
+/// contains the shapes most likely to break the predicate: other event types,
+/// the same event type on a different node, and repeats.
+#[tokio::test]
+async fn count_node_completions_matches_the_scan() {
+    // BOTH SQL backends carry their own copy of this query, and `for_tenant`
+    // returns the scoped one — so exercising only that would leave the plain
+    // backend's copy unpinned. Mutating the query in one file and watching the
+    // other file's test stay green is exactly how a half-fix survives.
+    let db = SqliteBackend::open("sqlite::memory:").await.unwrap();
+    let scoped = db.for_tenant(jamjet_state::tenant::TenantId::default());
+    check_count_parity(&scoped).await;
+
+    let plain = SqliteBackend::open("sqlite::memory:").await.unwrap();
+    check_count_parity(&plain).await;
+}
+
+async fn check_count_parity(backend: &dyn StateBackend) {
+    let execution_id = ExecutionId::new();
+    let now = chrono::Utc::now();
+    backend
+        .create_execution(WorkflowExecution {
+            execution_id: execution_id.clone(),
+            workflow_id: "wf".into(),
+            workflow_version: "1.0.0".into(),
+            status: WorkflowStatus::Running,
+            initial_input: json!({}),
+            current_state: json!({}),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            session_type: None,
+            parent_execution_id: None,
+            segment_number: 0,
+        })
+        .await
+        .unwrap();
+
+    let completed = |node: &str| EventKind::NodeCompleted {
+        node_id: node.into(),
+        output: json!({"big": "payload".repeat(50)}),
+        state_patch: json!({}),
+        duration_ms: 1,
+        gen_ai_system: None,
+        gen_ai_model: None,
+        input_tokens: None,
+        output_tokens: None,
+        finish_reason: None,
+        cost_usd: None,
+        provenance: None,
+        idempotency_key: None,
+    };
+
+    let kinds = vec![
+        EventKind::NodeScheduled {
+            node_id: "n1".into(),
+            queue_type: "general".into(),
+        },
+        completed("n1"),
+        EventKind::NodeStarted {
+            node_id: "n1".into(),
+            worker_id: "w".into(),
+            attempt: 0,
+        },
+        completed("other"), // same type, different node
+        completed("n1"),
+        EventKind::NodeScheduled {
+            node_id: "other".into(),
+            queue_type: "general".into(),
+        },
+    ];
+    for (i, kind) in kinds.into_iter().enumerate() {
+        backend
+            .append_event(Event::new(execution_id.clone(), (i + 1) as i64, kind))
+            .await
+            .unwrap();
+    }
+
+    for node in ["n1", "other", "never-ran"] {
+        let scanned = backend
+            .get_events(&execution_id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(
+                |e| matches!(&e.kind, EventKind::NodeCompleted { node_id, .. } if node_id == node),
+            )
+            .count() as u64;
+        let counted = backend
+            .count_node_completions(&execution_id, node)
+            .await
+            .unwrap();
+        assert_eq!(
+            counted, scanned,
+            "SQL count disagreed with the scan for {node:?} — every idempotency key \
+             derived from this execution would change"
+        );
+    }
+
+    // Spelled out, so a predicate that matches nothing cannot pass by agreeing
+    // with a scan that also broke.
+    assert_eq!(
+        backend
+            .count_node_completions(&execution_id, "n1")
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        backend
+            .count_node_completions(&execution_id, "other")
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        backend
+            .count_node_completions(&execution_id, "never-ran")
+            .await
+            .unwrap(),
+        0
+    );
+}

--- a/runtime/state/tests/tenant_isolation.rs
+++ b/runtime/state/tests/tenant_isolation.rs
@@ -724,3 +724,54 @@ async fn a_reservation_is_scoped_to_its_tenant() {
         "beta's own key must still be exclusive within beta"
     );
 }
+
+/// `get_work_item` must not read across tenants.
+///
+/// The complete route derives a tool-effect idempotency key from the
+/// coordinates this returns. An unfiltered lookup would let one tenant's worker
+/// resolve another tenant's item and file an effect under a key derived from it
+/// — the same cross-tenant shape as the reservation primary-key bug, where a
+/// globally-scoped row read as free to a tenant-filtered caller.
+#[tokio::test]
+async fn get_work_item_is_scoped_to_the_tenant() {
+    let db = open_test_db().await;
+    register_tenant(&db, "alpha", "Alpha").await;
+    register_tenant(&db, "bravo", "Bravo").await;
+
+    let tenant_a = db.for_tenant(TenantId::from("alpha"));
+    let tenant_b = db.for_tenant(TenantId::from("bravo"));
+
+    let exec_a = sample_execution("wf-a");
+    let exec_id = exec_a.execution_id.clone();
+    tenant_a.create_execution(exec_a).await.unwrap();
+
+    let item_id = uuid::Uuid::new_v4();
+    tenant_a
+        .enqueue_work_item(jamjet_state::WorkItem {
+            id: item_id,
+            execution_id: exec_id,
+            node_id: "node-1".to_string(),
+            queue_type: "general".to_string(),
+            payload: json!({}),
+            attempt: 0,
+            max_attempts: 3,
+            created_at: Utc::now(),
+            lease_expires_at: None,
+            worker_id: None,
+            lease_fence: 0,
+            tenant_id: "alpha".to_string(),
+        })
+        .await
+        .unwrap();
+
+    let own = tenant_a.get_work_item(item_id).await.unwrap();
+    assert!(own.is_some(), "a tenant must be able to read its own item");
+    assert_eq!(own.unwrap().node_id, "node-1");
+
+    let cross = tenant_b.get_work_item(item_id).await.unwrap();
+    assert!(
+        cross.is_none(),
+        "tenant bravo read alpha's work item — the coordinates an idempotency \
+         key is derived from must not cross tenants"
+    );
+}

--- a/runtime/workers/src/test_support.rs
+++ b/runtime/workers/src/test_support.rs
@@ -279,6 +279,13 @@ impl StateBackend for FailingGetEvents {
             .await
     }
 
+    async fn get_work_item(
+        &self,
+        item_id: jamjet_state::backend::WorkItemId,
+    ) -> jamjet_state::backend::BackendResult<Option<jamjet_state::backend::WorkItem>> {
+        self.inner.get_work_item(item_id).await
+    }
+
     async fn complete_work_item(
         &self,
         item_id: jamjet_state::backend::WorkItemId,


### PR DESCRIPTION
Closes #130.

`POST /work-items/:id/complete` persisted the caller's `idempotency_key` **verbatim**. A worker holding item B's lease could complete B while echoing item A's key — the backend filed B's output under A, and a later replay for A returned a result A never produced. A worker poisoning a node it never ran.

Body coordinates are no better: they are the same caller's word. So the route now reads **the item the engine recorded**.

## What changed

- `StateBackend::get_work_item` — so the route can *ask* which execution and node an item belongs to rather than believe the request.
- The tenant-scoped backend **filters that lookup by tenant**. An unfiltered one would let a tenant resolve another tenant's item and derive a key from it — the same cross-tenant shape as the reservation primary-key bug.
- `/complete` derives the key from those coordinates and records under it, ignoring the body's value.

## Derive-and-use, not derive-and-reject

You picked derive-again over persisting the key at claim time. Worth being explicit about how it's implemented, because the obvious form is unsafe:

Derivation runs **before** `commit_turn` appends this `NodeCompleted`, so the step count and accumulated state are the ones the claim saw. For a **linear** run that reproduces the claim's key exactly.

For a node running beside a sibling whose `state_patch` landed in between, it does not. Rejecting on mismatch would **strand those completions** — real work lost. So a mismatch warns and records under the derived key. That node loses replay exactness, which is already v1's documented posture (`F-2c-3` in `runtime/workers/src/worker.rs`), so it costs nothing new.

The warning is worth having on its own: the *other* cause of a mismatch is a caller filing under someone else's key, and that used to succeed silently.

## A side effect worth having

A worker that never learned to echo the field now gets replay coverage anyway — the engine derives it either way. Previously an absent key meant no effect recorded at all.

## Tests

Three guards, each mutation-checked:

| Mutation | Fails |
|---|---|
| trust `body.idempotency_key` again | `a_forged_idempotency_key_is_not_the_one_recorded` + 1 |
| drop the tenant filter from the scoped lookup | `get_work_item_is_scoped_to_the_tenant` |
| omit the key entirely | covered by `an_absent_key_no_longer_costs_the_effect` |

The forgery test asserts both halves: A's key is **not** written, and B's own effect still is — so it cannot pass by simply recording nothing.

## Verification

- `cargo test --workspace` — 821 passed, 0 failed; `cargo fmt --all --check` clean
- Clippy adds no new warnings (the `engram/tests` unused-import ones pre-date this)

---

# Update after review

Both bots independently found the same **Major** issue, and both were right: I fetched the authoritative coordinates and then used them only for the **key**, leaving `node_completed` on `body.execution_id` / `body.node_id`.

`commit_turn` settles by `item_id` + `lease_fence` but appends the event under `terminal_event.execution_id` — so a worker holding item B's lease could settle B while writing its `NodeCompleted` into **any execution it named**, corrupting a different run's log and the snapshot rebuilt from it. That is a bigger hole than the key confusion this PR set out to fix, and I left it open while editing exactly that code.

The terminal event and the read-model refresh now take both coordinates from the recorded item. **No item, no event** — without coordinates we can vouch for, the only honest options are settle quietly or write into a run we cannot verify.

**Dropped the 400 on a malformed echoed key** (CodeRabbit). It earned its place while that value was persisted; now that the engine derives its own, rejecting a malformed echo would fail a real completion over a field nothing reads. The test keeps the property that mattered — junk never becomes a filed effect — and now also asserts the completion still succeeds.

**Copilot caught a genuinely flaky test of mine.** Two claimable items plus `DashMap` iteration order meant the route could hand back A while the test completed B with A's fence. B is now seeded and claimed while it is the only claimable item, and the claim is asserted to be the one the test believes it holds.

The `work_item_genai` fixtures completed a `work_item_id` that was never enqueued — the vulnerable shape itself, since inventing an id would let a caller append to any execution. They enqueue the item they complete now.

## Also closes #131

`derive_idempotency_key` materialised the whole event log to length-check a filter, on the claim path every external worker polls. Adds `StateBackend::count_node_completions` with a **default that scans** — so any backend without an override stays correct, just slower — and a SQL `COUNT` override on both SQLite backends.

`step` is part of a persisted identity, so a count off by one, or one that silently returns 0 because the JSON predicate stopped matching serde, would change every key ever derived and re-fire every in-flight tool. Nothing else in the system would report that. So the override is pinned against the scan it replaced, over a log containing the shapes most likely to break the predicate.

**That parity test caught its own gap:** `for_tenant()` returns the *scoped* backend, so mutating the query in `sqlite.rs` left the test green. It now runs against both backends.

| Mutation | Fails |
|---|---|
| body coordinates for the terminal event | `a_forged_execution_id_cannot_write_into_another_run` |
| `'node_completed'` predicate broken | `count_node_completions_matches_the_scan` |
| count off by one | same |
| trust `body.idempotency_key` | `a_forged_idempotency_key_is_not_the_one_recorded` |
| drop the tenant filter | `get_work_item_is_scoped_to_the_tenant` |

`cargo test --workspace` — 823 passed, fmt clean.
