### PR TITLE
fix(python): Model() defaults to the governed middleware chain

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -14,6 +14,20 @@
   where the engine decides before any worker receives the payload. To run without gates
   deliberately, drop `approval_required`.
 
+- **`Model()` builds the default governed chain instead of an empty one.** Constructing
+  the seam with no `middleware` produced an empty chain, so the call reached the provider
+  with no PII redaction, no metering and no budget, one line below a module docstring
+  calling it "the single governed path for every model call". Every in-tree call site
+  already passed `default_model_middleware()`, so this was never a live hole in JamJet's
+  own paths. It was the public default, and the trap was the next caller who wrote
+  `Model()` and reasonably assumed the seam governed. `Model(middleware=[])` now raises
+  `ValueError` rather than quietly meaning the same thing; `Model(ungoverned=True)` is
+  the way to ask for no chain, and it has to be asked for by name.
+
+  Scope of what this closes: with no `GovernanceConfig` the default chain is an allow-all
+  allowlist, PII redaction, a no-op budget and metering. So it closes a PII-leak and
+  unmetered-spend default. It does not add model restriction where no policy exists.
+
 ### Fixed
 
 - **`blocked_tools` is enforced on `agent.run()`.** It was enforced only on the durable

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -24,9 +24,28 @@
   `ValueError` rather than quietly meaning the same thing; `Model(ungoverned=True)` is
   the way to ask for no chain, and it has to be asked for by name.
 
-  Scope of what this closes: with no `GovernanceConfig` the default chain is an allow-all
-  allowlist, PII redaction, a no-op budget and metering. So it closes a PII-leak and
-  unmetered-spend default. It does not add model restriction where no policy exists.
+  Scope, stated narrowly: with no `GovernanceConfig` the default chain is an allow-all
+  allowlist, PII redaction, a no-op budget and a metering recorder. So what it closes is
+  a PII-leak default. It does not add model restriction where no policy exists, and the
+  metering half is bookkeeping rather than enforcement: `MeteringMiddleware` is built with
+  no sink, and nothing in the package reads `.records`, so spend is recorded into the
+  instance and discarded with it.
+
+  `stream()` runs only the `before` chain, so a streamed call through a bare `Model()` is
+  redacted but not metered, and an all-streaming workload will not trip a budget. That
+  asymmetry predates this change and is unchanged by it.
+
+  Two behaviour changes for anyone who was constructing a bare `Model()` on purpose.
+  Redaction rewrites `ModelRequest.messages` in place, so the caller's own request object
+  comes back redacted. And redaction is fail-closed on content it cannot traverse, so a
+  call carrying provider SDK objects inside `tool_calls` now raises
+  `ModelDeniedError(code="pii_unredactable_content")` where it previously succeeded; the
+  JSON-shaped form of the same conversation is unaffected. `Model(ungoverned=True)`
+  restores the old behaviour exactly.
+
+  `Model(middleware=...)` now also rejects non-`ModelMiddleware` elements with `TypeError`
+  at construction. Previously `Model(middleware="pii")` iterated the string into
+  `['p','i','i']` and failed later with a bare `AttributeError` at the provider boundary.
 
 ### Fixed
 

--- a/sdk/python/jamjet/model/seam.py
+++ b/sdk/python/jamjet/model/seam.py
@@ -15,18 +15,47 @@ from jamjet.model.types import ModelRequest, ModelResponse, StreamChunk
 
 
 class Model:
+    """The governed seam.
+
+    Omitting ``middleware`` builds the default chain
+    (:func:`jamjet.model.defaults.default_model_middleware`), so a bare
+    ``Model()`` redacts PII and meters spend rather than reaching the provider
+    raw. Running with no middleware at all is available, but it has to be asked
+    for by name: ``Model(ungoverned=True)``.
+    """
+
     def __init__(
         self,
         *,
         middleware: list[ModelMiddleware] | None = None,
         backend: Any | None = None,
+        ungoverned: bool = False,
     ) -> None:
         if backend is None:
             from jamjet.model.litellm_backend import LiteLLMBackend
 
             backend = LiteLLMBackend()
         self._backend = backend
-        self._middleware: list[ModelMiddleware] = list(middleware or [])
+
+        if ungoverned and middleware is not None:
+            raise ValueError("Model(ungoverned=True) takes no middleware. Pass a chain, or ask for no chain, not both.")
+
+        chain: list[ModelMiddleware]
+        if ungoverned:
+            chain = []
+        elif middleware is None:
+            from jamjet.model.defaults import default_model_middleware
+
+            chain = default_model_middleware()
+        elif not middleware:
+            raise ValueError(
+                "Model(middleware=[]) would run the seam ungoverned: no PII "
+                "redaction, no metering, no budget. Pass ungoverned=True to mean "
+                "that deliberately, or omit `middleware` for the default chain."
+            )
+        else:
+            chain = list(middleware)
+        self._middleware: list[ModelMiddleware] = chain
 
     async def complete(self, request: ModelRequest) -> ModelResponse:
         for mw in self._middleware:

--- a/sdk/python/jamjet/model/seam.py
+++ b/sdk/python/jamjet/model/seam.py
@@ -6,7 +6,7 @@ User code never calls a provider directly. The seam runs the middleware chain
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from dataclasses import replace
 from typing import Any
 
@@ -36,7 +36,7 @@ class Model:
     def __init__(
         self,
         *,
-        middleware: list[ModelMiddleware] | None = None,
+        middleware: Iterable[ModelMiddleware] | None = None,
         backend: Any | None = None,
         ungoverned: bool = False,
     ) -> None:

--- a/sdk/python/jamjet/model/seam.py
+++ b/sdk/python/jamjet/model/seam.py
@@ -15,13 +15,22 @@ from jamjet.model.types import ModelRequest, ModelResponse, StreamChunk
 
 
 class Model:
-    """The governed seam.
+    """The seam, governed by default.
 
     Omitting ``middleware`` builds the default chain
-    (:func:`jamjet.model.defaults.default_model_middleware`), so a bare
-    ``Model()`` redacts PII and meters spend rather than reaching the provider
-    raw. Running with no middleware at all is available, but it has to be asked
-    for by name: ``Model(ungoverned=True)``.
+    (:func:`jamjet.model.defaults.default_model_middleware`): PII redaction and
+    a metering recorder, plus an allowlist and a budget that stay no-ops until a
+    ``GovernanceConfig`` supplies them.  ``Model(ungoverned=True)`` opts out.
+
+    Two limits, so this reads as the safe default it is rather than an
+    enforcement guarantee:
+
+    * ``stream()`` runs only the ``before`` chain, so a streamed call is
+      redacted but NOT metered and cannot trip a budget.  See ``stream``.
+    * Any non-empty chain of ``ModelMiddleware`` is accepted, whatever it does.
+      A caller-supplied no-op chain is as ungoverned as ``ungoverned=True``
+      without saying so.  The default protects the caller who does not think
+      about middleware; it does not constrain one who does.
     """
 
     def __init__(
@@ -52,12 +61,24 @@ class Model:
             # truthy, so checking the argument would let `(mw for mw in [])`
             # through as a silent ungoverned chain.
             chain = list(middleware)
-            if not chain:
-                raise ValueError(
-                    "Model(middleware=[]) would run the seam ungoverned: no PII "
-                    "redaction, no metering, no budget. Pass ungoverned=True to mean "
-                    "that deliberately, or omit `middleware` for the default chain."
+            bad = [mw for mw in chain if not isinstance(mw, ModelMiddleware)]
+            if bad:
+                # Without this, Model(middleware="pii") iterates into
+                # ['p','i','i'] and the failure surfaces as a bare
+                # AttributeError at the provider boundary instead of here.
+                raise TypeError(
+                    "Model(middleware=...) takes ModelMiddleware objects; got "
+                    f"{', '.join(type(mw).__name__ for mw in bad)}."
                 )
+
+        if not chain and not ungoverned:
+            # Also covers the default path, so the invariant holds however the
+            # chain was built rather than only on the caller-supplied branch.
+            raise ValueError(
+                "Model(middleware=[]) would run the seam ungoverned: no PII "
+                "redaction, no metering, no budget. Pass ungoverned=True to mean "
+                "that deliberately, or omit `middleware` for the default chain."
+            )
         self._middleware: list[ModelMiddleware] = chain
 
     async def complete(self, request: ModelRequest) -> ModelResponse:

--- a/sdk/python/jamjet/model/seam.py
+++ b/sdk/python/jamjet/model/seam.py
@@ -47,14 +47,17 @@ class Model:
             from jamjet.model.defaults import default_model_middleware
 
             chain = default_model_middleware()
-        elif not middleware:
-            raise ValueError(
-                "Model(middleware=[]) would run the seam ungoverned: no PII "
-                "redaction, no metering, no budget. Pass ungoverned=True to mean "
-                "that deliberately, or omit `middleware` for the default chain."
-            )
         else:
+            # Materialize BEFORE the emptiness check: an exhausted iterator is
+            # truthy, so checking the argument would let `(mw for mw in [])`
+            # through as a silent ungoverned chain.
             chain = list(middleware)
+            if not chain:
+                raise ValueError(
+                    "Model(middleware=[]) would run the seam ungoverned: no PII "
+                    "redaction, no metering, no budget. Pass ungoverned=True to mean "
+                    "that deliberately, or omit `middleware` for the default chain."
+                )
         self._middleware: list[ModelMiddleware] = chain
 
     async def complete(self, request: ModelRequest) -> ModelResponse:

--- a/sdk/python/tests/model/test_seam.py
+++ b/sdk/python/tests/model/test_seam.py
@@ -8,9 +8,15 @@ from jamjet.model.types import ModelRequest, ModelResponse, StreamChunk, parse_m
 class FakeBackend:
     def __init__(self):
         self.completed: list[ModelRequest] = []
+        # Snapshot the payload AS THE PROVIDER SAW IT. Appending the request
+        # alone stores it by reference, and PII redaction mutates messages in
+        # place, so a later read would show post-call state and could not tell
+        # "redacted before the call" from "redacted after it".
+        self.sent_text: list[str] = []
 
     async def complete(self, request):
         self.completed.append(request)
+        self.sent_text.append(str(request.messages))
         return ModelResponse(message=object(), input_tokens=1, output_tokens=2)
 
     async def stream(self, request):
@@ -93,7 +99,7 @@ def _pii_req():
 
 
 def _sent_text(backend):
-    return str(backend.completed[0].messages)
+    return backend.sent_text[0]
 
 
 async def test_bare_model_redacts_pii_before_the_backend_sees_it():
@@ -148,3 +154,25 @@ async def test_empty_generator_middleware_is_rejected_too():
     with pytest.raises(ValueError) as exc:
         Model(middleware=(mw for mw in []), backend=FakeBackend())  # type: ignore[arg-type]
     assert "ungoverned=True" in str(exc.value)
+
+
+async def test_non_middleware_chain_elements_are_rejected_at_construction():
+    # Model(middleware="pii") used to iterate the string into ['p','i','i'] and
+    # Model(middleware=[object()]) used to construct fine, both failing later
+    # with a bare AttributeError at the provider boundary instead of here.
+    for bad in ("pii", [object()], [DenyMiddleware(), object()]):
+        with pytest.raises(TypeError) as exc:
+            Model(middleware=bad, backend=FakeBackend())  # type: ignore[arg-type]
+        assert "ModelMiddleware" in str(exc.value)
+
+
+async def test_a_degenerate_default_chain_is_rejected_too(monkeypatch):
+    # The emptiness guard used to live only on the caller-supplied branch, so a
+    # default_model_middleware() that returned nothing produced a silent
+    # ungoverned Model() with no error. In-tree it always returns three, so
+    # this is defense in depth against a shadowed or patched symbol.
+    import jamjet.model.defaults as defaults
+
+    monkeypatch.setattr(defaults, "default_model_middleware", lambda *a, **k: [])
+    with pytest.raises(ValueError):
+        Model(backend=FakeBackend())

--- a/sdk/python/tests/model/test_seam.py
+++ b/sdk/python/tests/model/test_seam.py
@@ -139,3 +139,12 @@ async def test_ungoverned_gives_an_empty_chain():
 async def test_ungoverned_with_explicit_middleware_is_rejected():
     with pytest.raises(ValueError):
         Model(middleware=[DenyMiddleware()], backend=FakeBackend(), ungoverned=True)
+
+
+async def test_empty_generator_middleware_is_rejected_too():
+    # An exhausted iterator is truthy, so an emptiness check on the argument
+    # instead of the materialized list lets `(mw for mw in [])` through as a
+    # silent ungoverned chain.
+    with pytest.raises(ValueError) as exc:
+        Model(middleware=(mw for mw in []), backend=FakeBackend())  # type: ignore[arg-type]
+    assert "ungoverned=True" in str(exc.value)

--- a/sdk/python/tests/model/test_seam.py
+++ b/sdk/python/tests/model/test_seam.py
@@ -73,3 +73,69 @@ async def test_stream_denied_yields_nothing():
     model = Model(middleware=[DenyMiddleware()], backend=backend)
     with pytest.raises(ModelDeniedError):
         _ = [c async for c in model.stream(_req())]
+
+
+# --- Model() defaults to the governed chain -------------------------------
+#
+# A bare ``Model()`` used to build an EMPTY middleware chain, so it reached the
+# provider with no PII redaction, no metering and no budget. The seam's own
+# docstring calls it "the single governed path for every model call"; these
+# tests hold it to that, and keep the escape hatch explicit.
+
+_EMAIL = "alice@example.com"
+
+
+def _pii_req():
+    return ModelRequest(
+        ref=parse_model_ref("anthropic/claude-opus-4-8"),
+        messages=[{"role": "user", "content": f"email me at {_EMAIL}"}],
+    )
+
+
+def _sent_text(backend):
+    return str(backend.completed[0].messages)
+
+
+async def test_bare_model_redacts_pii_before_the_backend_sees_it():
+    backend = FakeBackend()
+    await Model(backend=backend).complete(_pii_req())
+    assert _EMAIL not in _sent_text(backend)
+    assert "[REDACTED:EMAIL]" in _sent_text(backend)
+
+
+async def test_bare_model_meters_the_completion():
+    from jamjet.model.metering import MeteringMiddleware
+
+    model = Model(backend=FakeBackend())
+    await model.complete(_pii_req())
+    meters = [mw for mw in model._middleware if isinstance(mw, MeteringMiddleware)]
+    assert len(meters) == 1
+    assert [(r.provider, r.input_tokens, r.output_tokens) for r in meters[0].records] == [("anthropic", 1, 2)]
+
+
+async def test_explicit_middleware_is_not_silently_wrapped_in_the_default_chain():
+    backend = FakeBackend()
+    log: list[str] = []
+    model = Model(middleware=[RecordingMiddleware(log, "1")], backend=backend)
+    await model.complete(_pii_req())
+    assert log == ["before:1", "after:1"]
+    assert _EMAIL in _sent_text(backend)  # caller's chain, verbatim, nothing appended
+
+
+async def test_empty_middleware_list_is_rejected():
+    with pytest.raises(ValueError) as exc:
+        Model(middleware=[], backend=FakeBackend())
+    assert "ungoverned=True" in str(exc.value)
+
+
+async def test_ungoverned_gives_an_empty_chain():
+    backend = FakeBackend()
+    model = Model(backend=backend, ungoverned=True)
+    assert model._middleware == []
+    await model.complete(_pii_req())
+    assert _EMAIL in _sent_text(backend)  # the escape hatch really does bypass
+
+
+async def test_ungoverned_with_explicit_middleware_is_rejected():
+    with pytest.raises(ValueError):
+        Model(middleware=[DenyMiddleware()], backend=FakeBackend(), ungoverned=True)

--- a/sdk/python/tests/model/test_seam.py
+++ b/sdk/python/tests/model/test_seam.py
@@ -152,7 +152,7 @@ async def test_empty_generator_middleware_is_rejected_too():
     # instead of the materialized list lets `(mw for mw in [])` through as a
     # silent ungoverned chain.
     with pytest.raises(ValueError) as exc:
-        Model(middleware=(mw for mw in []), backend=FakeBackend())  # type: ignore[arg-type]
+        Model(middleware=(mw for mw in []), backend=FakeBackend())
     assert "ungoverned=True" in str(exc.value)
 
 

--- a/sdk/python/tests/model/test_sidecar.py
+++ b/sdk/python/tests/model/test_sidecar.py
@@ -434,8 +434,11 @@ async def test_complete_route_model_denied_is_non_200(monkeypatch: pytest.Monkey
 def test_get_model_has_governed_middleware() -> None:
     """The real _get_model() constructs a Model with the default middleware chain.
 
-    This test would FAIL against the old bare ``Model()`` construction (no middleware)
-    and PASSES once ``default_model_middleware()`` is wired in.
+    Once ``Model()`` began defaulting to ``default_model_middleware()``, a bare
+    ``Model()`` here would pass this test too, so it no longer distinguishes the
+    bug it was written for. It is kept as a pin on the sidecar's own wiring: it
+    still fails if this call site is changed to ``Model(ungoverned=True)`` or to
+    a chain missing the allowlist, budget or metering.
     """
     from jamjet.model.budget import BudgetMiddleware
     from jamjet.model.metering import MeteringMiddleware


### PR DESCRIPTION
## What

`Model.__init__` did `self._middleware = list(middleware or [])`, so a bare `Model()` built an empty chain and reached the provider with no PII redaction, no metering and no budget. One line above, the module docstring calls it "the single governed path for every model call".

Omitting `middleware` now builds `default_model_middleware()`. Running with no chain is still available, but it has to be asked for by name.

```python
Model()                                  # governed: PII redaction + metering
Model(middleware=[mw])                   # exactly [mw], nothing appended
Model(middleware=[])                     # ValueError
Model(middleware=(mw for mw in []))      # ValueError
Model(ungoverned=True)                   # empty chain, explicit
Model(middleware=[mw], ungoverned=True)  # ValueError
```

## Why it is not a live hole, and why it still matters

All four in-tree call sites already pass `default_model_middleware()`: `llm/client.py:31`, `runtime/local/llm_adapters/seam_adapter.py:48`, `agents/agent.py:1026`, `model/sidecar_server.py:65`. The sidecar site was patched in June and left a regression test guarding that one call site.

So this was never a live bypass in the SDK's own paths. It was the public default, and the trap was the next caller who wrote `Model()` and assumed the seam governed.

## Scope, stated honestly

With no `GovernanceConfig` the default chain is an allow-all allowlist, PII redaction, a no-op budget and metering. This closes a PII-leak and unmetered-spend default. It does not add model restriction where no policy exists.

## The second commit

After the first commit I asked what else reaches the same state as `middleware=[]`. An exhausted iterator is truthy, so the emptiness check on the argument let `(mw for mw in [])` through as a silent ungoverned chain. The check now runs on the materialized list.

## Testing

Seven guards, each watched failing before the code existed. Six failed against the original `list(middleware or [])`. The seventh, that an explicit chain is not silently wrapped in the default one, passed both before and after, so it was mutation-checked separately by appending the default chain to an explicit one.

The PII guard asserts behavior, not structure: a bare `Model()` is driven end to end through a fake backend and the assertion is that the email address never reaches it.

Full gate: 1494 passed, 1 skipped, 1 xpassed. The two warnings are pre-existing (authlib deprecation, scipy precision in `test_eval_compare`). `ruff check`, `ruff format --check` and `mypy` clean.

## Breaking

`Model(middleware=[])` now raises. Filed under `Changed (breaking)` in `sdk/python/CHANGELOG.md`, riding the 0.13.0 that the `approval_required` change already requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `Model()` now automatically applies the standard governed middleware, including privacy redaction and usage metering.
  - Added an explicit `ungoverned=True` option to bypass default governance controls.

- **Breaking Changes**
  - Empty middleware configurations now raise an error unless ungoverned mode is explicitly enabled.
  - Invalid middleware entries and conflicting configuration options are rejected.
  - Unredactable sensitive content is denied safely with a specific error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->